### PR TITLE
DigitalOcean node provisioner

### DIFF
--- a/cli/lib/kontena/cli/nodes/commands.rb
+++ b/cli/lib/kontena/cli/nodes/commands.rb
@@ -1,6 +1,7 @@
 module Kontena::Cli::Nodes; end;
 
 require_relative 'nodes'
+require_relative 'digital_ocean'
 
 command 'node list' do |c|
   c.syntax = 'kontena node list'
@@ -23,5 +24,30 @@ command 'node remove' do |c|
   c.description = 'Remove node'
   c.action do |args, options|
     Kontena::Cli::Nodes::Nodes.new.destroy(args[0])
+  end
+end
+
+command 'node provision digitalocean' do |c|
+  c.syntax = 'node provision do'
+  c.description = 'Provision grid nodes'
+  c.option '--token STRING', String, 'DO token'
+  c.option '--ssh-key STRING', String, 'Path to ssh public key'
+  c.option '--size STRING', String, 'Droplet size (default: 1gb)'
+  c.option '--region STRING', String, 'Region (default: ams3)'
+  c.action do |args, options|
+    raise ArgumentError.new('--token is required') unless options.token
+    raise ArgumentError.new('--ssh-key is required') unless options.ssh_key
+    Kontena::Cli::Nodes::DigitalOcean.new.provision(options)
+  end
+end
+
+command 'node destroy digitalocean' do |c|
+  c.syntax = 'node destroy digitalocean'
+  c.description = 'Destroy node'
+  c.option '--name STRING', String, 'Node name'
+  c.option '--token STRING', String, 'DO token'
+  c.action do |args, options|
+    raise ArgumentError.new('--token is required') unless options.token
+    Kontena::Cli::Nodes::DigitalOcean.new.destroy(options)
   end
 end

--- a/cli/lib/kontena/cli/nodes/commands.rb
+++ b/cli/lib/kontena/cli/nodes/commands.rb
@@ -21,17 +21,18 @@ end
 
 command 'node remove' do |c|
   c.syntax = 'kontena node remove'
-  c.description = 'Remove node'
+  c.description = 'Remove node from grid'
   c.action do |args, options|
     Kontena::Cli::Nodes::Nodes.new.destroy(args[0])
   end
 end
 
-command 'node provision digitalocean' do |c|
-  c.syntax = 'node provision do'
-  c.description = 'Provision grid nodes'
+command 'node create digitalocean' do |c|
+  c.syntax = 'node create digitalocean'
+  c.description = 'Create node to DigitalOcean'
   c.option '--token STRING', String, 'DO token'
   c.option '--ssh-key STRING', String, 'Path to ssh public key'
+  c.option '--name STRING', String, 'Node name'
   c.option '--size STRING', String, 'Droplet size (default: 1gb)'
   c.option '--region STRING', String, 'Region (default: ams3)'
   c.action do |args, options|
@@ -41,13 +42,12 @@ command 'node provision digitalocean' do |c|
   end
 end
 
-command 'node destroy digitalocean' do |c|
-  c.syntax = 'node destroy digitalocean'
-  c.description = 'Destroy node'
-  c.option '--name STRING', String, 'Node name'
+command 'node terminate digitalocean' do |c|
+  c.syntax = 'node terminate digitalocean <name>'
+  c.description = 'Terminate node from DigitalOcean'
   c.option '--token STRING', String, 'DO token'
   c.action do |args, options|
     raise ArgumentError.new('--token is required') unless options.token
-    Kontena::Cli::Nodes::DigitalOcean.new.destroy(options)
+    Kontena::Cli::Nodes::DigitalOcean.new.destroy(args[0], options.token)
   end
 end

--- a/cli/lib/kontena/cli/nodes/digital_ocean.rb
+++ b/cli/lib/kontena/cli/nodes/digital_ocean.rb
@@ -1,0 +1,35 @@
+require 'kontena/client'
+require_relative '../common'
+
+module Kontena::Cli::Nodes
+  class DigitalOcean
+    include Kontena::Cli::Common
+
+    def provision(options)
+      require_api_url
+      require_current_grid
+
+      require 'kontena/machine/digital_ocean'
+      grid = client(require_token).get("grids/#{current_grid}")
+      provisioner = Kontena::Machine::DigitalOcean::NodeProvisioner.new(client(require_token), options.token)
+      provisioner.run!(
+        master_uri: api_url,
+        grid_token: grid['token'],
+        grid: current_grid,
+        ssh_key: options.ssh_key,
+        size: options.size || '1gb',
+        region: options.region || 'ams3',
+      )
+    end
+
+    def destroy(options)
+      require_api_url
+      require_current_grid
+
+      require 'kontena/machine/digital_ocean'
+      grid = client(require_token).get("grids/#{current_grid}")
+      provisioner = Kontena::Machine::DigitalOcean::NodeDestroyer.new(client(require_token), options.token)
+      provisioner.run!(grid, options.name)
+    end
+  end
+end

--- a/cli/lib/kontena/cli/nodes/digital_ocean.rb
+++ b/cli/lib/kontena/cli/nodes/digital_ocean.rb
@@ -17,19 +17,20 @@ module Kontena::Cli::Nodes
         grid_token: grid['token'],
         grid: current_grid,
         ssh_key: options.ssh_key,
+        name: options.name,
         size: options.size || '1gb',
         region: options.region || 'ams3',
       )
     end
 
-    def destroy(options)
+    def destroy(name, token)
       require_api_url
       require_current_grid
 
       require 'kontena/machine/digital_ocean'
       grid = client(require_token).get("grids/#{current_grid}")
-      provisioner = Kontena::Machine::DigitalOcean::NodeDestroyer.new(client(require_token), options.token)
-      provisioner.run!(grid, options.name)
+      destroyer = Kontena::Machine::DigitalOcean::NodeDestroyer.new(client(require_token), token)
+      destroyer.run!(grid, name)
     end
   end
 end

--- a/cli/lib/kontena/machine/digital_ocean.rb
+++ b/cli/lib/kontena/machine/digital_ocean.rb
@@ -1,0 +1,11 @@
+begin
+  require "droplet_kit"
+rescue LoadError
+  puts "It seems that you don't have Digital Ocean API installed."
+  puts "Install it using: gem install droplet_kit"
+  exit 1
+end
+
+require_relative 'random_name'
+require_relative 'digital_ocean/node_provisioner'
+require_relative 'digital_ocean/node_destroyer'

--- a/cli/lib/kontena/machine/digital_ocean/node_destroyer.rb
+++ b/cli/lib/kontena/machine/digital_ocean/node_destroyer.rb
@@ -1,0 +1,40 @@
+
+module Kontena
+  module Machine
+    module DigitalOcean
+      class NodeDestroyer
+        include RandomName
+
+        attr_reader :client, :api_client
+
+        # @param [Kontena::Client] api_client Kontena api client
+        # @param [String] token Digital Ocean token
+        def initialize(api_client, token)
+          @api_client = api_client
+          @client = DropletKit::Client.new(access_token: token)
+        end
+
+        def run!(grid, name)
+          droplet = client.droplets.all.find{|d| d.name == name}
+          if droplet
+            print "Destroying DigitalOcean droplet #{name} ."
+            client.droplets.delete(id: droplet.id)
+            until client.droplets.find(id: droplet.id).is_a?(String) do
+              print '.'
+              sleep 2
+            end
+            puts ' done!'
+          else
+            raise "Cannot find droplet with name #{name} in DigitalOcean"
+          end
+          node = api_client.get("grids/#{grid['id']}/nodes")['nodes'].find{|n| n['name'] == name}
+          if node
+            print "Removing node from Kontena master ..."
+            api_client.delete("grids/#{grid['id']}/nodes/#{name}")
+            puts " done!"
+          end
+        end
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/machine/digital_ocean/node_destroyer.rb
+++ b/cli/lib/kontena/machine/digital_ocean/node_destroyer.rb
@@ -17,7 +17,7 @@ module Kontena
         def run!(grid, name)
           droplet = client.droplets.all.find{|d| d.name == name}
           if droplet
-            print "Destroying DigitalOcean droplet #{name} ."
+            print "Destroying DigitalOcean droplet [#{name}] ."
             client.droplets.delete(id: droplet.id)
             until client.droplets.find(id: droplet.id).is_a?(String) do
               print '.'
@@ -25,11 +25,11 @@ module Kontena
             end
             puts ' done!'
           else
-            raise "Cannot find droplet with name #{name} in DigitalOcean"
+            raise "Cannot find droplet [#{name}] in DigitalOcean"
           end
           node = api_client.get("grids/#{grid['id']}/nodes")['nodes'].find{|n| n['name'] == name}
           if node
-            print "Removing node from Kontena master ..."
+            print "Removing node [#{name}] from grid [#{grid['name']}] ..."
             api_client.delete("grids/#{grid['id']}/nodes/#{name}")
             puts " done!"
           end

--- a/cli/lib/kontena/machine/digital_ocean/node_provisioner.rb
+++ b/cli/lib/kontena/machine/digital_ocean/node_provisioner.rb
@@ -1,0 +1,85 @@
+
+module Kontena
+  module Machine
+    module DigitalOcean
+      class NodeProvisioner
+        include RandomName
+
+        attr_reader :client, :api_client
+
+        # @param [Kontena::Client] api_client Kontena api client
+        # @param [String] token Digital Ocean token
+        def initialize(api_client, token)
+          @api_client = api_client
+          @client = DropletKit::Client.new(access_token: token)
+        end
+
+        def run!(opts)
+          raise ArgumentError.new('Invalid ssh key') unless File.exists?(File.expand_path(opts[:ssh_key]))
+
+          ssh_key = ssh_key(File.read(File.expand_path(opts[:ssh_key])).strip)
+          raise ArgumentError.new('Ssh key does not exist in Digital Ocean') unless ssh_key
+
+          droplet = DropletKit::Droplet.new(
+            name: generate_name,
+            region: opts[:region],
+            image: 'docker',
+            size: opts[:size],
+            private_networking: true,
+            user_data: user_data(opts[:master_uri], opts[:grid_token]),
+            ssh_keys: [ssh_key.id]
+          )
+          created = client.droplets.create(droplet)
+          print "DigitalOcean droplet [#{droplet.name}] provision has started, please wait ."
+          until client.droplets.find(id: created.id).status == 'active' do
+            print '.'
+            sleep 2
+          end
+          puts ' done!'
+          print "Waiting for node [#{droplet.name}] to register itself to master ."
+          until droplet_exists_in_grid?(opts[:grid], droplet)
+            print '.'
+            sleep 2
+          end
+          puts 'done!'
+        end
+
+        def user_data(master_uri, token)
+          data = <<USERDATA
+#cloud-config
+package_upgrade: true
+write_files:
+  - path: /usr/local/bin/bootstrap-agent.sh
+    permissions: '0700'
+    content: |
+      #!/bin/sh
+      export DEBIAN_FRONTEND=noninteractive
+      wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
+      echo deb http://dl.bintray.com/kontena/kontena-testing trusty main > /etc/apt/sources.list.d/kontena.list
+      apt-get update
+      echo kontena-agent kontena-agent/server_uri string %s | debconf-set-selections
+      echo kontena-agent kontena-agent/grid_token string %s | debconf-set-selections
+      apt-get install -q -y --force-yes kontena-agent
+      restart docker
+
+runcmd:
+  - /usr/local/bin/bootstrap-agent.sh
+
+final_message: "The system is finally up, after $UPTIME seconds"
+
+USERDATA
+
+          data % [master_uri, token]
+        end
+
+        def ssh_key(public_key)
+          ssh_key = client.ssh_keys.all.find{|key| key.public_key == public_key}
+        end
+
+        def droplet_exists_in_grid?(grid, droplet)
+          api_client.get("grids/#{grid}/nodes")['nodes'].find{|n| n['name'] == droplet.name}
+        end
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/machine/random_name.rb
+++ b/cli/lib/kontena/machine/random_name.rb
@@ -1,0 +1,42 @@
+module Kontena
+  module Machine
+    module RandomName
+
+      def generate_name
+        rnd = Random.rand(64)
+
+        "#{adjectives[rnd%adjectives.length]}-#{nouns[rnd%adjectives.length]}"
+      end
+
+      private
+
+      def adjectives
+        [
+            "autumn", "hidden", "bitter", "misty", "silent", "empty", "dry", "dark",
+            "summer", "icy", "delicate", "quiet", "white", "cool", "spring", "winter",
+            "patient", "twilight", "dawn", "crimson", "wispy", "weathered", "blue",
+            "billowing", "broken", "cold", "damp", "falling", "frosty", "green",
+            "long", "late", "bold", "little", "morning", "muddy",
+            "red", "rough", "still", "small", "sparkling", "shy",
+            "wandering", "withered", "wild", "black", "young", "holy", "solitary",
+            "fragrant", "aged", "snowy", "proud", "floral", "restless",
+            "polished", "purple", "lively", "nameless"
+        ]
+      end
+
+      def nouns
+        [
+            "waterfall", "river", "breeze", "moon", "rain", "wind", "sea", "morning",
+            "snow", "lake", "sunset", "pine", "shadow", "leaf", "dawn", "glitter",
+            "forest", "hill", "cloud", "meadow", "sun", "glade", "bird", "brook",
+            "butterfly", "bush", "dew", "dust", "field", "fire", "flower", "firefly",
+            "feather", "grass", "haze", "mountain", "night", "pond", "darkness",
+            "snowflake", "silence", "sound", "sky", "shape", "surf", "thunder",
+            "violet", "water", "wildflower", "wave", "water", "resonance", "sun",
+            "wood", "dream", "cherry", "tree", "fog", "frost", "voice", "paper",
+            "frog", "smoke", "star"
+        ]
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/scripts/completer
+++ b/cli/lib/kontena/scripts/completer
@@ -77,7 +77,7 @@ if words.size > 0
       end
     when 'node'
       completion.clear
-      sub_commands = %w(list show remove)
+      sub_commands = %w(list show remove create terminate)
       if words[1]
         completion.push(sub_commands) unless sub_commands.include?(words[1])
         completion.push helper.nodes


### PR DESCRIPTION
This PR provides cli helper commands to provision droplets to DigitalOcean that are automatically provisioned and joined to Kontena grid as nodes.

```sh
$ kontena node provision digitalocean --token=<do_token> --ssh-key=<path_to_ssh_public_key>

$ kontena node destroy digitalocean --token=<do_token> --name=<node_name>
```