### PR TITLE
Node (host level) statsd metrics

### DIFF
--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -132,6 +132,7 @@ module Kontena::Workers
       cadvisor.info['State']['Running'] == true
     end
 
+    # @param [String] name
     # @param [Hash] event
     def send_statsd_metrics(name, event)
       return unless statsd

--- a/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
@@ -42,6 +42,35 @@ describe Kontena::Workers::NodeInfoWorker do
     end
   end
 
+  describe '#on_node_info' do
+    it 'initializes statsd client if node has statsd config' do
+      info = {
+        'grid' => {
+          'stats' => {
+            'statsd' => {
+              'server' => '192.168.24.33',
+              'port' => 8125
+            }
+          }
+        }
+      }
+      expect(subject.statsd).to be_nil
+      subject.on_node_info('agent:node_info', info)
+      expect(subject.statsd).not_to be_nil
+    end
+
+    it 'does not initialize statsd if no statsd config exists' do
+      info = {
+        'grid' => {
+          'stats' => {}
+        }
+      }
+      expect(subject.statsd).to be_nil
+      subject.on_node_info('agent:node_info', info)
+      expect(subject.statsd).to be_nil
+    end
+  end
+
   describe '#publish_node_info' do
     before(:each) do
       allow(subject.wrapped_object).to receive(:interface_ip).with('eth1').and_return('192.168.66.2')

--- a/agent/spec/lib/kontena/workers/stats_workers_spec.rb
+++ b/agent/spec/lib/kontena/workers/stats_workers_spec.rb
@@ -46,23 +46,34 @@ describe Kontena::Workers::StatsWorker do
   end
 
   describe '#send_statsd_metrics' do
-    let(:event) {
+    let(:event) do
       {
         id: 'aaaaaa',
         spec: {
-
+          labels: {
+            :'io.kontena.service.name' => 'foobar'
+          }
         },
         cpu: {
           usage_pct: 12.32
         },
         memory: {
-          usage: current_stat[:memory][:usage],
-          working_set: current_stat[:memory][:working_set]
+          usage: 24 * 1024 * 1024
         },
-        filesystem: current_stat[:filesystem],
-        diskio: current_stat[:diskio],
-        network: current_stat[:network]
+        filesystem: [],
+        diskio: [],
+        network: []
       }
-    }
+    end
+
+    let(:statsd) do
+      spy(:statsd)
+    end
+
+    it 'sends statsd metrics' do
+      allow(subject.wrapped_object).to receive(:statsd).and_return(statsd)
+      expect(statsd).to receive(:gauge)
+      subject.send_statsd_metrics('foobar', event)
+    end
   end
 end


### PR DESCRIPTION
This PR enables node (host) level statsd metrics. Statds can be enabled per grid by setting `--statsd-server` option.