### PR TITLE
Pass external-registry add values as options

### DIFF
--- a/cli/lib/kontena/cli/external_registries/add_command.rb
+++ b/cli/lib/kontena/cli/external_registries/add_command.rb
@@ -2,19 +2,17 @@ module Kontena::Cli::ExternalRegistries
   class AddCommand < Clamp::Command
     include Kontena::Cli::Common
 
-    def execute
-      require 'highline/import'
+    parameter '[URL]', 'Docker Registry url', default: 'https://index.docker.io/v2/'
 
-      default_url = 'https://index.docker.io/v2/'
+    option ['-u', '--username'], 'USERNAME', 'Username', required: true
+    option ['-e', '--email'], 'EMAIL', 'Email', required: true
+    option ['-p', '--password'], 'PASSWORD', 'Password', required: true
+
+    def execute
       require_api_url
       require_current_grid
       token = require_token
 
-      username = ask("Username: ")
-      password = ask("Password: ") { |q| q.echo = "*" }
-      email = ask("Email: ")
-      url = ask("URL [#{default_url}]: ")
-      url = default_url if url.strip == ''
       data = { username: username, password: password, email: email, url: url }
       client(token).post("grids/#{current_grid}/external_registries", data)
     end


### PR DESCRIPTION
This allows to add extra long tokens as a password (for example with Google Container Registry)