### PR TITLE
Dc's with private networks can't see each other

### DIFF
--- a/cli/lib/kontena/cli/grid_command.rb
+++ b/cli/lib/kontena/cli/grid_command.rb
@@ -10,6 +10,8 @@ require_relative 'grids/audit_log_command'
 require_relative 'grids/list_users_command'
 require_relative 'grids/add_user_command'
 require_relative 'grids/remove_user_command'
+require_relative 'grids/add_custom_peer_command'
+require_relative 'grids/remove_custom_peer_command'
 
 class Kontena::Cli::GridCommand < Clamp::Command
 
@@ -25,6 +27,8 @@ class Kontena::Cli::GridCommand < Clamp::Command
   subcommand "list-users", "List current grid users", Kontena::Cli::Grids::ListUsersCommand
   subcommand "add-user", "Add user to the current grid", Kontena::Cli::Grids::AddUserCommand
   subcommand "remove-user", "Remove user from the current grid", Kontena::Cli::Grids::RemoveUserCommand
+  subcommand "add-custom-peer", "Add custom peer ip address to the current grid", Kontena::Cli::Grids::AddCustomPeerCommand
+  subcommand "remove-custom-peer", "Remove custom peer ip address from the current grid", Kontena::Cli::Grids::RemoveCustomPeerCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/grids/add_custom_peer_command.rb
+++ b/cli/lib/kontena/cli/grids/add_custom_peer_command.rb
@@ -1,0 +1,18 @@
+require_relative 'common'
+
+module Kontena::Cli::Grids
+  class AddCustomPeerCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    parameter "PEER", "Custom peer ip address"
+
+    def execute
+      require_api_url
+      token = require_token
+      data = { peer: peer }
+      client(token).post("grids/#{current_grid}/custom_peers", data)
+    end
+  end
+end

--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -11,6 +11,7 @@ module Kontena::Cli::Grids
       puts "  nodes: #{grid['node_count']}"
       puts "  services: #{grid['service_count']}"
       puts "  containers: #{grid['container_count']}"
+      puts "  custom_peers: #{grid['custom_peers'].join(',')}"
     end
 
     def grids

--- a/cli/lib/kontena/cli/grids/remove_custom_peer_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_custom_peer_command.rb
@@ -1,0 +1,16 @@
+require_relative 'common'
+
+module Kontena::Cli::Grids
+  class RemoveCustomPeerCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Common
+
+    parameter "PEER", "Custom peer ip address"
+
+    def execute
+      require_api_url
+      token = require_token
+      client(token).delete("grids/#{current_grid}/custom_peers/#{peer}")
+    end
+  end
+end

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -14,6 +14,7 @@ class Grid
   field :token, type: String
   field :initial_size, type: Integer, default: 1
   field :overlay_cidr, type: String, default: -> { Grid.default_overlay_cidr }
+  field :custom_peers, type: Array, default: []
 
   has_many :host_nodes, dependent: :destroy
   has_many :grid_services, dependent: :destroy

--- a/server/app/mutations/grids/add_custom_peer.rb
+++ b/server/app/mutations/grids/add_custom_peer.rb
@@ -1,0 +1,20 @@
+module Grids
+  class AddCustomPeer < Mutations::Command
+    required do
+      model :current_user, class: User
+      model :grid
+      string :peer
+    end
+
+    def validate
+      unless current_user.grids.include?(grid)
+        add_error(:grid, :invalid, 'Invalid grid')
+      end
+    end
+
+    def execute
+      grid.add_to_set(custom_peers: peer)
+      grid.reload
+    end
+  end
+end

--- a/server/app/mutations/grids/remove_custom_peer.rb
+++ b/server/app/mutations/grids/remove_custom_peer.rb
@@ -1,0 +1,20 @@
+module Grids
+  class RemoveCustomPeer < Mutations::Command
+    required do
+      model :current_user, class: User
+      model :grid
+      string :peer
+    end
+
+    def validate
+      unless current_user.grids.include?(grid)
+        add_error(:grid, :invalid, 'Invalid grid')
+      end
+    end
+
+    def execute
+      grid.pull(custom_peers: peer)
+      grid.reload
+    end
+  end
+end

--- a/server/app/routes/v1/grids/grid_custom_peers.rb
+++ b/server/app/routes/v1/grids/grid_custom_peers.rb
@@ -1,0 +1,50 @@
+require_relative '../../../mutations/grids/add_custom_peer'
+require_relative '../../../mutations/grids/remove_custom_peer'
+V1::GridsApi.route('grid_custom_peers') do |r|
+
+  # POST /v1/grids/:name/custom_peers
+  r.post do
+    data = parse_json_body
+    outcome = Grids::AddCustomPeer.run(
+      grid: @grid,
+      current_user: current_user,
+      peer: data['peer']
+    )
+    if outcome.success?
+      audit_event(r, @grid, @grid, 'add custom peer')
+      response.status = 201
+      {}
+    else
+      response.status = 422
+      {error: outcome.errors.message}
+    end
+  end
+
+  # DELETE /v1/grids/:name/custom_peers/:peer
+  r.delete do
+    r.on :peer do |peer|
+      outcome = Grids::RemoveCustomPeer.run(
+        grid: @grid,
+        current_user: current_user,
+        peer: peer
+      )
+      if outcome.success?
+        audit_event(r, @grid, @grid, 'remove custom peer')
+        response.status = 200
+        {}
+      else
+        response.status = 422
+        {error: outcome.errors.message}
+      end
+    end
+  end
+
+
+  # GET /v1/grids/:id/users
+  r.get do
+    r.is do
+      @users = @grid.users
+      render('users/index')
+    end
+  end
+end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -66,6 +66,12 @@ module V1
         r.route 'grid_secrets'
       end
 
+      # /v1/grids/:name/custom_peers
+      r.on ':name/custom_peers' do |name|
+        load_grid(name)
+        r.route 'grid_custom_peers'
+      end
+
       r.post do
         r.is do
           data = parse_json_body

--- a/server/app/views/v1/grids/_grid.json.jbuilder
+++ b/server/app/views/v1/grids/_grid.json.jbuilder
@@ -6,3 +6,4 @@ json.node_count grid.host_nodes.count
 json.service_count grid.grid_services.count
 json.container_count grid.containers.count
 json.user_count grid.users.count
+json.custom_peers grid.custom_peers

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -13,8 +13,16 @@ json.mem_limit node.mem_limit
 json.cpus node.cpus
 json.public_ip node.public_ip
 json.private_ip node.private_ip
-json.peer_ips node.grid.host_nodes.ne(id: node.id).map{|node| node.private_ip}.compact
+peer_ips = node.grid.host_nodes.ne(id: node.id).map{|node| node.private_ip}.compact
+peer_ips += grid.custom_peers
+json.peer_ips peer_ips
 json.node_number node.node_number
 json.grid do
-  json.partial!("app/views/v1/grids/grid", grid: node.grid) if node.grid
+  grid = node.grid
+  if grid
+    json.id grid.to_path
+    json.name grid.name
+    json.token grid.token
+    json.initial_size grid.initial_size
+  end
 end

--- a/server/spec/api/v1/grid_custom_peers_spec.rb
+++ b/server/spec/api/v1/grid_custom_peers_spec.rb
@@ -1,0 +1,68 @@
+require_relative '../../spec_helper'
+
+describe '/v1/grids/:name/custom_peers' do
+
+  let(:david) do
+    User.create!(email: 'david@domain.com', external_id: '123456')
+  end
+  let(:bob) do
+    User.create!(email: 'bob@domain.com', external_id: 'asdasdasd')
+  end
+
+  let(:david_token) { AccessToken.create!(user: david, scopes: ['user']) }
+  let(:bob_token) { AccessToken.create!(user: bob, scopes: ['user']) }
+  let(:request_headers) { { 'HTTP_AUTHORIZATION' => "Bearer #{david_token.token}" } }
+  let(:bob_request_headers) { { 'HTTP_AUTHORIZATION' => "Bearer #{bob_token.token}" } }
+
+  let(:grid) do
+    grid = Grid.create!(name: 'massive-grid')
+    grid.users << david
+    grid
+  end
+
+  describe 'POST' do
+    it 'adds custom peer' do
+      data = {peer: '192.168.121.22'}
+      expect {
+        post "/v1/grids/#{grid.to_path}/custom_peers", data.to_json, request_headers
+      }.to change{ grid.reload.custom_peers.size }.by(1)
+      expect(response.status).to eq(201)
+    end
+
+    it 'requires that user has access to grid' do
+      data = {peer: '192.168.121.22'}
+      post "/v1/grids/#{grid.to_path}/custom_peers", data.to_json, bob_request_headers
+      expect(response.status).to eq(404)
+    end
+
+    it 'requires authorization' do
+      data = {peer: '192.168.121.22'}
+      post "/v1/grids/#{grid.to_path}/custom_peers", data.to_json
+      expect(response.status).to eq(403)
+    end
+  end
+
+  describe 'DELETE' do
+    let(:peer) { '192.168.68.12' }
+    before(:each) do
+      grid.push(custom_peers: peer)
+    end
+
+    it 'deletes custom peer' do
+      expect {
+        delete "/v1/grids/#{grid.to_path}/custom_peers/#{peer}", nil, request_headers
+      }.to change{ grid.reload.custom_peers.size }.by(-1)
+      expect(response.status).to eq(200)
+    end
+
+    it 'requires that user has access to grid' do
+      delete "/v1/grids/#{grid.to_path}/custom_peers/#{peer}", nil, bob_request_headers
+      expect(response.status).to eq(404)
+    end
+
+    it 'requires authorization' do
+      delete "/v1/grids/#{grid.to_path}/custom_peers/#{peer}", nil
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -2,7 +2,9 @@ require_relative '../spec_helper'
 
 describe Grid do
   it { should be_timestamped_document }
-  it { should have_fields(:name, :token, :initial_size, :overlay_cidr)}
+  it { should have_fields(:name, :token, :overlay_cidr).of_type(String)}
+  it { should have_fields(:initial_size).of_type(Integer)}
+  it { should have_fields(:custom_peers).of_type(Array)}
 
   it { should have_and_belong_to_many(:users) }
   it { should have_many(:host_nodes) }


### PR DESCRIPTION
Reason: grid is weaved together using private addresses. This PR adds possibility to add/remove custom peer addresses per grid (basically public ip that can be seen/connected from outside of datacenter).