### PR TITLE
Cleanup only non-initial stateless nodes

### DIFF
--- a/server/app/jobs/node_cleanup_job.rb
+++ b/server/app/jobs/node_cleanup_job.rb
@@ -33,7 +33,7 @@ class NodeCleanupJob
   def cleanup_stale_nodes
     with_dlock('node_cleanup_job:stale_nodes', 0) do
       HostNode.where(:last_seen_at.lt => 1.hour.ago).each do |node|
-        unless node.connected?
+        if !node.grid.initial_node?(node) && !node.connected? && !node.stateful?
           node.destroy
         end
       end

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -41,22 +41,27 @@ class Grid
     (1..254).to_a - reserved_numbers
   end
 
+  # @return [String]
   def overlay_network_size
     self.overlay_cidr.split('/')[1]
   end
 
+  # @return [String]
   def overlay_network_ip
     self.overlay_cidr.split('/')[0]
   end
 
+  # @return [Array<IPAddr>]
   def all_overlay_ips
     @all_overlay_ips ||= (IPAddr.new(self.overlay_cidr).to_range.map(&:to_s) - IPAddr.new("#{self.overlay_network_ip}/#{OVERLAY_BRIDGE_NETWORK_SIZE}").to_range.map(&:to_s))
   end
 
+  # @return [Array<IPAddr>]
   def reserved_overlay_ips
-    reserved_ips = self.containers.map{|c| c.overlay_cidr.try(:ip) }.delete_if{|ip| ip.nil?}
+    self.containers.map{|c| c.overlay_cidr.try(:ip) }.delete_if{|ip| ip.nil?}
   end
 
+  # @return [Array<IPAddr>]
   def available_overlay_ips
     self.all_overlay_ips - self.reserved_overlay_ips
   end
@@ -66,6 +71,12 @@ class Grid
   # @return [Boolean]
   def has_initial_nodes?
     self.host_nodes.where(node_number: {:$lte => self.initial_size}).count == self.initial_size
+  end
+
+  # @param [HostNode] node
+  # @return [Boolean]
+  def initial_node?(node)
+    node.node_number <= self.initial_size.to_i
   end
 
   private

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -69,8 +69,14 @@ class HostNode
     end
   end
 
+  # @return [Boolean]
   def connected?
     self.connected == true
+  end
+
+  # @return [Boolean]
+  def stateful?
+    self.containers.unscoped.any?{|container| container.grid_service && container.grid_service.stateful? }
   end
 
   ##

--- a/server/spec/jobs/node_cleanup_job_spec.rb
+++ b/server/spec/jobs/node_cleanup_job_spec.rb
@@ -4,15 +4,38 @@ describe NodeCleanupJob do
   before(:each) { Celluloid.boot }
   after(:each) { Celluloid.shutdown }
 
+  let(:grid) { Grid.create!(name: 'test') }
+
   describe '#cleanup_stale_nodes' do
     it 'removes old nodes' do
-      HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago)
-      HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.hours.ago)
-      HostNode.create!(name: "node-3", connected: true, last_seen_at: 10.minutes.ago)
+      HostNode.create!(name: "node-1", grid: grid, connected: true, last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-2", grid: grid, connected: false, last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-3", grid: grid, connected: true, last_seen_at: 10.minutes.ago)
 
       expect {
         subject.cleanup_stale_nodes
       }.to change{ HostNode.count }.by(-1)
+    end
+
+    it 'does not remove initial node' do
+      HostNode.create!(name: "node-1", grid: grid, connected: false, last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-2", grid: grid, connected: true, last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-3", grid: grid, connected: true, last_seen_at: 10.minutes.ago)
+
+      expect {
+        subject.cleanup_stale_nodes
+      }.not_to change{ HostNode.count }
+    end
+
+    it 'does not remove node with stateful services' do
+      HostNode.create!(name: "node-1", grid: grid, connected: false, last_seen_at: 2.hours.ago)
+      node2 = HostNode.create!(name: "node-2", grid: grid, connected: false, last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-3", grid: grid, connected: true, last_seen_at: 10.minutes.ago)
+      service = GridService.create!(name: 'test', image_name: 'foo/bar:latest', grid: grid, stateful: true)
+      service.containers.create!(name: 'test-1', host_node: node2)
+      expect {
+        subject.cleanup_stale_nodes
+      }.not_to change{ HostNode.count }
     end
   end
 end

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -87,4 +87,18 @@ describe Grid do
       expect(grid.has_initial_nodes?).to eq(false)
     end
   end
+
+  describe '#initial_node``' do
+    let(:grid) { Grid.create!(name: 'test', initial_size: 3) }
+
+    it 'returns true if node is initial member' do
+      node = HostNode.create(grid: grid, node_id: 'aa', node_number: 2)
+      expect(grid.initial_node?(node)).to be_truthy
+    end
+
+    it 'returns false if node is not initial member' do
+      node = HostNode.create(grid: grid, node_id: 'aa', node_number: 4)
+      expect(grid.initial_node?(node)).to be_falsey
+    end
+  end
 end

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -30,6 +30,33 @@ describe HostNode do
     end
   end
 
+  describe '#stateful?' do
+    let(:grid) { Grid.create!(name: 'test') }
+    let(:stateful_service) { GridService.create!(name: 'stateful', image_name: 'foo/bar:latest', grid: grid, stateful: true) }
+    let(:stateless_service) { GridService.create!(name: 'stateless', image_name: 'foo/bar:latest', grid: grid, stateful: false) }
+    let(:node) { HostNode.create(name: 'node-1', grid: grid)}
+
+    it 'returns false by default' do
+      expect(subject.stateful?).to be_falsey
+    end
+
+    it 'returns true if node has stateful service' do
+      stateful_service.containers.create!(name: 'stateful-1', host_node: node)
+      expect(node.stateful?).to be_truthy
+    end
+
+    it 'returns false if node has stateless service' do
+      stateless_service.containers.create!(name: 'stateless-1', host_node: node)
+      expect(node.stateful?).to be_falsey
+    end
+
+    it 'returns true if node has stateful and stateless service' do
+      stateful_service.containers.create!(name: 'stateful-1', host_node: node)
+      stateless_service.containers.create!(name: 'stateless-1', host_node: node)
+      expect(node.stateful?).to be_truthy
+    end
+  end
+
   describe '#attributes_from_docker' do
     it 'sets name' do
       expect {


### PR DESCRIPTION
This PR changes automatic node cleanup logic a bit. From now on only non-initial stateless nodes are automatically removed from master.

stateless node: node that does not have any stateful services