### PR TITLE
Added pid option for service to put it in host pid namespace

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -6,7 +6,7 @@ module Kontena
                   :labels, :stateful, :image_name, :user, :cmd, :entrypoint, :memory,
                   :memory_swap, :cpu_shares, :privileged, :cap_add, :cap_drop,
                   :devices, :ports, :env, :volumes, :volumes_from, :net,
-                  :log_driver, :log_opts, :image_credentials
+                  :log_driver, :log_opts, :image_credentials, :pid
 
       # @param [Hash] attrs
       def initialize(attrs = {})
@@ -35,6 +35,7 @@ module Kontena
         @net = attrs['net'] || 'bridge'
         @log_driver = attrs['log_driver']
         @log_opts = attrs['log_opts']
+        @pid = attrs['pid']
       end
 
       # @return [String, NilClass]
@@ -124,6 +125,7 @@ module Kontena
         host_config['Privileged'] = self.privileged if self.privileged
         host_config['CapAdd'] = self.cap_add if self.cap_add && self.cap_add.size > 0
         host_config['CapDrop'] = self.cap_drop if self.cap_drop && self.cap_drop.size > 0
+        host_config['PidMode'] = self.pid if self.pid
 
         log_opts = self.build_log_opts
         host_config['LogConfig'] = log_opts unless log_opts.empty?

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -239,6 +239,11 @@ describe Kontena::Models::ServicePod do
       data['cpu_shares'] = 500
       expect(host_config['CpuShares']).to eq(500)
     end
+
+    it 'sets PidMode if set' do
+      data['pid'] = 'host'
+      expect(host_config['PidMode']).to eq('host')
+    end
   end
 
   describe '#build_exposed_ports' do

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -30,6 +30,7 @@ module Kontena::Cli::Services
     option "--deploy-strategy", "STRATEGY", "Deploy strategy to use (ha, random)"
     option "--deploy-wait-for-port", "PORT", "Wait for port to respond when deploying"
     option "--deploy-min-health", "FLOAT", "The minimum percentage (0.0 - 1.0) of healthy instances that do not sacrifice overall service availability while deploying"
+    option "--pid", "PID", "Pid namespace to use"
 
     def execute
       require_api_url
@@ -71,6 +72,7 @@ module Kontena::Cli::Services
       data[:deploy_opts] = {}
       data[:deploy_opts][:min_health] = deploy_min_health.to_f if deploy_min_health
       data[:deploy_opts][:wait_for_port] = deploy_wait_for_port.to_i if deploy_wait_for_port
+      data[:pid] = pid if pid
       data
     end
   end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -102,6 +102,8 @@ module Kontena
             puts "    #{opt}: #{value}"
           end
 
+          puts "  pid: #{service['pid']}"
+
           puts "  containers:"
           result = client(token).get("services/#{parse_service_id(service_id)}/containers")
           result['containers'].each do |container|

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -27,6 +27,8 @@ module Kontena::Cli::Services
     option "--deploy-strategy", "STRATEGY", "Deploy strategy to use (ha, random)"
     option "--deploy-wait-for-port", "PORT", "Wait for port to respond when deploying"
     option "--deploy-min-health", "FLOAT", "The minimum percentage (0.0 - 1.0) of healthy instances that do not sacrifice overall service availability while deploying"
+    option "--pid", "PID", "Pid namespace to use"
+
 
     def execute
       require_api_url
@@ -63,6 +65,7 @@ module Kontena::Cli::Services
       data[:deploy_opts][:min_health] = deploy_min_health.to_f if deploy_min_health
       data[:deploy_opts][:wait_for_port] = deploy_wait_for_port.to_i if deploy_wait_for_port
       data.delete(:deploy_opts) if data[:deploy_opts].empty?
+      data[:pid] = pid if pid
       data
     end
   end

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -28,6 +28,7 @@ class GridService
   field :log_driver, type: String
   field :log_opts, type: Hash, default: {}
   field :devices, type: Array, default: []
+  field :pid, type: String
 
   field :strategy, type: String, default: 'ha'
 

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -74,6 +74,7 @@ module GridServices
           float :min_health
         end
       end
+      string :pid, matches: /^(host)$/
     end
 
     def validate

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -66,6 +66,7 @@ module GridServices
           float :min_health
         end
       end
+      string :pid, matches: /^(host)$/
     end
 
     def validate

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -50,7 +50,8 @@ module Docker
         volumes_from: grid_service.volumes_from,
         net: grid_service.net,
         log_driver: grid_service.log_driver,
-        log_opts: grid_service.log_opts
+        log_opts: grid_service.log_opts,
+        pid: grid_service.pid
       }
       spec[:env] = build_env
       overlay_cidr = nil

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -25,3 +25,4 @@ json.log_driver grid_service.log_driver
 json.log_opts grid_service.log_opts
 json.strategy grid_service.strategy
 json.deploy_opts grid_service.deploy_opts
+json.pid grid_service.pid

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -61,7 +61,7 @@ describe '/v1/services' do
         id created_at updated_at image affinity name stateful user
         container_count cmd entrypoint ports env memory memory_swap cpu_shares
         volumes volumes_from cap_add cap_drop state grid_id links log_driver log_opts
-        strategy deploy_opts
+        strategy deploy_opts pid
       ).sort)
       expect(json_response['id']).to eq(redis_service.to_path)
       expect(json_response['image']).to eq(redis_service.image_name)

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 describe GridService do
   it { should be_timestamped_document }
   it { should have_fields(:image_name, :name, :user, :entrypoint, :state,
-                          :net, :log_driver).of_type(String) }
+                          :net, :log_driver, :pid).of_type(String) }
   it { should have_fields(:container_count, :memory,
                           :memory_swap, :cpu_shares).of_type(Fixnum) }
   it { should have_fields(:affinity, :cmd, :ports, :env, :volumes, :volumes_from,


### PR DESCRIPTION
Pid option allows to put the service containers into host pid namespace. Needed for example for Elastic Topbeat agent to pull host level process stats.