### PR TITLE
Add separate subcommand for service envs

### DIFF
--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -11,6 +11,7 @@ require_relative 'services/delete_command'
 require_relative 'services/containers_command'
 require_relative 'services/logs_command'
 require_relative 'services/stats_command'
+require_relative 'services/envs_command'
 require_relative 'services/add_env_command'
 require_relative 'services/remove_env_command'
 
@@ -29,6 +30,7 @@ class Kontena::Cli::ServiceCommand < Clamp::Command
   subcommand "containers", "List service containers", Kontena::Cli::Services::ContainersCommand
   subcommand "logs", "Show service logs", Kontena::Cli::Services::LogsCommand
   subcommand "stats", "Show service statistics", Kontena::Cli::Services::StatsCommand
+  subcommand "envs", "Show environment variables", Kontena::Cli::Services::EnvsCommand
   subcommand "add-env", "Add environment variable", Kontena::Cli::Services::AddEnvCommand
   subcommand "remove-env", "Remove environment variable", Kontena::Cli::Services::RemoveEnvCommand
 

--- a/cli/lib/kontena/cli/services/envs_command.rb
+++ b/cli/lib/kontena/cli/services/envs_command.rb
@@ -1,0 +1,19 @@
+require_relative 'services_helper'
+
+module Kontena::Cli::Services
+  class EnvsCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include ServicesHelper
+
+    parameter "NAME", "Service name"
+
+    def execute
+      require_api_url
+      token = require_token
+      service = client(token).get("services/#{parse_service_id(name)}")
+      service["env"].each do |env|
+        puts env
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -53,7 +53,13 @@ module Kontena
           end
 
           puts "  env: "
-          service['env'].to_a.each{|e| puts "    - #{e}"}
+          service['env'].to_a.each do |e|
+            if e.length > 50
+              puts "    - #{e[0..50]}..."
+            else
+              puts "    - #{e}"
+            end
+          end
 
           puts "  ports:"
           service['ports'].to_a.each do |p|


### PR DESCRIPTION
Long environment variables pollute service show output. This PR adds separate subcommand `kontena service envs <name>` that shows all env variables and truncates env output on `kontena service show <name>`.