### PR TITLE
Do not overwrite service environment variable if value is empty

### DIFF
--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -118,7 +118,7 @@ module GridServices
       attributes[:cap_add] = self.cap_add if self.cap_add
       attributes[:cap_drop] = self.cap_drop if self.cap_drop
       attributes[:cmd] = self.cmd if self.cmd
-      attributes[:env] = self.env if self.env
+      attributes[:env] = self.build_grid_service_envs(self.env) if self.env
       attributes[:net] = self.net if self.net
       attributes[:ports] = self.ports if self.ports
       attributes[:affinity] = self.affinity if self.affinity
@@ -143,6 +143,20 @@ module GridServices
       grid_service.save
 
       grid_service
+    end
+
+    # @param [Array<String>] envs
+    # @return [Array<String>]
+    def build_grid_service_envs(env)
+      new_env = GridService.new(env: env).env_hash
+      current_env = self.grid_service.env_hash
+      new_env.each do |k, v|
+        if v.empty? && current_env[k]
+          new_env[k] = current_env[k]
+        end
+      end
+
+      new_env.map{|k, v| "#{k}=#{v}"}
     end
 
     def strategies

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -75,4 +75,48 @@ describe GridServices::Update do
       expect(hooks[0].cmd).to eq('sleep 10')
     end
   end
+
+  describe '#build_grid_service_envs' do
+    let(:redis_service) do
+      GridService.create!(
+        grid: grid,
+        name: 'redis',
+        image_name: 'redis:2.8',
+        env: [
+          'FOO=bar',
+          'BAR=baz'
+        ]
+      )
+    end
+    let(:subject) do
+      described_class.new(
+        current_user: user,
+        grid_service: redis_service
+      )
+    end
+
+    it 'appends to env' do
+      env = redis_service.env.dup
+      env << 'TEST=test'
+      env = subject.build_grid_service_envs(env)
+      expect(env.size).to eq(3)
+      expect(env[2]).to eq('TEST=test')
+    end
+
+    it 'modifies env' do
+      env = redis_service.env.dup
+      env[1] = 'BAR=bazzz'
+      env = subject.build_grid_service_envs(env)
+      expect(env.size).to eq(2)
+      expect(env[1]).to eq('BAR=bazzz')
+    end
+
+    it 'does not modify env if value nil' do
+      env = redis_service.env.dup
+      env[1] = 'BAR='
+      env = subject.build_grid_service_envs(env)
+      expect(env.size).to eq(2)
+      expect(env[1]).to eq('BAR=baz')
+    end
+  end
 end


### PR DESCRIPTION
This PR makes it possible to set environment variables outside of `kontena.yml`. User just have to document environment variable keys in `kontena.yml` and use cli to set the actual values.

**kontena.yml:** (inside folder named "demo")
```
app:
  image: registry.kontena.local/demo-app:latest
  environment:
    - MY_VAR
    - OTHER_VAR
```
**cli:**
```
$ kontena service add-env demo-app MY_VAR=foo
$ kontena service add-env demo-app OTHER_VAR=bar
```


Fixes #614 

