### PR TITLE
Post-start service hooks

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -6,7 +6,8 @@ module Kontena
                   :labels, :stateful, :image_name, :user, :cmd, :entrypoint, :memory,
                   :memory_swap, :cpu_shares, :privileged, :cap_add, :cap_drop,
                   :devices, :ports, :env, :volumes, :volumes_from, :net,
-                  :log_driver, :log_opts, :image_credentials, :pid
+                  :log_driver, :log_opts, :image_credentials, :pid,
+                  :hooks
 
       # @param [Hash] attrs
       def initialize(attrs = {})
@@ -36,6 +37,7 @@ module Kontena
         @log_driver = attrs['log_driver']
         @log_opts = attrs['log_opts']
         @pid = attrs['pid']
+        @hooks = attrs['hooks'] || []
       end
 
       # @return [String, NilClass]

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -150,6 +150,8 @@ module Kontena::Cli::Apps
         data[:deploy] = deploy
       end
 
+      data[:hooks] = options['hooks'] || {}
+
       data
     end
 

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -45,66 +45,101 @@ module Kontena
           puts "    min_health: #{service['deploy_opts']['min_health']}"
           puts "  dns: #{service['name']}.#{grid}.kontena.local"
 
-          puts "  affinity: "
-          service['affinity'].to_a.each do |a|
-            puts "    - #{a}"
-          end
-
-          if service['cmd']
-            puts "  cmd: #{service['cmd'].join(' ')}"
-          else
-            puts "  cmd: "
-          end
-
-          puts "  env: "
-          service['env'].to_a.each do |e|
-            if e.length > 50
-              puts "    - #{e[0..50]}..."
-            else
-              puts "    - #{e}"
+          if service['affinity'].to_a.size > 0
+            puts "  affinity: "
+            service['affinity'].to_a.each do |a|
+              puts "    - #{a}"
             end
           end
 
-          puts "  ports:"
-          service['ports'].to_a.each do |p|
-            puts "    - #{p['node_port']}:#{p['container_port']}/#{p['protocol']}"
+          unless service['cmd'].to_s.empty?
+            if service['cmd']
+              puts "  cmd: #{service['cmd'].join(' ')}"
+            else
+              puts "  cmd: "
+            end
           end
 
-          puts "  volumes:"
-          service['volumes'].to_a.each do |v|
-            puts "    - #{v}"
+          if service['hooks'].to_a.size > 0
+            puts "  hooks: "
+            service['hooks'].to_a.each do |hook|
+                puts "    - name: #{hook['name']}"
+                puts "      type: #{hook['type']}"
+                puts "      cmd: #{hook['cmd']}"
+                puts "      oneshot: #{hook['oneshot']}"
+            end
           end
 
-          puts "  volumes_from:"
-          service['volumes_from'].to_a.each do |v|
-            puts "    - #{v}"
+          if service['env'].to_a.size > 0
+            puts "  env: "
+            service['env'].to_a.each do |e|
+              if e.length > 50
+                puts "    - #{e[0..50]}..."
+              else
+                puts "    - #{e}"
+              end
+            end
           end
 
-          puts "  links: "
-          service['links'].to_a.each do |l|
-            puts "    - #{l['alias']}"
+          unless service['net'].to_s.empty?
+            puts "  net: #{service['net']}"
           end
 
-          puts "  cap_add:"
-          service['cap_add'].to_a.each do |c|
-            puts "    - #{c}"
+          if service['ports'].to_a.size > 0
+            puts "  ports:"
+            service['ports'].to_a.each do |p|
+              puts "    - #{p['node_port']}:#{p['container_port']}/#{p['protocol']}"
+            end
           end
 
-          puts "  cap_drop:"
-          service['cap_drop'].to_a.each do |c|
-            puts "    - #{c}"
+          if service['volumes'].to_a.size > 0
+            puts "  volumes:"
+            service['volumes'].to_a.each do |v|
+              puts "    - #{v}"
+            end
           end
 
-          puts "  log_driver: #{service['log_driver']}"
-
-          puts "  log_opts:"
-          service['log_opts'].each do |opt, value|
-            puts "    #{opt}: #{value}"
+          if service['volumes_from'].to_a.size > 0
+            puts "  volumes_from:"
+            service['volumes_from'].to_a.each do |v|
+              puts "    - #{v}"
+            end
           end
 
-          puts "  pid: #{service['pid']}"
+          if service['links'].to_a.size > 0
+            puts "  links: "
+            service['links'].to_a.each do |l|
+              puts "    - #{l['alias']}"
+            end
+          end
 
-          puts "  containers:"
+          if service['cap_add'].to_a.size > 0
+            puts "  cap_add:"
+            service['cap_add'].to_a.each do |c|
+              puts "    - #{c}"
+            end
+          end
+
+          if service['cap_drop'].to_a.size > 0
+            puts "  cap_drop:"
+            service['cap_drop'].to_a.each do |c|
+              puts "    - #{c}"
+            end
+          end
+
+          unless service['log_driver'].to_s.empty?
+            puts "  log_driver: #{service['log_driver']}"
+            puts "  log_opts:"
+            service['log_opts'].each do |opt, value|
+              puts "    #{opt}: #{value}"
+            end
+          end
+
+          unless service['pid'].to_s.empty?
+            puts "  pid: #{service['pid']}"
+          end
+
+          puts "  instances:"
           result = client(token).get("services/#{parse_service_id(service_id)}/containers")
           result['containers'].each do |container|
             puts "    #{container['name']}:"

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -152,7 +152,7 @@ yml
               :ports=>[{:container_port=>"80", :node_port=>"80", :protocol=>"tcp"}]
           }
 
-          expect(subject).to receive(:create_service).with('1234567', '1', data)
+          expect(subject).to receive(:create_service).with('1234567', '1', hash_including(data))
           subject.run([])
         end
       end
@@ -177,7 +177,7 @@ yml
               :ports=>[{:container_port=>"80", :node_port=>"80", :protocol=>"tcp"}]
           }
 
-          expect(subject).to receive(:create_service).with('1234567', '1', data)
+          expect(subject).to receive(:create_service).with('1234567', '1', hash_including(data))
           subject.run([])
         end
       end
@@ -197,14 +197,20 @@ yml
             :ports=>[{:container_port => "80", :node_port => "80", :protocol => "tcp"}]
         }
 
-        expect(subject).to receive(:create_service).with('1234567', '1', data)
+        expect(subject).to receive(:create_service).with('1234567', '1', hash_including(data))
         subject.run([])
       end
 
       it 'creates mysql service before wordpress' do
         allow(subject).to receive(:current_dir).and_return("kontena-test")
-        data = {:name =>"kontena-test-mysql", :image=>'mysql:5.6', :env=>["MYSQL_ROOT_PASSWORD=kontena-test_secret"], :container_count=>nil, :stateful=>true}
-        expect(subject).to receive(:create_service).with('1234567', '1', data)
+        data = {
+            :name =>"kontena-test-mysql",
+            :image=>'mysql:5.6',
+            :env=>["MYSQL_ROOT_PASSWORD=kontena-test_secret"],
+            :container_count=>nil,
+            :stateful=>true,
+        }
+        expect(subject).to receive(:create_service).with('1234567', '1', hash_including(data))
 
         subject.run([])
       end
@@ -222,7 +228,7 @@ yml
             :links=>[{:name=>"kontena-test-mysql", :alias=>"mysql"}],
             :ports=>[{:container_port=>"80", :node_port=>"80", :protocol=>"tcp"}]
         }
-        expect(subject).to receive(:create_service).with('1234567', '1', data)
+        expect(subject).to receive(:create_service).with('1234567', '1', hash_including(data))
 
         subject.run([])
       end
@@ -244,6 +250,13 @@ yml
           subject.run(['wordpress'])
         end
       end
+    end
+  end
+
+  describe '#parse_data' do
+    it 'adds empty hooks hash if not defined' do
+      data = {'image' => 'foo/bar:latest'}
+      subject.send(:parse_data, data)
     end
   end
 end

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -39,6 +39,7 @@ class GridService
   has_many :container_stats
   has_many :audit_logs
   embeds_many :grid_service_links
+  embeds_many :hooks, class_name: 'GridServiceHook'
   embeds_one :deploy_opts, class_name: 'GridServiceDeployOpt', autobuild: true
 
   index({ grid_id: 1 })

--- a/server/app/models/grid_service_hook.rb
+++ b/server/app/models/grid_service_hook.rb
@@ -1,0 +1,19 @@
+class GridServiceHook
+  include Mongoid::Document
+
+  field :name, type: String
+  field :type, type: String
+  field :cmd, type: String
+  field :instances, type: Array, default: ['*']
+  field :oneshot, type: Boolean, default: false
+  field :done, type: Array, default: []
+
+  embedded_in :grid_service
+
+  # @param [Fixnum, String] instance_number
+  # @return [Boolean]
+  def done_for?(instance_number)
+    return false unless self.oneshot
+    self.done.include?(instance_number.to_s)
+  end
+end

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -18,5 +18,32 @@ module GridServices
       end
       grid_service_links
     end
+
+    # @param [Array<GridServiceHook>] existing_hooks
+    # @return [Array<GridServiceHook>]
+    def build_grid_service_hooks(existing_hooks)
+      service_hooks = []
+      self.hooks.each do |type, hooks|
+        hooks.each do |hook|
+          service_hook = existing_hooks.find{|h|
+            h.name == hook['name'] && h.type == type
+          }
+          unless service_hook
+            service_hook = GridServiceHook.new(
+              type: type,
+              name: hook['name']
+            )
+          end
+          service_hook.attributes = {
+            cmd: hook['cmd'],
+            instances: hook['instances'].split(','),
+            oneshot: hook['oneshot']
+          }
+          service_hooks << service_hook
+        end
+      end
+
+      service_hooks
+    end
   end
 end

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -75,6 +75,20 @@ module GridServices
         end
       end
       string :pid, matches: /^(host)$/
+      hash :hooks do
+        optional do
+          array :post_start do
+            hash do
+              required do
+                string :name
+                string :cmd
+                string :instances
+                boolean :oneshot, default: false
+              end
+            end
+          end
+        end
+      end
     end
 
     def validate
@@ -97,9 +111,15 @@ module GridServices
       attributes = self.inputs.clone
       attributes.delete(:current_user)
       attributes[:image_name] = attributes.delete(:image)
+
       attributes.delete(:links)
       if self.links
         attributes[:grid_service_links] = build_grid_service_links(self.grid, self.links)
+      end
+
+      attributes.delete(:hooks)
+      if self.hooks
+        attributes[:hooks] = self.build_grid_service_hooks([])
       end
 
       grid_service = GridService.new(attributes)

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -67,6 +67,20 @@ module GridServices
         end
       end
       string :pid, matches: /^(host)$/
+      hash :hooks do
+        optional do
+          array :post_start do
+            hash do
+              required do
+                string :name
+                string :cmd
+                string :instances
+                boolean :oneshot, default: false
+              end
+            end
+          end
+        end
+      end
     end
 
     def validate
@@ -104,8 +118,13 @@ module GridServices
       attributes[:log_opts] = self.log_opts if self.log_opts
       attributes[:devices] = self.devices if self.devices
       attributes[:deploy_opts] = self.deploy_opts if self.deploy_opts
+
       if self.links
         attributes[:grid_service_links] = build_grid_service_links(self.grid_service.grid, self.links)
+      end
+
+      if self.hooks
+        attributes[:hooks] = self.build_grid_service_hooks(self.grid_service.hooks.to_a)
       end
 
       grid_service.attributes = attributes

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -63,6 +63,7 @@ module Docker
         labels['io.kontena.container.overlay_cidr'] = overlay_cidr.to_s
       end
       spec[:labels] = labels
+      spec[:hooks] = build_hooks(instance_number)
 
       spec
     rescue => exc
@@ -130,6 +131,22 @@ module Docker
         labels['io.kontena.load_balancer.mode'] = mode
       end
       labels
+    end
+
+    # @return [Array<Hash>]
+    def build_hooks(instance_number)
+      hooks = []
+      grid_service.hooks.each do |hook|
+        if hook.instances.include?('*') || hook.instances.include?(instance_number.to_s)
+          unless hook.done_for?(instance_number.to_s)
+            hooks << {type: hook.type, cmd: hook.cmd}
+            hook.push(:done => instance_number.to_s) if hook.oneshot
+          end
+        end
+      end
+      hooks
+    rescue => exc
+      puts exc.message
     end
 
     def service_container

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -9,6 +9,7 @@ json.user grid_service.user
 json.container_count grid_service.container_count
 json.cmd grid_service.cmd
 json.entrypoint grid_service.entrypoint
+json.net grid_service.net
 json.ports grid_service.ports
 json.env grid_service.env
 json.memory grid_service.memory
@@ -30,3 +31,4 @@ json.instances do
   json.total grid_service.containers.count
   json.running grid_service.containers.where('state.running' => true).count
 end
+json.hooks grid_service.hooks.as_json(only: [:name, :type, :cmd, :oneshot])

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -61,7 +61,7 @@ describe '/v1/services' do
         id created_at updated_at image affinity name stateful user
         container_count cmd entrypoint ports env memory memory_swap cpu_shares
         volumes volumes_from cap_add cap_drop state grid_id links log_driver log_opts
-        strategy deploy_opts pid instances
+        strategy deploy_opts pid instances net hooks
       ).sort)
       expect(json_response['id']).to eq(redis_service.to_path)
       expect(json_response['image']).to eq(redis_service.image_name)

--- a/server/spec/models/grid_service_hook_spec.rb
+++ b/server/spec/models/grid_service_hook_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../spec_helper'
+
+describe GridServiceHook do
+  it { should be_embedded_in(:grid_service) }
+  it { should have_fields(:name, :type).of_type(String) }
+  it { should have_fields(:instances, :done).of_type(Array) }
+  it { should have_fields(:oneshot).of_type(Mongoid::Boolean) }
+end

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -13,6 +13,7 @@ describe GridService do
 
   it { should belong_to(:grid) }
   it { should embed_many(:grid_service_links) }
+  it { should embed_many(:hooks) }
   it { should embed_one(:deploy_opts) }
   it { should have_many(:containers) }
   it { should have_many(:container_logs) }

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -34,4 +34,45 @@ describe GridServices::Update do
       }.to change{ redis_service.reload.affinity }.to(['az==b1'])
     end
   end
+
+  describe '#build_grid_service_hooks' do
+    let(:subject) do
+      described_class.new(
+        current_user: user,
+        grid_service: redis_service,
+        hooks: {
+          post_start: [
+            {
+              name: 'foo',
+              cmd: 'sleep 10',
+              instances: ["1", "2"],
+              oneshot: false
+            }
+          ]
+        }
+      )
+    end
+
+    it 'builds hook' do
+      hooks = subject.build_grid_service_hooks
+      expect(hooks.size).to eq(1)
+      expect(hooks[0].cmd).to eq('sleep 10')
+    end
+
+    it 'updates existing hook' do
+      org_hook = GridServiceHook.new(
+        name: 'foo',
+        type: 'post_start',
+        cmd: 'sleep 1',
+        instances: ['*'],
+        oneshot: false
+      )
+      redis_service.hooks << org_hook
+      redis_service.save
+      hooks = subject.build_grid_service_hooks(redis_service.hooks.to_a)
+      expect(hooks.size).to eq(1)
+      expect(hooks[0].id).to eq(org_hook.id)
+      expect(hooks[0].cmd).to eq('sleep 10')
+    end
+  end
 end

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -54,7 +54,7 @@ describe GridServices::Update do
     end
 
     it 'builds hook' do
-      hooks = subject.build_grid_service_hooks
+      hooks = subject.build_grid_service_hooks([])
       expect(hooks.size).to eq(1)
       expect(hooks[0].cmd).to eq('sleep 10')
     end

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -105,6 +105,10 @@ describe Docker::ServiceCreator do
       expect(service_spec).to include(:log_opts => {})
     end
 
+    it 'includes hooks' do
+      expect(service_spec).to include(:hooks => [])
+    end
+
     describe '[:env]' do
       let(:env) { service_spec[:env] }
 


### PR DESCRIPTION
This PR implements post_start hooks for service.

```
mongo:
  image: mongo:3.0
  stateful: true
  command: --replSet kontena --smallfiles
  instances: 3
  hooks:
    post_start:
      - cmd: sleep 10
        name: sleep
        instances: 1
        oneshot: true
      - cmd: mongo --eval "printjson(rs.initiate());"
        name: rs_initiate
        instances: 1
        oneshot: true
      - cmd: mongo --eval "printjson(rs.add('cli-mongo-2'))"
        name: rs_add2
        instances: 1
        oneshot: true
      - cmd: mongo --eval "printjson(rs.add('cli-mongo-3'))"
        name: rs_add3
        instances: 1
        oneshot: true
```