### PR TITLE
Change grid default initial size to 1

### DIFF
--- a/server/app/mutations/grids/create.rb
+++ b/server/app/mutations/grids/create.rb
@@ -8,7 +8,7 @@ module Grids
     required do
       model :user
       string :name, nils: true, min_length: 3, matches: /^(\w|-)+$/
-      integer :initial_size, default: 3, min: 1, max: 7
+      integer :initial_size, default: 1, min: 1, max: 7
     end
 
     def execute


### PR DESCRIPTION
This changes grid default initial size from 3 to 1. I would like to change this because everyone is starting to test with only one node and it confuses if grid is fully functioning only after third node joins.