### PR TITLE
Authorize grid actions

### DIFF
--- a/server/app/authorizers/grid_authorizer.rb
+++ b/server/app/authorizers/grid_authorizer.rb
@@ -3,4 +3,12 @@ class GridAuthorizer < ApplicationAuthorizer
     user.master_admin?
   end
 
+  def updatable_by?(user)
+    user.master_admin? || user.grid_admin?(resource)
+  end
+
+  def deletable_by?(user)
+    user.master_admin?
+  end
+
 end

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -3,6 +3,7 @@ require 'ipaddr'
 class Grid
   include Mongoid::Document
   include Mongoid::Timestamps
+  include Authority::Abilities
 
   OVERLAY_BRIDGE_NETWORK_SIZE = 24
 

--- a/server/app/mutations/grids/create.rb
+++ b/server/app/mutations/grids/create.rb
@@ -11,6 +11,10 @@ module Grids
       integer :initial_size, default: 1, min: 1, max: 7
     end
 
+    def validate
+      add_error(:user, :invalid, 'Operation not allowed') unless user.can_create?(Grid)
+    end
+
     def execute
       self.name = generate_name if self.name.blank?
       grid = Grid.new(

--- a/server/app/mutations/grids/delete.rb
+++ b/server/app/mutations/grids/delete.rb
@@ -3,9 +3,12 @@ module Grids
 
     required do
       model :grid
+      model :user
     end
 
     def validate
+
+      add_error(:user, :invalid, 'Operation not allowed') unless user.can_delete?(grid)
       add_error(:grid, :services_exist, 'Grid has services') if grid.grid_services.exists?
       add_error(:grid, :host_nodes, 'Grid has nodes') if grid.host_nodes.exists?
     end

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -3,6 +3,7 @@ module Grids
 
     required do
       model :grid
+      model :user
     end
 
     optional do
@@ -16,6 +17,10 @@ module Grids
           end
         end
       end
+    end
+
+    def validate
+      add_error(:user, :invalid, 'Operation not allowed') unless user.can_update?(grid)
     end
 
     def execute

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -123,6 +123,7 @@ module V1
           r.is do
             data = parse_json_body
             data[:grid] = @grid
+            data[:user] = current_user
             outcome = Grids::Update.run(data)
             if outcome.success?
               @grid = outcome.result
@@ -143,7 +144,7 @@ module V1
 
           # DELETE /v1/grids/:name
           r.is do
-            outcome = Grids::Delete.run({grid: @grid})
+            outcome = Grids::Delete.run({user: current_user, grid: @grid})
             if outcome.success?
               audit_event(r, @grid, @grid, 'delete')
               response.status = 200

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -43,6 +43,10 @@ describe '/v1/grids' do
   end
 
   describe 'POST' do
+    before(:each) do
+      allow(GridAuthorizer).to receive(:creatable_by?).with(david).and_return(true)
+    end
+
     it 'creates a new grid' do
       expect {
         post '/v1/grids', {}.to_json, request_headers
@@ -275,6 +279,10 @@ describe '/v1/grids' do
 
 
   describe 'PUT /:name' do
+    before(:each) do
+      allow_any_instance_of(GridAuthorizer).to receive(:updatable_by?).with(david).and_return(true)
+    end
+
     it 'requires authorization' do
       request_headers.delete('HTTP_AUTHORIZATION')
       grid = david.grids.first
@@ -327,6 +335,10 @@ describe '/v1/grids' do
   end
 
   describe 'DELETE /:name' do
+    before(:each) do
+      allow_any_instance_of(GridAuthorizer).to receive(:deletable_by?).with(david).and_return(true)
+    end
+
     it 'requires authorization' do
       request_headers.delete('HTTP_AUTHORIZATION')
       grid = david.grids.first

--- a/server/spec/authorizers/grid_authorizer_spec.rb
+++ b/server/spec/authorizers/grid_authorizer_spec.rb
@@ -48,7 +48,7 @@ describe GridAuthorizer do
 
     context 'when user is grid admin' do
       it 'does not let delete grid' do
-        expect(grid.authorizer).not_täjo be_deletable_by(grid_admin)
+        expect(grid.authorizer).not_to be_deletable_by(grid_admin)
       end
     end
   end

--- a/server/spec/authorizers/grid_authorizer_spec.rb
+++ b/server/spec/authorizers/grid_authorizer_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../spec_helper'
+
+describe GridAuthorizer do
+
+  let(:master_admin) do
+    user = User.create!(email: 'joe@domain.com')
+    user.roles << Role.create!(name: 'master_admin', description: 'Master admin')
+    user
+  end
+
+  let(:grid_admin) do
+    user = User.create!(email: 'dan@domain.com')
+    user.roles << Role.create!(name: 'grid_admin', description: 'Grid admin')
+    user
+  end
+
+
+  let(:grid) {
+    grid = Grid.create!(name: 'test-grid')
+    grid.users << grid_admin
+    grid
+  }
+
+  let(:user) do
+    User.create!(email: 'jane@domain.com')
+  end
+
+  describe 'class' do
+    context 'when user is master admin' do
+      it 'lets create grid' do
+        expect(GridAuthorizer).to be_creatable_by(master_admin)
+      end
+    end
+
+    context 'when user is not master admin' do
+      it 'does not let create grid' do
+        expect(GridAuthorizer).not_to be_creatable_by(grid_admin)
+      end
+    end
+  end
+
+  describe 'instance' do
+    context 'when user is master admin' do
+      it 'lets delete grid' do
+        expect(grid.authorizer).to be_deletable_by(master_admin)
+      end
+    end
+
+    context 'when user is grid admin' do
+      it 'does not let delete grid' do
+        expect(grid.authorizer).not_täjo be_deletable_by(grid_admin)
+      end
+    end
+  end
+
+end

--- a/server/spec/mutations/grids/create_spec.rb
+++ b/server/spec/mutations/grids/create_spec.rb
@@ -6,66 +6,83 @@ describe Grids::Create do
   let(:user) { User.create!(email: 'joe@domain.com')}
 
   describe '#run' do
-    it 'creates a new grid' do
-      expect {
+    context 'when user has not permission to create grids' do
+      it 'returns error' do
         subject = described_class.new(
             user: user,
             name: nil
         )
-        allow(subject).to receive(:initialize_subnet)
-        subject.run
-      }.to change{ Grid.count }.by(1)
-    end
-
-    it 'initializes subnet' do
-      outcome = described_class.new(
-          user: user,
-          name: nil
-      ).run
-      sleep 0.1
-      grid = outcome.result
-      expect(grid.overlay_cidrs.count > 0).to be_truthy
-    end
-
-    context 'when name is provided' do
-      it 'does not generate random name ' do
-        subject = described_class.new(
-            user: user,
-            name: 'test-grid'
-        )
-        allow(subject).to receive(:initialize_subnet)
-        expect(subject).not_to receive(:generate_name)
-        subject.run
+        outcome = subject.run
+        expect(outcome.errors.size).to eq(1)
       end
     end
 
-    context 'when name is not provided' do
-      it 'generates random name' do
-        subject = described_class.new(
-            user: user,
-            name: nil
-        )
-        expect(subject).to receive(:generate_name)
-        subject.run
+    context 'when user has permission to create grids' do
+      before(:each) do
+        allow(GridAuthorizer).to receive(:creatable_by?).with(user).and_return(true)
       end
-    end
 
-    it 'assigns created grid to user' do
-      expect {
-        described_class.new(
+      it 'creates a new grid' do
+        expect {
+          subject = described_class.new(
+              user: user,
+              name: nil
+          )
+          allow(subject).to receive(:initialize_subnet)
+          subject.run
+        }.to change{ Grid.count }.by(1)
+      end
+
+      it 'initializes subnet' do
+        outcome = described_class.new(
             user: user,
             name: nil
         ).run
-      }.to change{ user.grids.size }.by(1)
-    end
+        sleep 0.1
+        grid = outcome.result
+        expect(grid.overlay_cidrs.count > 0).to be_truthy
+      end
 
-    it 'returns created grid' do
-      outcome = described_class.new(
-          user: user,
-          name: 'test-grid'
-      ).run
-      expect(outcome.result.is_a?(Grid)).to be_truthy
-      expect(outcome.result.name).to eq('test-grid')
+      context 'when name is provided' do
+        it 'does not generate random name ' do
+          subject = described_class.new(
+              user: user,
+              name: 'test-grid'
+          )
+          allow(subject).to receive(:initialize_subnet)
+          expect(subject).not_to receive(:generate_name)
+          subject.run
+        end
+      end
+
+      context 'when name is not provided' do
+        it 'generates random name' do
+          subject = described_class.new(
+              user: user,
+              name: nil
+          )
+          expect(subject).to receive(:generate_name)
+          subject.run
+        end
+      end
+
+      it 'assigns created grid to user' do
+        expect {
+          described_class.new(
+              user: user,
+              name: nil
+          ).run
+        }.to change{ user.grids.size }.by(1)
+      end
+
+      it 'returns created grid' do
+        outcome = described_class.new(
+            user: user,
+            name: 'test-grid'
+        ).run
+        expect(outcome.result.is_a?(Grid)).to be_truthy
+        expect(outcome.result.name).to eq('test-grid')
+      end
     end
   end
 end

--- a/server/spec/mutations/grids/delete_spec.rb
+++ b/server/spec/mutations/grids/delete_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-describe Grids::Delete do  
+describe Grids::Delete do
   let(:user) { User.create!(email: 'joe@domain.com')}
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
@@ -31,13 +31,13 @@ describe Grids::Delete do
 
     context 'when user has permission to delete grids' do
       before(:each) do
-        allow(GridAuthorizer).to receive(:deletable_by?).with(user).and_return(true)
+        allow_any_instance_of(GridAuthorizer).to receive(:deletable_by?).with(user).and_return(true)
       end
 
       it 'deletes a grid' do
-        grid
+        grid # create
         expect {
-          described_class.new(user: user, grid: grid).run
+          outcome = described_class.new(user: user, grid: grid).run
         }.to change{ Grid.count }.by(-1)
       end
 

--- a/server/spec/mutations/grids/delete_spec.rb
+++ b/server/spec/mutations/grids/delete_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-describe Grids::Delete do
+describe Grids::Delete do  
   let(:user) { User.create!(email: 'joe@domain.com')}
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
@@ -17,23 +17,41 @@ describe Grids::Delete do
   }
 
   describe '#run' do
-    it 'deletes a grid' do
-      grid
-      expect {
-        described_class.new(grid: grid).run
-      }.to change{ Grid.count }.by(-1)
+    context 'when user has not permission to delete grid' do
+      it 'returns error' do
+        grid # create
+        subject = described_class.new(
+            user: user,
+            grid: grid
+        )
+        outcome = subject.run
+        expect(outcome.errors.size).to eq(1)
+      end
     end
 
-    it 'returns error if grid has services' do
-      redis_service
-      outcome = described_class.new(grid: grid).run
-      expect(outcome.errors.size).to eq(1)
-    end
+    context 'when user has permission to delete grids' do
+      before(:each) do
+        allow(GridAuthorizer).to receive(:deletable_by?).with(user).and_return(true)
+      end
 
-    it 'returns error if grid has nodes' do
-      node
-      outcome = described_class.new(grid: grid).run
-      expect(outcome.errors.size).to eq(1)
+      it 'deletes a grid' do
+        grid
+        expect {
+          described_class.new(user: user, grid: grid).run
+        }.to change{ Grid.count }.by(-1)
+      end
+
+      it 'returns error if grid has services' do
+        redis_service
+        outcome = described_class.new(user: user, grid: grid).run
+        expect(outcome.errors.size).to eq(1)
+      end
+
+      it 'returns error if grid has nodes' do
+        node
+        outcome = described_class.new(user: user, grid: grid).run
+        expect(outcome.errors.size).to eq(1)
+      end
     end
   end
 end

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -12,6 +12,10 @@ describe Grids::Update do
   after(:each) { Celluloid.shutdown }
 
   describe '#run' do
+    before(:each) do
+      allow_any_instance_of(GridAuthorizer).to receive(:updatable_by?).with(user).and_return(true)
+    end
+
     it 'updates statsd settings' do
       stats = {
         statsd: {
@@ -19,12 +23,12 @@ describe Grids::Update do
           port: 8125
         }
       }
-      described_class.new(grid: grid, stats: stats).run
+      described_class.new(user: user, grid: grid, stats: stats).run
       expect(grid.reload.stats['statsd']['server']).to eq('127.0.0.1')
     end
 
     it 'returns error if grid has errors' do
-      outcome = described_class.new(grid: grid, stats: 'foo').run
+      outcome = described_class.new(user: user, grid: grid, stats: 'foo').run
       expect(outcome.success?).to be_falsey
     end
   end


### PR DESCRIPTION
This PR adds authorization of grid actions (create, update, delete). With this PR only `master_admin` can create and delete grids. `grid_admin` can also update grid.