### PR TITLE
Switch from fog-aws to aws-sdk

### DIFF
--- a/cli/lib/kontena/cli/master/aws/create_command.rb
+++ b/cli/lib/kontena/cli/master/aws/create_command.rb
@@ -6,18 +6,18 @@ module Kontena::Cli::Master::Aws
 
     option "--access-key", "ACCESS_KEY", "AWS access key ID", required: true
     option "--secret-key", "SECRET_KEY", "AWS secret key", required: true
-    option "--key-pair", "KEY_PAIR", "EC2 Key Pair", required: true
-    option "--ssl-cert", "SSL CERT", "SSL certificate file"
+    option "--key-pair", "KEY_PAIR", "EC2 key pair name", required: true
+    option "--ssl-cert", "SSL CERT", "SSL certificate file (default: generate self-signed cert)"
     option "--region", "REGION", "EC2 Region", default: 'eu-west-1'
     option "--zone", "ZONE", "EC2 Availability Zone", default: 'a'
-    option "--vpc-id", "VPC ID", "Virtual Private Cloud (VPC) ID"
-    option "--subnet-id", "SUBNET ID", "VPC option to specify subnet to launch instance into"
+    option "--vpc-id", "VPC ID", "Virtual Private Cloud (VPC) ID (default: default vpc)"
+    option "--subnet-id", "SUBNET ID", "VPC option to specify subnet to launch instance into (default: first subnet from vpc/az)"
     option "--type", "SIZE", "Instance type", default: 't2.small'
     option "--storage", "STORAGE", "Storage size (GiB)", default: '30'
-    option "--vault-secret", "VAULT_SECRET", "Secret key for Vault"
-    option "--vault-iv", "VAULT_IV", "Initialization vector for Vault"
+    option "--vault-secret", "VAULT_SECRET", "Secret key for Vault (default: generate random secret)"
+    option "--vault-iv", "VAULT_IV", "Initialization vector for Vault (default: generate random iv)"
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
-    option "--auth-provider-url", "AUTH_PROVIDER_URL", "Define authentication provider url"
+    option "--auth-provider-url", "AUTH_PROVIDER_URL", "Define authentication provider url (optional)"
 
     def execute
       require 'kontena/machine/aws'

--- a/cli/lib/kontena/cli/nodes/aws/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/aws/create_command.rb
@@ -6,11 +6,11 @@ module Kontena::Cli::Nodes::Aws
     parameter "[NAME]", "Node name"
     option "--access-key", "ACCESS_KEY", "AWS access key ID", required: true
     option "--secret-key", "SECRET_KEY", "AWS secret key", required: true
+    option "--key-pair", "KEY_PAIR", "EC2 Key Pair", required: true
     option "--region", "REGION", "EC2 Region", default: 'eu-west-1'
     option "--zone", "ZONE", "EC2 Availability Zone", default: 'a'
-    option "--vpc-id", "VPC ID", "Virtual Private Cloud (VPC) ID"
-    option "--subnet-id", "SUBNET ID", "VPC option to specify subnet to launch instance into"
-    option "--key-pair", "KEY_PAIR", "EC2 Key Pair", required: true
+    option "--vpc-id", "VPC ID", "Virtual Private Cloud (VPC) ID (default: default vpc)"
+    option "--subnet-id", "SUBNET ID", "VPC option to specify subnet to launch instance into (default: first subnet in vpc/az)"
     option "--type", "SIZE", "Instance type", default: 't2.small'
     option "--storage", "STORAGE", "Storage size (GiB)", default: '30'
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'

--- a/cli/lib/kontena/cli/nodes/aws/terminate_command.rb
+++ b/cli/lib/kontena/cli/nodes/aws/terminate_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Nodes::Aws
     parameter "NAME", "Node name"
     option "--access-key", "ACCESS_KEY", "AWS access key ID", required: true
     option "--secret-key", "SECRET_KEY", "AWS secret key", required: true
-    option "--region", "REGION", "EC2 Region", required: true
+    option "--region", "REGION", "EC2 Region", default: 'eu-west-1'
 
     def execute
       require_api_url

--- a/cli/lib/kontena/machine/aws.rb
+++ b/cli/lib/kontena/machine/aws.rb
@@ -1,13 +1,13 @@
 begin
-  require "fog/aws"
+  require "aws-sdk"
 rescue LoadError
   puts "It seems that you don't have gem for AWS API installed."
-  puts "Install it using: gem install fog-aws"
+  puts "Install it using: gem install aws-sdk"
   exit 1
 end
 
 require_relative 'random_name'
+require_relative 'cert_helper'
 require_relative 'aws/master_provisioner'
 require_relative 'aws/node_provisioner'
 require_relative 'aws/node_destroyer'
-

--- a/cli/lib/kontena/machine/aws/common.rb
+++ b/cli/lib/kontena/machine/aws/common.rb
@@ -20,7 +20,23 @@ module Kontena
           }
           images[region]
         end
-        
+
+        # @param [String] vpc_id
+        # @param [String] zone
+        # @return [Aws::EC2::Types::Subnet, NilClass]
+        def default_subnet(vpc_id, zone)
+          ec2.subnets({
+            filters: [
+              {name: "vpc-id", values: [vpc_id]},
+              {name: "availability-zone", values: [zone]}
+            ]
+          }).first
+        end
+
+        # @return [Aws::EC2::Types::Vpc, NilClass]
+        def default_vpc
+          ec2.vpcs({filters: [{name: "is-default", values: ["true"]}]}).first
+        end
       end
     end
   end

--- a/cli/lib/kontena/machine/aws/master_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/master_provisioner.rb
@@ -34,11 +34,11 @@ module Kontena
             end
           end
 
-          ami = resolve_ami(ec2.client.config.region)
+          ami = resolve_ami(region)
           abort('No valid AMI found for region') unless ami
           opts[:vpc] = default_vpc.vpc_id unless opts[:vpc]
           if opts[:subnet].nil?
-            subnet = default_subnet(opts[:vpc], ec2.client.config.region+opts[:zone])
+            subnet = default_subnet(opts[:vpc], region+opts[:zone])
           else
             subnet = ec2.subnet(opts[:subnet])
           end
@@ -138,6 +138,11 @@ module Kontena
           })
 
           sg
+        end
+
+        # @return [String]
+        def region
+          ec2.client.config.region
         end
 
         def user_data(vars)

--- a/cli/lib/kontena/machine/aws/master_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/master_provisioner.rb
@@ -10,35 +10,37 @@ module Kontena
       class MasterProvisioner
         include RandomName
         include Common
-        attr_reader :client, :http_client, :region
+        include Machine::CertHelper
+        attr_reader :ec2, :http_client, :region
 
         # @param [String] access_key_id aws_access_key_id
         # @param [String] secret_key aws_secret_access_key
         # @param [String] region
         def initialize(access_key_id, secret_key, region)
-          @client = Fog::Compute.new(
-            :provider => 'AWS',
-            :aws_access_key_id => access_key_id,
-            :aws_secret_access_key => secret_key,
-            :region => region
+          @ec2 = ::Aws::EC2::Resource.new(
+            region: region, credentials: ::Aws::Credentials.new(access_key_id, secret_key)
           )
         end
 
         # @param [Hash] opts
         def run!(opts)
+          ssl_cert = nil
           if opts[:ssl_cert]
             abort('Invalid ssl cert') unless File.exists?(File.expand_path(opts[:ssl_cert]))
             ssl_cert = File.read(File.expand_path(opts[:ssl_cert]))
+          else
+            ShellSpinner "Generating self-signed SSL certificate" do
+              ssl_cert = generate_self_signed_cert
+            end
           end
 
-          ami = resolve_ami(client.region)
+          ami = resolve_ami(ec2.client.config.region)
           abort('No valid AMI found for region') unless ami
-          opts[:vpc] = default_vpc.id unless opts[:vpc]
+          opts[:vpc] = default_vpc.vpc_id unless opts[:vpc]
           if opts[:subnet].nil?
-            subnet = default_subnet(opts[:vpc], client.region+opts[:zone])
-            opts[:subnet] = subnet.subnet_id
+            subnet = default_subnet(opts[:vpc], ec2.client.config.region+opts[:zone])
           else
-            subnet = client.subnets.get(opts[:subnet])
+            subnet = ec2.subnet(opts[:subnet])
           end
           userdata_vars = {
               ssl_cert: ssl_cert,
@@ -50,41 +52,39 @@ module Kontena
 
           security_group = ensure_security_group(opts[:vpc])
           name = generate_name
-          response = client.run_instances(
-              ami,
-              1,
-              1,
-              'InstanceType'  => opts[:type],
-              'SecurityGroupId' => security_group.group_id,
-              'KeyName'       => opts[:key_pair],
-              'SubnetId'      => opts[:subnet],
-              'UserData'      => user_data(userdata_vars),
-              'BlockDeviceMapping' => [
-                  {
-                      'DeviceName' => '/dev/xvda',
-                      'VirtualName' => 'Root',
-                      'Ebs.VolumeSize' => opts[:storage],
-                      'Ebs.VolumeType' => 'gp2'
-                  }
-              ]
-
-          )
-          instance_id = response.body['instancesSet'].first['instanceId']
-
-          instance = client.servers.get(instance_id)
+          ec2_instance = ec2.create_instances({
+            image_id: ami,
+            min_count: 1,
+            max_count: 1,
+            instance_type: opts[:type],
+            security_group_ids: [security_group.group_id],
+            key_name: opts[:key_pair],
+            subnet_id: subnet.subnet_id,
+            user_data: Base64.encode64(user_data(userdata_vars)),
+            block_device_mappings: [
+              {
+                device_name: '/dev/xvda',
+                virtual_name: 'Root',
+                ebs: {
+                  volume_size: opts[:storage],
+                  volume_type: 'gp2'
+                }
+              }
+            ]
+          }).first
+          ec2_instance.create_tags({
+            tags: [
+              {key: 'Name', value: name}
+            ]
+          })
           ShellSpinner "Creating AWS instance #{name.colorize(:cyan)} " do
-            instance.wait_for { ready? }
+            sleep 5 until ec2_instance.reload.state.name == 'running'
           end
-          if opts[:ssl_cert]
-            master_url = "https://#{instance.public_ip_address}"
-          else
-            master_url = "http://#{instance.public_ip_address}"
-          end
+          master_url = "https://#{ec2_instance.public_ip_address}"
           Excon.defaults[:ssl_verify_peer] = false
-          @http_client = Excon.new("#{master_url}", :connect_timeout => 10)
-
+          http_client = Excon.new(master_url, :connect_timeout => 10)
           ShellSpinner "Waiting for #{name.colorize(:cyan)} to start" do
-            sleep 5 until master_running?
+            sleep 5 until master_running?(http_client)
           end
 
           puts "Kontena Master is now running at #{master_url}"
@@ -92,38 +92,52 @@ module Kontena
         end
 
         ##
-        # @param [String] grid
-        # @return Fog::Compute::AWS::SecurityGroup
+        # @param [String] vpc_id
+        # @return [Aws::EC2::SecurityGroup]
         def ensure_security_group(vpc_id)
           group_name = "kontena_master"
-          if vpc_id
-            client.security_groups.all({'group-name' => group_name, 'vpc-id' => vpc_id}).first || create_security_group(group_name, vpc_id)
-          else
-            client.security_groups.get(group_name) || create_security_group(group_name)
+          sg = ec2.security_groups({
+            filters: [
+              {name: 'group-name', values: [group_name]},
+              {name: 'vpc-id', values: [vpc_id]}
+            ]
+          }).first
+          unless sg
+            ShellSpinner "Creating AWS security group" do
+              sg = create_security_group(group_name, vpc_id)
+            end
           end
+          sg
         end
 
         ##
         # creates security_group and authorizes default port ranges
         #
         # @param [String] name
-        # @return Fog::Compute::AWS::SecurityGroup
+        # @param [String, NilClass] vpc_id
+        # @return Aws::EC2::SecurityGroup
         def create_security_group(name, vpc_id = nil)
-          security_group = client.security_groups.new(:name => name, :description => "Kontena Master", :vpc_id => vpc_id)
-          security_group.save
+          sg = ec2.create_security_group({
+            group_name: name,
+            description: "Kontena Master",
+            vpc_id: vpc_id
+          })
 
-          security_group.authorize_port_range(80..80)
-          security_group.authorize_port_range(443..443)
-          security_group.authorize_port_range(22..22)
-          security_group
-        end
+          sg.authorize_ingress({
+            ip_protocol: 'tcp',
+            from_port: 443,
+            to_port: 443,
+            cidr_ip: '0.0.0.0/0'
+          })
 
-        def default_subnet(vpc, zone)
-          client.subnets.all('vpc-id' => vpc, 'availabilityZone' => zone).first
-        end
+          sg.authorize_ingress({
+            ip_protocol: 'tcp',
+            from_port: 22,
+            to_port: 22,
+            cidr_ip: '0.0.0.0/0'
+          })
 
-        def default_vpc
-          client.vpcs.all('isDefault' => true).first
+          sg
         end
 
         def user_data(vars)
@@ -135,14 +149,16 @@ module Kontena
           "kontena-master-#{super}-#{rand(1..99)}"
         end
 
-        def master_running?
+        def master_running?(http_client)
           http_client.get(path: '/').status == 200
         rescue
           false
         end
 
         def erb(template, vars)
-          ERB.new(template).result(OpenStruct.new(vars).instance_eval { binding })
+          ERB.new(template).result(
+            OpenStruct.new(vars).instance_eval { binding }
+          )
         end
       end
     end

--- a/cli/lib/kontena/machine/aws/node_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/node_provisioner.rb
@@ -11,7 +11,7 @@ module Kontena
         include RandomName
         include Common
 
-        attr_reader :client, :api_client, :region
+        attr_reader :ec2, :api_client
 
         # @param [Kontena::Client] api_client Kontena api client
         # @param [String] access_key_id aws_access_key_id
@@ -19,9 +19,8 @@ module Kontena
         # @param [String] region
         def initialize(api_client, access_key_id, secret_key, region)
           @api_client = api_client
-          @client = Fog::Compute.new(
-            :provider => 'AWS', :aws_access_key_id => access_key_id,
-            :aws_secret_access_key => secret_key, :region => region
+          @ec2 = ::Aws::EC2::Resource.new(
+            region: region, credentials: ::Aws::Credentials.new(access_key_id, secret_key)
           )
         end
 
@@ -33,48 +32,51 @@ module Kontena
           security_group = ensure_security_group(opts[:grid], opts[:vpc])
           name = opts[:name ] || generate_name
 
-          opts[:vpc] = default_vpc.id unless opts[:vpc]
+          opts[:vpc] = default_vpc.vpc_id unless opts[:vpc]
           if opts[:subnet].nil?
-            subnet = default_subnet(opts[:vpc], client.region+opts[:zone])
-            opts[:subnet] = subnet.subnet_id
+            subnet = default_subnet(opts[:vpc], ec2.client.config.region+opts[:zone])
           else
-            subnet = client.subnets.get(opts[:subnet])
+            subnet = ec2.subnet(opts[:subnet])
           end
           dns_server = aws_dns_supported?(opts[:vpc]) ? '169.254.169.253' : '8.8.8.8'
           userdata_vars = {
-              name: name,
-              version: opts[:version],
-              master_uri: opts[:master_uri],
-              grid_token: opts[:grid_token],
-              dns_server: dns_server
+            name: name,
+            version: opts[:version],
+            master_uri: opts[:master_uri],
+            grid_token: opts[:grid_token],
+            dns_server: dns_server
           }
 
-          response = client.run_instances(
-              ami,
-              1,
-              1,
-              'InstanceType'  => opts[:type],
-              'SecurityGroupId' => security_group.group_id,
-              'KeyName'       => opts[:key_pair],
-              'SubnetId'      => opts[:subnet],
-              'UserData'      => user_data(userdata_vars),
-              'BlockDeviceMapping' => [
-                  {
-                      'DeviceName' => '/dev/xvda',
-                      'VirtualName' => 'Root',
-                      'Ebs.VolumeSize' => opts[:storage],
-                      'Ebs.VolumeType' => 'gp2'
-                  }
-              ]
+          ec2_instance = ec2.create_instances({
+            image_id: ami,
+            min_count: 1,
+            max_count: 1,
+            instance_type: opts[:type],
+            security_group_ids: [security_group.group_id],
+            key_name: opts[:key_pair],
+            subnet_id: subnet.subnet_id,
+            user_data: Base64.encode64(user_data(userdata_vars)),
+            block_device_mappings: [
+              {
+                device_name: '/dev/xvda',
+                virtual_name: 'Root',
+                ebs: {
+                  volume_size: opts[:storage],
+                  volume_type: 'gp2'
+                }
+              }
+            ]
+          }).first
+          ec2_instance.create_tags({
+            tags: [
+              {key: 'Name', value: name},
+              {key: 'kontena_grid', value: opts[:grid]}
+            ]
+          })
 
-          )
-          instance_id = response.body['instancesSet'].first['instanceId']
-
-          instance = client.servers.get(instance_id)
           ShellSpinner "Creating AWS instance #{name.colorize(:cyan)} " do
-            instance.wait_for { ready? }
+            sleep 5 until ec2_instance.reload.state.name == 'running'
           end
-          client.create_tags(instance.id, {'Name' => name, 'kontena_grid' => opts[:grid]})
           node = nil
           ShellSpinner "Waiting for node #{name.colorize(:cyan)} join to grid #{opts[:grid].colorize(:cyan)} " do
             sleep 2 until node = instance_exists_in_grid?(opts[:grid], name)
@@ -85,40 +87,60 @@ module Kontena
 
         ##
         # @param [String] grid
-        # @return Fog::Compute::AWS::SecurityGroup
+        # @return [Aws::EC2::SecurityGroup]
         def ensure_security_group(grid, vpc_id)
           group_name = "kontena_grid_#{grid}"
-          if vpc_id
-            client.security_groups.all({'group-name' => group_name, 'vpc-id' => vpc_id}).first || create_security_group(group_name, vpc_id)
-          else
-            client.security_groups.get(group_name) || create_security_group(group_name)
+          sg = ec2.security_groups({
+            filters: [
+              {name: 'group-name', values: [group_name]},
+              {name: 'vpc-id', values: [vpc_id]}
+            ]
+          }).first
+          unless sg
+            ShellSpinner "Creating AWS security group" do
+              sg = create_security_group(group_name, vpc_id)
+            end
           end
+          sg
         end
 
         ##
         # creates security_group and authorizes default port ranges
         #
         # @param [String] name
-        # @return Fog::Compute::AWS::SecurityGroup
-        def create_security_group(name, vpc_id = nil)
-          security_group = client.security_groups.new(:name => name, :description => "Kontena Node", :vpc_id => vpc_id)
-          security_group.save
+        # @param [String] vpc_id
+        # @return [Aws::EC2::SecurityGroup]
+        def create_security_group(name, vpc_id)
+          sg = ec2.create_security_group({
+            group_name: name,
+            description: "Kontena Grid",
+            vpc_id: vpc_id
+          })
 
-          security_group.authorize_port_range(80..80)
-          security_group.authorize_port_range(443..443)
-          security_group.authorize_port_range(22..22)
-          security_group.authorize_port_range(1194..1194, ip_protocol: 'udp')
-          security_group.authorize_port_range(6783..6783, group: {security_group.owner_id => security_group.group_id}, ip_protocol: 'tcp')
-          security_group.authorize_port_range(6783..6784, group: {security_group.owner_id => security_group.group_id}, ip_protocol: 'udp')
-          security_group
-        end
+          sg.authorize_ingress({
+            ip_protocol: 'tcp', from_port: 22, to_port: 22, cidr_ip: '0.0.0.0/0'
+          })
+          sg.authorize_ingress({
+            ip_protocol: 'tcp', from_port: 80, to_port: 80, cidr_ip: '0.0.0.0/0'
+          })
+          sg.authorize_ingress({
+            ip_protocol: 'tcp', from_port: 443, to_port: 443, cidr_ip: '0.0.0.0/0'
+          })
+          sg.authorize_ingress({
+            ip_protocol: 'udp', from_port: 1194, to_port: 1194, cidr_ip: '0.0.0.0/0'
+          })
+          sg.authorize_ingress({
+            ip_protocol: 'tcp', from_port: 6783, to_port: 6783,
+            source_security_group_name: sg.group_id,
+            source_security_group_owner_id: sg.owner_id
+          })
+          sg.authorize_ingress({
+            ip_protocol: 'udp', from_port: 6783, to_port: 6784,
+            source_security_group_name: sg.group_id,
+            source_security_group_owner_id: sg.owner_id
+          })
 
-        def default_subnet(vpc, zone)
-          client.subnets.all('vpc-id' => vpc, 'availabilityZone' => zone).first
-        end
-
-        def default_vpc
-          client.vpcs.all('isDefault' => true).first
+          sg
         end
 
         def user_data(vars)
@@ -138,15 +160,20 @@ module Kontena
           ERB.new(template).result(OpenStruct.new(vars).instance_eval { binding })
         end
 
+        # @param [Hash] node
+        # @param [Array<String>] labels
         def set_labels(node, labels)
           data = {}
           data[:labels] = labels
           api_client.put("nodes/#{node['id']}", data, {}, {'Kontena-Grid-Token' => node['grid']['token']})
         end
 
+        # @param [String] vpc_id
+        # @return [Boolean]
         def aws_dns_supported?(vpc_id)
-          response = client.describe_vpc_attribute(vpc_id,'enableDnsSupport')
-          response.data[:body]['enableDnsSupport']
+          vpc = ec2.vpc(vpc_id)
+          response = vpc.describe_attribute({attribute: 'enableDnsSupport'})
+          response.enable_dns_support
         end
       end
     end

--- a/cli/lib/kontena/machine/aws/node_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/node_provisioner.rb
@@ -119,27 +119,33 @@ module Kontena
             vpc_id: vpc_id
           })
 
-          sg.authorize_ingress({
+          sg.authorize_ingress({ # SSH
             ip_protocol: 'tcp', from_port: 22, to_port: 22, cidr_ip: '0.0.0.0/0'
           })
-          sg.authorize_ingress({
+          sg.authorize_ingress({ # HTTP
             ip_protocol: 'tcp', from_port: 80, to_port: 80, cidr_ip: '0.0.0.0/0'
           })
-          sg.authorize_ingress({
+          sg.authorize_ingress({ # HTTPS
             ip_protocol: 'tcp', from_port: 443, to_port: 443, cidr_ip: '0.0.0.0/0'
           })
-          sg.authorize_ingress({
+          sg.authorize_ingress({ # OpenVPN
             ip_protocol: 'udp', from_port: 1194, to_port: 1194, cidr_ip: '0.0.0.0/0'
           })
-          sg.authorize_ingress({
-            ip_protocol: 'tcp', from_port: 6783, to_port: 6783,
-            source_security_group_name: sg.group_id,
-            source_security_group_owner_id: sg.owner_id
-          })
-          sg.authorize_ingress({
-            ip_protocol: 'udp', from_port: 6783, to_port: 6784,
-            source_security_group_name: sg.group_id,
-            source_security_group_owner_id: sg.owner_id
+          sg.authorize_ingress({ # Overlay / Weave network
+            ip_permissions: [
+              {
+                from_port: 6783, to_port: 6783, ip_protocol: 'tcp',
+                user_id_group_pairs: [
+                  { group_id: sg.group_id, vpc_id: vpc_id }
+                ]
+              },
+              {
+                from_port: 6783, to_port: 6784, ip_protocol: 'udp',
+                user_id_group_pairs: [
+                  { group_id: sg.group_id, vpc_id: vpc_id }
+                ]
+              }
+            ]
           })
 
           sg

--- a/cli/lib/kontena/machine/cert_helper.rb
+++ b/cli/lib/kontena/machine/cert_helper.rb
@@ -1,0 +1,39 @@
+require 'openssl'
+
+module Kontena
+  module Machine
+    module CertHelper
+
+      def generate_self_signed_cert
+        key = OpenSSL::PKey::RSA.new(2048)
+        public_key = key.public_key
+
+        subject = "/C=FI/O=Test/OU=Test/CN=Test"
+
+        cert = OpenSSL::X509::Certificate.new
+        cert.subject = cert.issuer = OpenSSL::X509::Name.parse(subject)
+        cert.not_before = Time.now
+        cert.not_after = Time.now + (10 * 365 * 24 * 60 * 60)
+        cert.public_key = public_key
+        cert.serial = 0x0
+        cert.version = 2
+
+        ef = OpenSSL::X509::ExtensionFactory.new
+        ef.subject_certificate = cert
+        ef.issuer_certificate = cert
+        cert.extensions = [
+          ef.create_extension("basicConstraints","CA:TRUE", true),
+          ef.create_extension("subjectKeyIdentifier", "hash")
+        ]
+        cert.add_extension ef.create_extension("authorityKeyIdentifier",
+                                               "keyid:always,issuer:always")
+
+        cert.sign key, OpenSSL::Digest::SHA1.new
+
+        pem = cert.to_pem
+        pem << key.to_s
+        pem
+      end
+    end
+  end
+end

--- a/docs/getting-started/installing/master.md
+++ b/docs/getting-started/installing/master.md
@@ -25,17 +25,18 @@ Usage:
 Options:
     --access-key ACCESS_KEY       AWS access key ID
     --secret-key SECRET_KEY       AWS secret key
+    --key-pair KEY_PAIR           EC2 key pair name
+    --ssl-cert SSL CERT           SSL certificate file (default: generate self-signed cert)
     --region REGION               EC2 Region (default: "eu-west-1")
     --zone ZONE                   EC2 Availability Zone (default: "a")
-    --vpc-id VPC ID               Virtual Private Cloud (VPC) ID
-    --subnet-id SUBNET ID         VPC option to specify subnet to launch instance into
-    --key-pair KEY_PAIR           EC2 Key Pair
+    --vpc-id VPC ID               Virtual Private Cloud (VPC) ID (default: default vpc)
+    --subnet-id SUBNET ID         VPC option to specify subnet to launch instance into (default: first subnet from vpc/az)
     --type SIZE                   Instance type (default: "t2.small")
     --storage STORAGE             Storage size (GiB) (default: "30")
-    --vault-secret VAULT_SECRET   Secret key for Vault
-    --vault-iv VAULT_IV           Initialization vector for Vault
+    --vault-secret VAULT_SECRET   Secret key for Vault (default: generate random secret)
+    --vault-iv VAULT_IV           Initialization vector for Vault (default: generate random iv)
     --version VERSION             Define installed Kontena version (default: "latest")
-    --auth-provider-url AUTH_PROVIDER_URL Define authentication provider url
+    --auth-provider-url AUTH_PROVIDER_URL Define authentication provider url (optional)
 ```
 
 ### Microsoft Azure

--- a/docs/getting-started/installing/nodes.md
+++ b/docs/getting-started/installing/nodes.md
@@ -23,14 +23,14 @@ Usage:
     kontena node aws create [OPTIONS]
 
 Options:
-    --name NAME                   Node name
+    --grid GRID                   Specify grid to use
     --access-key ACCESS_KEY       AWS access key ID
     --secret-key SECRET_KEY       AWS secret key
+    --key-pair KEY_PAIR           EC2 Key Pair
     --region REGION               EC2 Region (default: "eu-west-1")
     --zone ZONE                   EC2 Availability Zone (default: "a")
-    --vpc-id VPC ID               Virtual Private Cloud (VPC) ID
-    --subnet-id SUBNET ID         VPC option to specify subnet to launch instance into
-    --key-pair KEY_PAIR           EC2 Key Pair
+    --vpc-id VPC ID               Virtual Private Cloud (VPC) ID (default: default vpc)
+    --subnet-id SUBNET ID         VPC option to specify subnet to launch instance into (default: first subnet in vpc/az)
     --type SIZE                   Instance type (default: "t2.small")
     --storage STORAGE             Storage size (GiB) (default: "30")
     --version VERSION             Define installed Kontena version (default: "latest")


### PR DESCRIPTION
Fog-aws has nasty dependencies (nokogiri) that require user to install development packages. Aws-sdk should make installation so much easier.

This PR also adds minor tweak that generates self-signed ssl certificate for master if user does not provide any cert.