### PR TITLE
Add kontena master current command

### DIFF
--- a/cli/lib/kontena/cli/master/current_command.rb
+++ b/cli/lib/kontena/cli/master/current_command.rb
@@ -1,0 +1,17 @@
+module Kontena::Cli::Master
+  class CurrentCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    option ["--name"], :flag, "Show name only", default: false
+
+    def execute
+      master = current_master
+
+      if name?
+        puts master['name']
+      else
+        puts "#{master['name']} #{master['url']}"
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -5,6 +5,7 @@ require_relative 'master/azure_command'
 require_relative 'master/use_command'
 require_relative 'master/list_command'
 require_relative 'master/users_command'
+require_relative 'master/current_command'
 
 class Kontena::Cli::MasterCommand < Clamp::Command
 
@@ -15,6 +16,7 @@ class Kontena::Cli::MasterCommand < Clamp::Command
   subcommand ["list", "ls"], "List masters where client has logged in", Kontena::Cli::Master::ListCommand
   subcommand "use", "Switch to use selected master", Kontena::Cli::Master::UseCommand
   subcommand "users", "Users specific commands", Kontena::Cli::Master::UsersCommand
+  subcommand "current", "Show current master details", Kontena::Cli::Master::CurrentCommand
   def execute
   end
 end

--- a/cli/spec/kontena/cli/master/current_command_spec.rb
+++ b/cli/spec/kontena/cli/master/current_command_spec.rb
@@ -1,0 +1,57 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/master/current_command'
+
+describe Kontena::Cli::Master::CurrentCommand do
+  let(:settings) do
+    {'current_server' => 'alias',
+      'servers' => [
+        {'name' => 'some_master', 'url' => 'some_master'},
+        {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
+      ]
+    }
+  end
+
+  let(:subject) { described_class.new(File.basename($0)) }
+
+  describe '#execute' do
+    it 'puts master name and URL' do
+      allow(subject).to receive(:settings).and_return(settings)
+
+      expect {
+        subject.run([])
+      }.to output(/alias.*someurl/).to_stdout
+    end
+
+    it 'only outputs name if name-flag is set' do
+      allow(subject).to receive(:settings).and_return(settings)
+
+      expect {
+        subject.run(['--name'])
+      }.to output("alias\n").to_stdout
+    end
+
+    it 'does not raise error when logged in' do
+      allow(subject).to receive(:settings).and_return(settings)
+
+      expect {
+        subject.run([])
+      }.to_not raise_error
+    end
+
+    it 'raises error when not logged in' do
+      allow(subject).to receive(:settings).and_return(
+        {
+            'current_server' => nil,
+            'servers' => [
+                {'name' => 'some_master', 'url' => 'some_master'},
+                {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
+            ]
+        }
+      )
+
+      expect {
+        subject.run([])
+      }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Implements #612 with a `--name` flag (like `kontena grid current --name`).
Includes some basic tests.