### PR TITLE
Add --force-deploy option to app/service deploy commands

### DIFF
--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -6,12 +6,15 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
+    option '--force-deploy', :flag, 'Force deploy even if service does not have any changes'
 
     def execute
       require_api_url
       token = require_token
       service_id = name
-      deploy_service(token, service_id, {})
+      data = {}
+      data[:force] = true if force_deploy?
+      deploy_service(token, service_id, data)
     end
   end
 end

--- a/server/app/mutations/grid_services/deploy.rb
+++ b/server/app/mutations/grid_services/deploy.rb
@@ -11,14 +11,18 @@ module GridServices
 
     optional do
       model :current_user, class: User
-      boolean :touch, default: true
+      boolean :force, default: false
     end
 
     def execute
-      self.grid_service.set(
+      attrs = {
         :deploy_requested_at => Time.now.utc,
         :state => 'deploy_pending'
-      )
+      }
+      if self.force
+        attrs[:updated_at] = Time.now.utc
+      end
+      self.grid_service.set(attrs)
       worker(:grid_service_scheduler).async.perform(self.grid_service.id)
 
       self.grid_service

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -181,6 +181,27 @@ describe '/v1/services' do
       post "/v1/services/#{redis_service.to_path}/deploy", nil, request_headers
       expect(response.status).to eq(200)
     end
+
+    it 'changes state to deploy_pending' do
+      expect {
+        post "/v1/services/#{redis_service.to_path}/deploy", nil, request_headers
+        expect(response.status).to eq(200)
+      }.to change{ redis_service.reload.state }.to('deploy_pending')
+    end
+
+    it 'does not change updated_at by default' do
+      expect {
+        post "/v1/services/#{redis_service.to_path}/deploy", nil, request_headers
+        expect(response.status).to eq(200)
+      }.not_to change{ redis_service.reload.updated_at }
+    end
+
+    it 'changes updated_at when force=true' do
+      expect {
+        post "/v1/services/#{redis_service.to_path}/deploy", {force: true}.to_json, request_headers
+        expect(response.status).to eq(200)
+      }.to change{ redis_service.reload.updated_at }
+    end
   end
 
   describe 'POST /:id/stop' do

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -174,10 +174,14 @@ describe '/v1/services' do
   end
 
   describe 'POST /:id/deploy' do
+    let(:worker) { spy(:worker) }
+    before(:each) do
+      allow(Celluloid::Actor).to receive(:[]).with(:grid_service_scheduler_worker).and_return(worker)
+    end
     it 'deploys service' do
-      expect(GridServices::Deploy).to receive(:run)
-        .with(current_user: david, grid_service: redis_service)
-        .and_return(double.as_null_object)
+      spy = spy(:executor)
+      expect(worker).to receive(:async).once.and_return(spy)
+      expect(spy).to receive(:perform).with(redis_service.id)
       post "/v1/services/#{redis_service.to_path}/deploy", nil, request_headers
       expect(response.status).to eq(200)
     end


### PR DESCRIPTION
This PR adds `--force-deploy` option to `kontena app/service deploy` subcommands. This forces master to update service timestamp and by doing this, will force agent to replace container(s).