### PR TITLE
Update container by unique id

### DIFF
--- a/server/app/services/agent/message_handler.rb
+++ b/server/app/services/agent/message_handler.rb
@@ -68,12 +68,13 @@ module Agent
         container.attributes_from_docker(info)
         container.updated_at = Time.now.utc
         container.save
-      elsif !labels['io.kontena.container.name'].nil?
-        container = grid.containers.unscoped.find_by(name: labels['io.kontena.container.name'])
+      elsif !labels['io.kontena.container.id'].nil?
+        container = grid.containers.unscoped.find_by(id: labels['io.kontena.container.id'])
         unless container
           node = grid.host_nodes.find_by(node_id: data['node'])
           service = grid.grid_services.find_by(id: labels['io.kontena.service.id'])
           container = grid.containers.build(
+            id: BSON::ObjectId.from_string(labels['io.kontena.container.id']),
             container_id: container_id,
             name: labels['io.kontena.container.name'],
             container_type: labels['io.kontena.container.type'] || 'container',

--- a/server/app/services/docker/container_creator.rb
+++ b/server/app/services/docker/container_creator.rb
@@ -68,6 +68,7 @@ module Docker
           image: docker_opts['Image'],
           container_type: 'volume'
         )
+        volume_opts['Labels']['io.kontena.container.id'] = volume_container.id.to_s
         request_create_container(volume_opts)
         sleep 0.2 until container_created?(volume_container)
       end

--- a/server/app/services/docker/container_opts_builder.rb
+++ b/server/app/services/docker/container_opts_builder.rb
@@ -128,6 +128,7 @@ module Docker
     # @return [Hash]
     def self.build_labels(grid_service, container)
       labels = {
+        'io.kontena.container.id' => container.id.to_s,
         'io.kontena.container.name' => container.name,
         'io.kontena.service.id' => grid_service.id.to_s,
         'io.kontena.service.name' => grid_service.name.to_s,

--- a/server/spec/services/agent/message_handler_spec.rb
+++ b/server/spec/services/agent/message_handler_spec.rb
@@ -71,7 +71,7 @@ describe Agent::MessageHandler do
       expect(container.reload.running?).to eq(true)
     end
 
-    it 'updates container if container is found by label name' do
+    it 'updates container if container is found by internal id' do
       container_id = SecureRandom.hex(16)
       container = grid.containers.create!(name: 'foo-1')
       expect(container.running?).to eq(false)
@@ -84,7 +84,7 @@ describe Agent::MessageHandler do
           },
           'Config' => {
             'Labels' => {
-              'io.kontena.container.name' => 'foo-1'
+              'io.kontena.container.id' => container.id.to_s
             }
           },
 


### PR DESCRIPTION
When container is not found by docker container id, we should use our internal unique id (not name) to update container information.