### PR TITLE
Make default logs/stats capped collections smaller

### DIFF
--- a/server/db/migrations/03_migrate_container_logs_to_capped.rb
+++ b/server/db/migrations/03_migrate_container_logs_to_capped.rb
@@ -2,7 +2,7 @@ class MigrateContainerLogsToCapped < Mongodb::Migration
 
   def self.up
     unless ContainerLog.collection.capped?
-      size = (ENV['CONTAINER_LOGS_CAPPED_SIZE'] || 5000).to_i
+      size = (ENV['CONTAINER_LOGS_CAPPED_SIZE'] || 1000).to_i
       ContainerLog.collection.session.command(
         convertToCapped: ContainerLog.collection.name,
         capped: true,

--- a/server/db/migrations/04_migrate_container_stats_to_capped.rb
+++ b/server/db/migrations/04_migrate_container_stats_to_capped.rb
@@ -2,7 +2,7 @@ class MigrateContainerStatsToCapped < Mongodb::Migration
 
   def self.up
     unless ContainerStat.collection.capped?
-      size = (ENV['CONTAINER_STATS_CAPPED_SIZE'] || 1000).to_i
+      size = (ENV['CONTAINER_STATS_CAPPED_SIZE'] || 500).to_i
       ContainerStat.collection.session.command(
         convertToCapped: ContainerStat.collection.name,
         capped: true,


### PR DESCRIPTION
Reduce size of logs/stats of capped collections. Collection can be set when installing master via `CONTAINER_LOGS_CAPPED_SIZE` and `CONTAINER_STATS_CAPPED_SIZE` environment variables.