### PR TITLE
Multiple masters on cli

### DIFF
--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Grids
     # @param [Hash] grid
     def print_grid(grid)
       puts "#{grid['name']}:"
-      puts "  uri: #{settings['server']['url'].sub('http', 'ws')}"
+      puts "  uri: #{self.current_master['url'].sub('http', 'ws')}"
       puts "  token: #{grid['token']}"
       puts "  users: #{grid['user_count']}"
       puts "  nodes: #{grid['node_count']}"

--- a/cli/lib/kontena/cli/logout_command.rb
+++ b/cli/lib/kontena/cli/logout_command.rb
@@ -2,7 +2,6 @@ class Kontena::Cli::LogoutCommand < Clamp::Command
   include Kontena::Cli::Common
 
   def execute
-    settings['server'].delete('token')
-    save_settings
+    self.access_token = nil
   end
 end

--- a/cli/lib/kontena/cli/master/list_command.rb
+++ b/cli/lib/kontena/cli/master/list_command.rb
@@ -1,0 +1,18 @@
+module Kontena::Cli::Master
+  class ListCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    def execute
+      puts '%-24s %-30s' % ['Name', 'Url']
+      current_server = settings['current_server']
+      settings['servers'].each do |server|
+        if server['name'] == current_server
+          name = "* #{server['name']}"
+        else
+          name = server['name']
+        end
+        puts '%-24s %-30s' % [name, server['url']]
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -1,0 +1,26 @@
+module Kontena::Cli::Master
+  class UseCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    parameter "NAME", "Master name to use"
+
+    def execute
+      master = find_master_by_name(name)
+      if !master.nil?
+        self.current_master = master['name']
+        puts "Using master: #{master['name'].cyan}"
+        puts "URL: #{master['url'].cyan}"
+      else
+        abort "Could not resolve master by name [#{name}]. For a list of known masters please run: kontena master list".colorize(:red)
+      end
+    end
+
+    def find_master_by_name(name)
+      settings['servers'].each do |server|
+        return server if server['name'] == name
+      end
+    end
+
+  end
+
+end

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -2,6 +2,8 @@ require_relative 'master/vagrant_command'
 require_relative 'master/aws_command'
 require_relative 'master/digital_ocean_command'
 require_relative 'master/azure_command'
+require_relative 'master/use_command'
+require_relative 'master/list_command'
 
 class Kontena::Cli::MasterCommand < Clamp::Command
 
@@ -9,6 +11,8 @@ class Kontena::Cli::MasterCommand < Clamp::Command
   subcommand "aws", "AWS specific commands", Kontena::Cli::Master::AwsCommand
   subcommand "digitalocean", "DigitalOcean specific commands", Kontena::Cli::Master::DigitalOceanCommand
   subcommand "azure", "Azure specific commands", Kontena::Cli::Master::AzureCommand
+  subcommand ["list", "ls"], "List masters where client has logged in", Kontena::Cli::Master::ListCommand
+  subcommand "use", "Switch to use selected master", Kontena::Cli::Master::UseCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/whoami_command.rb
+++ b/cli/lib/kontena/cli/whoami_command.rb
@@ -10,7 +10,8 @@ class Kontena::Cli::WhoamiCommand < Clamp::Command
     end
 
     require_api_url
-    puts "Master: #{settings['server']['url']}"
+    puts "Master: #{self.current_master['name']}"
+    puts "URL: #{api_url}"
     token = require_token
     response = client(token).get('user')
     puts "User: #{response['email']}"

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -8,7 +8,28 @@ describe Kontena::Cli::Apps::DeployCommand do
   end
 
   let(:settings) do
-    {'server' => {'url' => 'http://kontena.test', 'token' => token}}
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'some_master', 'url' => 'some_master'},
+         {'name' => 'alias', 'url' => 'someurl', 'token' => token}
+     ]
+    }
+  end
+
+  let(:settings_without_api_url) do
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'alias', 'token' => token}
+     ]
+    }
+  end
+
+  let(:settings_without_token) do
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'alias', 'url' => 'url'}
+     ]
+    }
   end
 
   let(:token) do
@@ -89,14 +110,14 @@ yml
   describe '#deploy' do
     context 'when api_url is nil' do
       it 'raises error' do
-        allow(subject).to receive(:settings).and_return({'server' => {}})
+        allow(subject).to receive(:settings).and_return(settings_without_api_url)
         expect{subject.run([])}.to raise_error(ArgumentError)
       end
     end
 
     context 'when token is nil' do
       it 'raises error' do
-        allow(subject).to receive(:settings).and_return({'server' => {'url' => 'http://kontena.test'}})
+        allow(subject).to receive(:settings).and_return(settings_without_token)
         expect{subject.run([])}.to raise_error(ArgumentError)
       end
     end

--- a/cli/spec/kontena/cli/app/scale_spec.rb
+++ b/cli/spec/kontena/cli/app/scale_spec.rb
@@ -8,7 +8,12 @@ describe Kontena::Cli::Apps::ScaleCommand do
   end
 
   let(:settings) do
-    {'server' => {'url' => 'http://kontena.test', 'token' => token}}
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'some_master', 'url' => 'some_master'},
+         {'name' => 'alias', 'url' => 'someurl', 'token' => token}
+     ]
+    }
   end
 
   let(:token) do

--- a/cli/spec/kontena/cli/common_spec.rb
+++ b/cli/spec/kontena/cli/common_spec.rb
@@ -3,6 +3,10 @@ require "kontena/cli/common"
 
 describe Kontena::Cli::Common do
 
+  let(:masters) do
+
+  end
+
   let(:subject) do
     Class.new do
       include Kontena::Cli::Common
@@ -10,12 +14,20 @@ describe Kontena::Cli::Common do
   end
 
   before(:each) do
-    allow(subject).to receive(:settings).and_return({'server' => {}})
+    allow(subject).to receive(:settings).and_return({'current_server' => 'default',
+                                                     'servers' => [{}]
+                                                    })
     allow(subject).to receive(:save_settings)
   end
 
   describe '#current_grid' do
     it 'returns nil by default' do
+      allow(subject).to receive(:settings).and_return({'current_server' => 'alias',
+                                                       'servers' => [
+                                                           {'name' => 'some_master', 'url' => 'some_master'},
+                                                           {'name' => 'alias', 'url' => 'someurl'}
+                                                       ]
+                                                      })
       expect(subject.current_grid).to eq(nil)
     end
 
@@ -23,6 +35,17 @@ describe Kontena::Cli::Common do
       expect(ENV).to receive(:[]).with('KONTENA_GRID').and_return('foo')
       expect(subject.current_grid).to eq('foo')
     end
+
+    it 'returns grid from json' do
+      allow(subject).to receive(:settings).and_return({'current_server' => 'alias',
+                                                       'servers' => [
+                                                           {'name' => 'some_master', 'url' => 'some_master'},
+                                                           {'name' => 'alias', 'url' => 'someurl', 'grid' => 'foo_grid'}
+                                                       ]
+                                                      })
+      expect(subject.current_grid).to eq('foo_grid')
+    end
+
   end
 
   describe '#api_url' do
@@ -49,5 +72,50 @@ describe Kontena::Cli::Common do
       expect(ENV).to receive(:[]).with('KONTENA_TOKEN').and_return('secret_token')
       expect(subject.require_token).to eq('secret_token')
     end
+  end
+
+  describe '#current_master' do
+    it 'return correct master info' do
+      allow(subject).to receive(:settings).and_return({'current_server' => 'alias',
+                                                       'servers' => [
+                                                           {'name' => 'some_master', 'url' => 'some_master'},
+                                                           {'name' => 'alias', 'url' => 'someurl'}
+                                                       ]
+                                                      })
+
+      expect(subject.current_master['url']).to eq('someurl')
+      expect(subject.current_master['name']).to eq('alias')
+
+    end
+  end
+
+  describe '#settings' do
+    it 'migrates old settings' do
+      RSpec::Mocks.space.proxy_for(subject).reset
+
+      allow(File).to receive(:exists?).and_return(true)
+      allow(File).to receive(:read).and_return('{
+        "server": {
+          "url": "https://master.domain.com:8443",
+          "grid": "my-grid",
+          "token": "kontena-token"
+        }
+      }')
+      expected_settings = {
+          'current_server' => 'default',
+          'servers' => [
+              {
+                  "url" => "https://master.domain.com:8443",
+                  "grid" => "my-grid",
+                  "token" => "kontena-token",
+                  "name" => "default"
+              }
+          ]
+      }
+      expect(File).to receive(:write).with(subject.settings_filename, JSON.pretty_generate(expected_settings))
+
+      subject.settings
+    end
+
   end
 end

--- a/cli/spec/kontena/cli/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/deploy_command_spec.rb
@@ -8,8 +8,30 @@ describe Kontena::Cli::DeployCommand do
   end
 
   let(:settings) do
-    {'server' => {'url' => 'http://kontena.test', 'token' => token}}
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'some_master', 'url' => 'some_master'},
+         {'name' => 'alias', 'url' => 'someurl', 'token' => token}
+     ]
+    }
   end
+
+  let(:settings_without_api_url) do
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'alias', 'token' => token}
+     ]
+    }
+  end
+
+  let(:settings_without_token) do
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'alias', 'url' => 'url'}
+     ]
+    }
+  end
+
 
   let(:token) do
     '1234567'
@@ -75,14 +97,14 @@ yml
   describe '#deploy' do
     context 'when api_url is nil' do
       it 'raises error' do
-        allow(subject).to receive(:settings).and_return({'server' => {}})
+        allow(subject).to receive(:settings).and_return(settings_without_api_url)
         expect{subject.run([])}.to raise_error(ArgumentError)
       end
     end
 
     context 'when token is nil' do
       it 'raises error' do
-        allow(subject).to receive(:settings).and_return({'server' => {'url' => 'http://kontena.test'}})
+        allow(subject).to receive(:settings).and_return(settings_without_token)
         expect{subject.run([])}.to raise_error(ArgumentError)
       end
     end
@@ -118,6 +140,10 @@ yml
       end
 
       context 'when yml file has multiple env files' do
+        before(:each) do
+          allow(subject).to receive(:settings).and_return(settings)
+        end
+
         it 'merges environment variables correctly' do
           allow(subject).to receive(:current_dir).and_return("kontena-test")
           allow(YAML).to receive(:load).and_return(services)

--- a/cli/spec/kontena/cli/login_command_spec.rb
+++ b/cli/spec/kontena/cli/login_command_spec.rb
@@ -4,6 +4,15 @@ require "kontena/cli/login_command"
 describe Kontena::Cli::LoginCommand do
   describe '#register' do
 
+    let(:settings) do
+      {'current_server' => 'alias',
+       'servers' => [
+           {'name' => 'some_master', 'url' => 'some_master'},
+           {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
+       ]
+      }
+    end
+
     let(:auth_client) do
       double(Kontena::Client)
     end
@@ -11,6 +20,7 @@ describe Kontena::Cli::LoginCommand do
     let(:subject) { described_class.new(File.basename($0)) }
 
     it 'asks email and password' do
+      allow(subject).to receive(:settings).and_return(settings)
       expect(subject).to receive(:ask).once.with('Email: ').and_return('john.doe@acme.io')
       allow(subject).to receive(:ask).once.with('Password: ').and_return('secret')
       allow(Kontena::Client).to receive(:new).and_return(auth_client)

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -1,0 +1,29 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/master/use_command'
+
+describe Kontena::Cli::Master::UseCommand do
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:valid_settings) do
+    {'current_server' => 'alias',
+     'servers' => [
+         {'name' => 'some_master', 'url' => 'some_master'},
+         {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
+     ]
+    }
+  end
+
+  describe '#use' do
+
+    it 'should update current master' do
+      allow(subject).to receive(:settings).and_return(valid_settings)
+      expect(subject).to receive(:current_master=).with('some_master')
+      subject.run(['some_master'])
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR implements support for working with multiple masters on cli.
Commands:
```
$ kontena master
...
    list, ls                      List masters where client has logged in
    use                           Switch to use selected master
```
```
$ kontena login --help
Usage:
    kontena login [OPTIONS] URL

Parameters:
    URL                           Kontena Master URI

Options:
    -n, --name NAME               Local alias name for the master. Default default

```
The -n flag specifies the local name for the master when logging in.

The local config file has the following model:
```
{
  "current_server": "test",
  "servers": [
    {
      "url": "https://1.2.3.4:8443",
      "token": "kontena-xyz",
      "grid": "test-grid",
      "name": "test"
    },
    {
      "url": "https://other.master.com:8443",
      "token": "kontena-zyx",
      "grid": "test-grid",
      "name": "other"
    }
  ]
}
```
The new functionality takes care of "migrating" the client config on first use and configures the currently know only master with a alias name `default`and naturally sets that as current_server.

There's few things I still intend to work on:
- Clean up the common.rb code, it's a bit messy atm
- Some more testing, especially on the common functionality

What about logout, should logout actually forget the master totally? Now it just removes the token but leaves the master info into the config file. Or should there be some command like: `kontena mster forget my-master`which then fully removes the info?


Signed-off-by: Jussi Nummelin <jussi.nummelin@gmail.com>