### PR TITLE
Map container to node always on update

### DIFF
--- a/server/app/services/agent/container_info_mapper.rb
+++ b/server/app/services/agent/container_info_mapper.rb
@@ -17,12 +17,21 @@ module Agent
       container = grid.containers.unscoped.find_by(container_id: container_id)
       if container
         return false if container.deleted?
-        self.update_container_attributes(container, info)
+        self.update_service_container(node_id, container, info)
       elsif !labels['io.kontena.service.id'].nil?
         self.create_service_container(node_id, info)
       else
         self.create_container(node_id, info)
       end
+    end
+
+    # @param [String] node_id
+    # @param [Container] container
+    # @param [Hash] info
+    def update_service_container(node_id, container, info)
+      node = grid.host_nodes.find_by(node_id: node_id)
+      container.host_node = node if node
+      self.update_container_attributes(container, info)
     end
 
     # @param [Container] container

--- a/server/spec/services/agent/container_info_mapper_spec.rb
+++ b/server/spec/services/agent/container_info_mapper_spec.rb
@@ -3,6 +3,7 @@ require_relative '../../spec_helper'
 describe Agent::ContainerInfoMapper do
   let(:grid) { Grid.create! }
   let(:node) { HostNode.create!(name: 'node-1', node_id: 'aaa', grid: grid) }
+  let(:node2) { HostNode.create!(name: 'node-2', node_id: 'bbb', grid: grid) }
   let(:service) do
     GridService.create!(
       grid: grid,
@@ -12,14 +13,27 @@ describe Agent::ContainerInfoMapper do
   end
   let(:subject) { described_class.new(grid) }
 
-  describe '#from_agent' do
+  describe '#update_service_container' do
+    let(:container) do
+      service.containers.create!(name: 'app-1', host_node: node, container_id: SecureRandom.hex(32))
+    end
 
-
+    it 'updates container host_node' do
+      data = {
+          'Id' => container.container_id,
+          'Config' => {
+              'Labels' => {}
+          }
+      }
+      node2
+      subject.update_service_container('bbb', container, data)
+      expect(container.reload.host_node).to eq(node2)
+    end
   end
 
   describe '#create_service_container' do
     it 'creates a new container to grid' do
-      data= {
+      data = {
         'Id' => SecureRandom.hex(32),
         'Config' => {
           'Labels' => {


### PR DESCRIPTION
Master should always try to update container node when it receives updated container information from agent. Reason: in some (really rare) cases node might have been gone so long that master has removed node information.