### PR TITLE
Increase RPC client's timeout on container creation

### DIFF
--- a/server/app/services/docker/container_creator.rb
+++ b/server/app/services/docker/container_creator.rb
@@ -79,7 +79,7 @@ module Docker
     ##
     # @return [RpcClient]
     def client
-      self.host_node.rpc_client(10)
+      self.host_node.rpc_client(60)
     end
 
     # @param [Container] container


### PR DESCRIPTION
When creating services with devicemapper driver, sometimes container creation may take more than 10 seconds and RPC client raises RpcClient::TimeoutError. This PR increases timeout to 60 seconds.

Fixes #246 