### PR TITLE
Service affinity filter

### DIFF
--- a/server/app/services/scheduler/filter/affinity.rb
+++ b/server/app/services/scheduler/filter/affinity.rb
@@ -19,6 +19,10 @@ module Scheduler
               unless node_match?(node, comparator, value)
                 candidates.delete(node)
               end
+            elsif key == 'service'
+              unless service_match?(node, comparator, value)
+                candidates.delete(node)
+              end
             elsif key == 'container'
               unless container_match?(node, comparator, value)
                 candidates.delete(node)
@@ -34,12 +38,17 @@ module Scheduler
         candidates
       end
 
+      # @param [String] affinity
+      # @return [String, NilClass]
       def split_affinity(affinity)
         if match = affinity.match(/^(.+)(==|!=)(.+)/)
           match.to_a[1..-1]
         end
       end
 
+      # @param [HostNode] node
+      # @param [String] compare
+      # @param [String] value
       def node_match?(node, compare, value)
         if compare == '=='
           node.name == value
@@ -50,6 +59,9 @@ module Scheduler
         end
       end
 
+      # @param [HostNode] node
+      # @param [String] compare
+      # @param [String] value
       def container_match?(node, compare, value)
         container_names = node.containers.map{|c| c.name}
         if compare == '=='
@@ -59,6 +71,21 @@ module Scheduler
         end
       end
 
+      # @param [HostNode] node
+      # @param [String] compare
+      # @param [String] value
+      def service_match?(node, compare, value)
+        service_names = node.containers.map{|c| c.grid_service.name}.uniq
+        if compare == '=='
+          service_names.any?{|n| n == value}
+        elsif compare == '!='
+          !service_names.any?{|n| n == value}
+        end
+      end
+
+      # @param [HostNode] node
+      # @param [String] compare
+      # @param [String] value
       def label_match?(node, compare, value)
         if compare == '=='
           node.labels.include?(value)

--- a/server/spec/services/scheduler/filter/affinity_spec.rb
+++ b/server/spec/services/scheduler/filter/affinity_spec.rb
@@ -86,5 +86,28 @@ describe Scheduler::Filter::Affinity do
         expect(filtered).to eq(nodes - [nodes[1]])
       end
     end
+
+    context 'service' do
+      let(:redis_service) { GridService.create!(name: 'redis', image_name: 'redis:2.8')}
+
+      before(:each) do
+        redis_service.containers.create!(name: 'redis-1', host_node: nodes[0])
+        redis_service.containers.create!(name: 'redis-2', host_node: nodes[2])
+      end
+
+      it 'returns node-1 if affinity: service==redis' do
+        service = double(:service, affinity: ['service==redis'])
+        filtered = subject.for_service(service, 'app-1', nodes)
+        expect(filtered.size).to eq(2)
+        expect(filtered).to eq([nodes[0], nodes[2]])
+      end
+
+      it 'does not return node-2 if affinity: service!=redis' do
+        service = double(:service, affinity: ['service!=redis'])
+        filtered = subject.for_service(service, 'app-1', nodes)
+        expect(filtered.size).to eq(1)
+        expect(filtered).to eq([nodes[1]])
+      end
+    end
   end
 end


### PR DESCRIPTION
Example 1:

serviceB will be deployed only to nodes that already has serviceA deployed

```
serviceA:
  image: my/app:latest
  instances: 4
  affinity:
    - label==az=1a
    - label==az=1b
  
serviceB:
  image: my/follower:latest
  instances: 2
  affinity:
    - service==%{project}-serviceA
```

Example 2:

serviceB will be deployed only to nodes that does not have serviceA deployed

```
serviceA:
  image: my/app:latest
  instances: 4
  affinity:
    - label==az=1a
    - label==az=1b
  
serviceB:
  image: my/follower:latest
  instances: 2
  affinity:
    - service!=%{project}-serviceA
```
