### PR TITLE
Add rollbar support to server 

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -17,6 +17,7 @@ gem 'msgpack'
 gem 'httpclient', '~> 2.3'
 gem 'authority'
 gem 'ruby_dig'
+gem 'rollbar', require: false
 
 group :development, :test do
   gem 'dotenv'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       listen (~> 2.7, >= 2.7.3)
     roda (2.5.0)
       rack
+    rollbar (2.11.3)
+      multi_json
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -134,6 +136,7 @@ DEPENDENCIES
   random_token
   rerun
   roda (~> 2.5.0)
+  rollbar
   rspec (~> 3.1.0)
   ruby_dig
   simplecov

--- a/server/app/initializers/rollbar.rb
+++ b/server/app/initializers/rollbar.rb
@@ -1,0 +1,9 @@
+if ENV['ROLLBAR_TOKEN'].to_s != ''
+  require 'rollbar'
+
+  Rollbar.configure do |config|
+    config.access_token = ENV['ROLLBAR_TOKEN']
+  end
+
+  Celluloid.exception_handler { |ex| Rollbar.error(ex) }
+end

--- a/server/app/initializers/rollbar.rb
+++ b/server/app/initializers/rollbar.rb
@@ -1,8 +1,9 @@
-if ENV['ROLLBAR_TOKEN'].to_s != ''
+unless ENV['ROLLBAR_TOKEN'].to_s.empty?
   require 'rollbar'
 
   Rollbar.configure do |config|
     config.access_token = ENV['ROLLBAR_TOKEN']
+    config.environment = ENV['ROLLBAR_ENVIRONMENT']
   end
 
   Celluloid.exception_handler { |ex| Rollbar.error(ex) }


### PR DESCRIPTION
This PR adds support for Rollbar error tracking service. Rollbar can be enabled by setting `ROLLBAR_TOKEN` environment variable to Kontena master. Rollbar environment can be defined via `ROLLBAR_ENVIRONMENT` env variable.


Fixes #475 