### PR TITLE
Auto-update agents to match master version

### DIFF
--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -1,6 +1,8 @@
 module Kontena
   class Agent
 
+    VERSION = File.read('./VERSION').strip
+
     def initialize(opts)
       @opts = opts
 

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -48,10 +48,11 @@ module Kontena
 
       # @param [String] container_id
       def remove_dns(container_id)
+        retries = 0
         begin
           dns_client.delete(path: "/name/#{container_id}")
         rescue Docker::Error::NotFoundError
-          
+
         rescue Excon::Errors::SocketError => exc
           retries += 1
           if retries < 5

--- a/agent/lib/kontena/queue_worker.rb
+++ b/agent/lib/kontena/queue_worker.rb
@@ -15,19 +15,19 @@ module Kontena
       Pubsub.subscribe('websocket:connect') do |client|
         self.client = client
       end
+      Pubsub.subscribe('websocket:connected') do |event|
+        self.register_client_events
+      end
     end
 
     ##
     # @param [WebsocketClient] client
     def client=(client)
       @client = client
-      self.register_client_events
     end
 
     def register_client_events
-      client.on :open do |event|
-        self.start_queue_processing
-      end
+      self.start_queue_processing
       client.on :close do |event|
         self.stop_queue_processing
       end

--- a/agent/lib/kontena/rpc/agent_api.rb
+++ b/agent/lib/kontena/rpc/agent_api.rb
@@ -2,6 +2,13 @@ module Kontena
   module Rpc
     class AgentApi
 
+      # @param [Hash] data
+      def master_info(data)
+        Pubsub.publish('websocket:connected', {master: data})
+        update_version(data['version']) if data['version']
+        {}
+      end
+
       ##
       # @param [String] ip
       # @param [String] port
@@ -18,6 +25,18 @@ module Kontena
         end
       rescue Timeout::Error
         {open: false}
+      end
+
+      private
+
+      # @param [String] version
+      def update_version(version)
+        env_file = '/etc/kontena.env'
+        if File.exist?(env_file)
+          env = File.read(env_file)
+          env.gsub!(/^KONTENA_VERSION=.+$/, "KONTENA_VERSION=#{version}")
+          File.write(env_file, env)
+        end
       end
     end
   end

--- a/agent/lib/kontena/rpc_server.rb
+++ b/agent/lib/kontena/rpc_server.rb
@@ -50,5 +50,21 @@ module Kontena
         return [1, msg_id, {error: 'service not implemented'}, nil]
       end
     end
+
+    ##
+    # @param [Array] message msgpack-rpc notification array
+    def handle_notification(message)
+      handler = message[1].split('/')[1]
+      method = message[1].split('/')[2]
+      if klass = HANDLERS[handler]
+        begin
+          logger.info(LOG_NAME) { "rpc notification: #{klass.name}##{method} #{message[2]}" }
+          result = klass.new.send(method, *message[2])
+        rescue => exc
+          logger.error(LOG_NAME) { "#{exc.class.name}: #{exc.message}" }
+          logger.error(LOG_NAME) { exc.backtrace.join("\n") }
+        end
+      end
+    end
   end
 end

--- a/cli/lib/kontena/machine/aws/cloudinit.yml
+++ b/cli/lib/kontena/machine/aws/cloudinit.yml
@@ -9,7 +9,7 @@ write_files:
       KONTENA_TOKEN="<%= grid_token %>"
       KONTENA_PEER_INTERFACE=eth1
       KONTENA_VERSION=<%= version %>
-  - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
+  - path: /etc/systemd/system/docker.service.d/50-kontena.conf
     content: |
         [Service]
         Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.42.1/16"'
@@ -61,5 +61,6 @@ coreos:
             -e KONTENA_TOKEN=${KONTENA_TOKEN} \
             -e KONTENA_PEER_INTERFACE=${KONTENA_PEER_INTERFACE} \
             -v=/var/run/docker.sock:/var/run/docker.sock \
+            -v=/etc/kontena-agent.env:/etc/kontena.env \
             --net=host \
             kontena/agent:${KONTENA_VERSION}

--- a/cli/lib/kontena/machine/azure/cloudinit.yml
+++ b/cli/lib/kontena/machine/azure/cloudinit.yml
@@ -54,5 +54,6 @@ coreos:
             -e KONTENA_TOKEN=${KONTENA_TOKEN} \
             -e KONTENA_PEER_INTERFACE=${KONTENA_PEER_INTERFACE} \
             -v=/var/run/docker.sock:/var/run/docker.sock \
+            -v=/etc/kontena-agent.env:/etc/kontena.env \
             --net=host \
             kontena/agent:${KONTENA_VERSION}

--- a/cli/lib/kontena/machine/digital_ocean/cloudinit.yml
+++ b/cli/lib/kontena/machine/digital_ocean/cloudinit.yml
@@ -54,5 +54,6 @@ coreos:
             -e KONTENA_TOKEN=${KONTENA_TOKEN} \
             -e KONTENA_PEER_INTERFACE=${KONTENA_PEER_INTERFACE} \
             -v=/var/run/docker.sock:/var/run/docker.sock \
+            -v=/etc/kontena-agent.env:/etc/kontena.env \
             --net=host \
             kontena/agent:${KONTENA_VERSION}

--- a/cli/lib/kontena/machine/vagrant/cloudinit.yml
+++ b/cli/lib/kontena/machine/vagrant/cloudinit.yml
@@ -8,7 +8,7 @@ write_files:
       KONTENA_TOKEN="<%= grid_token %>"
       KONTENA_PEER_INTERFACE=eth1
       KONTENA_VERSION=<%= version %>
-  - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
+  - path: /etc/systemd/system/docker.service.d/50-kontena.conf
     content: |
         [Service]
         Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.42.1/16"'
@@ -61,5 +61,6 @@ coreos:
             -e KONTENA_TOKEN=${KONTENA_TOKEN} \
             -e KONTENA_PEER_INTERFACE=${KONTENA_PEER_INTERFACE} \
             -v=/var/run/docker.sock:/var/run/docker.sock \
+            -v=/etc/kontena-agent.env:/etc/kontena.env \
             --net=host \
             kontena/agent:${KONTENA_VERSION}

--- a/server/app/jobs/node_cleanup_job.rb
+++ b/server/app/jobs/node_cleanup_job.rb
@@ -29,7 +29,7 @@ class NodeCleanupJob
   def cleanup_stale_nodes
     with_dlock('node_cleanup_job:stale_nodes', 0) do
       info 'NodeCleanupJob: starting to cleanup stale nodes'
-      HostNode.where(:updated_at.lt => 1.hour.ago).each do |node|
+      HostNode.where(:last_seen_at.lt => 1.hour.ago).each do |node|
         unless node.connected?
           node.destroy
         end

--- a/server/spec/jobs/node_cleanup_job_spec.rb
+++ b/server/spec/jobs/node_cleanup_job_spec.rb
@@ -6,9 +6,9 @@ describe NodeCleanupJob do
 
   describe '#cleanup_stale_nodes' do
     it 'removes old nodes' do
-      HostNode.create!(name: "node-1", connected: false, updated_at: 2.hours.ago)
-      HostNode.create!(name: "node-2", connected: true, updated_at: 2.hours.ago)
-      HostNode.create!(name: "node-3", connected: true, updated_at: 10.minutes.ago)
+      HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-3", connected: true, last_seen_at: 10.minutes.ago)
 
       expect {
         subject.cleanup_stale_nodes

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../spec_helper'
+require_relative '../../app/middlewares/websocket_backend'
+
+describe WebsocketBackend do
+  let(:app) { spy(:app) }
+  let(:subject) { described_class.new(app) }
+
+  before(:each) do
+    stub_const('Server::VERSION', '0.9.1')
+  end
+
+  describe '#our_version' do
+    it 'retuns baseline version with patch level 0' do
+      expect(subject.our_version).to eq('0.9.0')
+    end
+  end
+
+  describe '#valid_agent_version?' do
+    it 'returns true when exact match' do
+      expect(subject.valid_agent_version?('0.9.1')).to eq(true)
+    end
+
+    it 'returns true when patch level is greater' do
+      expect(subject.valid_agent_version?('0.9.2')).to eq(true)
+    end
+
+    it 'returns true when patch level is less than' do
+      expect(subject.valid_agent_version?('0.9.0')).to eq(true)
+    end
+
+    it 'returns false when minor version is different' do
+      expect(subject.valid_agent_version?('0.8.4')).to eq(false)
+    end
+
+    it 'returns false when major version is different' do
+      expect(subject.valid_agent_version?('1.0.1')).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This PR implements automatic version sync between master and agent nodes. If major or minor number is different, master will close the connection (and agent will shutdown). If only patch number is different connection is accepted. In any case master will send information to agent that can persist this information.

Optionally if agent has mount to `/etc/kontena.env` it will write `KONTENA_VERSION=X.Y.Z` there so that next start can pull same agent version that master has.

![agent](https://media.giphy.com/media/nGnKGLOqzhfGM/giphy.gif)