### PR TITLE
Merge secrets when extending services

### DIFF
--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -75,7 +75,8 @@ module Kontena::Cli::Apps
     # @return [Hash]
     def extend_options(options, file, service_name, prefix)
       parent_options = parse_services(file, service_name, prefix)
-      options['environment'] = extend_env_vars(parent_options, options)
+      options['environment'] = extend_env_vars(parent_options['environment'], options['environment'])
+      options['secrets'] = extend_secrets(parent_options['secrets'], options['secrets'])
       parent_options.merge(options)
     end
 
@@ -86,17 +87,30 @@ module Kontena::Cli::Apps
       end
     end
 
-    # @param [Hash] from
-    # @param [Hash] to
+    # @param [Array] from
+    # @param [Array] to
     # @return [Array]
     def extend_env_vars(from, to)
-      env_vars = to['environment'] || []
-      if from['environment']
-        from['environment'].each do |env|
-          env_vars << env unless to['environment'] && to['environment'].find {|key| key.split('=').first == env.split('=').first}
+      env_vars = to || []
+      if from
+        from.each do |env|
+          env_vars << env unless to && to.find {|key| key.split('=').first == env.split('=').first}
         end
       end
       env_vars
+    end
+
+    # @param [Array] from
+    # @param [Array] to
+    # @return [Array]
+    def extend_secrets(from, to)
+      secrets = to || []
+      if from
+        from.each do |from_secret|
+          secrets << from_secret unless to && to.any? {|to_secret| to_secret['secret'] == from_secret['secret']}
+        end
+      end
+      secrets
     end
 
     # @param [Hash] services

--- a/cli/spec/kontena/cli/app/common_spec.rb
+++ b/cli/spec/kontena/cli/app/common_spec.rb
@@ -78,26 +78,74 @@ describe Kontena::Cli::Apps::Common do
 
   describe '#extend_env_vars' do
     it 'inherites env vars from upper level' do
-      from = {'environment' => ['FOO=bar']}
-      to = {}
+      from = ['FOO=bar']
+      to = nil
       env_vars = subject.extend_env_vars(from, to)
       expect(env_vars).to eq(['FOO=bar'])
     end
 
     it 'overrides values' do
-      from = {'environment' => ['FOO=bar']}
-      to = {'environment' => ['FOO=baz']}
+      from = ['FOO=bar']
+      to = ['FOO=baz']
       env_vars = subject.extend_env_vars(from, to)
       expect(env_vars).to eq(['FOO=baz'])
     end
 
     it 'combines variables' do
-      from = {'environment' => ['FOO=bar']}
-      to = {'environment' => ['BAR=baz']}
+      from = ['FOO=bar']
+      to = ['BAR=baz']
       env_vars = subject.extend_env_vars(from, to)
       expect(env_vars).to eq(['BAR=baz', 'FOO=bar'])
     end
+  end
 
+  describe '#extend_secrets' do
+    it 'inherites secrets from upper level' do
+      secret = {
+        'secret' => 'CUSTOMER_DB_PASSWORD',
+        'name' => 'MYSQL_PASSWORD',
+        'type' => 'env'
+      }
+      from = [secret]
+      to = nil
+      secrets = subject.extend_secrets(from, to)
+      expect(secrets).to eq([secret])
+    end
 
+    it 'overrides secrets' do
+      from_secret = {
+        'secret' => 'CUSTOMER_DB_PASSWORD',
+        'name' => 'MYSQL_PASSWORD',
+        'type' => 'env'
+      }
+
+      to_secret = {
+        'secret' => 'CUSTOMER_DB_PASSWORD',
+        'name' => 'MYSQL_ROOT_PASSWORD',
+        'type' => 'env'
+      }
+      from = [from_secret]
+      to = [to_secret]
+      secrets = subject.extend_secrets(from, to)
+      expect(secrets).to eq([to_secret])
+    end
+
+    it 'combines secrets' do
+      from_secret = {
+        'secret' => 'CUSTOMER_DB_PASSWORD',
+        'name' => 'MYSQL_PASSWORD',
+        'type' => 'env'
+      }
+
+      to_secret = {
+        'secret' => 'CUSTOMER_API_TOKEN',
+        'name' => 'API_TOKEN',
+        'type' => 'env'
+      }
+      from = [from_secret]
+      to = [to_secret]
+      secrets = subject.extend_secrets(from, to)
+      expect(secrets).to eq([to_secret, from_secret])
+    end
   end
 end


### PR DESCRIPTION
This PR enhances service extending by merging secrets:

When having following YAML files
```
# base.yml
serviceA:
  ...
  secrets:
    - secret: CUSTOMER_DB_PASSWORD
      name: MYSQL_PASSWORD
      type: env

# kontena.yml
serviceA:
  extends:
     file: base.yml
     service: serviceA
  secrets:
    - secret: CUSTOMER_API_TOKEN
      name: API_TOKEN
      type: env
```

and deploying application `serviceA` will have both `CUSTOMER_DB_PASSWORD` and `CUSTOMER_API_TOKEN` secrets.
