### PR TITLE
Confirm dialog on destructive commands

### DIFF
--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -8,6 +8,7 @@ module Kontena::Cli::Apps
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
+    option '--confirm', :flag, 'Confirm remove', default: false, attribute_name: :confirmed
 
     parameter "[SERVICE] ...", "Remove services"
 
@@ -17,6 +18,7 @@ module Kontena::Cli::Apps
       require_api_url
       require_token
       require_config_file(filename)
+      confirm unless confirmed?
       
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0

--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Apps
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
-    option '--confirm', :flag, 'Confirm remove', default: false, attribute_name: :confirmed
+    option '--force', :flag, 'Force remove', default: false, attribute_name: :forced
 
     parameter "[SERVICE] ...", "Remove services"
 
@@ -18,8 +18,8 @@ module Kontena::Cli::Apps
       require_api_url
       require_token
       require_config_file(filename)
-      confirm unless confirmed?
-      
+      confirm unless forced?
+
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         remove_services(services)

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -122,6 +122,29 @@ module Kontena
         save_settings
       end
 
+      def error(message = nil)
+        $stderr.puts(message) if message
+        exit(1)
+      end
+
+      def prompt(prefix = '> ')
+        require 'highline/import'
+        ask(prefix)
+      end
+
+      def confirm_command(name, message = nil)
+        puts message if message
+        puts "Destructive command. To proceed, type \"#{name}\" or re-run this command with --confirm option."
+
+        prompt == name || error("Confirmation did not match #{name}. Aborted command.")
+      end
+
+      def confirm(message = 'Destructive command. Are you sure? (y/n) or re-run this command with --confirm option.')
+        puts message
+
+        ['y', 'yes'].include?(prompt) || error("Aborted command.")
+      end
+
       def api_url=(api_url)
         settings['servers'][current_master_index]['url'] = api_url
         save_settings

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -134,12 +134,12 @@ module Kontena
 
       def confirm_command(name, message = nil)
         puts message if message
-        puts "Destructive command. To proceed, type \"#{name}\" or re-run this command with --confirm option."
+        puts "Destructive command. To proceed, type \"#{name}\" or re-run this command with --force option."
 
         prompt == name || error("Confirmation did not match #{name}. Aborted command.")
       end
 
-      def confirm(message = 'Destructive command. Are you sure? (y/n) or re-run this command with --confirm option.')
+      def confirm(message = 'Destructive command. Are you sure? (y/n) or re-run this command with --force option.')
         puts message
 
         ['y', 'yes'].include?(prompt) || error("Aborted command.")

--- a/cli/lib/kontena/cli/etcd/remove_command.rb
+++ b/cli/lib/kontena/cli/etcd/remove_command.rb
@@ -9,13 +9,13 @@ module Kontena::Cli::Etcd
     parameter "KEY", "Etcd key"
 
     option "--recursive", :flag, "Remove keys recursively"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
       validate_key
-      confirm unless confirmed?
+      confirm unless forced?
 
       data = {}
       data[:recursive] = true if recursive?

--- a/cli/lib/kontena/cli/etcd/remove_command.rb
+++ b/cli/lib/kontena/cli/etcd/remove_command.rb
@@ -9,11 +9,13 @@ module Kontena::Cli::Etcd
     parameter "KEY", "Etcd key"
 
     option "--recursive", :flag, "Remove keys recursively"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
     def execute
       require_api_url
       token = require_token
       validate_key
+      confirm unless confirmed?
 
       data = {}
       data[:recursive] = true if recursive?

--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -6,12 +6,12 @@ module Kontena::Cli::Grids
     include Common
 
     parameter "NAME", "Grid name"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      confirm_command(name) unless confirmed?
+      confirm_command(name) unless forced?
       grid = find_grid_by_name(name)
 
       if !grid.nil?

--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -6,10 +6,12 @@ module Kontena::Cli::Grids
     include Common
 
     parameter "NAME", "Grid name"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
     def execute
       require_api_url
       token = require_token
+      confirm_command(name) unless confirmed?
       grid = find_grid_by_name(name)
 
       if !grid.nil?

--- a/cli/lib/kontena/cli/grids/users/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/users/remove_command.rb
@@ -7,10 +7,13 @@ module Kontena::Cli::Grids::Users
     include Kontena::Cli::Grids::Common
 
     parameter "EMAIL", "Email address"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
     def execute
       require_api_url
       token = require_token
+      confirm_command(email) unless confirmed?
+
       result = client(token).delete("grids/#{current_grid}/users/#{email}")
     end
   end

--- a/cli/lib/kontena/cli/grids/users/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/users/remove_command.rb
@@ -7,12 +7,12 @@ module Kontena::Cli::Grids::Users
     include Kontena::Cli::Grids::Common
 
     parameter "EMAIL", "Email address"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      confirm_command(email) unless confirmed?
+      confirm_command(email) unless forced?
 
       result = client(token).delete("grids/#{current_grid}/users/#{email}")
     end

--- a/cli/lib/kontena/cli/master/users/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/remove_command.rb
@@ -5,10 +5,13 @@ module Kontena::Cli::Master::Users
     include Kontena::Cli::Common
 
     parameter "EMAIL ...", "List of emails"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
     def execute
       require_api_url
       token = require_token
+      confirm unless confirmed?
+
       email_list.each do |email|
         begin
           client(token).delete("users/#{email}")

--- a/cli/lib/kontena/cli/master/users/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/remove_command.rb
@@ -5,12 +5,12 @@ module Kontena::Cli::Master::Users
     include Kontena::Cli::Common
 
     parameter "EMAIL ...", "List of emails"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      confirm unless confirmed?
+      confirm unless forced?
 
       email_list.each do |email|
         begin

--- a/cli/lib/kontena/cli/master/users/roles/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/roles/remove_command.rb
@@ -6,11 +6,13 @@ module Kontena::Cli::Master::Users::Roles
 
     parameter "ROLE", "Role name"
     parameter "USER ...", "List of users"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
 
     def execute
       require_api_url
       token = require_token
+      confirm unless confirmed?
 
       user_list.each do |email|
         begin

--- a/cli/lib/kontena/cli/master/users/roles/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/roles/remove_command.rb
@@ -6,13 +6,13 @@ module Kontena::Cli::Master::Users::Roles
 
     parameter "ROLE", "Role name"
     parameter "USER ...", "List of users"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
 
     def execute
       require_api_url
       token = require_token
-      confirm unless confirmed?
+      confirm unless forced?
 
       user_list.each do |email|
         begin

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -4,13 +4,13 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::GridOptions
 
     parameter "NODE_ID", "Node id"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       require_current_grid
       token = require_token
-      confirm_command(node_id) unless confirmed?
+      confirm_command(node_id) unless forced?
 
       client(token).delete("grids/#{current_grid}/nodes/#{node_id}")
     end

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -4,11 +4,13 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::GridOptions
 
     parameter "NODE_ID", "Node id"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
     def execute
       require_api_url
       require_current_grid
       token = require_token
+      confirm_command(node_id) unless confirmed?
 
       client(token).delete("grids/#{current_grid}/nodes/#{node_id}")
     end

--- a/cli/lib/kontena/cli/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/registry/remove_command.rb
@@ -2,9 +2,12 @@ module Kontena::Cli::Registry
   class RemoveCommand < Clamp::Command
     include Kontena::Cli::Common
 
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+
     def execute
       require_api_url
       token = require_token
+      confirm unless confirmed?
 
       registry = client(token).get("services/#{current_grid}/registry") rescue nil
       abort("Docker Registry service does not exist") if registry.nil?

--- a/cli/lib/kontena/cli/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/registry/remove_command.rb
@@ -2,12 +2,12 @@ module Kontena::Cli::Registry
   class RemoveCommand < Clamp::Command
     include Kontena::Cli::Common
 
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      confirm unless confirmed?
+      confirm unless forced?
 
       registry = client(token).get("services/#{current_grid}/registry") rescue nil
       abort("Docker Registry service does not exist") if registry.nil?

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -6,10 +6,12 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
     def execute
       require_api_url
       token = require_token
+      confirm_command(name) unless confirmed?
 
       result = client(token).delete("services/#{parse_service_id(name)}")
     end

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -6,12 +6,12 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      confirm_command(name) unless confirmed?
+      confirm_command(name) unless forced?
 
       result = client(token).delete("services/#{parse_service_id(name)}")
     end

--- a/cli/lib/kontena/cli/vault/list_command.rb
+++ b/cli/lib/kontena/cli/vault/list_command.rb
@@ -5,6 +5,8 @@ module Kontena::Cli::Vault
 
     def execute
       require_api_url
+      require_current_grid
+
       token = require_token
       result = client(token).get("grids/#{current_grid}/secrets")
 

--- a/cli/lib/kontena/cli/vault/read_command.rb
+++ b/cli/lib/kontena/cli/vault/read_command.rb
@@ -7,6 +7,8 @@ module Kontena::Cli::Vault
 
     def execute
       require_api_url
+      require_current_grid
+
       token = require_token
       result = client(token).get("secrets/#{current_grid}/#{name}")
       puts "#{result['name']}:"

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -4,10 +4,12 @@ module Kontena::Cli::Vault
     include Kontena::Cli::GridOptions
 
     parameter "NAME", "Secret name"
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
 
     def execute
       require_api_url
       require_current_grid
+      confirm_command(name) unless confirmed?
 
       token = require_token
       client(token).delete("secrets/#{current_grid}/#{name}")

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -4,12 +4,12 @@ module Kontena::Cli::Vault
     include Kontena::Cli::GridOptions
 
     parameter "NAME", "Secret name"
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       require_current_grid
-      confirm_command(name) unless confirmed?
+      confirm_command(name) unless forced?
 
       token = require_token
       client(token).delete("secrets/#{current_grid}/#{name}")

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -7,6 +7,8 @@ module Kontena::Cli::Vault
 
     def execute
       require_api_url
+      require_current_grid
+
       token = require_token
       client(token).delete("secrets/#{current_grid}/#{name}")
     end

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -8,6 +8,8 @@ module Kontena::Cli::Vault
 
     def execute
       require_api_url
+      require_current_grid
+
       token = require_token
       secret = value
       if secret.to_s == ''

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -8,6 +8,8 @@ module Kontena::Cli::Vault
 
     def execute
       require_api_url
+      require_current_grid
+
       token = require_token
       secret = value
       if secret.to_s == ''

--- a/cli/lib/kontena/cli/vpn/remove_command.rb
+++ b/cli/lib/kontena/cli/vpn/remove_command.rb
@@ -2,12 +2,12 @@ module Kontena::Cli::Vpn
   class RemoveCommand < Clamp::Command
     include Kontena::Cli::Common
 
-    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      confirm unless confirmed?
+      confirm unless forced?
 
       vpn = client(token).get("services/#{current_grid}/vpn") rescue nil
       abort("VPN service does not exist") if vpn.nil?

--- a/cli/lib/kontena/cli/vpn/remove_command.rb
+++ b/cli/lib/kontena/cli/vpn/remove_command.rb
@@ -2,9 +2,12 @@ module Kontena::Cli::Vpn
   class RemoveCommand < Clamp::Command
     include Kontena::Cli::Common
 
+    option "--confirm", :flag, "Confirm remove", default: false, attribute_name: :confirmed
+
     def execute
       require_api_url
       token = require_token
+      confirm unless confirmed?
 
       vpn = client(token).get("services/#{current_grid}/vpn") rescue nil
       abort("VPN service does not exist") if vpn.nil?

--- a/cli/spec/kontena/cli/common_spec.rb
+++ b/cli/spec/kontena/cli/common_spec.rb
@@ -89,7 +89,6 @@ describe Kontena::Cli::Common do
 
       expect(subject.current_master['url']).to eq('someurl')
       expect(subject.current_master['name']).to eq('alias')
-
     end
   end
 
@@ -121,5 +120,44 @@ describe Kontena::Cli::Common do
       subject.settings
     end
 
+  end
+
+  describe '#error' do
+    it 'prints error message to stderr if given and raise error' do
+      expect($stderr).to receive(:puts).with('error message!')
+      expect{subject.error('error message!')}.to raise_error(SystemExit)
+    end
+  end
+
+  describe '#confirm_command' do
+    it 'returns true if input matches' do
+      allow(subject).to receive(:prompt).and_return('name-to-confirm')
+
+      expect(subject.confirm_command('name-to-confirm')).to be_truthy
+      expect{subject.confirm_command('name-to-confirm')}.to_not raise_error
+    end
+
+    it 'raises error unless input matches' do
+      expect(subject).to receive(:prompt).and_return('wrong-name')
+      expect(subject).to receive(:error).with(/did not match/)
+
+      subject.confirm_command('name-to-confirm')
+    end
+  end
+
+  describe '#confirm' do
+    it 'returns true if confirmed' do
+      allow(subject).to receive(:prompt).and_return('y')
+
+      expect(subject.confirm).to be_truthy
+      expect{subject.confirm}.to_not raise_error
+    end
+
+    it 'raises error unless confirmed' do
+      expect(subject).to receive(:prompt).and_return('ei')
+      expect(subject).to receive(:error).with(/Aborted/)
+
+      subject.confirm
+    end
   end
 end

--- a/cli/spec/kontena/cli/master/users/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/remove_command_spec.rb
@@ -8,8 +8,17 @@ describe Kontena::Cli::Master::Users::RemoveCommand do
 
   describe '#execute' do
 
+    before(:each) do
+      allow(subject).to receive(:confirm).and_return(true)
+    end
+
     it 'requires api url' do
       expect(subject).to receive(:require_api_url).once
+      subject.run(['john@domain.com'])
+    end
+
+    it 'it requires confirmation' do
+      expect(subject).to receive(:confirm).once
       subject.run(['john@domain.com'])
     end
 

--- a/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
@@ -23,11 +23,13 @@ describe Kontena::Cli::Master::Users::Roles::RemoveCommand do
     before(:each) do
       allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:settings).and_return(valid_settings)
+      allow(subject).to receive(:confirm).and_return(true)
     end
 
     it 'makes remove role request for all given users' do
       expect(client).to receive(:delete).with("users/john@example.org/roles/role").once
       expect(client).to receive(:delete).with("users/jane@example.org/roles/role").once
+      expect(subject).to receive(:confirm).once
 
       subject.run(['role', 'john@example.org', 'jane@example.org'])
     end


### PR DESCRIPTION
Prompts users on destructive commands either with a y/n dialog or a name to confirm.
Can be overridden with `--confirm` option.

Also introduces an `error` helper that I suggest to replace the error handling/printing in `bin/kontena`. (Related https://github.com/kontena/kontena/pull/710)