### PR TITLE
Do not generate MAINTAINER to Dockerfile

### DIFF
--- a/cli/lib/kontena/cli/apps/dockerfile_generator.rb
+++ b/cli/lib/kontena/cli/apps/dockerfile_generator.rb
@@ -5,11 +5,10 @@ module Kontena::Cli::Apps
   class DockerfileGenerator
     include Common
 
-    def generate(base_image, maintainer)
+    def generate(base_image)
 
       dockerfile = File.new('Dockerfile', 'w')
       dockerfile.puts "FROM #{base_image}"
-      dockerfile.puts "MAINTAINER #{maintainer}"
       dockerfile.puts 'CMD ["/start", "web"]'
       dockerfile.close
     end

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -27,7 +27,7 @@ module Kontena::Cli::Apps
         puts 'Found Dockerfile'
       elsif create_dockerfile?
         puts "Creating #{'Dockerfile'.colorize(:cyan)}"
-        DockerfileGenerator.new.generate(base_image, current_user['email'])
+        DockerfileGenerator.new.generate(base_image)
       end
 
       if File.exist?('Procfile')
@@ -86,11 +86,6 @@ module Kontena::Cli::Apps
         return '.env'
       end
       nil
-    end
-
-    def current_user
-      token = require_token
-      client(token).get('user') rescue ''
     end
 
     def create_docker_compose_yml?


### PR DESCRIPTION
This PR removes maintainer generation from Dockerfile. It is not needed in Dockerfile and if user is not logged in to Kontena Master when running `kontena app init` it triggers error.