### PR TITLE
Hide internal services

### DIFF
--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -29,13 +29,15 @@ class GridService
   has_many :container_stats
   has_many :audit_logs
   embeds_many :grid_service_links
-  
+
   index({ grid_id: 1 })
   index({ name: 1 })
   index({ grid_service_ids: 1 })
 
   validates_presence_of :name, :image_name
   validates_uniqueness_of :name, scope: [:grid_id]
+
+  scope :visible, -> { where(name: {'$nin' => ['vpn', 'registry']}) }
 
   def set_state(state)
     self.update_attribute(:state, state)

--- a/server/app/routes/v1/grids/grid_services.rb
+++ b/server/app/routes/v1/grids/grid_services.rb
@@ -22,7 +22,7 @@ V1::GridsApi.route('grid_services') do |r|
   # GET /v1/grids/:id/services
   r.get do
     r.is do
-      @grid_services = @grid.grid_services
+      @grid_services = @grid.grid_services.visible
       render('grid_services/index')
     end
   end

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -121,6 +121,16 @@ describe '/v1/grids' do
         expect(response.status).to eq(200)
         expect(json_response['services'].size).to eq(1)
       end
+
+      it 'does not show internal services' do
+        grid = david.grids.first
+        grid.grid_services.create!(name: 'foo', image_name: 'foo/bar')
+        grid.grid_services.create!(name: 'vpn', image_name: 'kontena/openvpn:latest')
+        grid.grid_services.create!(name: 'registry', image_name: 'registry:2.0')
+        get "/v1/grids/#{grid.id}/services", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response['services'].size).to eq(1)
+      end
     end
 
     describe '/nodes' do


### PR DESCRIPTION
This PR hides internal services from grid service listings. 

Fixes #20 .