### PR TITLE
Add missing users remove command

### DIFF
--- a/cli/lib/kontena/cli/master/users/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/remove_command.rb
@@ -1,0 +1,22 @@
+require_relative '../../common'
+
+module Kontena::Cli::Master::Users
+  class RemoveCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    parameter "EMAIL ...", "List of emails"
+
+    def execute
+      require_api_url
+      token = require_token
+      email_list.each do |email|
+        begin
+          client(token).delete("users/#{email}")
+        rescue => exc
+          STDERR.puts "Failed to remove user #{email}".colorize(:red)
+          STDERR.puts exc.message
+        end
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/master/users_command.rb
+++ b/cli/lib/kontena/cli/master/users_command.rb
@@ -1,12 +1,14 @@
 module Kontena::Cli::Master
 
-  require_relative 'users/add_role_command'
   require_relative 'users/invite_command'
+  require_relative 'users/remove_command'
   require_relative 'users/list_command'
+  require_relative 'users/add_role_command'
   require_relative 'users/remove_role_command'
 
   class UsersCommand < Clamp::Command
     subcommand "invite", "Invite user to Kontena Master", Users::InviteCommand
+    subcommand ["remove", "rm"], "Remove user from Kontena Master", Users::RemoveCommand
     subcommand ["list", "ls"], "List users", Users::ListCommand
     subcommand "add-role", "Add role to user", Users::AddRoleCommand
     subcommand "remove-role", "Remove role from user", Users::RemoveRoleCommand

--- a/cli/spec/kontena/cli/master/users/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/remove_command_spec.rb
@@ -1,0 +1,28 @@
+require_relative "../../../../spec_helper"
+require 'kontena/cli/master/users_command'
+require "kontena/cli/master/users/remove_command"
+
+describe Kontena::Cli::Master::Users::RemoveCommand do
+
+  include ClientHelpers
+
+  describe '#execute' do
+
+    it 'requires api url' do
+      expect(subject).to receive(:require_api_url).once
+      subject.run(['john@domain.com'])
+    end
+
+    it 'requires token' do
+      expect(subject).to receive(:require_token).and_return(token)
+      subject.run(['john@domain.com'])
+    end
+
+    it 'sends email to master' do
+      expect(client).to receive(:delete).with(
+        'users/john@domain.com'
+      )
+      subject.run(['john@domain.com'])
+    end
+  end
+end

--- a/docs/using-kontena/users.md
+++ b/docs/using-kontena/users.md
@@ -29,6 +29,7 @@ Kontena has built-in role based user management. The first user that logs in to 
 * [Remove Users from Role](users#remove-users-from-role)
 * [Add User to Grid](users#add-users-to-role)
 * [Remove User from Grid](users#remove-user-from-grid)
+* [Remove User from Kontena Master](users#remove-user-from-kontena-master)
 
 ### Register a New Kontena Account
 
@@ -82,4 +83,10 @@ $ kontena grid remove-user <email>
 
 ```
 --grid GRID                   Specify grid to use
+```
+
+### Remove User from Kontena Master
+
+```
+$ kontena master users remove <email>
 ```

--- a/server/app/authorizers/user_authorizer.rb
+++ b/server/app/authorizers/user_authorizer.rb
@@ -11,4 +11,8 @@ class UserAuthorizer < ApplicationAuthorizer
     grid = options[:to]
     user.master_admin? || user.grid_admin?(grid)
   end
+
+  def self.deletable_by?(user)
+    user.master_admin?
+  end
 end

--- a/server/app/mutations/users/remove.rb
+++ b/server/app/mutations/users/remove.rb
@@ -1,0 +1,22 @@
+module Users
+  class Remove < Mutations::Command
+    required do
+      model :user
+      model :current_user, class: User
+    end
+
+    def validate
+      unless self.current_user.can_delete?(User)
+        add_error(:user, :invalid, 'Operation not allowed')
+      end
+      if current_user == user
+        add_error(:user, :invalid, 'Cannot remove itself')
+      end
+    end
+
+    def execute
+      user.destroy
+      user
+    end
+  end
+end

--- a/server/app/routes/v1/users/user_roles.rb
+++ b/server/app/routes/v1/users/user_roles.rb
@@ -1,9 +1,6 @@
 V1::UsersApi.route('user_roles') do |r|
   r.is do
     r.post do
-      validate_access_token
-      require_current_user
-
       params = parse_json_body
 
       role = Role.find_by(name: params['role'])
@@ -25,9 +22,6 @@ V1::UsersApi.route('user_roles') do |r|
 
   r.on ':role' do |role|
     r.delete do
-      validate_access_token
-      require_current_user
-
       role = Role.find_by(name: role)
       options = {
         current_user: current_user,

--- a/server/app/routes/v1/users_api.rb
+++ b/server/app/routes/v1/users_api.rb
@@ -11,15 +11,38 @@ module V1
     Dir[File.join(__dir__, '/users/*.rb')].each{|f| require f}
 
     route do |r|
-      r.on ':username/roles' do |username|
+      r.on ':username' do |username|
+        validate_access_token
+        require_current_user
         @user = User.find_by(email: username)
-        r.route 'user_roles'
+
+        unless @user
+          halt_request(404, {error: 'Not found'})
+        end
+
+        r.on 'roles' do
+          r.route 'user_roles'
+        end
+
+        r.is do
+          r.delete do
+            outcome = Users::Remove.run(user: @user, current_user: current_user)
+            if outcome.success?
+              response.status = 200
+              {}
+            else
+              response.status = 400
+              {error: outcome.errors.message}
+            end
+          end
+        end
       end
 
       r.is do
+        validate_access_token
+        require_current_user
+
         r.get do
-          validate_access_token
-          require_current_user
           if !current_user.can_read?(User)
             response.status = 403
             {error: 'Operation not allowed'}
@@ -31,9 +54,6 @@ module V1
         end
 
         r.post do
-          validate_access_token
-          require_current_user
-
           params = parse_json_body
           params[:user] = current_user
           outcome = Users::Invite.run(params)

--- a/server/spec/authorizers/user_authorizer_spec.rb
+++ b/server/spec/authorizers/user_authorizer_spec.rb
@@ -34,6 +34,10 @@ describe UserAuthorizer do
       it 'lets read users' do
         expect(UserAuthorizer).to be_readable_by(master_admin)
       end
+
+      it 'lets remove users' do
+        expect(UserAuthorizer).to be_deletable_by(master_admin)
+      end
     end
 
     context 'when user is not master admin' do
@@ -43,6 +47,10 @@ describe UserAuthorizer do
 
       it 'does not let read users' do
         expect(UserAuthorizer).not_to be_readable_by(grid_admin)
+      end
+
+      it 'does not let remove users' do
+        expect(UserAuthorizer).not_to be_deletable_by(grid_admin)
       end
     end
   end
@@ -56,5 +64,4 @@ describe UserAuthorizer do
       expect(user.authorizer).to be_assignable_by(grid_admin, {to: grid})
     end
   end
-
 end


### PR DESCRIPTION
This PR adds to cli missing `master users remove <email>` command. 