### PR TITLE
Expire container logs after 3 months

### DIFF
--- a/server/app/models/container_log.rb
+++ b/server/app/models/container_log.rb
@@ -14,5 +14,6 @@ class ContainerLog
   index({ grid_service_id: 1 })
   index({ container_id: 1 })
   index({ name: 1 })
-  index({ data: 'text' })
+  index({ data: 'text' }, { background: true })
+  index({ created_at: -1 }, { name: 'created_at_expire', expire_after_seconds: 3.months })
 end


### PR DESCRIPTION
We don't want to keep container logs forever. Let's expire them after 3 months.