### PR TITLE
Fix service environment variable option parsing

### DIFF
--- a/cli/lib/kontena/cli/services/commands.rb
+++ b/cli/lib/kontena/cli/services/commands.rb
@@ -83,7 +83,7 @@ command 'service update' do |c|
   c.syntax = 'kontena service update <service_id>'
   c.description = 'Update service'
   c.option '-p', '--ports Array', Array, 'Exposed ports'
-  c.option '-e', '--env Array', Array, 'Environment variables'
+  c.option '-e', '--env Array', Array, 'Environment variables separated with commas'
   c.option '--image STRING', String, 'Service image'
   c.option '--instances INTEGER', Integer, 'How many instances should be deployed'
   c.option '--cmd STRING', String, 'Command to execute'

--- a/cli/lib/kontena/cli/services/services.rb
+++ b/cli/lib/kontena/cli/services/services.rb
@@ -144,7 +144,7 @@ module Kontena::Cli::Services
       data[:memory_swap] = parse_memory(options.memory_swap) if options.memory_swap
       data[:cpu_shares] = options.cpu_shares if options.cpu_shares
       data[:affinity] = options.affinity if options.affinity
-      data[:env] = options.env if options.env
+      data[:env] = parse_env_options(options.env) if options.env
       data[:container_count] = options.instances if options.instances
       data[:cmd] = options.cmd.split(" ") if options.cmd
       data[:user] = options.user if options.user
@@ -152,6 +152,27 @@ module Kontena::Cli::Services
       data[:cap_add] = options.cap_add if options.cap_add
       data[:cap_drop] = options.cap_drop if options.cap_drop
       data
+    end
+
+    ##
+    # @param [Array<String>] values
+    # @return [Array<String>]
+    def parse_env_options(values)
+      env = {}
+      prev_key = nil
+      values.each do |v|
+        key, value = v.split("=", 2)
+        if value.nil?
+          env[prev_key] = "#{env[prev_key]},#{key}"
+        elsif key != key.upcase
+          env[prev_key] = "#{env[prev_key]},#{key}"
+          prev_key = key
+        else
+          env[key] = value
+          prev_key = key
+        end
+      end
+      env.map{|k,v| "#{k}=#{v}"}
     end
   end
 end


### PR DESCRIPTION
This PR fixes environment variable parsing when environment variable value contains "," and/or "=" characters.