### PR TITLE
Generate self-signed cert for DO master if no cert provided

### DIFF
--- a/cli/lib/kontena/machine/digital_ocean.rb
+++ b/cli/lib/kontena/machine/digital_ocean.rb
@@ -7,6 +7,7 @@ rescue LoadError
 end
 
 require_relative 'random_name'
+require_relative 'cert_helper'
 require_relative 'digital_ocean/node_provisioner'
 require_relative 'digital_ocean/node_destroyer'
 require_relative 'digital_ocean/master_provisioner'

--- a/cli/lib/kontena/machine/digital_ocean/master_provisioner.rb
+++ b/cli/lib/kontena/machine/digital_ocean/master_provisioner.rb
@@ -8,6 +8,7 @@ module Kontena
     module DigitalOcean
       class MasterProvisioner
         include RandomName
+        include Machine::CertHelper
 
         attr_reader :client, :http_client
 
@@ -25,6 +26,10 @@ module Kontena
           if opts[:ssl_cert]
             abort('Invalid ssl cert') unless File.exists?(File.expand_path(opts[:ssl_cert]))
             ssl_cert = File.read(File.expand_path(opts[:ssl_cert]))
+          else
+            ShellSpinner "Generating self-signed SSL certificate" do
+              ssl_cert = generate_self_signed_cert
+            end
           end
 
           userdata_vars = {
@@ -52,11 +57,8 @@ module Kontena
               sleep 5
             end
           end
-          if opts[:ssl_cert]
-            master_url = "https://#{droplet.public_ip}"
-          else
-            master_url = "http://#{droplet.public_ip}"
-          end
+
+          master_url = "https://#{droplet.public_ip}"
           Excon.defaults[:ssl_verify_peer] = false
           @http_client = Excon.new("#{master_url}", :connect_timeout => 10)
 


### PR DESCRIPTION
Sometimes it's cumbersome (particularly when testing) to generate certs manually for master provisioning. This PR adds a little helper that will generate self-signed SSL certificate for master if user does not provide any. Also enhances security because user does not have option to provision master without https.