### PR TITLE
CLI: debug help only for non Kontena StandardErrors 

### DIFF
--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -76,6 +76,6 @@ rescue Kontena::Errors::StandardError => exc
 rescue => exc
   raise exc if ENV['DEBUG']
   $stderr.puts "Kontena error: #{exc.message}"
-  $stderr.puts "Rerun the command with environment DEBUG=true set to get full the exception"
+  $stderr.puts "Rerun the command with environment DEBUG=true set to get the full exception"
   abort
 end

--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -70,12 +70,12 @@ rescue Excon::Errors::SocketError => exc
   else
     abort(exc.message)
   end
+rescue Kontena::Errors::StandardError => exc
+  raise exc if ENV['DEBUG']
+  abort(exc.message)
 rescue => exc
-  if ENV['DEBUG']
-    raise exc
-  else
-    puts "Kontena error: #{exc.message}"
-    puts "Rerun the command with environment DEBUG=true set to get full the exception"
-    abort()
-  end
+  raise exc if ENV['DEBUG']
+  $stderr.puts "Kontena error: #{exc.message}"
+  $stderr.puts "Rerun the command with environment DEBUG=true set to get full the exception"
+  abort
 end


### PR DESCRIPTION
Fixes regression in 0.13

```
$ kontena version
cli: 0.12.3
$ kontena container exec web-1 pwd
{"error":"Not found"}

$ kontena version
cli: 0.13.1
$ kontena container exec web-1 pwd
Kontena error: {"error":"Not found"}
Rerun the command with environment DEBUG=true set to get full the exception
```
