### PR TITLE
Do not re-deploy containers that are not changed since last deploy

### DIFF
--- a/server/app/models/container.rb
+++ b/server/app/models/container.rb
@@ -9,7 +9,7 @@ class Container
   field :driver, type: String
   field :exec_driver, type: String
   field :image, type: String
-  field :image_id, type: String
+  field :image_version, type: String
   field :env, type: Array, default: []
   field :network_settings, type: Hash, default: {}
   field :state, type: Hash, default: {}
@@ -103,7 +103,7 @@ class Container
         driver: info['Driver'],
         exec_driver: info['ExecDriver'],
         image: config['Image'],
-        image_id: info['Image'],
+        image_version: info['Image'],
         env: config['Env'],
         network_settings: self.parse_docker_network_settings(info['NetworkSettings']),
         state: {
@@ -173,6 +173,6 @@ class Container
   end
 
   def up_to_date?
-    self.image_id == self.grid_service.image.image_id && self.created_at > self.grid_service.updated_at
+    self.image_version == self.grid_service.image.image_id && self.created_at > self.grid_service.updated_at
   end
 end

--- a/server/app/models/container.rb
+++ b/server/app/models/container.rb
@@ -9,6 +9,7 @@ class Container
   field :driver, type: String
   field :exec_driver, type: String
   field :image, type: String
+  field :image_id, type: String
   field :env, type: Array, default: []
   field :network_settings, type: Hash, default: {}
   field :state, type: Hash, default: {}
@@ -102,6 +103,7 @@ class Container
         driver: info['Driver'],
         exec_driver: info['ExecDriver'],
         image: config['Image'],
+        image_id: info['Image'],
         env: config['Env'],
         network_settings: self.parse_docker_network_settings(info['NetworkSettings']),
         state: {
@@ -168,5 +170,9 @@ class Container
     else
       raise e
     end
+  end
+
+  def up_to_date?
+    self.image_id == self.grid_service.image.image_id && self.created_at > self.grid_service.updated_at
   end
 end

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -50,7 +50,9 @@ class GridService
 
   # @param [String] state
   def set_state(state)
-    self.update_attribute(:state, state)
+    result = self.timeless.update_attribute(:state, state)
+    self.clear_timeless_option
+    result
   end
 
   # @return [Boolean]

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -95,7 +95,7 @@ class GridServiceDeployer
   # @param [String] deploy_rev
   def deploy_service_container(node, container_name, deploy_rev)
     old_container = self.grid_service.container_by_name(container_name)
-    if self.grid_service.state == 'running' && old_container && old_container.up_to_date?
+    if old_container && old_container.up_to_date? && old_container.status == 'running'
       old_container.update_attribute(:deploy_rev, deploy_rev)
       return
     end

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -95,7 +95,10 @@ class GridServiceDeployer
   # @param [String] deploy_rev
   def deploy_service_container(node, container_name, deploy_rev)
     old_container = self.grid_service.container_by_name(container_name)
-    return if old_container && old_container.up_to_date?
+    if self.grid_service.state == 'running' && old_container && old_container.up_to_date?
+      old_container.update_attribute(:deploy_rev, deploy_rev)
+      return
+    end
     if old_container && old_container.exists_on_node?
       self.remove_service_container(old_container)
     end

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -38,7 +38,7 @@ class GridServiceDeployer
   # @param [Hash] creds
   def deploy(creds = nil)
     prev_state = self.grid_service.state
-    self.grid_service.update_attribute(:state, 'deploying')
+    self.grid_service.set_state('deploying')
 
     self.configure_load_balancer
     pulled_nodes = Set.new
@@ -59,15 +59,15 @@ class GridServiceDeployer
     self.grid_service.containers.where(:deploy_rev => {:$ne => deploy_rev}).each do |container|
       self.remove_service_container(container)
     end
-    self.grid_service.update_attribute(:state, 'running')
+    self.grid_service.set_state('running')
 
     true
   rescue RpcClient::Error => exc
-    self.grid_service.update_attribute(:state, prev_state)
+    self.grid_service.set_state(prev_state)
     error "RPC error: #{exc.class.name} #{exc.message}"
     false
   rescue => exc
-    self.grid_service.update_attribute(:state, prev_state)
+    self.grid_service.set_state(prev_state)
     error "Unknown error: #{exc.class.name} #{exc.message}"
     error exc.backtrace.join("\n") if exc.backtrace
     false
@@ -95,6 +95,7 @@ class GridServiceDeployer
   # @param [String] deploy_rev
   def deploy_service_container(node, container_name, deploy_rev)
     old_container = self.grid_service.container_by_name(container_name)
+    return if old_container && old_container.up_to_date?
     if old_container && old_container.exists_on_node?
       self.remove_service_container(old_container)
     end

--- a/server/spec/models/container_spec.rb
+++ b/server/spec/models/container_spec.rb
@@ -4,7 +4,7 @@ describe Container do
   it { should be_timestamped_document }
   it { should have_fields(
         :container_id, :name, :driver,
-        :exec_driver, :image, :image_id).of_type(String) }
+        :exec_driver, :image, :image_version).of_type(String) }
   it { should have_fields(:env, :volumes).of_type(Array) }
   it { should have_fields(:network_settings, :state).of_type(Hash) }
   it { should have_fields(:finished_at, :started_at).of_type(Time) }
@@ -122,7 +122,7 @@ describe Container do
         subject.grid_service = grid_service
 
         grid_service.image.image_id = '12345'
-        subject.image_id = '1234567'
+        subject.image_version = '1234567'
         expect(subject.up_to_date?).to be_falsey
       end
     end
@@ -139,7 +139,7 @@ describe Container do
     context 'when image is not updated and container is created after last update of grid service' do
       it 'return false' do
         subject.grid_service = grid_service
-        subject.image_id = '12345'
+        subject.image_version = '12345'
         grid_service.timeless.updated_at = Time.now.utc - 3
         subject.created_at = Time.now.utc
         expect(subject.up_to_date?).to be_truthy

--- a/server/spec/models/container_spec.rb
+++ b/server/spec/models/container_spec.rb
@@ -4,7 +4,7 @@ describe Container do
   it { should be_timestamped_document }
   it { should have_fields(
         :container_id, :name, :driver,
-        :exec_driver, :image).of_type(String) }
+        :exec_driver, :image, :image_id).of_type(String) }
   it { should have_fields(:env, :volumes).of_type(Array) }
   it { should have_fields(:network_settings, :state).of_type(Hash) }
   it { should have_fields(:finished_at, :started_at).of_type(Time) }
@@ -21,6 +21,20 @@ describe Container do
   it { should have_index_for(host_node_id: 1) }
   it { should have_index_for(container_id: 1) }
   it { should have_index_for(state: 1) }
+
+  let(:grid) do
+    Grid.create(name: 'test-grid')
+  end
+
+  let(:grid_service) do
+    service = GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8')
+    service.image = image
+    service
+  end
+
+  let(:image) do
+    Image.create(image_id: '12345', name: 'redis:2.8')
+  end
 
   describe '#status' do
     it 'returns deleted when deleted_at timestamp is set' do
@@ -100,5 +114,37 @@ describe Container do
         ]
       )
     end
+  end
+
+  describe '#up_to_date?' do
+    context 'when image id differs from grid service image id' do
+      it 'returns false ' do
+        subject.grid_service = grid_service
+
+        grid_service.image.image_id = '12345'
+        subject.image_id = '1234567'
+        expect(subject.up_to_date?).to be_falsey
+      end
+    end
+
+    context 'when grid service is updated after container is created' do
+      it 'returns false' do
+        subject.grid_service = grid_service
+        grid_service.timeless.updated_at = Time.now.utc + 3
+        subject.created_at = Time.now.utc
+        expect(subject.up_to_date?).to be_falsey
+      end
+    end
+
+    context 'when image is not updated and container is created after last update of grid service' do
+      it 'return false' do
+        subject.grid_service = grid_service
+        subject.image_id = '12345'
+        grid_service.timeless.updated_at = Time.now.utc - 3
+        subject.created_at = Time.now.utc
+        expect(subject.up_to_date?).to be_truthy
+      end
+    end
+
   end
 end

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -51,6 +51,21 @@ describe GridService do
     end
   end
 
+  describe '#set_state' do
+    it 'sets value of state column' do
+      subject.set_state('running')
+      expect(subject.state).to eq('running')
+    end
+
+    it 'does not modify updated_at field' do
+      five_hours_ago = Time.now.utc - 5.hours
+      grid_service.timeless.update_attribute(:updated_at, five_hours_ago)
+      grid_service.clear_timeless_option
+      grid_service.set_state('running')
+      expect(grid_service.updated_at).to eq(five_hours_ago)
+    end
+  end
+
   describe '#container_by_name' do
     it 'returns related container by name' do
       container = grid_service.containers.create!(name: 'redis-1')

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -35,15 +35,28 @@ describe GridServiceDeployer do
     end
 
     context 'when container is up-to-date' do
-      it 'does not re-deploy it' do
+      before(:each) do
         grid_service.image = ubuntu_trusty
+        grid_service.state = 'running'
         grid_service.save
+      end
+
+      it 'does not re-deploy it' do
         container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id)
         allow(grid_service).to receive(:container_by_name).and_return(container)
         expect(subject).not_to receive(:remove_service_container).with(container)
         expect(subject).not_to receive(:create_service_container)
         subject.deploy_service_container(node, 'redis-1', 'v1.0')
       end
+
+      it "updates container's deploy revision" do
+        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id)
+        allow(grid_service).to receive(:container_by_name).and_return(container)
+        subject.deploy_service_container(node, 'redis-1', 'v1.0')
+        container.reload
+        expect(container.deploy_rev).to eq('v1.0')
+      end
+
     end
 
     context 'when container is outdated' do

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -9,7 +9,7 @@ describe GridServiceDeployer do
   let(:node) { HostNode.create!(node_id: SecureRandom.uuid) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
   let(:subject) { described_class.new(strategy, grid_service, []).wrapped_object }
-  let(:ubuntu_trusty) { Image.create!(name:'ubuntu-trusty', exposed_ports: [{'port' => '3306', 'protocol' => 'tcp'}]) }
+  let(:ubuntu_trusty) { Image.create!(name:'ubuntu-trusty', image_id: '86ce37374f40e95cfe8af7327c34ea9919ef216ea965377565fcfad3c378a2c3', exposed_ports: [{'port' => '3306', 'protocol' => 'tcp'}]) }
 
   describe '#deploy_service_container' do
     it 'calls create and start' do
@@ -21,6 +21,8 @@ describe GridServiceDeployer do
     end
 
     it 'removes previous container if it exists' do
+      grid_service.image = ubuntu_trusty
+      grid_service.save
       container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo')
       allow(container).to receive(:exists_on_node?).and_return(true)
       allow(grid_service).to receive(:container_by_name).and_return(container)
@@ -31,6 +33,36 @@ describe GridServiceDeployer do
 
       subject.deploy_service_container(node, 'redis-1', 'v1.0')
     end
+
+    context 'when container is up-to-date' do
+      it 'does not re-deploy it' do
+        grid_service.image = ubuntu_trusty
+        grid_service.save
+        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_id: ubuntu_trusty.image_id)
+        allow(grid_service).to receive(:container_by_name).and_return(container)
+        expect(subject).not_to receive(:remove_service_container).with(container)
+        expect(subject).not_to receive(:create_service_container)
+        subject.deploy_service_container(node, 'redis-1', 'v1.0')
+      end
+    end
+
+    context 'when container is outdated' do
+      it 'deploys it' do
+        grid_service.image = ubuntu_trusty
+        grid_service.save
+        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_id: ubuntu_trusty.image_id)
+        allow(container).to receive(:exists_on_node?).and_return(true)
+        allow(grid_service).to receive(:container_by_name).and_return(container)
+        grid_service.timeless.update_attribute(:updated_at, (Time.now.utc + 3 * 60))
+        grid_service.reload
+
+        expect(subject).to receive(:remove_service_container).with(container).once
+        expect(subject).to receive(:create_service_container).and_return(spy)
+
+        subject.deploy_service_container(node, 'redis-1', 'v1.0')
+      end
+    end
+
   end
 
   describe '#ensure_image' do

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -38,7 +38,7 @@ describe GridServiceDeployer do
       it 'does not re-deploy it' do
         grid_service.image = ubuntu_trusty
         grid_service.save
-        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_id: ubuntu_trusty.image_id)
+        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id)
         allow(grid_service).to receive(:container_by_name).and_return(container)
         expect(subject).not_to receive(:remove_service_container).with(container)
         expect(subject).not_to receive(:create_service_container)
@@ -50,7 +50,7 @@ describe GridServiceDeployer do
       it 'deploys it' do
         grid_service.image = ubuntu_trusty
         grid_service.save
-        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_id: ubuntu_trusty.image_id)
+        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id)
         allow(container).to receive(:exists_on_node?).and_return(true)
         allow(grid_service).to receive(:container_by_name).and_return(container)
         grid_service.timeless.update_attribute(:updated_at, (Time.now.utc + 3 * 60))

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -34,7 +34,7 @@ describe GridServiceDeployer do
       subject.deploy_service_container(node, 'redis-1', 'v1.0')
     end
 
-    context 'when container is up-to-date' do
+    context 'when container is running and up-to-date' do
       before(:each) do
         grid_service.image = ubuntu_trusty
         grid_service.state = 'running'
@@ -42,7 +42,7 @@ describe GridServiceDeployer do
       end
 
       it 'does not re-deploy it' do
-        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id)
+        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id, state: {'running' => 1})
         allow(grid_service).to receive(:container_by_name).and_return(container)
         expect(subject).not_to receive(:remove_service_container).with(container)
         expect(subject).not_to receive(:create_service_container)
@@ -50,7 +50,7 @@ describe GridServiceDeployer do
       end
 
       it "updates container's deploy revision" do
-        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id)
+        container = grid_service.containers.create!(name: 'redis-1', container_id: 'foo', image_version: ubuntu_trusty.image_id, state: {'running' => 1})
         allow(grid_service).to receive(:container_by_name).and_return(container)
         subject.deploy_service_container(node, 'redis-1', 'v1.0')
         container.reload


### PR DESCRIPTION
At the moment services are deployed even if there was no change in the service configuration. This PR changes this behavior by checking is Docker image or service configuration changed before deploy is made.

Fixes #22 