### PR TITLE
Append values to env if secrets have same name

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -236,8 +236,18 @@ module Kontena
       # @return [Array]
       def build_env
         env = self.env.dup
-        self.secrets.each do |s|
-          env << "#{s['name']}=#{s['value']}" if s['type'] == 'env'
+        secrets_hash = {}
+        self.secrets.select{|s| s['type'] == 'env'}.each do |s|
+          val = secrets_hash[s['name']]
+          if val.nil?
+            val = s['value']
+          else
+            val = "#{val}\n#{s['value']}"
+          end
+          secrets_hash[s['name']] = val
+        end
+        secrets_hash.each do |name, value|
+          env << "#{name}=#{value}"
         end
         env
       end

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -127,8 +127,14 @@ describe Kontena::Models::ServicePod do
       expect(subject.service_config['Env']).to include('KONTENA_SERVICE_NAME=redis-cache')
     end
 
-    it 'includes secrest in Env' do
+    it 'includes secrets in Env' do
       expect(subject.service_config['Env']).to include('PASSWD=secret123')
+    end
+
+    it 'includes secrets in Env with same key' do
+      data['secrets'] << {'name' => 'SSL_CERTS', 'value' => 'foo', 'type' => 'env'}
+      data['secrets'] << {'name' => 'SSL_CERTS', 'value' => 'bar', 'type' => 'env'}
+      expect(subject.service_config['Env'].last).to eq("SSL_CERTS=foo\nbar")
     end
 
     it 'does not include user if nil' do


### PR DESCRIPTION
```
lb:
  image: kontena/lb:latest
  secrets:
    - secret: DOMAIN_NET_CERT
      name: SSL_CERTS
      type: env
    - secret: DOMAIN_COM_CERT
      name: SSL_CERTS
      type: env
```
creates environment variable `SSL_CERTS` that includes both secrets.