### PR TITLE
Fix `kontena master vagrant start`

### DIFF
--- a/cli/lib/kontena/cli/master/vagrant/start_command.rb
+++ b/cli/lib/kontena/cli/master/vagrant/start_command.rb
@@ -5,9 +5,9 @@ module Kontena::Cli::Master::Vagrant
     def execute
       require 'kontena/machine/vagrant'
       vagrant_path = "#{Dir.home}/.kontena/vagrant_master"
-      abort("Cannot find Vagrant node #{name}".colorize(:red)) unless Dir.exist?(vagrant_path)
+      abort("Cannot find Vagrant node kontena-master".colorize(:red)) unless Dir.exist?(vagrant_path)
       Dir.chdir(vagrant_path) do
-        ShellSpinner "Starting Vagrant machine #{name.colorize(:cyan)} " do
+        ShellSpinner "Starting Vagrant machine kontena-master " do
           Open3.popen2('vagrant up') do |stdin, output, wait|
             while o = output.gets
               print o if ENV['DEBUG']


### PR DESCRIPTION
Fixes `kontena master vagrant start` command, which referenced non-existent `name` variable.

```
$ DEBUG=1 kontena master vagrant start
~/.rvm/gems/ruby-2.2.3/gems/kontena-cli-0.9.1/lib/kontena/cli/master/vagrant/start_command.rb:10:in `block in execute': undefined local variable or method `name' for #<Kontena::Cli::Master::Vagrant::StartCommand:0x00000002327088> (NameError)
  from ~/.rvm/gems/ruby-2.2.3/gems/kontena-cli-0.9.1/lib/kontena/cli/master/vagrant/start_command.rb:9:in `chdir'
  from ~/.rvm/gems/ruby-2.2.3/gems/kontena-cli-0.9.1/lib/kontena/cli/master/vagrant/start_command.rb:9:in `execute'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/subcommand/execution.rb:11:in `execute'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
  from ~/.rvm/gems/ruby-2.2.3/gems/clamp-1.0.0/lib/clamp/command.rb:133:in `run'
  from ~/.rvm/gems/ruby-2.2.3/gems/kontena-cli-0.9.1/bin/kontena:67:in `<top (required)>'
  from ~/.rvm/gems/ruby-2.2.3/bin/kontena:23:in `load'
  from ~/.rvm/gems/ruby-2.2.3/bin/kontena:23:in `<main>'
  from ~/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `eval'
  from ~/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `<main>'
```