### PR TITLE
Allow to set custom weave peers via env to agent

### DIFF
--- a/agent/spec/lib/kontena/weave_adapter_spec.rb
+++ b/agent/spec/lib/kontena/weave_adapter_spec.rb
@@ -55,4 +55,43 @@ describe Kontena::WeaveAdapter do
       expect(opts['HostConfig']['VolumesFrom']).to include('weavewait:ro')
     end
   end
+
+  describe '#resolve_peer_ips' do
+    it 'returns empty array by default' do
+      expect(subject.resolve_peer_ips({})).to eq([])
+    end
+
+    it 'returns peer_ips from info' do
+      peer_ips = ['192.168.22.13', '192.168.22.14']
+      info = {'peer_ips' => peer_ips}
+      expect(subject.resolve_peer_ips(info)).to eq(peer_ips)
+    end
+
+    it 'returns custom_peer_ips if they are set' do
+      allow(ENV).to receive(:[]).with('WEAVE_CUSTOM_PEERS').and_return('10.12.0.23,10.12.0.24')
+      peer_ips = ['192.168.22.13', '192.168.22.14']
+      info = {'peer_ips' => peer_ips}
+      expect(subject.resolve_peer_ips(info)).to eq(['10.12.0.23', '10.12.0.24'])
+    end
+  end
+
+  describe '#expose_bridge' do
+    it 'calls exec with correct ip' do
+      info = {'node_number' => 2}
+      ip = "10.81.0.2/19"
+      expect(subject).to receive(:exec).with(['--local', 'expose', "ip:#{ip}"])
+      subject.expose_bridge(info)
+    end
+  end
+
+  describe '#custom_peer_ips' do
+    it 'returns nil by default' do
+      expect(subject.custom_peer_ips).to be_nil
+    end
+
+    it 'returns custom peers from WEAVE_CUSTOM_PEERS env' do
+      allow(ENV).to receive(:[]).with('WEAVE_CUSTOM_PEERS').and_return('192.168.22.13')
+      expect(subject.custom_peer_ips).to eq(['192.168.22.13'])
+    end
+  end
 end


### PR DESCRIPTION
Sometimes it's necessary to give custom weave peer ips to agent that overrides peers coming from the master. This is only necessary when network topology is complex and weave should not try to connect to all other peers.