### PR TITLE
Add --mongodb-uri option to digitalocean master create command

### DIFF
--- a/cli/lib/kontena/cli/master/digital_ocean/create_command.rb
+++ b/cli/lib/kontena/cli/master/digital_ocean/create_command.rb
@@ -9,8 +9,9 @@ module Kontena::Cli::Master::DigitalOcean
     option "--ssl-cert", "SSL CERT", "SSL certificate file"
     option "--size", "SIZE", "Droplet size", default: '1gb'
     option "--region", "REGION", "Region", default: 'ams2'
-    option "--vault-secret", "VAULT_SECRET", "Secret key for Vault"
-    option "--vault-iv", "VAULT_IV", "Initialization vector for Vault"
+    option "--vault-secret", "VAULT_SECRET", "Secret key for Vault (optional)"
+    option "--vault-iv", "VAULT_IV", "Initialization vector for Vault (optional)"
+    option "--mongodb-uri", "URI", "External MongoDB uri (optional)"
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--auth-provider-url", "AUTH_PROVIDER_URL", "Define authentication provider url"
 
@@ -28,7 +29,8 @@ module Kontena::Cli::Master::DigitalOcean
           version: version,
           auth_server: auth_provider_url,
           vault_secret: vault_secret || SecureRandom.hex(24),
-          vault_iv: vault_iv || SecureRandom.hex(24)
+          vault_iv: vault_iv || SecureRandom.hex(24),
+          mongodb_uri: mongodb_uri
       )
     end
 

--- a/cli/lib/kontena/machine/digital_ocean/cloudinit_master.yml
+++ b/cli/lib/kontena/machine/digital_ocean/cloudinit_master.yml
@@ -30,6 +30,7 @@ write_files:
         -p 80:80 -p 443:443 kontena/haproxy:latest
 coreos:
   units:
+<% unless mongodb_uri -%>
     - name: kontena-server-mongo.service
       command: start
       enable: true
@@ -53,7 +54,7 @@ coreos:
         ExecStart=/usr/bin/docker run --name=kontena-server-mongo \
             --volumes-from=kontena-server-mongo-data \
             mongo:3.0 mongod --smallfiles
-
+<% end -%>
     - name: kontena-server-api.service
       command: start
       enable: true
@@ -65,9 +66,13 @@ coreos:
         After=kontena-server-mongo.service
         Description=Kontena Master
         Documentation=http://www.kontena.io/
+        Before=kontena-server-haproxy.service
+        Wants=kontena-server-haproxy.service
         Requires=network-online.target
         Requires=docker.service
+<% unless mongodb_uri -%>
         Requires=kontena-server-mongo.service
+<% end %>
 
         [Service]
         Restart=always
@@ -77,10 +82,16 @@ coreos:
         ExecStartPre=-/usr/bin/docker rm kontena-server-api
         ExecStartPre=/usr/bin/docker pull kontena/server:${KONTENA_VERSION}
         ExecStart=/usr/bin/docker run --name kontena-server-api \
+<% if mongodb_uri -%>
+            -e MONGODB_URI=<%= mongodb_uri %> \
+<% else -%>
             --link kontena-server-mongo:mongodb \
             -e MONGODB_URI=mongodb://mongodb:27017/kontena_server \
+<% end -%>
+<% if auth_server %>
+            -e AUTH_API_URL=<%= auth_server %> \
+<% end -%>
             -e VAULT_KEY=${KONTENA_VAULT_KEY} -e VAULT_IV=${KONTENA_VAULT_IV} \
-            <% if auth_server %>-e AUTH_API_URL=<%= auth_server %><% end %> \
             kontena/server:${KONTENA_VERSION}
 
     - name: kontena-server-haproxy.service
@@ -95,6 +106,7 @@ coreos:
         Documentation=http://www.kontena.io/
         Requires=network-online.target
         Requires=docker.service
+        Requires=kontena-server-api.service
 
         [Service]
         Restart=always

--- a/cli/lib/kontena/machine/digital_ocean/master_provisioner.rb
+++ b/cli/lib/kontena/machine/digital_ocean/master_provisioner.rb
@@ -32,7 +32,8 @@ module Kontena
               auth_server: opts[:auth_server],
               version: opts[:version],
               vault_secret: opts[:vault_secret],
-              vault_iv: opts[:vault_iv]
+              vault_iv: opts[:vault_iv],
+              mongodb_uri: opts[:mongodb_uri]
           }
 
           droplet = DropletKit::Droplet.new(
@@ -65,7 +66,7 @@ module Kontena
           end
 
           puts "Kontena Master is now running at #{master_url}"
-          puts "Use #{"kontena login #{master_url}".colorize(:light_black)} to complete Kontena Master setup"
+          puts "Use #{"kontena login --name=#{droplet.name.sub('kontena-master-', '')} #{master_url}".colorize(:light_black)} to complete Kontena Master setup"
         end
 
         def user_data(vars)
@@ -74,7 +75,7 @@ module Kontena
         end
 
         def generate_name
-          "kontena-master-#{super}-#{rand(1..99)}"
+          "kontena-master-#{super}-#{rand(1..9)}"
         end
 
         def ssh_key(public_key)
@@ -88,7 +89,7 @@ module Kontena
         end
 
         def erb(template, vars)
-          ERB.new(template).result(OpenStruct.new(vars).instance_eval { binding })
+          ERB.new(template, nil, '%<>-').result(OpenStruct.new(vars).instance_eval { binding })
         end
       end
     end


### PR DESCRIPTION
With this option user can easily use external mongodb (hosted or on-premise) when provisioning Kontena Master to DigitalOcean