### PR TITLE
Improve pubsub performance 

### DIFF
--- a/server/app/services/rpc_client.rb
+++ b/server/app/services/rpc_client.rb
@@ -78,7 +78,7 @@ class RpcClient
       rescue
         raise RpcClient::TimeoutError.new(503, "Connection timeout (#{self.timeout}s)")
       ensure
-        subscription.terminate if subscription.alive?
+        subscription.terminate
       end
 
       [result, error]


### PR DESCRIPTION
By using threads only when subscription is receiving messages. Improves throughput  > 4x when there are a lot of subscriptions.