### PR TITLE
Cli vpn commands

### DIFF
--- a/cli/lib/kontena/cli/grids/commands.rb
+++ b/cli/lib/kontena/cli/grids/commands.rb
@@ -3,6 +3,7 @@ module Kontena::Cli::Grids; end;
 require_relative 'grids'
 require_relative 'users'
 require_relative 'audit_log'
+require_relative 'vpn'
 
 
 command 'grid list' do |c|
@@ -85,5 +86,32 @@ command 'grid remove-user' do |c|
   c.description = 'Unassign user from grid'
   c.action do |args, options|
     Kontena::Cli::Grids::Users.new.remove(args[0])
+  end
+end
+
+
+command 'vpn create' do |c|
+  c.syntax = 'kontena vpn create'
+  c.description = 'Create vpn service'
+  c.option '--node STRING', String, 'Node name'
+  c.option '--ip STRING', String, 'Node ip'
+  c.action do |args, options|
+    Kontena::Cli::Grids::Vpn.new.create(options)
+  end
+end
+
+command 'vpn delete' do |c|
+  c.syntax = 'kontena vpn delete'
+  c.description = 'Delete vpn service'
+  c.action do |args, options|
+    Kontena::Cli::Grids::Vpn.new.delete
+  end
+end
+
+command 'vpn config' do |c|
+  c.syntax = 'kontena vpn config'
+  c.description = 'Show vpn client config'
+  c.action do |args, options|
+    Kontena::Cli::Grids::Vpn.new.config
   end
 end

--- a/cli/lib/kontena/cli/grids/vpn.rb
+++ b/cli/lib/kontena/cli/grids/vpn.rb
@@ -1,0 +1,71 @@
+require 'kontena/client'
+require_relative '../common'
+
+module Kontena::Cli::Grids
+  class Vpn
+    include Kontena::Cli::Common
+
+    def create(opts)
+      require_api_url
+      token = require_token
+      preferred_node = opts.node
+
+      vpn = client(token).get("services/vpn") rescue nil
+      raise ArgumentError.new('Vpn already exists') if vpn
+
+      nodes = client(token).get("grids/#{current_grid}/nodes")
+      if preferred_node.nil?
+        node = nodes['nodes'].find{|n| n['connected']}
+        raise ArgumentError.new('Cannot find any online nodes') if node.nil?
+      else
+        node = nodes['nodes'].find{|n| n['connected'] && n['name'] == preferred_node }
+        raise ArgumentError.new('Node not found') if node.nil?
+      end
+
+      public_ip = opts.ip || node['public_ip']
+
+      data = {
+        name: 'vpn',
+        stateful: true,
+        image: 'kontena/openvpn:latest',
+        ports: [
+          {
+            container_port: '1194',
+            node_port: '1194',
+            protocol: 'udp'
+          }
+        ],
+        cap_add: ['NET_ADMIN'],
+        env: ["OVPN_SERVER_URL=udp://#{public_ip}:1194"],
+        affinity: ["node==#{node['name']}"]
+      }
+      client(token).post("grids/#{current_grid}/services", data)
+      result = client(token).post("services/vpn/deploy", {})
+      print 'deploying '
+      until client(token).get("services/vpn")['state'] != 'deploying' do
+        print '.'
+        sleep 1
+      end
+      puts ' done'
+      puts "OpenVPN service is now started (udp://#{public_ip}:1194)."
+      puts "Use 'kontena vpn config' to fetch OpenVPN client config to your machine (it takes a while until config is ready)."
+    end
+
+    def delete
+      require_api_url
+      token = require_token
+
+      vpn = client(token).get("services/vpn") rescue nil
+      raise ArgumentError.new("VPN service does not exist") if vpn.nil?
+
+      client(token).delete("services/vpn")
+    end
+
+    def config
+      require_api_url
+      payload = {cmd: ['/usr/local/bin/ovpn_getclient', 'KONTENA_VPN_CLIENT']}
+      stdout, stderr = client(require_token).post("containers/vpn-1/exec", payload)
+      puts stdout
+    end
+  end
+end


### PR DESCRIPTION
This PR adds initial cli commands for managing an OpenVPN service. OpenVPN can be used to access internal virtual network and it's services that are not exposed to internet.