### PR TITLE
Add wait after removing app services that are linked to other services

### DIFF
--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -32,6 +32,7 @@ module Kontena::Cli::Apps
       services.find_all {|service_name, options| options['links'] && options['links'].size > 0 }.each do |service_name, options|
         delete(service_name, options)
         services.delete(service_name)
+        sleep 1
       end
       services.each do |service_name, options|
         delete(service_name, options)


### PR DESCRIPTION
When removing application services master might raise error if trying to delete a service that has links to other services. This PR adds wait time after deletion of service to CLI to ensure that master has deleted the service before deleting other services.