### PR TITLE
Add etcd RPC api

### DIFF
--- a/agent/lib/kontena/rpc/etcd_api.rb
+++ b/agent/lib/kontena/rpc/etcd_api.rb
@@ -1,0 +1,44 @@
+require 'etcd'
+require 'docker'
+require 'active_support/core_ext/hash/keys'
+
+module Kontena
+  module Rpc
+    class EtcdApi
+
+      attr_reader :etcd
+
+      def initialize
+        @etcd = Etcd.client(host: gateway, port: 2379)
+      end
+
+      # @param [String] key
+      def get(key)
+        etcd.get(key)
+      end
+
+      # @param [String] key
+      # @param [Hash] opts
+      def set(key, opts = {})
+        etcd.set(key, opts.symbolize_keys).value
+      end
+
+      # @param [String] key
+      # @param [Hash] opts
+      def delete(key, opts = {})
+        etcd.delete(key, opts.symbolize_keys)
+      end
+
+      private
+
+      ##
+      # @return [String, NilClass]
+      def gateway
+        agent = Docker::Container.get(ENV['AGENT_NAME'] || 'kontena-agent') rescue nil
+        if agent
+          agent.json['NetworkSettings']['Gateway']
+        end
+      end
+    end
+  end
+end

--- a/agent/lib/kontena/rpc_server.rb
+++ b/agent/lib/kontena/rpc_server.rb
@@ -1,18 +1,20 @@
 require_relative 'rpc/docker_container_api'
 require_relative 'rpc/docker_image_api'
 require_relative 'rpc/agent_api'
+require_relative 'rpc/etcd_api'
 require_relative 'logging'
 
 module Kontena
   class RpcServer
     include Kontena::Logging
-    
+
     LOG_NAME = 'RpcServer'
 
     HANDLERS = {
         'containers' => Kontena::Rpc::DockerContainerApi,
         'images' => Kontena::Rpc::DockerImageApi,
-        'agent' => Kontena::Rpc::AgentApi
+        'agent' => Kontena::Rpc::AgentApi,
+        'etcd' => Kontena::Rpc::EtcdApi
     }
 
     class Error < StandardError


### PR DESCRIPTION
This PR implements "passthrough" api to etcd. Purpose for this api is to give master access to grid etcd k/v store. 