### PR TITLE
Fix daemon strategy instance count with affinity

### DIFF
--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -41,7 +41,7 @@ class GridServiceDeployer
   # @return [Array<HostNode>]
   def selected_nodes
     nodes = []
-    self.grid_service.container_count.times do |i|
+    self.instance_count.times do |i|
       node = self.scheduler.select_node(
         self.grid_service, i + 1, self.nodes
       )
@@ -62,7 +62,7 @@ class GridServiceDeployer
     %w(TERM).each do |signal|
       Signal.trap(signal) { self.grid_service.set_state('running') }
     end
-    total_instances = self.scheduler.instance_count(self.nodes.size, self.grid_service.container_count)
+    total_instances = self.instance_count
     total_instances.times do |i|
       instance_number = i + 1
       unless self.grid_service.deploying?
@@ -162,7 +162,16 @@ class GridServiceDeployer
 
   # @return [Integer]
   def instance_count
-    self.scheduler.instance_count(self.nodes.size, self.grid_service.container_count)
+    max_instances = self.scheduler.instance_count(self.nodes.size, self.grid_service.container_count)
+    nodes = []
+    max_instances.times do |i|
+      node = self.scheduler.select_node(
+        self.grid_service, i + 1, self.nodes
+      )
+      nodes << node if node
+    end
+    filtered_count = nodes.uniq.size
+    self.scheduler.instance_count(filtered_count, self.grid_service.container_count)
   end
 
   # @return [Float]

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -3,9 +3,9 @@ require_relative '../spec_helper'
 describe GridServiceDeployer do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
-  let(:node) { HostNode.create!(node_id: SecureRandom.uuid) }
+  let(:node1) { HostNode.create!(node_id: SecureRandom.uuid, grid: grid) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
-  let(:subject) { described_class.new(strategy, grid_service, []) }
+  let(:subject) { described_class.new(strategy, grid_service, grid.host_nodes.to_a) }
 
   describe '#registry_name' do
     it 'returns DEFAULT_REGISTRY by default' do
@@ -21,6 +21,47 @@ describe GridServiceDeployer do
   describe '#creds_for_registry' do
     it 'return nil by default' do
       expect(subject.creds_for_registry).to be_nil
+    end
+  end
+
+  describe '#selected_nodes' do
+    before(:each) do
+      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
+      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
+    end
+
+    it 'returns instance_count amount of nodes by default' do
+      expect(subject.selected_nodes.size).to eq(1)
+    end
+
+    it 'returns filtered amount of unique nodes if service has affinity' do
+      service = GridService.create!(
+        image_name: 'kontena/redis:2.8', name: 'redis', grid: grid,
+        container_count: 3, affinity: ['label==foo']
+      )
+      subject = described_class.new(strategy, service, grid.host_nodes.to_a)
+      expect(subject.selected_nodes.size).to eq(3)
+      expect(subject.selected_nodes.uniq.size).to eq(2)
+    end
+  end
+
+  describe '#instance_count' do
+    it 'returns grid_service#container_count by default' do
+      expect(subject.instance_count).to eq(grid_service.container_count)
+    end
+
+    it 'returns count based on filtered nodes if strategy is daemon' do
+      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
+      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
+      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['bar'])
+      service = GridService.create!(
+        image_name: 'kontena/redis:2.8', name: 'redis', grid: grid,
+        container_count: 3, affinity: ['label==foo']
+      )
+      subject = described_class.new(
+        Scheduler::Strategy::Daemon.new, service, grid.host_nodes.to_a
+      )
+      expect(subject.instance_count).to eq(6)
     end
   end
 end


### PR DESCRIPTION
If daemon strategy was used with affinity it did not result in a correct number of service instances.