### PR TITLE
Return 404 error code when (un)assigning nonexistent user to grid

### DIFF
--- a/server/app/routes/v1/grids/grid_users.rb
+++ b/server/app/routes/v1/grids/grid_users.rb
@@ -5,6 +5,7 @@ V1::GridsApi.route('grid_users') do |r|
   r.post do
     data = parse_json_body
     user = User.find_by(email: data['email'])
+    halt_request(404, {error: 'User not found'}) unless user
     outcome = Grids::AssignUser.run({grid: @grid, current_user: current_user, user: user})
     if outcome.success?
       audit_event(r, @grid, user, 'assign user')
@@ -21,6 +22,7 @@ V1::GridsApi.route('grid_users') do |r|
   r.delete do
     r.on :email do |email|
       user = User.find_by(email: email)
+      halt_request(404, {error: 'User not found'}) unless user
       outcome = Grids::UnassignUser.run({grid: @grid, current_user: current_user, user: user})
       if outcome.success?
         audit_event(r, @grid, user, 'unassign user')

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -117,7 +117,7 @@ describe '/v1/grids' do
         david.roles << Role.create(name: 'master_admin', description: 'Master admin')
         emily # create
 
-        get "/v1/grids", nil, request_headers        
+        get "/v1/grids", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['grids'].size).to eq(2)
       end
@@ -210,7 +210,7 @@ describe '/v1/grids' do
     it 'requires existing email' do
       grid = david.grids.first
       post "/v1/grids/#{grid.to_path}/users", {email: 'invalid@domain.com'}.to_json, request_headers
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(404)
     end
     it 'assigns user to grid' do
       grid = david.grids.first
@@ -266,7 +266,7 @@ describe '/v1/grids' do
     it 'requires existing email' do
       grid = david.grids.first
       delete "/v1/grids/#{grid.to_path}/users/invalid@domain.com", nil, request_headers
-      expect(response.status).to eq(422)
+      expect(response.status).to eq(404)
     end
 
     it 'unassigns user from grid' do


### PR DESCRIPTION
This PR makes API to return 404 / "User not found" error when trying to assign or remove nonexistent user to/from grid. Previously it returned status 422 with cryptic "User can't be nil" message