### PR TITLE
Do not auto remove initial nodes

### DIFF
--- a/server/app/jobs/node_cleanup_job.rb
+++ b/server/app/jobs/node_cleanup_job.rb
@@ -33,7 +33,7 @@ class NodeCleanupJob
   def cleanup_stale_nodes
     with_dlock('node_cleanup_job:stale_nodes', 0) do
       HostNode.where(:last_seen_at.lt => 1.hour.ago).each do |node|
-        unless node.connected?
+        if !node.initial_node? && !node.connected?
           node.destroy
         end
       end

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -74,6 +74,13 @@ class HostNode
     RpcClient.new(self.node_id, timeout)
   end
 
+  # @return [Boolean]
+  def initial_node?
+    self.node_number <= self.grid.initial_size
+  rescue
+    false
+  end
+
   private
 
   def reserve_node_number

--- a/server/spec/jobs/node_cleanup_job_spec.rb
+++ b/server/spec/jobs/node_cleanup_job_spec.rb
@@ -1,18 +1,45 @@
 require_relative '../spec_helper'
 
 describe NodeCleanupJob do
-  before(:each) { Celluloid.boot }
+  let(:grid) { Grid.create!(name: 'test', initial_size: 1)}
+  before(:each) do
+    Celluloid.boot
+    HostNode.create!(
+      grid: grid,
+      name: "node-1",
+      node_number: 1,
+      connected: true,
+      last_seen_at: 2.hours.ago
+    )
+    HostNode.create!(
+      grid: grid,
+      name: "node-2",
+      node_number: 2,
+      connected: false,
+      last_seen_at: 2.hours.ago
+    )
+    HostNode.create!(
+      grid: grid,
+      name: "node-3",
+      node_number: 3,
+      connected: true,
+      last_seen_at: 10.minutes.ago
+    )
+  end
   after(:each) { Celluloid.shutdown }
 
   describe '#cleanup_stale_nodes' do
     it 'removes old nodes' do
-      HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago)
-      HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.hours.ago)
-      HostNode.create!(name: "node-3", connected: true, last_seen_at: 10.minutes.ago)
-
       expect {
         subject.cleanup_stale_nodes
       }.to change{ HostNode.count }.by(-1)
+    end
+
+    it 'does not remove old node if its part of initial grid' do
+      expect {
+        grid.set(initial_size: 3)
+        subject.cleanup_stale_nodes
+      }.to change{ HostNode.count }.by(0)
     end
   end
 end

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -62,4 +62,31 @@ describe HostNode do
       expect(subject.node_number).to eq(2)
     end
   end
+
+  describe '#initial_node?' do
+    let(:grid) { Grid.new(name: 'test') }
+    before(:each) do
+      subject.grid = grid
+    end
+
+    it 'returns true if node is part of initial cluster' do
+      allow(subject).to receive(:node_number).and_return(1)
+      allow(grid).to receive(:initial_size).and_return(3)
+      expect(subject.initial_node?).to eq(true)
+
+      allow(subject).to receive(:node_number).and_return(3)
+      allow(grid).to receive(:initial_size).and_return(3)
+      expect(subject.initial_node?).to eq(true)
+    end
+
+    it 'returns false if node is not part of initial cluster' do
+      allow(subject).to receive(:node_number).and_return(2)
+      allow(grid).to receive(:initial_size).and_return(1)
+      expect(subject.initial_node?).to eq(false)
+
+      allow(subject).to receive(:node_number).and_return(4)
+      allow(grid).to receive(:initial_size).and_return(3)
+      expect(subject.initial_node?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
We should not remove initial nodes automatically because it might break local/dev setups too easily.