### PR TITLE
-t/--tail instead -f/--follow

### DIFF
--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Apps
     option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
     option "--since", "SINCE", "Show logs since given timestamp"
     option ["-s", "--search"], "SEARCH", "Search from logs"
-    option ["-t", "--follow"], :flag, "Follow (tail) logs", default: false
+    option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     parameter "[SERVICE] ...", "Show only specified service logs"
 
     attr_reader :services, :service_prefix
@@ -50,7 +50,7 @@ module Kontena::Cli::Apps
           puts "#{prefix} #{log['data']}"
           last_id = log['id']
         end
-        break unless follow?
+        break unless tail?
         sleep(2)
       end
     end

--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Grids
   class LogsCommand < Clamp::Command
     include Kontena::Cli::Common
 
-    option ["-f", "--follow"], :flag, "Follow (tail) logs", default: false
+    option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     option ["-s", "--search"], "SEARCH", "Search from logs"
     option "--lines", "LINES", "Number of lines to show from the end of the logs"
     option "--since", "SINCE", "Show logs since given timestamp"
@@ -22,7 +22,7 @@ module Kontena::Cli::Grids
       query_params[:limit] = lines if lines
       query_params[:since] = since if since
 
-      if follow?
+      if tail?
         @buffer = ''
         query_params[:follow] = 1
         stream_logs(token, query_params)

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
-    option ["-f", "--follow"], :flag, "Follow (tail) logs", default: false
+    option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
     option "--since", "SINCE", "Show logs since given timestamp"
     option ["-s", "--search"], "SEARCH", "Search from logs"
@@ -34,7 +34,7 @@ module Kontena::Cli::Services
           puts "#{prefix} #{log['data']}"
           last_id = log['id']
         end
-        break unless follow?
+        break unless tail?
         sleep(2)
       end
     end

--- a/cli/lib/kontena/cli/services/stats_command.rb
+++ b/cli/lib/kontena/cli/services/stats_command.rb
@@ -7,18 +7,18 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
-    option ["-f", "--follow"], :flag, "Follow stats in real time", default: false
+    option ["-t", "--tail"], :flag, "Tail (follow) stats in real time", default: false
 
     def execute
       require_api_url
       token = require_token
-      if follow?
+      if tail?
         system('clear')
         render_header
       end
       loop do
-        fetch_stats(token, name, follow?)
-        break unless follow?
+        fetch_stats(token, name, tail?)
+        break unless tail?
         sleep(2)
       end
     end


### PR DESCRIPTION
`kontena app -f` specifies kontena compose file, and it should be like that.

This would also be in-line with `heroku logs -t/--tail`

https://github.com/kontena/kontena/issues/579