### PR TITLE
Sets kontena vault list width to be 80 characters and not cropping

### DIFF
--- a/cli/lib/kontena/cli/vault/list_command.rb
+++ b/cli/lib/kontena/cli/vault/list_command.rb
@@ -7,9 +7,11 @@ module Kontena::Cli::Vault
       require_api_url
       token = require_token
       result = client(token).get("grids/#{current_grid}/secrets")
-      puts '%-30.30s %-30.30s' % ['NAME', 'CREATED AT']
+
+      column_width_paddings = '%-54s %-25.25s'
+      puts column_width_paddings % ['NAME', 'CREATED AT']
       result['secrets'].each do |secret|
-        puts '%-30.30s %-30.30s' % [secret['name'], secret['created_at']]
+        puts column_width_paddings % [secret['name'], secret['created_at']]
       end
     end
   end


### PR DESCRIPTION
See issue #615 

If the key is longer than 54, then the whole line will be longer (with the timestamp at the end). This ensures that no keys get cropped.