### PR TITLE
Add initial service log filters

### DIFF
--- a/cli/lib/kontena/cli/services/commands.rb
+++ b/cli/lib/kontena/cli/services/commands.rb
@@ -123,6 +123,8 @@ command 'service logs' do |c|
   c.syntax = 'kontena service logs <service_id>'
   c.description = 'Show service logs'
   c.option '-f', '--follow', 'Follow logs in real time'
+  c.option '-s STRING', '--search STRING', String, 'Search from logs'
+  c.option '-c STRING', '--container STRING', String, 'Show only specified container logs' 
   c.action do |args, options|
     Kontena::Cli::Services::Logs.new.show(args[0], options)
   end

--- a/cli/lib/kontena/cli/services/logs.rb
+++ b/cli/lib/kontena/cli/services/logs.rb
@@ -12,11 +12,15 @@ module Kontena::Cli::Services
       token = require_token
       last_id = nil
       loop do
-        query_params = last_id.nil? ? '' : "from=#{last_id}"
-        result = client(token).get("services/#{current_grid}/#{service_id}/container_logs?#{query_params}")
+        query_params = []
+        query_params << "from=#{last_id}" unless last_id.nil?
+        query_params << "search=#{options.search}" if options.search
+        query_params << "container=#{options.container}" if options.container
+
+        result = client(token).get("services/#{current_grid}/#{service_id}/container_logs?#{query_params.join('&')}")
         result['logs'].each do |log|
           color = color_for_container(log['name'])
-          puts "#{log['name'][0..12].colorize(color)} | #{log['data']}"
+          puts "#{log['name'].colorize(color)} | #{log['data']}"
           last_id = log['id']
         end
         break unless options.follow

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -51,10 +51,12 @@ module V1
 
           r.on 'container_logs' do
             scope = @grid_service.container_logs
-            limit = (r['limit'] || 500).to_i
-            unless r['from'].nil?
-              scope = scope.where(:id.gt => r['from'] )
-            end
+            limit = (r['limit'] || 100).to_i
+
+            scope = scope.where(name: r['container']) unless r['container'].nil?
+            scope = scope.where(:$text => {:$search => r['search']}) unless r['search'].nil?
+            scope = scope.where(:id.gt => r['from'] ) unless r['from'].nil?
+
             @logs = scope.order(:_id => -1).limit(limit).to_a.reverse
             render('container_logs/index')
           end


### PR DESCRIPTION
This PR adds `--search` & `--container` options to `kontena service logs <name>` command.