### PR TITLE
Refactor cli specs

### DIFF
--- a/cli/spec/fixtures/docker-compose.yml
+++ b/cli/spec/fixtures/docker-compose.yml
@@ -1,0 +1,8 @@
+wordpress:
+  image: wordpress:4.1
+  ports:
+    - 80:80
+  links:
+    - mysql:mysql
+mysql:
+  image: mysql:5.6

--- a/cli/spec/fixtures/kontena.yml
+++ b/cli/spec/fixtures/kontena.yml
@@ -1,0 +1,17 @@
+wordpress:
+  extends:
+    file: docker-compose.yml
+    service: wordpress
+  stateful: true
+  environment:
+    - WORDPRESS_DB_PASSWORD=%{project}_secret
+  instances: 2
+  deploy:
+    strategy: ha
+mysql:
+  extends:
+    file: docker-compose.yml
+    service: mysql
+  stateful: true
+  environment:
+    - MYSQL_ROOT_PASSWORD=%{project}_secret

--- a/cli/spec/fixtures/mysql.yml
+++ b/cli/spec/fixtures/mysql.yml
@@ -1,0 +1,3 @@
+mysql:
+  image: mysql:5.6
+

--- a/cli/spec/fixtures/wordpress-scaled.yml
+++ b/cli/spec/fixtures/wordpress-scaled.yml
@@ -1,0 +1,3 @@
+wordpress:
+  image: wordpress:latest
+  instances: 2

--- a/cli/spec/fixtures/wordpress.yml
+++ b/cli/spec/fixtures/wordpress.yml
@@ -1,0 +1,2 @@
+wordpress:
+  image: wordpress:latest

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -3,6 +3,7 @@ require 'kontena/cli/grid_options'
 require "kontena/cli/apps/deploy_command"
 
 describe Kontena::Cli::Apps::DeployCommand do
+  include FixturesHelpers
 
   let(:subject) do
     described_class.new(File.basename($0))
@@ -38,40 +39,11 @@ describe Kontena::Cli::Apps::DeployCommand do
   end
 
   let(:docker_compose_yml) do
-    yml_content = <<yml
-wordpress:
-  image: wordpress:4.1
-  ports:
-    - 80:80
-  links:
-    - mysql:mysql
-mysql:
-  image: mysql:5.6
-yml
-    yml_content
+    fixture('docker-compose.yml')
   end
 
   let(:kontena_yml) do
-    yml_content = <<yml
-wordpress:
-  extends:
-    file: docker-compose.yml
-    service: wordpress
-  stateful: true
-  environment:
-    - WORDPRESS_DB_PASSWORD=%{project}_secret
-  instances: 2
-  deploy:
-    strategy: ha
-mysql:
-  extends:
-    file: docker-compose.yml
-    service: mysql
-  stateful: true
-  environment:
-    - MYSQL_ROOT_PASSWORD=%{project}_secret
-yml
-    yml_content
+    fixture('kontena.yml')
   end
 
   let(:services) do

--- a/cli/spec/kontena/cli/app/scale_spec.rb
+++ b/cli/spec/kontena/cli/app/scale_spec.rb
@@ -2,42 +2,23 @@ require_relative "../../../spec_helper"
 require "kontena/cli/apps/scale_command"
 
 describe Kontena::Cli::Apps::ScaleCommand do
+  include FixturesHelpers
+  include ClientHelpers
 
   let(:subject) do
     described_class.new(File.basename($0))
   end
 
-  let(:settings) do
-    {'current_server' => 'alias',
-     'servers' => [
-         {'name' => 'some_master', 'url' => 'some_master'},
-         {'name' => 'alias', 'url' => 'someurl', 'token' => token}
-     ]
-    }
-  end
-
-  let(:token) do
-    '1234567'
-  end
-
   let(:kontena_yml) do
-    yml_content = <<yml
-wordpress:
-  image: wordpress:latest
-  instances: 2
-yml
+    fixture('wordpress-scaled.yml')
   end
 
   let(:kontena_yml_no_instances) do
-    yml_content = <<yml
-wordpress:
-  image: wordpress:latest
-yml
+    fixture('wordpress.yml')
   end
 
   describe '#execute' do
     before(:each) do
-      allow(subject).to receive(:settings).and_return(settings)
       allow(subject).to receive(:current_dir).and_return("kontena-test")
       allow(File).to receive(:exists?).and_return(true)
       allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_yml)

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -30,6 +30,7 @@ describe Kontena::Cli::Master::UseCommand do
       allow(subject).to receive(:require_token).and_return('token')
       allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:settings).and_return(valid_settings)
+      expect(subject).to receive(:current_master=).with('some_master')
       expect(client).to receive(:get).with('grids')
       subject.run(['some_master'])
     end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -18,7 +18,10 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
-
+  config.before(:each) do
+    allow(Dir).to receive(:home).and_return('/tmp/')
+  end
 end
 
 require_relative 'support/client_helpers'
+require_relative 'support/fixtures_helpers'

--- a/cli/spec/support/fixtures_helpers.rb
+++ b/cli/spec/support/fixtures_helpers.rb
@@ -1,0 +1,7 @@
+module FixturesHelpers
+  FIXTURES_PATH = File.dirname(__FILE__) + '/../fixtures/'
+
+  def fixture(file)
+    IO.read(FIXTURES_PATH+file)
+  end
+end


### PR DESCRIPTION
This PR simplifies cli spec files when operating with YAML files by introducing fixtures directory and mechanism.

Also `Dir.home` path is pointed to `/tmp`. Before that test execution could override kontena cli config file.