### PR TITLE
Show both cli & master in version sub-command

### DIFF
--- a/cli/lib/kontena/cli/version_command.rb
+++ b/cli/lib/kontena/cli/version_command.rb
@@ -1,8 +1,16 @@
 require_relative 'version'
 
 class Kontena::Cli::VersionCommand < Clamp::Command
+  include Kontena::Cli::Common
 
   def execute
-    puts Kontena::Cli::VERSION
+    url = api_url rescue nil
+    puts "cli: #{Kontena::Cli::VERSION}"
+    if url
+      resp = JSON.parse(client.http_client.get(path: '/').body) rescue nil
+      if resp
+        puts "master: #{resp['version']} (#{url})"
+      end
+    end
   end
 end

--- a/cli/spec/kontena/cli/version_command_spec.rb
+++ b/cli/spec/kontena/cli/version_command_spec.rb
@@ -1,0 +1,17 @@
+require_relative "../../spec_helper"
+require "kontena/cli/version_command"
+
+describe Kontena::Cli::VersionCommand do
+
+  include ClientHelpers
+
+  describe '#execute' do
+    before(:each) do
+      allow(subject).to receive(:client).and_return(client)
+    end
+
+    it 'runs without errors' do
+      subject.run([])
+    end
+  end
+end


### PR DESCRIPTION
```
$ kontena version
cli: 0.12.0
master: 0.12.0 (https://foo-bar.kontena.io)
```