### PR TITLE
Add service link/unlink subcommands

### DIFF
--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -21,6 +21,9 @@ require_relative 'services/remove_env_command'
 require_relative 'services/add_secret_command'
 require_relative 'services/remove_secret_command'
 
+require_relative 'services/link_command'
+require_relative 'services/unlink_command'
+
 class Kontena::Cli::ServiceCommand < Clamp::Command
 
   subcommand ["list","ls"], "List services", Kontena::Cli::Services::ListCommand
@@ -45,6 +48,9 @@ class Kontena::Cli::ServiceCommand < Clamp::Command
 
   subcommand "add-secret", "Add secret from Vault", Kontena::Cli::Services::AddSecretCommand
   subcommand "remove-secret", "Remove secret", Kontena::Cli::Services::RemoveSecretCommand
+
+  subcommand "link", "Link service to another service", Kontena::Cli::Services::LinkCommand
+  subcommand "unlink", "Unlink service from another service", Kontena::Cli::Services::UnlinkCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/services/link_command.rb
+++ b/cli/lib/kontena/cli/services/link_command.rb
@@ -1,0 +1,26 @@
+require_relative '../grid_options'
+require_relative 'services_helper'
+
+module Kontena::Cli::Services
+  class LinkCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include ServicesHelper
+
+    parameter "NAME", "Service name"
+    parameter "TARGET", "Link target service name"
+
+    def execute
+      require_api_url
+      token = require_token
+
+      service = client(token).get("services/#{parse_service_id(name)}")
+      existing_targets = service['links'].map{|l| l['grid_service_id'].split('/')[1]}
+      abort("Service is already linked to #{target.to_s}") if existing_targets.include?(target.to_s)
+      links = service['links'].map{|l| {name: l['grid_service_id'].split('/')[1], alias: l['alias']} }
+      links << {name: target.to_s, alias: target.to_s}
+      data = {links: links}
+      update_service(token, name, data)
+    end
+  end
+end

--- a/cli/lib/kontena/cli/services/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/unlink_command.rb
@@ -1,0 +1,25 @@
+require_relative '../grid_options'
+require_relative 'services_helper'
+
+module Kontena::Cli::Services
+  class UnlinkCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include ServicesHelper
+
+    parameter "NAME", "Service name"
+    parameter "TARGET", "Link target service name"
+
+    def execute
+      require_api_url
+      token = require_token
+
+      service = client(token).get("services/#{parse_service_id(name)}")
+      links = service['links'].map{|l| {name: l['grid_service_id'].split('/')[1], alias: l['alias']} }
+      abort("Service is not linked to #{target.to_s}") unless links.find{|l| l[:name] == target.to_s}
+      links.delete_if{|l| l[:name] == target.to_s}
+      data = {links: links}
+      update_service(token, name, data)
+    end
+  end
+end

--- a/cli/spec/kontena/cli/services/link_command_spec.rb
+++ b/cli/spec/kontena/cli/services/link_command_spec.rb
@@ -1,0 +1,43 @@
+require_relative "../../../spec_helper"
+require "kontena/cli/services/link_command"
+
+describe Kontena::Cli::Services::LinkCommand do
+
+  include ClientHelpers
+
+  describe '#execute' do
+    before(:each) do
+      allow(client).to receive(:get).and_return({
+        'links' => []
+      })
+    end
+
+    it 'requires api url' do
+      expect(subject).to receive(:require_api_url).once
+      subject.run(['service-a', 'service-b'])
+    end
+
+    it 'requires token' do
+      expect(subject).to receive(:require_token).and_return(token)
+      subject.run(['service-a', 'service-b'])
+    end
+
+    it 'aborts if service is already linked' do
+      allow(client).to receive(:get).and_return({
+        'links' => [
+          {'alias' => 'service-b', 'grid_service_id' => "grid/service-b"}
+        ]
+      })
+      expect {
+        subject.run(['service-a', 'service-b'])
+      }.to raise_error(SystemExit)
+    end
+
+    it 'sends link to master' do
+      expect(client).to receive(:put).with(
+        'services/test-grid/service-a', {links: [{name: 'service-b', alias: 'service-b'}]}
+      )
+      subject.run(['service-a', 'service-b'])
+    end
+  end
+end

--- a/cli/spec/kontena/cli/services/unlink_command_spec.rb
+++ b/cli/spec/kontena/cli/services/unlink_command_spec.rb
@@ -1,0 +1,43 @@
+require_relative "../../../spec_helper"
+require "kontena/cli/services/unlink_command"
+
+describe Kontena::Cli::Services::UnlinkCommand do
+
+  include ClientHelpers
+
+  describe '#execute' do
+    before(:each) do
+      allow(client).to receive(:get).and_return({
+        'links' => [
+          {'alias' => 'service-b', 'grid_service_id' => "grid/service-b"}
+        ]
+      })
+    end
+
+    it 'requires api url' do
+      expect(subject).to receive(:require_api_url).once
+      subject.run(['service-a', 'service-b'])
+    end
+
+    it 'requires token' do
+      expect(subject).to receive(:require_token).and_return(token)
+      subject.run(['service-a', 'service-b'])
+    end
+
+    it 'aborts if service is not linked' do
+      allow(client).to receive(:get).and_return({
+        'links' => []
+      })
+      expect {
+        subject.run(['service-a', 'service-b'])
+      }.to raise_error(SystemExit)
+    end
+
+    it 'sends link to master' do
+      expect(client).to receive(:put).with(
+        'services/test-grid/service-a', {links: []}
+      )
+      subject.run(['service-a', 'service-b'])
+    end
+  end
+end

--- a/docs/using-kontena/services.md
+++ b/docs/using-kontena/services.md
@@ -34,6 +34,8 @@ Kontena monitors the state of each service instance and actively manages to ensu
 * [Remove Environment Variable](services#remove-environment-variable-from-service)
 * [Add Secret](services#add-secret-to-service)
 * [Remove Secret](services#remove-secret-from-service)
+* [Link Service](services#link-service)
+* [Unlink Service](services#unlink-service)
 * [Remove Service](services#remove-service)
 
 ### List Services
@@ -298,6 +300,30 @@ $ kontena service add-secret <name> <secret>
 
 ```
 $ kontena service remove-secret <name> <secret>
+```
+
+**Options:**
+
+```
+--grid GRID                   Specify grid to use
+```
+
+### Link Service
+
+```
+$ kontena service link <name> <target>
+```
+
+**Options:**
+
+```
+--grid GRID                   Specify grid to use
+```
+
+### Unlink Service
+
+```
+$ kontena service unlink <name> <target>
 ```
 
 **Options:**


### PR DESCRIPTION
```
$ kontena service link -h
Usage:
    kontena service link [OPTIONS] NAME TARGET

Parameters:
    NAME                          Service name
    TARGET                        Link target service name

Options:
    --grid GRID                   Specify grid to use
    -h, --help                    print help
```

```
$ kontena service unlink -h
Usage:
    kontena service unlink [OPTIONS] NAME TARGET

Parameters:
    NAME                          Service name
    TARGET                        Link target service name

Options:
    --grid GRID                   Specify grid to use
    -h, --help                    print help
```