### PR TITLE
Schedule deploy for related services on secret update

### DIFF
--- a/server/app/mutations/grid_secrets/common.rb
+++ b/server/app/mutations/grid_secrets/common.rb
@@ -1,0 +1,14 @@
+module GridSecrets
+  module Common
+    include Workers
+
+    ##
+    # @param [GridSecret]
+    def refresh_grid_services(secret)
+      secret.grid.grid_services.where(:'secrets.secret' => secret.name).each do |grid_service|
+        grid_service.set(updated_at: Time.now.utc)
+        worker(:grid_service_scheduler).async.perform(grid_service.id)
+      end
+    end
+  end
+end

--- a/server/app/mutations/grid_secrets/create.rb
+++ b/server/app/mutations/grid_secrets/create.rb
@@ -1,5 +1,8 @@
+require_relative 'common'
+
 module GridSecrets
   class Create < Mutations::Command
+    include Common
 
     required do
       model :grid, class: Grid
@@ -19,7 +22,7 @@ module GridSecrets
         end
         return
       end
-
+      self.refresh_grid_services(grid_secret)
       grid_secret
     end
   end

--- a/server/app/mutations/grid_secrets/update.rb
+++ b/server/app/mutations/grid_secrets/update.rb
@@ -1,5 +1,8 @@
+require_relative 'common'
+
 module GridSecrets
   class Update < Mutations::Command
+    include Common
 
     required do
       model :grid_secret, class: GridSecret
@@ -15,7 +18,7 @@ module GridSecrets
         end
         return
       end
-
+      self.refresh_grid_services(grid_secret)
       grid_secret
     end
   end

--- a/server/spec/mutations/grid_secrets/create_spec.rb
+++ b/server/spec/mutations/grid_secrets/create_spec.rb
@@ -1,0 +1,56 @@
+require_relative '../../spec_helper'
+
+describe GridSecrets::Create do
+
+  let(:subject) { described_class.new(grid: grid, name: 'secret', value: 'v3rys3cr3t') }
+  let(:user) { User.create!(email: 'joe@domain.com')}
+  let(:grid) {
+    grid = Grid.create!(name: 'test-grid')
+    grid.users << user
+    grid
+  }
+  let(:web) {
+    service = GridService.create(grid: grid, name: 'web', image_name: 'web:latest')
+    service.secrets << GridServiceSecret.create(grid_service: service, secret: 'secret', name: 'service_secret', type: 'env')
+    service
+  }
+  let(:db) {
+    service = GridService.create(grid: grid, name: 'db', image_name: 'redis:2.8')
+    service.secrets << GridServiceSecret.create(grid_service: service, secret: 'db_secret', name: 'service_secret', type: 'env')
+    service
+  }
+  let(:worker) { spy(:worker) }
+
+  describe '#run' do
+    before(:each) do
+      allow(subject).to receive(:worker).with(:grid_service_scheduler).and_return(worker)
+    end
+    
+    it 'creates a new grid secret' do
+      expect {
+        subject.run
+      }.to change{ GridSecret.count }.by(1)
+    end
+
+    it 'updates related grid services' do
+      web # create
+      db # create
+      hour_ago = Time.now.utc - 1.hour
+      web.set(updated_at: hour_ago)
+      db.set(updated_at: hour_ago)
+      subject.run
+      expect(web.reload.updated_at.to_s).not_to eq(hour_ago.to_s)
+      expect(db.reload.updated_at.to_s).to eq(hour_ago.to_s)
+    end
+
+    it 'schedules deploy for related grid services' do
+      web # create
+      db # create
+
+      expect(subject).to receive(:worker).with(:grid_service_scheduler).once.and_return(worker)
+      expect(worker).to receive(:perform).once.with(web.id)
+      expect(worker).not_to receive(:perform).with(web.id)
+      subject.run
+    end
+  end
+end

--- a/server/spec/mutations/grid_secrets/update_spec.rb
+++ b/server/spec/mutations/grid_secrets/update_spec.rb
@@ -1,0 +1,60 @@
+require_relative '../../spec_helper'
+
+describe GridSecrets::Update do
+
+  let(:subject) { described_class.new(grid_secret: grid_secret, value: 'v3rys3cr3t')}
+  let(:user) { User.create!(email: 'joe@domain.com')}
+  let(:grid) {
+    grid = Grid.create!(name: 'test-grid')
+    grid.users << user
+    grid
+  }
+  let(:grid_secret) do
+    secret = GridSecret.create!(name: 'secret', value: 'secret')
+    grid.grid_secrets << secret
+    secret
+  end
+  let(:web) {
+    service = GridService.create(grid: grid, name: 'web', image_name: 'web:latest')
+    service.secrets << GridServiceSecret.create(grid_service: service, secret: 'secret', name: 'service_secret', type: 'env')
+    service
+  }
+  let(:db) {
+    service = GridService.create(grid: grid, name: 'db', image_name: 'redis:2.8')
+    service.secrets << GridServiceSecret.create(grid_service: service, secret: 'db_secret', name: 'service_secret', type: 'env')
+    service
+  }
+  let(:worker) { spy(:worker) }
+
+  describe '#run' do
+    before(:each) do
+      allow(subject).to receive(:worker).with(:grid_service_scheduler).and_return(worker)
+    end
+
+    it 'updates grid secret' do
+      expect {
+        subject.run
+      }.to change{ grid_secret.reload.value }.to('v3rys3cr3t')
+    end
+
+    it 'updates related grid services' do
+      web # create
+      db # create
+      hour_ago = Time.now.utc - 1.hour
+      web.set(updated_at: hour_ago)
+      db.set(updated_at: hour_ago)
+      subject.run
+      expect(web.reload.updated_at.to_s).not_to eq(hour_ago.to_s)
+      expect(db.reload.updated_at.to_s).to eq(hour_ago.to_s)
+    end
+
+    it 'schedules deploy for related grid services' do
+      web # create
+      db # create
+      expect(subject).to receive(:worker).with(:grid_service_scheduler).once.and_return(worker)
+      expect(worker).to receive(:perform).once.with(web.id)
+      expect(worker).not_to receive(:perform).with(db.id)
+      subject.run
+    end
+  end
+end


### PR DESCRIPTION
This PR schedules deploy for related grid services when creating or updating secrets. 

Fixes #650

