### PR TITLE
Improve cli logs options/output

### DIFF
--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -5,6 +5,7 @@ module Kontena::Cli::Grids
     option ["-f", "--follow"], :flag, "Follow (tail) logs", default: false
     option ["-s", "--search"], "SEARCH", "Search from logs"
     option "--lines", "LINES", "Number of lines to show from the end of the logs"
+    option "--since", "SINCE", "Show logs since given timestamp"
     option "--node", "NODE", "Filter by node name", multivalued: true
     option "--service", "SERVICE", "Filter by service name", multivalued: true
     option ["-c", "--container"], "CONTAINER", "Filter by container", multivalued: true
@@ -19,7 +20,7 @@ module Kontena::Cli::Grids
       query_params[:containers] = container_list.join(",") unless container_list.empty?
       query_params[:search] = search if search
       query_params[:limit] = lines if lines
-
+      query_params[:since] = since if since
 
       if follow?
         @buffer = ''
@@ -34,7 +35,11 @@ module Kontena::Cli::Grids
       result = client(token).get("grids/#{current_grid}/container_logs", query_params)
       result['logs'].each do |log|
         color = color_for_container(log['name'])
-        puts "#{log['name'].colorize(color)} | #{log['data']}"
+        prefix = ""
+        prefix << "#{log['created_at']} "
+        prefix << "#{log['name']}:"
+        prefix = prefix.colorize(color)
+        puts "#{prefix} #{log['data']}"
       end
     end
 

--- a/server/app/routes/v1/grids/grid_container_logs.rb
+++ b/server/app/routes/v1/grids/grid_container_logs.rb
@@ -10,6 +10,7 @@ V1::GridsApi.route('grid_container_logs') do |r|
       limit = (r['limit'] || 100).to_i
       follow = r['follow'] || false
       from = r['from']
+      since = r['since']
 
       unless r['containers'].nil?
         container_names = r['containers'].split(',')
@@ -35,6 +36,10 @@ V1::GridsApi.route('grid_container_logs') do |r|
           scope = scope.where(name: {:$in => container_names}) if container_names
           scope = scope.where(:$text => {:$search => r['search']}) unless r['search'].nil?
           scope = scope.where(:id.gt => from) unless from.nil?
+          if !since.nil? && from.nil?
+            since = DateTime.parse(since) rescue nil
+            scope = scope.where(:created_at.gt => since)
+          end
           scope = scope.order(:_id => -1)
           if first_run
             logs = scope.limit(limit).to_a.reverse
@@ -54,6 +59,10 @@ V1::GridsApi.route('grid_container_logs') do |r|
         scope = scope.where(name: {:$in => container_names}) if container_names
         scope = scope.where(:$text => {:$search => r['search']}) unless r['search'].nil?
         scope = scope.where(:id.gt => from ) unless from.nil?
+        if !since.nil? && from.nil?
+          since = DateTime.parse(since) rescue nil
+          scope = scope.where(:created_at.gt => since)
+        end
         @logs = scope.order(:_id => -1).limit(limit).to_a.reverse
         render('container_logs/index')
       end

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -62,6 +62,10 @@ module V1
             scope = scope.where(name: r['container']) unless r['container'].nil?
             scope = scope.where(:$text => {:$search => r['search']}) unless r['search'].nil?
             scope = scope.where(:id.gt => r['from'] ) unless r['from'].nil?
+            if !r['since'].nil? && r['from'].nil?
+              since = DateTime.parse(r['since']) rescue nil
+              scope = scope.where(:created_at.gt => since)
+            end
 
             @logs = scope.order(:_id => -1).limit(limit).to_a.reverse
             render('container_logs/index')

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -144,7 +144,25 @@ describe '/v1/services' do
         expect(json_response['logs'].size).to eq(1)
         expect(json_response['logs'].first['data']).to eq('foo2')
       end
+    end
 
+    context 'when since parameter is passed' do
+      it 'returns service container logs created after passed timestamp' do
+        container = redis_service.containers.create!(name: 'redis-1', container_id: 'aaa')
+        log1 = container.container_logs.create!(
+          data: 'foo', type: 'stdout', grid_service: redis_service, created_at: 5.minutes.ago
+        )
+        log2 = container.container_logs.create!(
+          data: 'foo2', type: 'stdout', grid_service: redis_service, created_at: 3.minutes.ago
+        )
+        log3 = container.container_logs.create!(
+          data: 'foo3', type: 'stdout', grid_service: redis_service, created_at: 1.minutes.ago
+        )
+        get "/v1/services/#{redis_service.to_path}/container_logs?since=#{log2.created_at}", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response['logs'].size).to eq(2)
+        expect(json_response['logs'].first['data']).to eq('foo2')
+      end
     end
   end
 


### PR DESCRIPTION
service logs output (prefix lines with timestamp + service instance number):
```
2016-03-12T08:54:29.000Z [1]: Puma starting in single mode...
2016-03-12T08:54:29.000Z [1]: * Version 2.15.3 (ruby 2.2.4-p230), codename: Autumn Arbor Airbrush
2016-03-12T08:54:29.000Z [1]: * Min threads: 16, max threads: 16
2016-03-12T08:54:29.000Z [1]: * Environment: production
2016-03-12T08:54:29.000Z [1]: * Listening on tcp://0.0.0.0:9292
2016-03-12T08:54:29.000Z [1]: Use Ctrl-C to stop
2016-03-12T09:04:40.000Z [2]: Puma starting in single mode...
2016-03-12T09:04:40.000Z [2]: * Version 2.15.3 (ruby 2.2.4-p230), codename: Autumn Arbor Airbrush
2016-03-12T09:04:40.000Z [2]: * Min threads: 16, max threads: 16
2016-03-12T09:04:40.000Z [2]: * Environment: production
2016-03-12T09:04:40.000Z [2]: * Listening on tcp://0.0.0.0:9292
```

PR also adds `--since` option to both service & grid logs.