### PR TITLE
Log options for containers

### DIFF
--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -133,6 +133,8 @@ module Kontena::Cli::Apps
       data[:cap_add] = options['cap_add'] if options['cap_add']
       data[:cap_drop] = options['cap_drop'] if options['cap_drop']
       data[:net] = options['net'] if options['net']
+      data[:log_driver] = options['log_driver'] if options['log_driver']
+      data[:log_opt] = options['log_opt_list'] unless options['log_opt_list']
       data
     end
 

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -134,7 +134,8 @@ module Kontena::Cli::Apps
       data[:cap_drop] = options['cap_drop'] if options['cap_drop']
       data[:net] = options['net'] if options['net']
       data[:log_driver] = options['log_driver'] if options['log_driver']
-      data[:log_opt] = options['log_opt_list'] unless options['log_opt_list']
+      data[:log_opts] = options['log_opt'] if options['log_opt'] && !options['log_opt'].empty?
+
       data
     end
 

--- a/cli/lib/kontena/cli/deploy_command.rb
+++ b/cli/lib/kontena/cli/deploy_command.rb
@@ -148,6 +148,9 @@ class Kontena::Cli::DeployCommand < Clamp::Command
     data[:stateful] = options['stateful'] == true
     data[:cap_add] = options['cap_add'] if options['cap_add']
     data[:cap_drop] = options['cap_drop'] if options['cap_drop']
+    data[:log_driver] = options['log_driver'] if options['log_driver']
+    data[:log_opts] = options['log_opt'] if options['log_opt'] && !options['log_opt'].empty?
+
     data
   end
 

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -63,7 +63,7 @@ module Kontena::Cli::Services
       data[:cap_drop] = cap_drop_list unless cap_drop_list.empty?
       data[:net] = net if net
       data[:log_driver] = log_driver if log_driver
-      data[:log_opts] = log_opt_list unless log_opt_list.empty?
+      data[:log_opts] = parse_log_opts(log_opt_list)
       data
     end
   end

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -25,6 +25,8 @@ module Kontena::Cli::Services
     option "--cap-add", "CAP_ADD", "Add capabitilies", multivalued: true
     option "--cap-drop", "CAP_DROP", "Drop capabitilies", multivalued: true
     option "--net", "NET", "Network mode"
+    option "--log-driver", "LOG_DRIVER", "Set logging driver"
+    option "--log-opt", "LOG_OPT", "Add logging options", multivalued: true
 
     def execute
       require_api_url
@@ -60,6 +62,8 @@ module Kontena::Cli::Services
       data[:cap_add] = cap_add_list unless cap_add_list.empty?
       data[:cap_drop] = cap_drop_list unless cap_drop_list.empty?
       data[:net] = net if net
+      data[:log_driver] = log_driver if log_driver
+      data[:log_opt] = log_opt_list unless log_opt_list.empty?
       data
     end
   end

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -63,7 +63,7 @@ module Kontena::Cli::Services
       data[:cap_drop] = cap_drop_list unless cap_drop_list.empty?
       data[:net] = net if net
       data[:log_driver] = log_driver if log_driver
-      data[:log_opt] = log_opt_list unless log_opt_list.empty?
+      data[:log_opts] = log_opt_list unless log_opt_list.empty?
       data
     end
   end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -85,6 +85,13 @@ module Kontena
             puts "    - #{c}"
           end
 
+          puts "  log_driver: #{service['log_driver']}"
+
+          puts "  log_opts:"
+          service['log_opts'].to_a.each do |opt|
+            puts "    - #{opt}"
+          end
+
           puts "  containers:"
           result = client(token).get("services/#{parse_service_id(service_id)}/containers")
           result['containers'].each do |container|

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -88,8 +88,8 @@ module Kontena
           puts "  log_driver: #{service['log_driver']}"
 
           puts "  log_opts:"
-          service['log_opts'].to_a.each do |opt|
-            puts "    - #{opt}"
+          service['log_opts'].each do |opt, value|
+            puts "    #{opt}: #{value}"
           end
 
           puts "  containers:"
@@ -208,6 +208,18 @@ module Kontena
             image = "#{image}:latest"
           end
           image
+        end
+
+        ##
+        # @param [Array] log_opts
+        # @return [Hash]
+        def parse_log_opts(log_opts)
+          opts = {}
+          log_opts.each do |opt|
+            key, value = opt.split('=')
+            opts[key] = value
+          end
+          opts
         end
       end
     end

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -21,6 +21,8 @@ module Kontena::Cli::Services
     option "--cap-add", "CAP_ADD", "Add capabitilies", multivalued: true
     option "--cap-drop", "CAP_DROP", "Drop capabitilies", multivalued: true
     option "--net", "NET", "Network mode"
+    option "--log-driver", "LOG_DRIVER", "Set logging driver"
+    option "--log-opt", "LOG_OPT", "Add logging options", multivalued: true
 
     def execute
       require_api_url
@@ -49,6 +51,8 @@ module Kontena::Cli::Services
       data[:cap_add] = cap_add_list unless cap_add_list.empty?
       data[:cap_drop] = cap_drop_list unless cap_drop_list.empty?
       data[:net] = net if net
+      data[:log_driver] = log_driver if log_driver
+      data[:log_opts] = parse_log_opts(log_opt_list)
       data
     end
   end

--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -221,3 +221,24 @@ deploy:
   strategy: ha
   wait_for_port: true
 ```
+
+
+#### log_driver
+
+Specify the log driver for docker to use with all containers of this service. For details on available drivers and their configs see [Docker log drivers](https://docs.docker.com/reference/logging/overview/)
+
+#### log_opts
+
+Specify options for log driver
+
+```
+nginx:
+  image: nginx:latest
+  ports:
+    - 80:80
+  log_driver: fluentd
+  log_opt:
+    fluentd-address: 192.168.99.1:24224
+    fluentd-tag: docker.{{.Name}}
+
+```

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -25,6 +25,8 @@ class GridService
   field :cap_drop, type: Array, default: []
   field :net, type: String, default: 'bridge'
   field :state, type: String, default: 'initialized'
+  field :log_driver, type: String
+  field :log_opt, type: Array, default: []
 
   belongs_to :grid
   belongs_to :image

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -26,7 +26,7 @@ class GridService
   field :net, type: String, default: 'bridge'
   field :state, type: String, default: 'initialized'
   field :log_driver, type: String
-  field :log_opt, type: Array, default: []
+  field :log_opts, type: Array, default: []
 
   belongs_to :grid
   belongs_to :image

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -26,7 +26,7 @@ class GridService
   field :net, type: String, default: 'bridge'
   field :state, type: String, default: 'initialized'
   field :log_driver, type: String
-  field :log_opts, type: Array, default: []
+  field :log_opts, type: Hash, default: {}
 
   belongs_to :grid
   belongs_to :image

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -56,6 +56,10 @@ module GridServices
       array :affinity do
         string
       end
+      array :log_opts do
+        string
+      end
+      string :log_driver
     end
 
     def validate

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -56,8 +56,8 @@ module GridServices
       array :affinity do
         string
       end
-      array :log_opts do
-        string
+      hash :log_opts do
+        string :*
       end
       string :log_driver
     end

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -40,6 +40,10 @@ module GridServices
       array :affinity do
         string
       end
+      hash :log_opts do
+        string :*
+      end
+      string :log_driver
     end
 
     def execute
@@ -58,6 +62,9 @@ module GridServices
       attributes[:net] = self.net if self.net
       attributes[:ports] = self.ports if self.ports
       attributes[:affinity] = self.affinity if self.affinity
+      attributes[:log_driver] = self.log_driver if self.log_driver
+      attributes[:log_opts] = self.log_opts if self.log_opts
+
       grid_service.attributes = attributes
       grid_service.save
 

--- a/server/app/services/docker/container_opts_builder.rb
+++ b/server/app/services/docker/container_opts_builder.rb
@@ -41,6 +41,8 @@ module Docker
       host_config['NetworkMode'] = grid_service.net if grid_service.net
 
       docker_opts['HostConfig'] = host_config
+      log_opts = self.build_log_opts(grid_service)
+      docker_opts['LogConfig'] = log_opts unless log_opts.empty?
       docker_opts
     end
 
@@ -168,6 +170,20 @@ module Docker
         bindings["#{p['container_port']}/#{p['protocol']}"] = [{'HostPort' => p['node_port'].to_s}]
       end
       bindings
+    end
+
+    ##
+    # @param [GridService] grid_service
+    # @return [Hash]
+    def self.build_log_opts(grid_service)
+      log_config = {}
+      log_config['Type'] = grid_service.log_driver if grid_service.log_driver
+      log_config['Config'] = {}
+      grid_service.log_opt.each { |log_opt|
+        key, value = log_opt.split("=")
+        log_config['Config'][key] = value
+      }
+      log_config
     end
   end
 end

--- a/server/app/services/docker/container_opts_builder.rb
+++ b/server/app/services/docker/container_opts_builder.rb
@@ -180,10 +180,11 @@ module Docker
       log_config = {}
       log_config['Type'] = grid_service.log_driver if grid_service.log_driver
       log_config['Config'] = {}
-      grid_service.log_opts.each { |log_opt|
-        key, value = log_opt.split("=")
-        log_config['Config'][key] = value
+      puts grid_service.log_opts
+      grid_service.log_opts.each { |key, value|
+        log_config['Config'][key.to_s] = value
       }
+      puts log_config
       log_config
     end
   end

--- a/server/app/services/docker/container_opts_builder.rb
+++ b/server/app/services/docker/container_opts_builder.rb
@@ -42,7 +42,8 @@ module Docker
 
       docker_opts['HostConfig'] = host_config
       log_opts = self.build_log_opts(grid_service)
-      docker_opts['LogConfig'] = log_opts unless log_opts.empty?
+      host_config['LogConfig'] = log_opts unless log_opts.empty?
+
       docker_opts
     end
 
@@ -179,7 +180,7 @@ module Docker
       log_config = {}
       log_config['Type'] = grid_service.log_driver if grid_service.log_driver
       log_config['Config'] = {}
-      grid_service.log_opt.each { |log_opt|
+      grid_service.log_opts.each { |log_opt|
         key, value = log_opt.split("=")
         log_config['Config'][key] = value
       }

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -21,3 +21,5 @@ json.cap_drop grid_service.cap_drop
 json.state grid_service.state
 json.grid_id grid_service.grid_id.to_s
 json.links grid_service.grid_service_links.map{|s| {alias: s.alias, grid_service_id: s.linked_grid_service.to_path }}
+json.log_driver grid_service.log_driver
+json.log_opts grid_service.log_opts

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,5 +1,6 @@
 api:
   build: .
+  dockerfile: Dockerfile.alpine
   ports:
     - 4040:9292
   environment:

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -50,7 +50,7 @@ describe '/v1/services' do
       expect(json_response.keys.sort).to eq(%w(
         id created_at updated_at image affinity name stateful user
         container_count cmd entrypoint ports env memory memory_swap cpu_shares
-        volumes volumes_from cap_add cap_drop state grid_id links
+        volumes volumes_from cap_add cap_drop state grid_id links log_driver log_opts
       ).sort)
       expect(json_response['id']).to eq(redis_service.to_path)
       expect(json_response['image']).to eq(redis_service.image_name)

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -4,8 +4,8 @@ describe GridService do
   it { should be_timestamped_document }
   it { should have_fields(:image_name, :name, :user, :entrypoint, :state, :net, :log_driver).of_type(String) }
   it { should have_fields(:container_count, :memory, :memory_swap, :cpu_shares).of_type(Fixnum) }
-  it { should have_fields(:affinity, :cmd, :ports, :env, :volumes, :volumes_from, :cap_add, :cap_drop, :log_opts).of_type(Array) }
-  it { should have_fields(:labels).of_type(Hash) }
+  it { should have_fields(:affinity, :cmd, :ports, :env, :volumes, :volumes_from, :cap_add, :cap_drop).of_type(Array) }
+  it { should have_fields(:labels, :log_opts).of_type(Hash) }
   it { should have_fields(:privileged).of_type(Mongoid::Boolean) }
 
   it { should belong_to(:grid) }

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -2,9 +2,9 @@ require_relative '../spec_helper'
 
 describe GridService do
   it { should be_timestamped_document }
-  it { should have_fields(:image_name, :name, :user, :entrypoint, :state, :net).of_type(String) }
+  it { should have_fields(:image_name, :name, :user, :entrypoint, :state, :net, :log_driver).of_type(String) }
   it { should have_fields(:container_count, :memory, :memory_swap, :cpu_shares).of_type(Fixnum) }
-  it { should have_fields(:affinity, :cmd, :ports, :env, :volumes, :volumes_from, :cap_add, :cap_drop).of_type(Array) }
+  it { should have_fields(:affinity, :cmd, :ports, :env, :volumes, :volumes_from, :cap_add, :cap_drop, :log_opts).of_type(Array) }
   it { should have_fields(:labels).of_type(Hash) }
   it { should have_fields(:privileged).of_type(Mongoid::Boolean) }
 

--- a/server/spec/services/docker/container_opts_builder_spec.rb
+++ b/server/spec/services/docker/container_opts_builder_spec.rb
@@ -155,7 +155,7 @@ describe Docker::ContainerOptsBuilder do
 
     it 'sets logging opts' do
       grid_service.log_driver = 'gelf'
-      grid_service.log_opts = ['gelf-address=udp://192.168.0.42:12201', 'gelf-tag=foo']
+      grid_service.log_opts = {:'gelf-address'=>'udp://192.168.0.42:12201', :'gelf-tag'=>'foo'}
       opts = described_class.build_opts(grid_service, container)
       expect(opts['HostConfig']['LogConfig']['Type']).to eq('gelf')
       expect(opts['HostConfig']['LogConfig']['Config'].size).to eq(2)

--- a/server/spec/services/docker/container_opts_builder_spec.rb
+++ b/server/spec/services/docker/container_opts_builder_spec.rb
@@ -175,6 +175,24 @@ describe Docker::ContainerOptsBuilder do
       expect(labels).to include('io.kontena.load_balancer.mode' => 'http')
       expect(labels).to include('io.kontena.load_balancer.internal_port' => '80')
     end
+
+    it 'sets logging driver' do
+      grid_service.log_driver = 'gelf'
+      opts = described_class.build_opts(grid_service, container)
+      expect(opts['LogConfig']['Type']).to eq('gelf')
+    end
+
+    it 'sets logging opts' do
+      grid_service.log_driver = 'gelf'
+      grid_service.log_opt = ['gelf-address=udp://192.168.0.42:12201', 'gelf-tag=foo']
+      opts = described_class.build_opts(grid_service, container)
+      expect(opts['LogConfig']['Type']).to eq('gelf')
+      expect(opts['LogConfig']['Config'].size).to eq(2)
+      expect(opts['LogConfig']['Config']['gelf-address']).to eq('udp://192.168.0.42:12201')
+      expect(opts['LogConfig']['Config']['gelf-tag']).to eq('foo')
+
+    end
+
   end
 
   describe '.build_volumes' do

--- a/server/spec/services/docker/container_opts_builder_spec.rb
+++ b/server/spec/services/docker/container_opts_builder_spec.rb
@@ -146,6 +146,24 @@ describe Docker::ContainerOptsBuilder do
       opts = described_class.build_opts(grid_service, container)
       expect(opts['HostConfig'].has_key?('NetworkMode')).to eq(false)
     end
+
+    it 'sets logging driver' do
+      grid_service.log_driver = 'gelf'
+      opts = described_class.build_opts(grid_service, container)
+      expect(opts['HostConfig']['LogConfig']['Type']).to eq('gelf')
+    end
+
+    it 'sets logging opts' do
+      grid_service.log_driver = 'gelf'
+      grid_service.log_opts = ['gelf-address=udp://192.168.0.42:12201', 'gelf-tag=foo']
+      opts = described_class.build_opts(grid_service, container)
+      expect(opts['HostConfig']['LogConfig']['Type']).to eq('gelf')
+      expect(opts['HostConfig']['LogConfig']['Config'].size).to eq(2)
+      expect(opts['HostConfig']['LogConfig']['Config']['gelf-address']).to eq('udp://192.168.0.42:12201')
+      expect(opts['HostConfig']['LogConfig']['Config']['gelf-tag']).to eq('foo')
+
+    end
+
   end
 
   describe '.build_labels' do
@@ -174,23 +192,6 @@ describe Docker::ContainerOptsBuilder do
       expect(labels).to include('io.kontena.load_balancer.name' => lb.name)
       expect(labels).to include('io.kontena.load_balancer.mode' => 'http')
       expect(labels).to include('io.kontena.load_balancer.internal_port' => '80')
-    end
-
-    it 'sets logging driver' do
-      grid_service.log_driver = 'gelf'
-      opts = described_class.build_opts(grid_service, container)
-      expect(opts['LogConfig']['Type']).to eq('gelf')
-    end
-
-    it 'sets logging opts' do
-      grid_service.log_driver = 'gelf'
-      grid_service.log_opt = ['gelf-address=udp://192.168.0.42:12201', 'gelf-tag=foo']
-      opts = described_class.build_opts(grid_service, container)
-      expect(opts['LogConfig']['Type']).to eq('gelf')
-      expect(opts['LogConfig']['Config'].size).to eq(2)
-      expect(opts['LogConfig']['Config']['gelf-address']).to eq('udp://192.168.0.42:12201')
-      expect(opts['LogConfig']['Config']['gelf-tag']).to eq('foo')
-
     end
 
   end


### PR DESCRIPTION
This PR adds support to provide log driver options for containers. Follows the same conventions as normal docker cli:
```
kontena service create --log-driver=fluentd --log-opt fluentd-address=192.168.99.1:24224 --log-opt fluentd-tag=docker.{{.Name}} nginx_log nginx:latest
```
Through YAML the following makes the tricks:
```
nginx:
  image: nginx:latest
  ports:
    - 80:80
  log_driver: fluentd
  log_opt:
    - fluentd-address=192.168.99.1:24224
    - fluentd-tag=docker.{{.Name}}
```