### PR TITLE
Option for upserting secrets on update

### DIFF
--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -4,6 +4,7 @@ module Kontena::Cli::Vault
 
     parameter 'NAME', 'Secret name'
     parameter '[VALUE]', 'Secret value'
+    option ['-u', '--upsert'], :flag, 'Create secret unless already exists', default: false
 
     def execute
       require_api_url
@@ -13,7 +14,11 @@ module Kontena::Cli::Vault
         secret = STDIN.read
       end
       abort('No value provided') if secret.to_s == ''
-      data = {value: secret}
+      data = {
+        name: name,
+        value: secret,
+        upsert: upsert?
+      }
       client(token).put("grids/#{current_grid}/secrets/#{name}", data)
     end
   end

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,5 @@
 RACK_ENV=development
 MONGODB_URI=mongodb://127.0.0.1:27017/kontena_server_development
 PORT=9292
+VAULT_KEY=Random string. E.g. SecureRandom.base64(64)
+VAULT_IV=Random string. E.g. SecureRandom.base64(64)

--- a/server/app/helpers/request_helpers.rb
+++ b/server/app/helpers/request_helpers.rb
@@ -33,7 +33,7 @@ module RequestHelpers
     request.halt
   end
 
-  def halt_request(status, body)
+  def halt_request(status, body = {})
     response.status = status
     response.write(body.to_json)
     request.halt

--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -1,23 +1,19 @@
 development:
   sessions:
     default:
-      database: kontena_development
-      hosts:
-        - localhost:27017
+      uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost:27017/kontena_development' %>
   options:
     use_utc: true
     raise_not_found_error: false
 test:
   sessions:
     default:
-      database: kontena_test
       options:
         pool_size: 25
         read: :primary
         write:
           w: 1
-      hosts:
-        - localhost:27017
+      uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost:27017/kontena_test' %>
   options:
     use_utc: true
     raise_not_found_error: false


### PR DESCRIPTION
Implements: https://github.com/kontena/kontena/issues/673

Thought about audit log: Maybe extend Mutation outcomes to generate the audit message based on the outcome? So you could do for example:

> outcome.audit_message # Successful
=> 'created secret'
> outcome.audit_message # Failure
=> 'failed to create secret'

