### PR TITLE
Check that initial nodes are setup before allowing deploys

### DIFF
--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -8,7 +8,7 @@ class Grid
 
   field :name, type: String
   field :token, type: String
-  field :initial_size, type: Integer
+  field :initial_size, type: Integer, default: 1
   field :overlay_cidr, type: String, default: '10.81.0.0/19'
 
   has_many :host_nodes
@@ -25,6 +25,7 @@ class Grid
 
   before_create :set_token
 
+  # @return [String]
   def to_path
     self.name
   end
@@ -33,7 +34,6 @@ class Grid
     super(args.merge({:except => [:_id] }))
   end
 
-  ##
   # @return [Array<Integer>]
   def free_node_numbers
     reserved_numbers = self.host_nodes.map{|node| node.node_number }.flatten
@@ -58,6 +58,13 @@ class Grid
 
   def available_overlay_ips
     self.all_overlay_ips - self.reserved_overlay_ips
+  end
+
+  # Does grid have all the initial nodes created?
+  #
+  # @return [Boolean]
+  def has_initial_nodes?
+    self.host_nodes.where(node_number: {:$lte => self.initial_size}).count == self.initial_size
   end
 
   private

--- a/server/app/mutations/grid_services/deploy.rb
+++ b/server/app/mutations/grid_services/deploy.rb
@@ -23,6 +23,10 @@ module GridServices
     end
 
     def validate
+      unless self.grid_service.grid.has_initial_nodes?
+        add_error(:grid, :invalid_state, 'Grid does not have initial nodes ready')
+        return
+      end
       if self.grid_service.deploying?
         add_error(:service, :invalid_state, 'Service is currently deploying')
         return

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -60,4 +60,28 @@ describe Grid do
       expect(grid.available_overlay_ips).not_to include(container.overlay_cidr.split('/')[0])
     end
   end
+
+  describe '#has_initial_nodes?' do
+    let(:grid) { Grid.create!(name: 'test', initial_size: 3) }
+
+    it 'returns true if initial nodes are created' do
+      HostNode.create(grid: grid, node_id: 'aa', node_number: 1)
+      HostNode.create(grid: grid, node_id: 'bb', node_number: 2)
+      HostNode.create(grid: grid, node_id: 'cc', node_number: 3)
+      expect(grid.has_initial_nodes?).to eq(true)
+    end
+
+    it 'returns false if nodes are missing' do
+      HostNode.create(grid: grid, node_id: 'aa', node_number: 1)
+      HostNode.create(grid: grid, node_id: 'bb', node_number: 2)
+      expect(grid.has_initial_nodes?).to eq(false)
+    end
+
+    it 'returns false if there are enough nodes but initial node is missing' do
+      HostNode.create(grid: grid, node_id: 'aa', node_number: 1)
+      HostNode.create(grid: grid, node_id: 'bb', node_number: 2)
+      HostNode.create(grid: grid, node_id: 'cc', node_number: 4)
+      expect(grid.has_initial_nodes?).to eq(false)
+    end
+  end
 end

--- a/server/spec/mutations/grid_services/deploy_spec.rb
+++ b/server/spec/mutations/grid_services/deploy_spec.rb
@@ -3,11 +3,13 @@ require_relative '../../spec_helper'
 describe GridServices::Deploy do
   before(:each) { Celluloid.boot }
   after(:each) { Celluloid.shutdown }
-  
+
   let(:user) { User.create!(email: 'joe@domain.com')}
+  let(:host_node) { HostNode.create(node_id: 'aa')}
   let(:grid) {
-    grid = Grid.create!(name: 'test-grid')
+    grid = Grid.create!(name: 'test-grid', initial_size: 1)
     grid.users << user
+    grid.host_nodes << host_node
     grid
   }
   let(:deploy_actor) { spy(:deploy_actor) }
@@ -16,6 +18,11 @@ describe GridServices::Deploy do
   let(:subject) { described_class.new(current_user: user, grid_service: redis_service, strategy: 'ha')}
 
   describe '#run' do
+    it 'checks grid initial node status' do
+      expect(grid).to receive(:has_initial_nodes?).once
+      subject.run
+    end
+
     it 'sends deploy call to deployer' do
       # since validate method is called in constructor we need to stub deployer method globally before initialization
       allow_any_instance_of(described_class).to receive(:deployer).and_return(deployer)


### PR DESCRIPTION
Check that grid has all the initial nodes registered before allowing service deploys.