### PR TITLE
Check that weave is running when creating a service

### DIFF
--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -27,6 +27,9 @@ module Kontena
           service_pod.volumes_from << data_container.id
         end
         service_container = get_container(service_pod.name)
+
+        sleep 1 until overlay_adapter.running?
+
         if service_container
           if service_uptodate?(service_container)
             info "service is up-to-date: #{service_pod.name}"

--- a/agent/lib/kontena/weave_adapter.rb
+++ b/agent/lib/kontena/weave_adapter.rb
@@ -20,6 +20,13 @@ module Kontena
       false
     end
 
+    # @return [Boolean]
+    def running?
+      weave = Docker::Container.get('weave') rescue nil
+      return false if weave.nil?
+      weave.running?
+    end
+
     # @param [Hash] opts
     def modify_create_opts(opts)
       ensure_weave_wait

--- a/agent/spec/lib/kontena/weave_adapter_spec.rb
+++ b/agent/spec/lib/kontena/weave_adapter_spec.rb
@@ -18,6 +18,28 @@ describe Kontena::WeaveAdapter do
     end
   end
 
+  describe '#running?' do
+    it 'returns true if weave is running' do
+      weave = spy(:weave, :running? => true)
+      allow(Docker::Container).to receive(:get).with('weave').and_return(weave)
+      expect(subject.running?).to be_truthy
+    end
+
+    it 'returns false if weave is not running' do
+      weave = spy(:weave, :running? => false)
+      allow(Docker::Container).to receive(:get).with('weave').and_return(weave)
+      expect(subject.running?).to be_falsey
+    end
+
+    it 'returns false if weave does not exist' do
+      weave = spy(:weave, :running? => false)
+      allow(Docker::Container).to receive(:get).with('weave') {
+        raise Docker::Error::NotFoundError.new
+      }
+      expect(subject.running?).to be_falsey
+    end
+  end
+
   describe '#modify_host_config' do
     it 'adds weavewait to empty VolumesFrom' do
       opts = {}


### PR DESCRIPTION
If weave image pull takes a long time it will raise on error when master sends service pod create request. This PR fixes this problem by adding a check that weave is actually running before proceeding with request.