### PR TITLE
Fix duplication on app deploy command

### DIFF
--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -91,7 +91,7 @@ module Kontena::Cli::Apps
     end
 
     def in_deploy_queue?(name)
-      deploy_queue.find {|service| service['id'] == prefixed_name(name)} != nil
+      deploy_queue.find {|service| service['name'] == prefixed_name(name)} != nil
     end
 
     def merge_env_vars(options)

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -108,7 +108,7 @@ yml
         allow(File).to receive(:read).with('kontena.yml').and_return(kontena_yml)
         allow(File).to receive(:read).with('docker-compose.yml').and_return(docker_compose_yml)
         allow(subject).to receive(:get_service).and_raise(Kontena::Errors::StandardError.new(404, 'Not Found'))
-        allow(subject).to receive(:create_service).and_return({'id' => 'kontena-test-mysql'},{'id' => 'kontena-test-wordpress'})
+        allow(subject).to receive(:create_service).and_return({'id' => 'cli/kontena-test-mysql', 'name' => 'kontena-test-mysql'},{'id' => 'cli/kontena-test-wordpress', 'name' => 'kontena-test-wordpress'})
         allow(subject).to receive(:current_grid).and_return('1')
         allow(subject).to receive(:deploy_service).and_return(nil)
       end


### PR DESCRIPTION
`kontena app deploy` deploys linked services twice unintentionally. This PR fixes that problem and services are deployed only once.