### PR TITLE
Retry weave, etcd and cadvisor starts on docker exception

### DIFF
--- a/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
+++ b/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
@@ -21,5 +21,14 @@ describe Kontena::Launchers::Cadvisor do
       expect(subject.wrapped_object).to receive(:create_container).with(subject.image)
       subject.start
     end
+
+    it 'retries 4 times if Docker::Error::ServerError is raised' do
+      allow(subject.wrapped_object).to receive(:start_cadvisor) do
+        raise Docker::Error::ServerError
+      end
+      expect(subject.wrapped_object).to receive(:start_cadvisor).exactly(5).times
+      subject.start
+      sleep 0.01
+    end
   end
 end

--- a/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
+++ b/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
@@ -28,6 +28,21 @@ describe Kontena::Launchers::Etcd do
     end
   end
 
+  describe '#on_overlay_start' do
+    it 'starts etcd' do
+      expect(subject.wrapped_object).to receive(:start_etcd).and_return(true)
+      subject.on_overlay_start('topic', {})
+    end
+
+    it 'retries 4 times if Docker::Error::ServerError is raised' do
+      allow(subject.wrapped_object).to receive(:start_etcd) do
+        raise Docker::Error::ServerError
+      end
+      expect(subject.wrapped_object).to receive(:start_etcd).exactly(5).times
+      subject.on_overlay_start('topic', {})
+    end
+  end
+
   describe '#start_etcd' do
     it 'creates etcd containers after image is pulled' do
       allow(subject.wrapped_object).to receive(:image_pulled?).and_return(true)


### PR DESCRIPTION
When using devicemapper and trying to restart  `kontena-agent`, restart of `kontena-etcd` and `kontena-cadvisor` containers often fails with error like this: 
`Docker::Error::ServerError: Cannot destroy container 7203c7163a4fbb1fff2a76b6473f684c469f07e417e83eff75ce29947cb4a24a: Driver devicemapper failed to remove root filesystem 7203c7163a4fbb1fff2a76b6473f684c469f07e417e83eff75ce29947cb4a24a: Device is Busy`

With this PR `kontena-agent` will retry to start those containers if they are raising Docker::Error::ServerError at first time.