### PR TITLE
Remove container_log fulltext indexing

### DIFF
--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -10,7 +10,6 @@ module Kontena::Cli::Apps
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
     option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
     option "--since", "SINCE", "Show logs since given timestamp"
-    option ["-s", "--search"], "SEARCH", "Search from logs"
     option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     parameter "[SERVICE] ...", "Show only specified service logs"
 
@@ -36,7 +35,6 @@ module Kontena::Cli::Apps
         query_params << "from=#{last_id}" unless last_id.nil?
         query_params << "limit=#{lines}"
         query_params << "since=#{since}" if !since.nil? && last_id.nil?
-        query_params << "search=#{search}" if search
         logs = []
         services.each do |service_name, opts|
           service = get_service(token, prefixed_name(service_name)) rescue false

--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -3,7 +3,6 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
 
     option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
-    option ["-s", "--search"], "SEARCH", "Search from logs"
     option "--lines", "LINES", "Number of lines to show from the end of the logs"
     option "--since", "SINCE", "Show logs since given timestamp"
     option "--node", "NODE", "Filter by node name", multivalued: true
@@ -18,7 +17,6 @@ module Kontena::Cli::Grids
       query_params[:nodes] = node_list.join(",") unless node_list.empty?
       query_params[:services] = service_list.join(",") unless service_list.empty?
       query_params[:containers] = container_list.join(",") unless container_list.empty?
-      query_params[:search] = search if search
       query_params[:limit] = lines if lines
       query_params[:since] = since if since
 

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -10,7 +10,6 @@ module Kontena::Cli::Services
     option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
     option "--since", "SINCE", "Show logs since given timestamp"
-    option ["-s", "--search"], "SEARCH", "Search from logs"
     option ["-i", "--instance"], "INSTANCE", "Show only given instance specific logs"
 
     def execute
@@ -22,7 +21,6 @@ module Kontena::Cli::Services
         query_params << "limit=#{lines}"
         query_params << "from=#{last_id}" unless last_id.nil?
         query_params << "since=#{since}" if !since.nil? && last_id.nil?
-        query_params << "search=#{search}" if search
         query_params << "container=#{name}-#{instance}" if instance
 
         result = client(token).get("services/#{current_grid}/#{name}/container_logs?#{query_params.join('&')}")

--- a/server/app/models/container_log.rb
+++ b/server/app/models/container_log.rb
@@ -16,6 +16,5 @@ class ContainerLog
   index({ grid_service_id: 1 })
   index({ container_id: 1 })
   index({ name: 1 })
-  index({ data: 'text' }, { background: true })
   index({ created_at: 1 })
 end

--- a/server/app/routes/v1/grids/grid_container_logs.rb
+++ b/server/app/routes/v1/grids/grid_container_logs.rb
@@ -34,7 +34,6 @@ V1::GridsApi.route('grid_container_logs') do |r|
           scope = scope.where(grid_service_id: {:$in => services}) if services
           scope = scope.where(host_node_id: {:$in => nodes}) if nodes
           scope = scope.where(name: {:$in => container_names}) if container_names
-          scope = scope.where(:$text => {:$search => r['search']}) unless r['search'].nil?
           scope = scope.where(:id.gt => from) unless from.nil?
           if !since.nil? && from.nil?
             since = DateTime.parse(since) rescue nil
@@ -57,7 +56,6 @@ V1::GridsApi.route('grid_container_logs') do |r|
         scope = scope.where(grid_service_id: {:$in => services}) if services
         scope = scope.where(host_node_id: {:$in => nodes}) if nodes
         scope = scope.where(name: {:$in => container_names}) if container_names
-        scope = scope.where(:$text => {:$search => r['search']}) unless r['search'].nil?
         scope = scope.where(:id.gt => from ) unless from.nil?
         if !since.nil? && from.nil?
           since = DateTime.parse(since) rescue nil

--- a/server/db/migrations/09_remove_container_logs_text_index.rb
+++ b/server/db/migrations/09_remove_container_logs_text_index.rb
@@ -1,0 +1,8 @@
+class RemoveContainerLogsTextIndex < Mongodb::Migration
+
+  def self.up
+    ContainerLog.collection.indexes.drop(
+      "_fts" => "text", "_ftsx" => 1
+    )
+  end
+end

--- a/server/spec/models/container_log_spec.rb
+++ b/server/spec/models/container_log_spec.rb
@@ -15,5 +15,4 @@ describe ContainerLog do
   it { should have_index_for(host_node_id: 1) }
   it { should have_index_for(grid_service_id: 1) }
   it { should have_index_for(name: 1) }
-  it { should have_index_for(data: 'text') }
 end


### PR DESCRIPTION
Fulltext indexes take too much disk space. Proper way to search logs is to stream them from mongo to some log service and do queries there.