### PR TITLE
Daemon strategy

### DIFF
--- a/docs/using-kontena/deploy.md
+++ b/docs/using-kontena/deploy.md
@@ -4,16 +4,26 @@ toc_order: 7
 ---
 
 ## Deployment strategies
-Kontena can use different scheduling algorithms when deploying containers to more than one node. At the moment the following strategies are available:
+Kontena can use different scheduling algorithms when deploying services to more than one node. At the moment the following strategies are available:
 
 **High Availability (HA)**
 
-Service with `ha` strategy will deploy its containers to different host nodes. This means that the containers will be spread across all nodes.
+Service with `ha` strategy will deploy its instances to different host nodes. This means that the service instances will be spread across all nodes.
 
 ```
 deploy:
   strategy: ha
 ```
+
+**Daemon**
+
+Service with `daemon` strategy will deploy given number of instances to all nodes.
+
+```
+deploy:
+  strategy: daemon
+```
+
 
 **Random**
 
@@ -26,7 +36,7 @@ deploy:
 
 **Wait for port**
 
-When a service has multiple instances and `wait_for_port` definition, Kontena's scheduler will wait that container is responding to port before starting to deploy another instance. This way it is possible to achieve zero-downtime deploys. 
+When a service has multiple instances and `wait_for_port` definition, Kontena's scheduler will wait that container is responding to port before starting to deploy another instance. This way it is possible to achieve zero-downtime deploys.
 
 ```
 instances: 3

--- a/server/app/services/scheduler/strategy/daemon.rb
+++ b/server/app/services/scheduler/strategy/daemon.rb
@@ -1,0 +1,14 @@
+require_relative 'high_availability'
+
+module Scheduler
+  module Strategy
+    class Daemon < Strategy::HighAvailability
+
+      # @param [Integer] node_count
+      # @param [Integer] instance_count
+      def instance_count(node_count, instance_count)
+        node_count.to_i * instance_count.to_i
+      end
+    end
+  end
+end

--- a/server/spec/services/scheduler/strategy/daemon_spec.rb
+++ b/server/spec/services/scheduler/strategy/daemon_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../../spec_helper'
+
+describe Scheduler::Strategy::Daemon do
+
+  describe '#instance_count' do
+    it 'returns node count multiplied with instance count' do
+      expect(subject.instance_count(3, 2)).to eq(6)
+    end
+  end
+end


### PR DESCRIPTION
Many users have requested for a way to run a daemon on every node in a Kontena Grid, or on a certain set of nodes in a grid. This is essential for use cases such as building a sharded datastore, or running a logger on every node. In comes the `daemon` strategy, a way to conveniently create and manage daemon-like workloads in Kontena.

Depends on #272 

![daemon](http://www.mckusick.com/beastie/gif/bsd4_3.gif)