### PR TITLE
Tell how to get the full exception when an error occurs.

### DIFF
--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -77,6 +77,8 @@ rescue => exc
   if ENV['DEBUG']
     raise exc
   else
-    abort(exc.message)
+    puts "Kontena error: #{exc.message}"
+    puts "Rerun the command with environment DEBUG=true set to get full the exception"
+    abort()
   end
 end


### PR DESCRIPTION
old:
```
$ kontena app deploy
updating web
creating sidekiq
undefined method `include?' for nil:NilClass
```

new and improved:
```
$ kontena app deploy
updating web
creating sidekiq
Kontena error: undefined method `include?' for nil:NilClass
Rerun the command with environment DEBUG=true set to get full the exception
```