### PR TITLE
Add --mongodb-uri option to aws master create command

### DIFF
--- a/cli/lib/kontena/machine/aws/cloudinit_master.yml
+++ b/cli/lib/kontena/machine/aws/cloudinit_master.yml
@@ -30,6 +30,7 @@ write_files:
         -p 80:80 -p 443:443 kontena/haproxy:latest
 coreos:
   units:
+<% unless mongodb_uri -%>
     - name: kontena-server-mongo.service
       command: start
       enable: true
@@ -53,7 +54,7 @@ coreos:
         ExecStart=/usr/bin/docker run --name=kontena-server-mongo \
             --volumes-from=kontena-server-mongo-data \
             mongo:3.0 mongod --smallfiles
-
+<% end -%>
     - name: kontena-server-api.service
       command: start
       enable: true
@@ -65,11 +66,13 @@ coreos:
         After=kontena-server-mongo.service
         Description=Kontena Master
         Documentation=http://www.kontena.io/
-        Requires=network-online.target
-        Requires=docker.service
-        Requires=kontena-server-mongo.service
         Before=kontena-server-haproxy.service
         Wants=kontena-server-haproxy.service
+        Requires=network-online.target
+        Requires=docker.service
+<% unless mongodb_uri -%>
+        Requires=kontena-server-mongo.service
+<% end %>
 
         [Service]
         Restart=always
@@ -79,10 +82,16 @@ coreos:
         ExecStartPre=-/usr/bin/docker rm kontena-server-api
         ExecStartPre=/usr/bin/docker pull kontena/server:${KONTENA_VERSION}
         ExecStart=/usr/bin/docker run --name kontena-server-api \
+  <% if mongodb_uri -%>
+            -e MONGODB_URI=<%= mongodb_uri %> \
+  <% else -%>
             --link kontena-server-mongo:mongodb \
             -e MONGODB_URI=mongodb://mongodb:27017/kontena_server \
+  <% end -%>
+  <% if auth_server %>
+            -e AUTH_API_URL=<%= auth_server %> \
+  <% end -%>
             -e VAULT_KEY=${KONTENA_VAULT_KEY} -e VAULT_IV=${KONTENA_VAULT_IV} \
-            <% if auth_server %>-e AUTH_API_URL=<%= auth_server %><% end %> \
             kontena/server:${KONTENA_VERSION}
 
     - name: kontena-server-haproxy.service

--- a/cli/lib/kontena/machine/aws/master_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/master_provisioner.rb
@@ -47,7 +47,8 @@ module Kontena
               auth_server: opts[:auth_server],
               version: opts[:version],
               vault_secret: opts[:vault_secret],
-              vault_iv: opts[:vault_iv]
+              vault_iv: opts[:vault_iv],
+              mongodb_uri: opts[:mongodb_uri]
           }
 
           security_group = ensure_security_group(opts[:vpc])
@@ -83,12 +84,12 @@ module Kontena
           master_url = "https://#{ec2_instance.public_ip_address}"
           Excon.defaults[:ssl_verify_peer] = false
           http_client = Excon.new(master_url, :connect_timeout => 10)
-          ShellSpinner "Waiting for #{name.colorize(:cyan)} to start" do
+          ShellSpinner "Waiting for #{name.colorize(:cyan)} to start " do
             sleep 5 until master_running?(http_client)
           end
 
           puts "Kontena Master is now running at #{master_url}"
-          puts "Use #{"kontena login #{master_url}".colorize(:light_black)} to complete Kontena Master setup"
+          puts "Use #{"kontena login --name=#{name.sub('kontena-master-', '')} #{master_url}".colorize(:light_black)} to complete Kontena Master setup"
         end
 
         ##
@@ -151,7 +152,7 @@ module Kontena
         end
 
         def generate_name
-          "kontena-master-#{super}-#{rand(1..99)}"
+          "kontena-master-#{super}-#{rand(1..9)}"
         end
 
         def master_running?(http_client)
@@ -161,7 +162,7 @@ module Kontena
         end
 
         def erb(template, vars)
-          ERB.new(template).result(
+          ERB.new(template, nil, '%<>-').result(
             OpenStruct.new(vars).instance_eval { binding }
           )
         end


### PR DESCRIPTION
With this option user can easily use external mongodb (hosted or on-premise) when provisioning Kontena Master to AWS.