### PR TITLE
Add memory filter to scheduler

### DIFF
--- a/server/app/services/grid_service_scheduler.rb
+++ b/server/app/services/grid_service_scheduler.rb
@@ -18,6 +18,7 @@ class GridServiceScheduler
     @filters = [
         Scheduler::Filter::Affinity.new,
         Scheduler::Filter::Port.new,
+        Scheduler::Filter::Memory.new,
         Scheduler::Filter::Dependency.new
     ]
     @mutex = Mutex.new

--- a/server/app/services/scheduler/filter/memory.rb
+++ b/server/app/services/scheduler/filter/memory.rb
@@ -1,0 +1,54 @@
+module Scheduler
+  module Filter
+    class Memory
+
+      ##
+      # @param [GridService] service
+      # @param [Integer] instance_number
+      # @param [Array<HostNode>] nodes
+      # @return [Array<HostNode>]
+      def for_service(service, instance_number, nodes)
+        candidates = nodes.dup
+        memory = service.memory || service.memory_swap
+        unless memory
+          container = service.containers.first
+          if container
+            stats = container.container_stats.last
+            memory = stats.memory['usage'] * 1.25
+          end
+        end
+
+        return candidates unless memory # we cannot calculate so let's return all candidates
+
+        instance_name = "#{service.name}-#{instance_number}"
+        candidates.delete_if{|c|
+          reject_candidate?(c, memory, instance_name)
+        }
+
+        candidates
+      end
+
+      # @param [HostNode] candidate
+      # @param [Float] memory
+      # @param [String] instance_name
+      def reject_candidate?(candidate, memory, instance_name)
+        return true if candidate.mem_total.to_i < memory
+
+        node_stat = candidate.host_node_stats.last
+        return false if node_stat.nil?
+
+        all_used = node_stat.memory['total'] - node_stat.memory['free']
+        mem_used = all_used - (node_stat.memory['cached'] + node_stat.memory['buffers'])
+        mem_free = node_stat.memory['total'] - mem_used
+
+        if instance = candidate.containers.find_by(name: instance_name)
+          mem_free += memory
+        end
+
+        return true if mem_free < memory
+
+        false
+      end
+    end
+  end
+end

--- a/server/spec/services/scheduler/filter/memory_spec.rb
+++ b/server/spec/services/scheduler/filter/memory_spec.rb
@@ -1,0 +1,101 @@
+require_relative '../../../spec_helper'
+
+describe Scheduler::Filter::Memory do
+
+  let(:nodes) do
+    nodes = []
+    nodes << HostNode.create!(node_id: 'node1', name: 'node-1')
+    nodes << HostNode.create!(node_id: 'node2', name: 'node-2')
+    nodes << HostNode.create!(node_id: 'node3', name: 'node-3')
+    nodes
+  end
+
+  let(:test_service) {
+    GridService.create(name: 'test-service', image_name: 'test-service:latest')
+  }
+
+  describe '#for_service' do
+    it 'returns all nodes if memory consumption cannot be calculated' do
+      filtered = subject.for_service(test_service, 'test-service-1', nodes)
+      expect(filtered).to eq(nodes)
+    end
+
+    it 'returns all nodes if service instance memory stats are not available' do
+      test_service.update_attribute(:memory, 512.megabytes)
+      nodes.each{|n| n.update_attribute(:total_memory, 1.gigabytes) }
+      filtered = subject.for_service(test_service, 'test-service-1', nodes)
+      expect(filtered).to eq(nodes)
+    end
+
+    it 'returns none of the nodes if node memory is not available' do
+      test_service.update_attribute(:memory, 512.megabytes)
+      filtered = subject.for_service(test_service, 'test-service-1', nodes)
+      expect(filtered).to eq([])
+    end
+  end
+
+
+  describe '#reject_candidate?' do
+    let(:candidate) {
+      candidate = nodes[0]
+      candidate.mem_total = 1.gigabytes
+      candidate
+    }
+
+    it 'rejects candidate if node does not have enough total memory' do
+      reject = subject.reject_candidate?(
+        candidate, 1300.megabytes, 'test-service-1'
+      )
+      expect(reject).to be_truthy
+    end
+
+    it 'rejects candidate if it does not have enough memory available' do
+      candidate.host_node_stats.create!(
+        memory: {
+          'total' => 1.gigabytes,
+          'free' => 128.megabytes,
+          'cached' => 128.megabytes,
+          'buffers' => 128.megabytes
+        }
+      )
+      reject = subject.reject_candidate?(
+        candidate, 500.megabytes, 'test-service-1'
+      )
+      expect(reject).to be_truthy
+    end
+
+    it 'accepts candidate if there is enough free memory' do
+      candidate.host_node_stats.create!(
+        memory: {
+          'total' => 1.gigabytes,
+          'free' => 512.megabytes,
+          'cached' => 128.megabytes,
+          'buffers' => 128.megabytes
+        }
+      )
+      reject = subject.reject_candidate?(
+        candidate, 500.megabytes, 'test-service-1'
+      )
+      expect(reject).to be_falsey
+    end
+
+    it 'accepts candidate if there is enough memory to swap service instance' do
+      candidate.host_node_stats.create!(
+        memory: {
+          'total' => 1.gigabytes,
+          'free' => 128.megabytes,
+          'cached' => 128.megabytes,
+          'buffers' => 128.megabytes
+        }
+      )
+      service_instance = test_service.containers.create!(
+        name: 'test-service-1',
+        host_node: candidate
+      )
+      reject = subject.reject_candidate?(
+        candidate, 500.megabytes, 'test-service-1'
+      )
+      expect(reject).to be_falsey
+    end
+  end
+end

--- a/server/spec/services/scheduler/filter/memory_spec.rb
+++ b/server/spec/services/scheduler/filter/memory_spec.rb
@@ -22,7 +22,7 @@ describe Scheduler::Filter::Memory do
 
     it 'returns all nodes if service instance memory stats are not available' do
       test_service.update_attribute(:memory, 512.megabytes)
-      nodes.each{|n| n.update_attribute(:total_memory, 1.gigabytes) }
+      nodes.each{|n| n.update_attribute(:mem_total, 1.gigabytes) }
       filtered = subject.for_service(test_service, 'test-service-1', nodes)
       expect(filtered).to eq(nodes)
     end


### PR DESCRIPTION
This PR implements new scheduler filter that calculates node memory usage and compares that to service instance memory requirements. If node does not have enough free memory it will be filtered out.