### PR TITLE
Sort logs by _id

### DIFF
--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -55,7 +55,7 @@ module V1
             unless r['from'].nil?
               scope = scope.where(:id.gt => r['from'] )
             end
-            @logs = scope.order(:$natural => -1).limit(limit).to_a.reverse
+            @logs = scope.order(:_id => -1).limit(limit).to_a.reverse
             render('container_logs/index')
           end
         end


### PR DESCRIPTION
We should sort logs by _id (instead of $natural) because it allows mongo to use indexes.