### PR TITLE
Use optional name parameter instead of --name switch on node provision

### DIFF
--- a/cli/lib/kontena/cli/nodes/digital_ocean/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/digital_ocean/create_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Nodes::DigitalOcean
   class CreateCommand < Clamp::Command
     include Kontena::Cli::Common
 
-    option "--name", "NAME", "Node name"
+    parameter "[NAME]", "Node name"
     option "--token", "TOKEN", "DigitalOcean API token", required: true
     option "--ssh-key", "SSH_KEY", "Path to ssh public key", required: true
     option "--size", "SIZE", "Droplet size", default: '1gb'

--- a/cli/lib/kontena/cli/nodes/vagrant/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/vagrant/create_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Nodes::Vagrant
   class CreateCommand < Clamp::Command
     include Kontena::Cli::Common
 
-    option "--name", "NAME", "Node name"
+    parameter "[NAME]", "Node name"
     option "--memory", "MEMORY", "How much memory node has", default: '1024'
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
 

--- a/docs/getting-started/installing/nodes-cli.md
+++ b/docs/getting-started/installing/nodes-cli.md
@@ -16,25 +16,32 @@ We are adding support for other platforms gradually based on your requests. If y
 
 ```
 Usage:
-    kontena node vagrant create [OPTIONS]
+    kontena node vagrant create [OPTIONS] [NAME]
+
+Parameters:
+    [NAME]                        Node name
 
 Options:
-    --name NAME                   Node name
-    --memory MEMORY               How much memory node has (default: 1024)
-    --version VERSION             Define installed Kontena version (default: latest)
+    --memory MEMORY               How much memory node has (default: "1024")
+    --version VERSION             Define installed Kontena version (default: "latest")
+    -h, --help                    print help
+
 ```
 
 ## Digital Ocean
 
 ```
 Usage:
-    kontena node digitalocean create [OPTIONS]
+    kontena node digitalocean create [OPTIONS] [NAME]
+
+Parameters:
+    [NAME]                        Node name
 
 Options:
-    --name NAME                   Node name
     --token TOKEN                 DigitalOcean API token
     --ssh-key SSH_KEY             Path to ssh public key
     --size SIZE                   Droplet size (default: "1gb")
     --region REGION               Region (default: "ams2")
-    --version VERSION             Define installed Kontena version (default: latest)
+    --version VERSION             Define installed Kontena version (default: "latest")
+    -h, --help                    print help
 ```


### PR DESCRIPTION
This PR changes node provision format so that instead  --name switch, optional node name is given as command parameter as on other node commands.

Also on DigitalOcean node provision given region is stored to node labels.

Fixes #157