### PR TITLE
Login email into local storage

### DIFF
--- a/cli/lib/kontena/cli/login_command.rb
+++ b/cli/lib/kontena/cli/login_command.rb
@@ -24,7 +24,7 @@ class Kontena::Cli::LoginCommand < Clamp::Command
     response = do_login(email, password)
 
     if response
-      update_master_info(name, url, response['access_token'])
+      update_master_info(name, url, response['access_token'], email)
       display_logo
       puts ''
       puts "Logged in as #{response['user']['name'].green}"
@@ -97,12 +97,13 @@ class Kontena::Cli::LoginCommand < Clamp::Command
   # @param [String] url
   # @param [String] token
   #
-  def update_master_info(name, url, token)
+  def update_master_info(name, url, token, email)
     name = name || 'default'
     master = {
         'name' => name,
         'url' => url,
-        'token' => token
+        'token' => token,
+        'email' => email
     }
 
     self.add_master(name, master)

--- a/cli/lib/kontena/cli/whoami_command.rb
+++ b/cli/lib/kontena/cli/whoami_command.rb
@@ -13,9 +13,23 @@ class Kontena::Cli::WhoamiCommand < Clamp::Command
     puts "Master: #{self.current_master['name']}"
     puts "URL: #{api_url}"
     puts "Grid: #{current_grid}"
-    token = require_token
-    user = client(token).get('user')
-    puts "User: #{user['email']}"
+    if current_master['email']
+      puts "User: #{current_master['email']}"
+    else # In case local storage doesn't have the user email yet
+      token = require_token
+      user = client(token).get('user')
+      puts "User: #{user['email']}"
+      master = {
+          'name' => current_master['name'],
+          'url' => current_master['url'],
+          'token' => current_master['token'],
+          'email' => user['email'],
+          'grid' => current_master['grid']
+      }
+
+      self.add_master(current_master['name'], master)
+    end
+
 
   end
 


### PR DESCRIPTION
This PR adds login email into local `~/kontena_client.json`file. If the email is not known when executing the `kontena whoami` command it is added. Otherwise the email is added during login.

Fixes #525 