### PR TITLE
Pre-build hooks

### DIFF
--- a/cli/spec/kontena/cli/app/docker_helper_spec.rb
+++ b/cli/spec/kontena/cli/app/docker_helper_spec.rb
@@ -7,6 +7,45 @@ describe Kontena::Cli::Apps::DockerHelper do
     Class.new { include Kontena::Cli::Apps::DockerHelper}.new
   end
 
+  let(:services_with_valid_hooks) do
+    {
+        'test_service' => {
+            'build' => '.',
+            'image' => 'test_service',
+            'hooks' => {
+              'pre_build' => [
+                { 'cmd' => "echo PREBUILD1", 'name' => 'hook1' },
+                { 'cmd' => "echo PREBUILD2", 'name' => 'hook2' }
+              ]
+            }
+        }
+    }
+  end
+
+  let(:services_with_invalid_hook) do
+    {
+        'test_service' => {
+            'build' => '.',
+            'image' => 'test_service',
+            'hooks' => {
+              'pre_build' => [
+                { 'cmd' => "echo PREBUILD1", 'name' => 'hook1' },
+                { 'cmd' => "some_non_existing_command", 'name' => 'failing hook' },
+              ]
+            }
+        }
+    }
+  end
+
+  let(:services_with_no_hook) do
+    {
+        'test_service' => {
+            'build' => '.',
+            'image' => 'test_service',
+        }
+    }
+  end
+
   describe '#validate_image_name' do
     context 'when image name is valid' do
       it 'returns true' do
@@ -29,4 +68,39 @@ describe Kontena::Cli::Apps::DockerHelper do
       end
     end
   end
+
+  describe '#run_pre_build_hook' do
+    
+    context 'when hook defined' do
+      it 'runs the hook' do
+        allow(subject).to receive(:build_docker_image)
+        allow(subject).to receive(:push_docker_image)
+        expect(subject).to receive(:system).with("echo PREBUILD1"). and_return(true)
+        expect(subject).to receive(:system).with("echo PREBUILD2"). and_return(true)
+
+        subject.process_docker_images(services_with_valid_hooks)
+      end
+
+      it 'fails to run the hook' do
+        allow(subject).to receive(:build_docker_image)
+        allow(subject).to receive(:push_docker_image)
+        expect(subject).to receive(:system).with("echo PREBUILD1"). and_return(true)
+        expect(subject).to receive(:system).with("some_non_existing_command"). and_return(false)
+
+        expect {
+          subject.process_docker_images(services_with_invalid_hook)
+        }.to raise_error(SystemExit)
+      end
+    end
+    context 'when no hook defined' do
+      it 'runs no hooks' do
+        allow(subject).to receive(:build_docker_image)
+        allow(subject).to receive(:push_docker_image)
+        expect(subject).not_to receive(:run_pre_build_hook)
+
+        subject.process_docker_images(services_with_no_hook)
+      end
+    end
+  end
+
 end

--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -266,6 +266,22 @@ hooks:
       oneshot: true
 ```
 
+**pre_build**
+
+`pre_build` hooks define executables that are executed before the actual docker image building. If multiple hooks are provided they are executed in the order defined. If any of the commands fail the build is aborted.
+
+```
+hooks:
+  pre_build
+    - name: npm install
+      cmd: npm install
+    - name: grunt
+      cmd: grunt dist
+```
+
+
+
+
 #### log_driver
 
 Specify the log driver for docker to use with all containers of this service. For details on available drivers and their configs see [Docker log drivers](https://docs.docker.com/reference/logging/overview/)


### PR DESCRIPTION
This PR adds named pre-build hooks. The hooks are executed in the order defined and the build is aborted if any of the commands fail.

resolves #479 