### PR TITLE
Added restart flag for services

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -31,7 +31,8 @@ module Kontena
                   :log_opts,
                   :pid,
                   :hooks,
-                  :secrets
+                  :secrets,
+                  :restart
 
       # @param [Hash] attrs
       def initialize(attrs = {})
@@ -63,6 +64,7 @@ module Kontena
         @pid = attrs['pid']
         @hooks = attrs['hooks'] || []
         @secrets = attrs['secrets'] || []
+        @restart = attrs['restart']
       end
 
       # @return [String, NilClass]
@@ -131,7 +133,7 @@ module Kontena
       def service_host_config
         host_config = {
           'RestartPolicy' => {
-            'Name' => 'always'
+            'Name' => self.restart || 'always'
           }
         }
         bind_volumes = self.build_bind_volumes

--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -133,7 +133,7 @@ module Kontena
       def service_host_config
         host_config = {
           'RestartPolicy' => {
-            'Name' => self.restart || 'always'
+            'Name' => self.restart
           }
         }
         bind_volumes = self.build_bind_volumes

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -268,10 +268,6 @@ describe Kontena::Models::ServicePod do
       data['restart'] = 'no'
       expect(host_config['RestartPolicy']['Name']).to eq('no')
     end
-
-    it 'sets restart to always if not set' do
-      expect(host_config['RestartPolicy']['Name']).to eq('always')
-    end
   end
 
   describe '#build_exposed_ports' do

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -34,7 +34,8 @@ describe Kontena::Models::ServicePod do
       'volumes' => nil,
       'volumes_from' => nil,
       'net' => 'bridge',
-      'log_driver' => nil
+      'log_driver' => nil,
+      'restart' => nil
     }
   end
 
@@ -261,6 +262,15 @@ describe Kontena::Models::ServicePod do
     it 'sets PidMode if set' do
       data['pid'] = 'host'
       expect(host_config['PidMode']).to eq('host')
+    end
+
+    it 'sets restart if set' do
+      data['restart'] = 'no'
+      expect(host_config['RestartPolicy']['Name']).to eq('no')
+    end
+
+    it 'sets restart to always if not set' do
+      expect(host_config['RestartPolicy']['Name']).to eq('always')
     end
   end
 

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -177,6 +177,7 @@ module Kontena::Cli::Apps
 
       data[:hooks] = options['hooks'] || {}
       data[:secrets] = options['secrets'] if options['secrets']
+      data[:restart] = options['restart'] if options['restart']
 
       data
     end

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -33,6 +33,11 @@ module Kontena::Cli::Services
     option "--deploy-min-health", "FLOAT", "The minimum percentage (0.0 - 1.0) of healthy instances that do not sacrifice overall service availability while deploying"
     option "--pid", "PID", "Pid namespace to use"
     option "--secret", "SECRET", "Import secret from Vault (format: <secret>:<name>:<env>)", multivalued: true
+    option "--restart", "RESTART", "Restart policy of the container" do |opt|
+      re = Regexp.union('^no$', '^on-failure', '^always$', '^unless-stopped$')
+      raise ArgumentError unless opt.match(re)
+      opt
+    end
 
     def execute
       require_api_url
@@ -76,6 +81,7 @@ module Kontena::Cli::Services
       data[:deploy_opts][:min_health] = deploy_min_health.to_f if deploy_min_health
       data[:deploy_opts][:wait_for_port] = deploy_wait_for_port.to_i if deploy_wait_for_port
       data[:pid] = pid if pid
+      data[:restart] = restart if restart
       data
     end
   end

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -596,5 +596,17 @@ describe Kontena::Cli::Apps::DeployCommand do
         expect(result[:secrets]).to be_nil
       end
     end
+
+    context 'restart' do
+      it 'returns restart policy given' do
+        data = {
+          'image' => 'foo/bar:latest',
+          'restart' => 'always'
+        }
+        result = subject.send(:parse_data, data)
+        expect(result[:restart]).to eq('always')
+      end
+
+    end
   end
 end

--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -266,6 +266,18 @@ hooks:
       oneshot: true
 ```
 
+#### restart
+The restart policy for the service and containers
+
+```
+restart: no | on-failure[:max-retries] | always | unless-stopped
+```
+
+For the container restart policies see: https://docs.docker.com/engine/reference/run/#restart-policies-restart
+
+At service level it means that only services with policies `always` or `unless-stopped` will be restarted and/or rescheduled by the master automatically.
+
+
 #### log_driver
 
 Specify the log driver for docker to use with all containers of this service. For details on available drivers and their configs see [Docker log drivers](https://docs.docker.com/reference/logging/overview/)

--- a/server/app/jobs/service_balancer_job.rb
+++ b/server/app/jobs/service_balancer_job.rb
@@ -32,6 +32,7 @@ class ServiceBalancerJob
   # @return [Boolean]
   def should_balance_service?(service)
     if service.running? && service.stateless?
+      return false if %w(no unless-stopped).include?(service.restart)
       return true if !service.all_instances_exist?
       return false if service.deployed_at.nil?
       return true if service.updated_at > service.deployed_at

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -29,6 +29,7 @@ class GridService
   field :log_opts, type: Hash, default: {}
   field :devices, type: Array, default: []
   field :pid, type: String
+  field :restart, type: String
 
   field :deploy_requested_at, type: DateTime
   field :deployed_at, type: DateTime

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -29,7 +29,7 @@ class GridService
   field :log_opts, type: Hash, default: {}
   field :devices, type: Array, default: []
   field :pid, type: String
-  field :restart, type: String
+  field :restart, type: String, default: 'always'
 
   field :deploy_requested_at, type: DateTime
   field :deployed_at, type: DateTime

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -114,8 +114,8 @@ module GridServices
       if self.strategy && !self.strategies[self.strategy]
         add_error(:strategy, :invalid_strategy, 'Strategy not supported')
       end
-      @re ||= Regexp.union(/^no$/, /^on-failure/, /^always$/, /^unless-stopped$/)
-      if self.restart && self.restart.match(@re).nil?
+      re = Regexp.union(/^no$/, /^on-failure/, /^always$/, /^unless-stopped$/)
+      if self.restart && self.restart.match(re).nil?
         add_error(:restart, :invalid_restart, 'Invalid restart option provided')
       end 
     end

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -97,6 +97,7 @@ module GridServices
           end
         end
       end
+      string :restart
     end
 
     def validate
@@ -113,6 +114,10 @@ module GridServices
       if self.strategy && !self.strategies[self.strategy]
         add_error(:strategy, :invalid_strategy, 'Strategy not supported')
       end
+      @re ||= Regexp.union(/^no$/, /^on-failure/, /^always$/, /^unless-stopped$/)
+      if self.restart && self.restart.match(@re).nil?
+        add_error(:restart, :invalid_restart, 'Invalid restart option provided')
+      end 
     end
 
     def execute

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -51,7 +51,8 @@ module Docker
         net: grid_service.net,
         log_driver: grid_service.log_driver,
         log_opts: grid_service.log_opts,
-        pid: grid_service.pid
+        pid: grid_service.pid,
+        restart: grid_service.restart
       }
       spec[:env] = build_env
       spec[:secrets] = build_secrets

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -28,6 +28,7 @@ json.log_opts grid_service.log_opts
 json.strategy grid_service.strategy
 json.deploy_opts grid_service.deploy_opts
 json.pid grid_service.pid
+json.restart grid_service.restart
 json.instances do
   json.total grid_service.containers.count
   json.running grid_service.containers.where('state.running' => true).count

--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -17,7 +17,7 @@ test:
         write:
           w: 1
       hosts:
-        - localhost:27017
+        - <%= ENV['MONGODB_HOST'] || ('localhost:27017') %>
   options:
     use_utc: true
     raise_not_found_error: false

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -61,7 +61,7 @@ describe '/v1/services' do
         id created_at updated_at image affinity name stateful user
         container_count cmd entrypoint ports env memory memory_swap cpu_shares
         volumes volumes_from cap_add cap_drop state grid_id links log_driver log_opts
-        strategy deploy_opts pid instances net hooks secrets
+        strategy deploy_opts pid instances net hooks secrets restart
       ).sort)
       expect(json_response['id']).to eq(redis_service.to_path)
       expect(json_response['image']).to eq(redis_service.image_name)

--- a/server/spec/jobs/service_balancer_job_spec.rb
+++ b/server/spec/jobs/service_balancer_job_spec.rb
@@ -1,0 +1,37 @@
+require_relative '../spec_helper'
+
+describe ServiceBalancerJob do
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
+  let(:grid) { Grid.create(name: 'test')}
+
+  let(:service) do
+    GridService.create(
+      name: 'test',
+      image_name: 'foo/bar:latest',
+      grid: grid,
+      restart: 'always'
+    )
+  end
+
+  describe '#should_balance_service' do
+    it 'balances service with always restart option' do
+      allow(service).to receive(:running?).and_return(true)
+      allow(service).to receive(:stateless?).and_return(true)
+      expect(subject.should_balance_service?(service)).to be_truthy
+    end
+    it 'does not balance for no restart policy' do
+      allow(service).to receive(:running?).and_return(true)
+      allow(service).to receive(:stateless?).and_return(true)
+      service['restart'] = 'no'
+      expect(subject.should_balance_service?(service)).to be_falsey
+    end
+    it 'does not balance for unless-stopped restart policy' do
+      allow(service).to receive(:running?).and_return(true)
+      allow(service).to receive(:stateless?).and_return(true)
+      service['restart'] = 'no'
+      expect(subject.should_balance_service?(service)).to be_falsey
+    end
+  end
+end

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 describe GridService do
   it { should be_timestamped_document }
   it { should have_fields(:image_name, :name, :user, :entrypoint, :state,
-                          :net, :log_driver, :pid).of_type(String) }
+                          :net, :log_driver, :pid, :restart).of_type(String) }
   it { should have_fields(:container_count, :memory,
                           :memory_swap, :cpu_shares).of_type(Fixnum) }
   it { should have_fields(:affinity, :cmd, :ports, :env, :volumes, :volumes_from,

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -288,9 +288,9 @@ describe GridServices::Create do
           image: 'redis:2.8',
           name: 'redis',
           stateful: false,
-          restart: 'always'
+          restart: 'on-failure:10'
       ).run
-      expect(outcome.result.restart).to eq('always')
+      expect(outcome.result.restart).to eq('on-failure:10')
     end
 
     it 'returns error if invalid restart' do

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -280,5 +280,29 @@ describe GridServices::Create do
       ).run
       expect(outcome.result.cap_drop).to eq(['SETUID'])
     end
+
+    it 'saves valid restart' do
+      outcome = described_class.new(
+          current_user: user,
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          restart: 'always'
+      ).run
+      expect(outcome.result.restart).to eq('always')
+    end
+
+    it 'returns error if invalid restart' do
+      outcome = described_class.new(
+          current_user: user,
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: true,
+          restart: 'foobar'
+      ).run
+      expect(outcome.success?).to be_falsey
+    end
   end
 end

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -120,7 +120,7 @@ describe Docker::ServiceCreator do
     end
 
     it 'includes restart' do
-      expect(service_spec).to include(:restart => nil)
+      expect(service_spec).to include(:restart => 'always')
     end
 
     describe '[:env]' do

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -119,6 +119,10 @@ describe Docker::ServiceCreator do
       expect(service_spec).to include(:secrets => [])
     end
 
+    it 'includes restart' do
+      expect(service_spec).to include(:restart => nil)
+    end
+
     describe '[:env]' do
       let(:env) { service_spec[:env] }
 


### PR DESCRIPTION
This PR adds restart flag for service containers.

Currently the defaulting to `always` policy happens in agent, would it make more sense to have it on master model level?
