### PR TITLE
Add/remove service env commands

### DIFF
--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -11,6 +11,8 @@ require_relative 'services/delete_command'
 require_relative 'services/containers_command'
 require_relative 'services/logs_command'
 require_relative 'services/stats_command'
+require_relative 'services/add_env_command'
+require_relative 'services/remove_env_command'
 
 class Kontena::Cli::ServiceCommand < Clamp::Command
 
@@ -27,6 +29,8 @@ class Kontena::Cli::ServiceCommand < Clamp::Command
   subcommand "containers", "List service containers", Kontena::Cli::Services::ContainersCommand
   subcommand "logs", "Show service logs", Kontena::Cli::Services::LogsCommand
   subcommand "stats", "Show service statistics", Kontena::Cli::Services::StatsCommand
+  subcommand "add-env", "Add environment variable", Kontena::Cli::Services::AddEnvCommand
+  subcommand "remove-env", "Remove environment variable", Kontena::Cli::Services::RemoveEnvCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/services/add_env_command.rb
+++ b/cli/lib/kontena/cli/services/add_env_command.rb
@@ -1,0 +1,18 @@
+require_relative 'services_helper'
+
+module Kontena::Cli::Services
+  class AddEnvCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include ServicesHelper
+
+    parameter "NAME", "Service name"
+    parameter "ENV", "Environment variable"
+
+    def execute
+      require_api_url
+      token = require_token
+      data = {env: env}
+      result = client(token).post("services/#{parse_service_id(name)}/envs", data)
+    end
+  end
+end

--- a/cli/lib/kontena/cli/services/remove_env_command.rb
+++ b/cli/lib/kontena/cli/services/remove_env_command.rb
@@ -1,0 +1,17 @@
+require_relative 'services_helper'
+
+module Kontena::Cli::Services
+  class RemoveEnvCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include ServicesHelper
+
+    parameter "NAME", "Service name"
+    parameter "ENV", "Environment variable name"
+
+    def execute
+      require_api_url
+      token = require_token
+      client(token).delete("services/#{parse_service_id(name)}/envs/#{env}")
+    end
+  end
+end

--- a/server/app/mutations/grid_services/add_env.rb
+++ b/server/app/mutations/grid_services/add_env.rb
@@ -1,0 +1,13 @@
+module GridServices
+  class AddEnv < Mutations::Command
+    required do
+      model :grid_service
+      string :env
+    end
+
+    def execute
+      self.grid_service.env << env
+      self.grid_service.save
+    end
+  end
+end

--- a/server/app/mutations/grid_services/remove_env.rb
+++ b/server/app/mutations/grid_services/remove_env.rb
@@ -1,0 +1,18 @@
+module GridServices
+  class RemoveEnv < Mutations::Command
+    required do
+      model :grid_service
+      string :env
+    end
+
+    def execute
+      self.grid_service.env.dup.each do |e|
+        k, v = e.split("=", 2)
+        if k == env
+          self.grid_service.env.delete(e)
+        end
+      end
+      self.grid_service.save
+    end
+  end
+end

--- a/server/app/routes/v1/services/service_envs.rb
+++ b/server/app/routes/v1/services/service_envs.rb
@@ -1,0 +1,36 @@
+V1::ServicesApi.route('service_envs') do |r|
+
+  # GET /v1/services/:grid_name/:service_name/envs
+  r.post do
+    r.is do
+      data = parse_json_body
+      outcome = GridServices::AddEnv.run(
+        grid_service: @grid_service,
+        env: data['env']
+      )
+      if outcome.success?
+        audit_event(r, @grid_service.grid, @grid_service, 'add_env', @grid_service)
+        {}
+      else
+        response.status = 422
+        outcome.errors.message
+      end
+    end
+  end
+
+  r.delete do
+    r.on ':env' do |env|
+      outcome = GridServices::RemoveEnv.run(
+        grid_service: @grid_service,
+        env: env
+      )
+      if outcome.success?
+        audit_event(r, @grid_service.grid, @grid_service, 'remove_env', @grid_service)
+        {}
+      else
+        response.status = 422
+        outcome.errors.message
+      end
+    end
+  end
+end

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -39,6 +39,12 @@ module V1
         r.route 'service_stats'
       end
 
+      # /v1/services/:grid_name/:service_name/envs
+      r.on ':grid_name/:service_name/envs' do |grid_name, service_name|
+        @grid_service = load_grid_service(grid_name, service_name)
+        r.route 'service_envs'
+      end
+
       # /v1/services/:grid_name/:service_name
       r.on ':grid_name/:service_name' do |grid_name, service_name|
         @grid_service = load_grid_service(grid_name, service_name)

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -34,7 +34,8 @@ describe '/v1/services' do
       grid: david.grids.first,
       name: 'redis',
       image_name: 'redis:2.8',
-      stateful: true
+      stateful: true,
+      env: ['FOO=BAR']
     )
   end
 
@@ -221,5 +222,20 @@ describe '/v1/services' do
     end
   end
 
+  describe 'POST /:id/envs' do
+    it 'adds env variable' do
+      data = {env: 'BAR=BAZ'}
+      post "/v1/services/#{redis_service.to_path}/envs", data.to_json, request_headers
+      expect(response.status).to eq(200)
+      expect(redis_service.reload.env).to include('BAR=BAZ')
+    end
+  end
 
+  describe 'DELETE /:id/envs' do
+    it 'removes env variable' do
+      delete "/v1/services/#{redis_service.to_path}/envs/FOO", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(redis_service.reload.env).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
This PR adds `kontena service add-env` and `kontena service remove-env` subcommands for easier service env variable manipulation.