### PR TITLE
Fix too aggressive overlay cidr cleanup

### DIFF
--- a/server/app/jobs/container_cleanup_job.rb
+++ b/server/app/jobs/container_cleanup_job.rb
@@ -23,7 +23,7 @@ class ContainerCleanupJob
   end
 
   def cleanup_reserved_overlay_cidrs
-    OverlayCidr.where(:reserved_at.ne => nil, :reserved_at.lt => 2.minutes.ago, :container_id => nil).each do |c|
+    OverlayCidr.where(:reserved_at.ne => nil, :reserved_at.lt => 20.minutes.ago, :container_id => nil).each do |c|
       c.set(:reserved_at => nil)
     end
   end

--- a/server/spec/jobs/container_cleanup_job_spec.rb
+++ b/server/spec/jobs/container_cleanup_job_spec.rb
@@ -4,7 +4,7 @@ describe ContainerCleanupJob do
   before(:each) { Celluloid.boot }
   after(:each) { Celluloid.shutdown }
 
-  let(:grid) { Grid.create!(name: 'test-grid') }
+  let(:grid) { Grid.create!(name: 'test-grid', overlay_cidr: '10.81.0.0/23') }
   let(:node1) { HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago) }
   let(:node2) { HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.seconds.ago) }
   let(:node3) { HostNode.create!(name: "node-3", connected: true, last_seen_at: 3.seconds.ago) }
@@ -27,6 +27,26 @@ describe ContainerCleanupJob do
       expect {
         subject.destroy_deleted_containers
       }.to change{ Container.unscoped.count }.by(0)
+    end
+  end
+
+  describe '#cleanup_reserved_overlay_cidrs' do
+    let(:allocator) do
+      Docker::OverlayCidrAllocator.new(grid)
+    end
+
+    it 'removes stale overlay_cidrs' do
+      allocator.initialize_grid_subnet
+      10.times do |i|
+        allocator.allocate_for_service_instance("app-#{i + 1}")
+      end
+
+      cidr = allocator.allocate_for_service_instance("app-n")
+      cidr.update_attribute(:reserved_at, 21.minutes.ago)
+      expect {
+        subject.cleanup_reserved_overlay_cidrs
+      }.to change{ cidr.reload.reserved_at }.to(nil)
+      expect(grid.overlay_cidrs.where(:reserved_at.ne => nil).count).to eq(10)
     end
   end
 end


### PR DESCRIPTION
If deploying a service instance is taking long time we might accidentally release ip that has been reserved.