### PR TITLE
Fix kontena deploy

### DIFF
--- a/cli/lib/kontena/cli/stacks/stacks.rb
+++ b/cli/lib/kontena/cli/stacks/stacks.rb
@@ -44,7 +44,7 @@ module Kontena::Cli::Stacks
           data[:strategy] = service['deploy']['strategy'] if service['deploy']['strategy']
           data[:wait_for_port] = service['deploy']['wait_for_port'] if service['deploy']['wait_for_port']
         end
-        deploy_service(token, service['id'], data)
+        deploy_service(token, service['id'].split('/').last, data)
       end
     end
 

--- a/cli/spec/kontena/cli/stacks/stacks_spec.rb
+++ b/cli/spec/kontena/cli/stacks/stacks_spec.rb
@@ -198,6 +198,7 @@ content
           it 'deploys only given services' do
             allow(subject).to receive(:current_dir).and_return("kontena-test")
             allow(options).to receive(:service).and_return(['wordpress'])
+            allow(subject).to receive(:deploy_services).and_return({})
             expect(subject).to receive(:create).once.with('wordpress', anything).and_return({})
             expect(subject).not_to receive(:create).with('mysql', services['mysql'])
 


### PR DESCRIPTION
There is regression on 0.7 release that breaks `kontena deploy` command. This PR will fix this issue.

Fixes #88 