### PR TITLE
add env option to grid

### DIFF
--- a/cli/lib/kontena/cli/grid_command.rb
+++ b/cli/lib/kontena/cli/grid_command.rb
@@ -5,6 +5,7 @@ require_relative 'grids/show_command'
 require_relative 'grids/logs_command'
 require_relative 'grids/remove_command'
 require_relative 'grids/current_command'
+require_relative 'grids/env_command'
 require_relative 'grids/audit_log_command'
 require_relative 'grids/list_users_command'
 require_relative 'grids/add_user_command'
@@ -19,6 +20,7 @@ class Kontena::Cli::GridCommand < Clamp::Command
   subcommand "logs", "Show logs from grid containers", Kontena::Cli::Grids::LogsCommand
   subcommand "remove", "Remove a grid", Kontena::Cli::Grids::RemoveCommand
   subcommand "current", "Show current grid details", Kontena::Cli::Grids::CurrentCommand
+  subcommand "env", "Show the current grid environment details", Kontena::Cli::Grids::EnvCommand
   subcommand "audit-log", "Show audit log of the current grid", Kontena::Cli::Grids::AuditLogCommand
   subcommand "list-users", "List current grid users", Kontena::Cli::Grids::ListUsersCommand
   subcommand "add-user", "Add user to the current grid", Kontena::Cli::Grids::AddUserCommand

--- a/cli/lib/kontena/cli/grids/env_command.rb
+++ b/cli/lib/kontena/cli/grids/env_command.rb
@@ -1,0 +1,22 @@
+require_relative 'common'
+
+module Kontena::Cli::Grids
+  class EnvCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Common
+
+    option ["-e", "--export"], :flag, "Add export", default: false
+
+    def execute
+      require_api_url
+      if current_grid.nil?
+        abort 'No grid selected. To select grid, please run: kontena grid use <grid name>'
+      else
+        grid = client(require_token).get("grids/#{current_grid}")
+        prefix = export? ? 'export ' : ''
+        puts "#{prefix}KONTENA_URI=#{settings['server']['url'].sub('http', 'ws')}"
+        puts "#{prefix}KONTENA_TOKEN=#{grid['token']}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
optional -e flag to prefix with 'export'
lists KONTENA_URI and KONTENA_TOKEN either for:
- `eval "$(kontena grid env -e)"`
- or `kontena grid env > kontena.env`
to use it for further node deployment