### PR TITLE
Improved memory parsing in CLI

### DIFF
--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -281,14 +281,17 @@ module Kontena
         # @param [String] memory
         # @return [Integer]
         def parse_memory(memory)
-          if memory.end_with?('k')
+          case memory
+          when /^\d+(k|K)$/
             memory.to_i * 1024
-          elsif memory.end_with?('m')
+          when /^\d+(m|M)$/
             memory.to_i * 1024 * 1024
-          elsif memory.end_with?('g')
+          when /^\d+(g|G)$/
             memory.to_i * 1024 * 1024 * 1024
-          else
+          when /^\d+$/
             memory.to_i
+          else
+            raise ArgumentError.new("Invalid memory value: #{memory}")
           end
         end
 

--- a/cli/spec/kontena/cli/services/services_helper_spec.rb
+++ b/cli/spec/kontena/cli/services/services_helper_spec.rb
@@ -134,18 +134,26 @@ module Kontena::Cli::Services
     describe '#parse_memory' do
       it 'parses kilobytes' do
         expect(subject.parse_memory("1024k")).to eq(1 * 1024 * 1024)
+        expect(subject.parse_memory("1024K")).to eq(1 * 1024 * 1024)
       end
 
       it 'parses megabytes' do
         expect(subject.parse_memory("32m")).to eq(32 * 1024 * 1024)
+        expect(subject.parse_memory("32M")).to eq(32 * 1024 * 1024)
       end
 
       it 'parses gigabytes' do
         expect(subject.parse_memory("2g")).to eq(2 * 1024 * 1024 * 1024)
+        expect(subject.parse_memory("2G")).to eq(2 * 1024 * 1024 * 1024)
       end
 
       it 'parses plain bytes' do
         expect(subject.parse_memory("#{12 * 1024 * 1024}")).to eq(12 * 1024 * 1024)
+      end
+
+      it 'raises error if invalid format' do
+        expect{subject.parse_memory("1.024g")}.to raise_error(ArgumentError)
+        expect{subject.parse_memory("1MG")}.to raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION
Allows capitalised letters (docker-compose does this) and raises error if invalid.