### PR TITLE
Prevent deleting linked service

### DIFF
--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -70,4 +70,8 @@ class GridService
   def volume_by_name(name)
     self.containers.unscoped.volumes.find_by(name: name.to_s)
   end
+
+  def linked_to_services
+    self.grid.grid_services.where(:'grid_service_links.linked_grid_service_id' => self.id)
+  end
 end

--- a/server/app/mutations/grid_services/delete.rb
+++ b/server/app/mutations/grid_services/delete.rb
@@ -5,6 +5,14 @@ module GridServices
       model :grid_service
     end
 
+    def validate
+
+      linked_to_services = self.grid_service.linked_to_services
+      if linked_to_services.count > 0
+        add_error(:service, :invalid, "Cannot delete service that is linked to another service (#{linked_to_services.map{|s| s.name}.join(', ')})")
+      end
+    end
+
     def execute
       prev_state = self.grid_service.state
       begin

--- a/server/spec/mutations/grid_services/delete_spec.rb
+++ b/server/spec/mutations/grid_services/delete_spec.rb
@@ -8,6 +8,14 @@ describe GridServices::Delete do
     grid
   }
   let(:redis_service) { GridService.create(grid: grid, name: 'redis', image_name: 'redis:2.8')}
+  let(:web_service) do
+    link = GridServiceLink.new(
+        linked_grid_service: redis_service,
+        alias: 'redis'
+    )
+    GridService.create(grid: grid, name: 'web', image_name: 'web:latest', grid_service_links: [link])
+
+  end
 
   describe '#run' do
     it 'deletes a service' do
@@ -33,6 +41,19 @@ describe GridServices::Delete do
       subject = described_class.new(current_user: user, grid_service: redis_service)
       expect(subject).to receive(:remover_for).with(container).once.and_return(remover)
       subject.run
+    end
+
+    context 'when service is linked to another service' do
+      it 'returns error' do
+        web_service
+
+        service = redis_service
+        expect {
+          outcome = described_class.new(current_user: user, grid_service: service).run
+          expect(outcome.success?).to be_falsey
+          expect(outcome.errors.message["service"]).to eq("Cannot delete service that is linked to another service (web)")
+        }.to change{ GridService.count }.by(0)
+      end
     end
   end
 end


### PR DESCRIPTION
Currently when deleting service that is linked to another service, another service will have broken service link. To avoid this situtation this PR prevents deletion and returns error instead.