### PR TITLE
Grid trusted subnets

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -163,11 +163,15 @@ module Kontena::NetworkAdapters
       weave = nil
       peer_ips = info['peer_ips'] || []
       until weave && weave.running? do
-        self.exec([
+        exec_params = [
           '--local', 'launch-router', '--ipalloc-range', '', '--dns-domain', 'kontena.local',
           '--password', ENV['KONTENA_TOKEN']
-          ] + peer_ips
-        )
+        ]
+        if info['trusted_subnets']
+          exec_params += ['--trusted-subnets', info['trusted_subnets']]
+        end
+        exec_params += peer_ips
+        self.exec(exec_params)
         weave = Docker::Container.get('weave') rescue nil
         wait = Time.now.to_f + 10.0
         sleep 0.5 until (weave && weave.running?) || (wait < Time.now.to_f)

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -167,8 +167,8 @@ module Kontena::NetworkAdapters
           '--local', 'launch-router', '--ipalloc-range', '', '--dns-domain', 'kontena.local',
           '--password', ENV['KONTENA_TOKEN']
         ]
-        if info['trusted_subnets']
-          exec_params += ['--trusted-subnets', info['trusted_subnets']]
+        if info['grid']['trusted_subnets']
+          exec_params += ['--trusted-subnets', info['grid']['trusted_subnets'].join(',')]
         end
         exec_params += peer_ips
         self.exec(exec_params)
@@ -185,6 +185,9 @@ module Kontena::NetworkAdapters
         info "router started with peers #{peer_ips.join(', ')}"
       else
         info "router started without known peers"
+      end
+      if info['grid']['trusted_subnets']
+        info "using trusted subnets: #{info['grid']['trusted_subnets']}"
       end
 
       if info['node_number']

--- a/cli/lib/kontena/cli/grid_command.rb
+++ b/cli/lib/kontena/cli/grid_command.rb
@@ -12,6 +12,7 @@ require_relative 'grids/list_users_command'
 require_relative 'grids/add_user_command'
 require_relative 'grids/remove_user_command'
 require_relative 'grids/cloud_config_command'
+require_relative 'grids/trusted_subnet_command'
 
 class Kontena::Cli::GridCommand < Clamp::Command
 
@@ -29,6 +30,7 @@ class Kontena::Cli::GridCommand < Clamp::Command
   subcommand "add-user", "Add user to the current grid", Kontena::Cli::Grids::AddUserCommand
   subcommand "remove-user", "Remove user from the current grid", Kontena::Cli::Grids::RemoveUserCommand
   subcommand "cloud-config", "Generate cloud-config", Kontena::Cli::Grids::CloudConfigCommand
+  subcommand "trusted-subnet", "Trusted subnet related commands", Kontena::Cli::Grids::TrustedSubnetCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
@@ -1,0 +1,12 @@
+module Kontena::Cli::Grids
+
+  require_relative 'trusted_subnets/list_command'
+  require_relative 'trusted_subnets/add_command'
+  require_relative 'trusted_subnets/remove_command'
+
+  class TrustedSubnetCommand < Clamp::Command
+    subcommand ["list", "ls"], "List trusted subnets", TrustedSubnets::ListCommand
+    subcommand "add", "Add trusted subnet", TrustedSubnets::AddCommand
+    subcommand ["remove", "rm"], "Remove trusted subnet", TrustedSubnets::RemoveCommand
+  end
+end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
@@ -1,0 +1,16 @@
+module Kontena::Cli::Grids::TrustedSubnets
+  class AddCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    parameter "NAME", "Grid name"
+    parameter "SUBNET", "Trusted subnet"
+
+    def execute
+      require_api_url
+      token = require_token
+      grid = client(token).get("grids/#{current_grid}")
+      data = {trusted_subnets: grid['trusted_subnets'] + [self.subnet]}
+      client(token).put("grids/#{current_grid}", data)
+    end
+  end
+end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
@@ -1,0 +1,17 @@
+module Kontena::Cli::Grids::TrustedSubnets
+  class ListCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    parameter "NAME", "Grid name"
+
+    def execute
+      require_api_url
+      token = require_token
+      grid = client(token).get("grids/#{current_grid}")
+      trusted_subnets = grid['trusted_subnets'] || []
+      trusted_subnets.each do |subnet|
+        puts subnet
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -1,0 +1,20 @@
+module Kontena::Cli::Grids::TrustedSubnets
+  class RemoveCommand < Clamp::Command
+    include Kontena::Cli::Common
+
+    parameter "NAME", "Grid name"
+    parameter "SUBNET", "Trusted subnet"
+
+    def execute
+      require_api_url
+      token = require_token
+      grid = client(token).get("grids/#{current_grid}")
+      trusted_subnets = grid['trusted_subnets'] || []
+      unless trusted_subnets.delete(self.subnet)
+        abort("Grid does not have trusted subnet #{self.subnet}")
+      end
+      data = {trusted_subnets: trusted_subnets}
+      client(token).put("grids/#{current_grid}", data)
+    end
+  end
+end

--- a/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
@@ -1,0 +1,38 @@
+require_relative "../../../../spec_helper"
+require "kontena/cli/grids/trusted_subnet_command"
+require "kontena/cli/grids/trusted_subnets/add_command"
+
+describe Kontena::Cli::Grids::TrustedSubnets::AddCommand do
+
+  include ClientHelpers
+
+  describe '#execute' do
+    it 'requires api url' do
+      expect(subject).to receive(:require_api_url).once
+      subject.run(['grid', 'subnet'])
+    end
+
+    it 'requires token' do
+      expect(subject).to receive(:require_token).and_return(token)
+      subject.run(['grid', 'subnet'])
+    end
+
+    it 'requires grid as param' do
+      expect {
+        subject.run([])
+      }.to raise_error(Clamp::UsageError)
+    end
+
+    it 'adds subnet to grid' do
+      allow(client).to receive(:get).with("grids/test-grid").and_return(
+        'trusted_subnets' => ['192.168.12.0/24']
+      )
+      expect(client).to receive(:put).with(
+        'grids/test-grid', hash_including({trusted_subnets: [
+          '192.168.12.0/24', '10.12.0.0/19'
+        ]})
+      )
+      subject.run(['test-grid', '10.12.0.0/19'])
+    end
+  end
+end

--- a/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
@@ -1,0 +1,31 @@
+require_relative "../../../../spec_helper"
+require "kontena/cli/grids/trusted_subnet_command"
+require "kontena/cli/grids/trusted_subnets/list_command"
+
+describe Kontena::Cli::Grids::TrustedSubnets::ListCommand do
+
+  include ClientHelpers
+
+  describe '#execute' do
+    it 'requires api url' do
+      expect(subject).to receive(:require_api_url).once
+      subject.run(['grid'])
+    end
+
+    it 'requires token' do
+      expect(subject).to receive(:require_token).and_return(token)
+      subject.run(['grid'])
+    end
+
+    it 'requires grid as param' do
+      expect {
+        subject.run([])
+      }.to raise_error(Clamp::UsageError)
+    end
+
+    it 'requests grid details from master' do
+      expect(client).to receive(:get).with("grids/test-grid")
+      subject.run(['test-grid'])
+    end
+  end
+end

--- a/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
@@ -1,0 +1,38 @@
+require_relative "../../../../spec_helper"
+require "kontena/cli/grids/trusted_subnet_command"
+require "kontena/cli/grids/trusted_subnets/remove_command"
+
+describe Kontena::Cli::Grids::TrustedSubnets::RemoveCommand do
+
+  include ClientHelpers
+
+  describe '#execute' do
+    it 'requires api url' do
+      expect(subject).to receive(:require_api_url).once
+      subject.run(['grid', 'subnet'])
+    end
+
+    it 'requires token' do
+      expect(subject).to receive(:require_token).and_return(token)
+      subject.run(['grid', 'subnet'])
+    end
+
+    it 'requires grid as param' do
+      expect {
+        subject.run([])
+      }.to raise_error(Clamp::UsageError)
+    end
+
+    it 'removes subnet from grid' do
+      allow(client).to receive(:get).with("grids/test-grid").and_return(
+        'trusted_subnets' => ['192.168.12.0/24', '192.168.50.0/24']
+      )
+      expect(client).to receive(:put).with(
+        'grids/test-grid', hash_including({trusted_subnets: [
+          '192.168.12.0/24'
+        ]})
+      )
+      subject.run(['test-grid', '192.168.50.0/24'])
+    end
+  end
+end

--- a/docs/using-kontena/grids.md
+++ b/docs/using-kontena/grids.md
@@ -7,9 +7,14 @@ toc_order: 2
 
 The [Grid](../core-concepts/architecture.md#the-grid) is top-level object in Kontena that describes a single cluster of Kontena Nodes.
 
-## Manage Grids
+* [Manage](grids#manage-grids)
+* [Logs](grids#grid-logs)
+* [Users](grids#grid-users)
+* [Trusted Subnets](grids#grid-trusted-subnets)
 
-### Create a New Grid
+### Manage Grids
+
+#### Create a New Grid
 
 ```
 $ kontena grid create --initial-size=3 mygrid
@@ -17,13 +22,13 @@ $ kontena grid create --initial-size=3 mygrid
 
 Creates a new grid named `mygrid` with initial size of 3 nodes (grid must have at least 3 nodes that are part of etcd cluster).
 
-### List Grids
+#### List Grids
 
 ```
 $ kontena grid list
 ```
 
-### Switch to Grid
+#### Switch to Grid
 
 ```
 $ kontena grid use another_grid
@@ -31,7 +36,7 @@ $ kontena grid use another_grid
 
 Switches cli scope to grid named `another_grid`.
 
-### Remove a Grid
+#### Remove a Grid
 
 ```
 $ kontena grid remove mygrid
@@ -39,11 +44,6 @@ $ kontena grid remove mygrid
 ```
 
 Removes a grid named `mygrid`.
-
-
-
-
-## Current Grid
 
 #### Show Current Grid
 
@@ -53,7 +53,7 @@ $ kontena grid current
 
 Shows currently used grid details.
 
-### Logs
+### Grid Logs
 
 #### Show Current Grid Logs
 
@@ -102,3 +102,25 @@ $ kontena grid remove-user not@val.id
 ```
 
 Removes a user with an email `not@val.id` from the current grid.
+
+### Grid Trusted Subnets
+
+If some of grid nodes are colocated in a trusted network (for example within the boundary of your own datacenter) you can add subnets to grid trusted subnet list. This disables data plane encryption within trusted subnet and switches overlay to faster (near-native) mode as an optimization.
+
+#### List Trusted Subnets
+
+```
+$ kontena grid trusted-subnet ls
+```
+
+#### Add Trusted Subnet
+
+```
+$ kontena grid trusted-subnet add <grid> <subnet>
+```
+
+#### Remove Trusted Subnet
+
+```
+$ kontena grid trusted-subnet remove <grid> <subnet>
+```

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -15,6 +15,7 @@ class Grid
   field :token, type: String
   field :initial_size, type: Integer, default: 1
   field :overlay_cidr, type: String, default: -> { Grid.default_overlay_cidr }
+  field :trusted_subnets, type: Array, default: []
   field :stats, type: Hash, default: {}
 
   has_many :host_nodes, dependent: :destroy

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -17,16 +17,31 @@ module Grids
           end
         end
       end
+      array :trusted_subnets do
+        string
+      end
     end
 
     def validate
       add_error(:user, :invalid, 'Operation not allowed') unless user.can_update?(grid)
+      if self.trusted_subnets
+        self.trusted_subnets.each do |subnet|
+          begin
+            IPAddr.new(subnet)
+          rescue IPAddr::InvalidAddressError
+            add_error(:trusted_subnets, :invalid, "Invalid trusted_subnet #{subnet}")
+          end
+        end
+      end
     end
 
     def execute
       attributes = {}
       if self.stats
         attributes[:stats] = self.stats
+      end
+      if self.trusted_subnets
+        attributes[:trusted_subnets] = self.trusted_subnets
       end
       grid.update_attributes(attributes)
       if grid.errors.size > 0

--- a/server/app/views/v1/grids/_grid.json.jbuilder
+++ b/server/app/views/v1/grids/_grid.json.jbuilder
@@ -5,6 +5,7 @@ json.initial_size grid.initial_size
 json.stats do
   json.statsd grid.stats['statsd']
 end
+json.trusted_subnets grid.trusted_subnets
 json.node_count grid.host_nodes.count
 json.service_count grid.grid_services.count
 json.container_count grid.containers.count

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -117,7 +117,7 @@ describe '/v1/grids' do
         david.roles << Role.create(name: 'master_admin', description: 'Master admin')
         emily # create
 
-        get "/v1/grids", nil, request_headers        
+        get "/v1/grids", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['grids'].size).to eq(2)
       end
@@ -138,6 +138,7 @@ describe '/v1/grids' do
       get "/v1/grids/#{grid.to_path}", nil, request_headers
       expect(response.status).to eq(200)
       expect(json_response['id']).to eq(grid.to_path)
+      expect(json_response['trusted_subnets']).to eq([])
     end
 
     describe '/services' do
@@ -334,6 +335,20 @@ describe '/v1/grids' do
       statsd = grid.reload.stats['statsd']
       expect(statsd['server']).to eq(server)
       expect(statsd['port']).to eq(port)
+    end
+
+    it 'updates trusted_subnets' do
+      grid = david.grids.first
+      data = {
+        trusted_subnets: ['192.168.10.0/24']
+      }
+      put "/v1/grids/#{grid.to_path}", data.to_json, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['trusted_subnets']).to eq(data[:trusted_subnets])
+
+      put "/v1/grids/#{grid.to_path}", {}, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['trusted_subnets']).to eq(data[:trusted_subnets])
     end
 
     it 'returns grid' do

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -2,7 +2,10 @@ require_relative '../spec_helper'
 
 describe Grid do
   it { should be_timestamped_document }
-  it { should have_fields(:name, :token, :initial_size, :overlay_cidr, :stats)}
+  it { should have_fields(:name, :token, :overlay_cidr).of_type(String) }
+  it { should have_fields(:initial_size).of_type(Integer) }
+  it { should have_fields(:stats).of_type(Hash) }
+  it { should have_fields(:trusted_subnets).of_type(Array) }
 
   it { should have_and_belong_to_many(:users) }
   it { should have_many(:host_nodes) }


### PR DESCRIPTION
This PR adds support for trusted subnets within a grid. 

> If some of grid nodes are colocated in a trusted network (for example within the boundary of your own datacenter) you can add subnets to grid trusted subnet list. This disables data plane encryption within trusted subnet and switches overlay to faster (near-native) mode as an optimization.