### PR TITLE
Add support for external_links key in kontena.yml

### DIFF
--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -57,6 +57,12 @@ module Kontena::Cli::Apps
         end
       end
 
+      if options['external_links']
+        options['links'] ||= []
+        options['links'] = options['links'] + options['external_links']
+        options.delete('external_links')
+      end
+
       merge_env_vars(options)
 
       if service_exists?(name)

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -57,12 +57,7 @@ module Kontena::Cli::Apps
         end
       end
 
-      if options['external_links']
-        options['links'] ||= []
-        options['links'] = options['links'] + options['external_links']
-        options.delete('external_links')
-      end
-
+      merge_external_links(options)
       merge_env_vars(options)
 
       if service_exists?(name)
@@ -111,6 +106,14 @@ module Kontena::Cli::Apps
       end
 
       options['environment'].uniq! {|s| s.split('=').first}
+    end
+
+    def merge_external_links(options)
+      if options['external_links']
+        options['links'] ||= []
+        options['links'] = options['links'] + options['external_links']
+        options.delete('external_links')
+      end
     end
 
     def read_env_file(path)

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -180,6 +180,24 @@ yml
         end
       end
 
+      it 'merges external links to links' do
+        allow(subject).to receive(:current_dir).and_return("kontena-test")
+        allow(YAML).to receive(:load).and_return(services)
+        services['wordpress']['external_links'] = ['loadbalancer:loadbalancer']
+        data = {
+            :name =>"kontena-test-wordpress",
+            :image=>"wordpress:latest",
+            :env=> nil,
+            :container_count=>2,
+            :stateful=>false,
+            :links=>[{:name => "kontena-test-mysql", :alias => "db"}, {:name => "loadbalancer", :alias => "loadbalancer"}],
+            :ports=>[{:container_port => "80", :node_port => "80", :protocol => "tcp"}]
+        }
+
+        expect(subject).to receive(:create_service).with('1234567', '1', data)
+        subject.run([])
+      end
+
       it 'creates mysql service before wordpress' do
         allow(subject).to receive(:current_dir).and_return("kontena-test")
         data = {:name =>"kontena-test-mysql", :image=>'mysql:5.6', :env=>["MYSQL_ROOT_PASSWORD=kontena-test_secret"], :container_count=>nil, :stateful=>true}


### PR DESCRIPTION
This PR add support for `external_links` key. External links are like normal service links but their name won't be prefixed.