### PR TITLE
Expire container stats after 1 month

### DIFF
--- a/server/app/models/container_stat.rb
+++ b/server/app/models/container_stat.rb
@@ -16,5 +16,5 @@ class ContainerStat
   index({ grid_id: 1 })
   index({ grid_service_id: 1 })
   index({ container_id: 1 })
-  index({ created_at: 1 })
+  index({ created_at: -1 }, { expire_after_seconds: 1.month })
 end

--- a/server/spec/models/container_stat_spec.rb
+++ b/server/spec/models/container_stat_spec.rb
@@ -12,6 +12,6 @@ describe ContainerStat do
   it { should have_index_for(container_id: 1) }
   it { should have_index_for(grid_id: 1) }
   it { should have_index_for(grid_service_id: 1) }
-  it { should have_index_for(created_at: 1) }
+  it { should have_index_for(created_at: -1) }
 
 end


### PR DESCRIPTION
We don't want to keep container stats forever. Let's expire them after 1 month.