### PR TITLE
Use optional name parameter instead of --name switch on AWS node provision

### DIFF
--- a/cli/lib/kontena/cli/nodes/aws/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/aws/create_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Nodes::Aws
   class CreateCommand < Clamp::Command
     include Kontena::Cli::Common
 
-    option "--name", "NAME", "Node name"
+    parameter "[NAME]", "Node name"
     option "--access-key", "ACCESS_KEY", "AWS access key ID", required: true
     option "--secret-key", "SECRET_KEY", "AWS secret key", required: true
     option "--region", "REGION", "EC2 Region", default: 'eu-west-1'


### PR DESCRIPTION
This PR updates AWS node provision to follow node provision conventions introduced in #166. 