### PR TITLE
Node ssh subcommand

### DIFF
--- a/cli/lib/kontena/cli/node_command.rb
+++ b/cli/lib/kontena/cli/node_command.rb
@@ -2,6 +2,7 @@ require_relative 'nodes/list_command'
 require_relative 'nodes/remove_command'
 require_relative 'nodes/show_command'
 require_relative 'nodes/update_command'
+require_relative 'nodes/ssh_command'
 
 require_relative 'nodes/vagrant_command'
 require_relative 'nodes/digital_ocean_command'
@@ -12,6 +13,7 @@ class Kontena::Cli::NodeCommand < Clamp::Command
 
   subcommand "list", "List grid nodes", Kontena::Cli::Nodes::ListCommand
   subcommand "show", "Show node", Kontena::Cli::Nodes::ShowCommand
+  subcommand "ssh", "Ssh into node", Kontena::Cli::Nodes::SshCommand
   subcommand "update", "Update node", Kontena::Cli::Nodes::UpdateCommand
   subcommand "remove", "Remove node", Kontena::Cli::Nodes::RemoveCommand
 

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -3,10 +3,10 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
 
     parameter "NODE_ID", "Node id"
-    option ["-i", "--identity-file"], "IDENTITY_FILE", "Ssh private key to use"
+    option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
     option ["-u", "--user"], "USER", "Login as a user", default: "core"
-    option "--private-ip", :flag, "Connect to node using private ip"
-    option "--internal-ip", :flag, "Connect to node through VPN"
+    option "--private-ip", :flag, "Connect to node's private IP address"
+    option "--internal-ip", :flag, "Connect to node's internal IP address (requires VPN connection)"
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -1,0 +1,30 @@
+module Kontena::Cli::Nodes
+  class SshCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    parameter "NODE_ID", "Node id"
+    option ["-i", "--identity-file"], "IDENTITY_FILE", "Ssh private key to use"
+    option ["-u", "--user"], "USER", "Login as a user", default: "core"
+    option "--private-ip", :flag, "Connect to node using private ip"
+    option "--internal-ip", :flag, "Connect to node through VPN"
+
+    def execute
+      require_api_url
+      require_current_grid
+      token = require_token
+
+      node = client(token).get("grids/#{current_grid}/nodes/#{node_id}")
+      cmd = ['ssh']
+      cmd << "-i #{identity_file}" if identity_file
+      if internal_ip?
+        ip = "10.81.0.#{node['node_number']}"
+      elsif private_ip?
+        ip = node['private_ip']
+      else
+        ip = node['public_ip']
+      end
+      cmd << "#{user}@#{ip}"
+      exec(cmd.join(" "))
+    end
+  end
+end


### PR DESCRIPTION
This PR adds helper command for accessing host nodes through ssh.

```
$ kontena node ssh -h
Usage:
    kontena node ssh [OPTIONS] NODE_ID

Parameters:
    NODE_ID                       Node id

Options:
    -i, --identity-file IDENTITY_FILE Ssh private key to use
    -u, --user USER               Login as a user (default: "core")
    --private-ip                  Connect to node using private ip
    --internal-ip                 Connect to node through VPN
    -h, --help                    print help
```