### PR TITLE
allow user to register Kontena account without invitation to Kontena server

### DIFF
--- a/app/mutations/users/register.rb
+++ b/app/mutations/users/register.rb
@@ -8,25 +8,29 @@ module Users
     end
 
     def execute
+
+      kontena_user = register_user(email, password)
+      if kontena_user.nil?
+        add_error(:external_id, :invalid, 'Kontena account registration failed')
+        return
+      end
       if User.count == 0
         user = create_admin_user(email)
       else
         user = User.find_by(email: email)
         if user.nil?
-          add_error(:email, :invalid, 'User not allowed to use this server.')
+          add_error(:email, :invalid, 'Kontena account registered successfully, but user is not allowed to use this server.')
           return
         end
       end
-      kontena_user = AuthService::Client.new.register({'email' => email, 'password' => password})
-      if kontena_user.nil?
-        add_error(:external_id, :invalid, 'User registering failed')
-        return
-      end
-
       user.update_attribute(:external_id, kontena_user['id'])
 
       user
 
+    end
+
+    def register_user(email, password)
+      AuthService::Client.new.register({'email' => email, 'password' => password})
     end
 
     ##

--- a/spec/api/v1/users_spec.rb
+++ b/spec/api/v1/users_spec.rb
@@ -83,7 +83,7 @@ describe '/v1/users' do
             email: 'john@domain.com'
         }
 
-        expect_any_instance_of(AuthService).not_to receive(:register).once.with(data.stringify_keys).and_return(kontena_user.stringify_keys)
+        expect_any_instance_of(AuthService::Client).not_to receive(:register).once.with(data.stringify_keys).and_return(kontena_user.stringify_keys)
         post '/v1/users/register', data.to_json
         expect(response.status).to eq(422)
         expect(json_response['error']['password']).not_to be_nil
@@ -92,16 +92,27 @@ describe '/v1/users' do
     end
 
     context 'when user is not invited' do
+      it 'registers Kontena account' do
+        data = {
+            email: 'david@domain.com',
+            password: 'secret1234'
+        }
+        john
+        expect_any_instance_of(AuthService::Client).to receive(:register).once.with(data.stringify_keys).and_return(kontena_user.stringify_keys)
+        post '/v1/users/register', data.to_json
+      end
+
       it 'returns error' do
         data = {
             email: 'david@domain.com',
             password: 'secret1234'
         }
         john
+        expect_any_instance_of(AuthService::Client).to receive(:register).and_return(kontena_user.stringify_keys)
         post '/v1/users/register', data.to_json
-        expect_any_instance_of(AuthService).not_to receive(:register).once.with(data.stringify_keys).and_return(kontena_user.stringify_keys)
+
         expect(response.status).to eq(422)
-        expect(json_response['error']['email']).not_to be_nil
+        expect(json_response['error']['email']).to eq("Kontena account registered successfully, but user is not allowed to use this server.")
       end
     end
   end


### PR DESCRIPTION
Currently user is not able to register Kontena account if he/she has not invitation to a Kontena server. This PR fixes this issue.
Fixes #8