### PR TITLE
Change docker bip to non-default value

### DIFF
--- a/cli/lib/kontena/machine/aws/cloudinit.yml
+++ b/cli/lib/kontena/machine/aws/cloudinit.yml
@@ -12,7 +12,7 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-kontena.conf
     content: |
         [Service]
-        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.42.1/16"'
+        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.43.1/16"'
 coreos:
   units:
     - name: 00-eth.network
@@ -22,7 +22,7 @@ coreos:
         Name=eth*
         [Network]
         DHCP=yes
-        DNS=172.17.42.1
+        DNS=172.17.43.1
         DNS=<%= dns_server %>
         DOMAINS=kontena.local
         [DHCP]

--- a/cli/lib/kontena/machine/azure/cloudinit.yml
+++ b/cli/lib/kontena/machine/azure/cloudinit.yml
@@ -11,12 +11,12 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-kontena.conf
     content: |
         [Service]
-        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.42.1/16"'
+        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.43.1/16"'
   - path: /etc/resolv.conf
     permissions: 0644
     owner: root
     content: |
-      nameserver 172.17.42.1
+      nameserver 172.17.43.1
       nameserver 8.8.8.8
       nameserver 8.8.4.4
 coreos:

--- a/cli/lib/kontena/machine/digital_ocean/cloudinit.yml
+++ b/cli/lib/kontena/machine/digital_ocean/cloudinit.yml
@@ -11,12 +11,12 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-kontena.conf
     content: |
         [Service]
-        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.42.1/16"'
+        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.43.1/16"'
   - path: /etc/resolv.conf
     permissions: 0644
     owner: root
     content: |
-      nameserver 172.17.42.1
+      nameserver 172.17.43.1
       nameserver 8.8.8.8
       nameserver 8.8.4.4
 coreos:

--- a/cli/lib/kontena/machine/vagrant/cloudinit.yml
+++ b/cli/lib/kontena/machine/vagrant/cloudinit.yml
@@ -11,7 +11,7 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-kontena.conf
     content: |
         [Service]
-        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.42.1/16"'
+        Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/19" --bip="172.17.43.1/16"'
 coreos:
   units:
     - name: 00-eth.network
@@ -21,7 +21,7 @@ coreos:
         Name=eth*
         [Network]
         DHCP=yes
-        DNS=172.17.42.1
+        DNS=172.17.43.1
         DNS=172.28.128.1
         DNS=8.8.8.8
         DOMAINS=kontena.local


### PR DESCRIPTION
Current docker bridge ip causes conflict with linux users because local docker bridge has the same ip. Fixes #263 .