### PR TITLE
etcd member replacement functionality

### DIFF
--- a/agent/lib/kontena/launchers/etcd.rb
+++ b/agent/lib/kontena/launchers/etcd.rb
@@ -8,7 +8,7 @@ module Kontena::Launchers
     include Kontena::Logging
     include Kontena::Helpers::IfaceHelper
 
-    ETCD_VERSION = ENV['ETCD_VERSION'] || '2.2.4'
+    ETCD_VERSION = ENV['ETCD_VERSION'] || '2.3.3'
     ETCD_IMAGE = ENV['ETCD_IMAGE'] || 'kontena/etcd'
 
     def initialize(autostart = true)
@@ -85,6 +85,7 @@ module Kontena::Launchers
     # @param [String] image
     # @param [Hash] info
     def create_container(image, info)
+      cluster_state = 'new'
       container = Docker::Container.get('kontena-etcd') rescue nil
       if container && container.info['Config']['Image'] != image
         container.delete(force: true)
@@ -92,31 +93,37 @@ module Kontena::Launchers
         info "etcd is already running"
         @running = true
         return
+      elsif container && !container.running?
+        info "etcd container exists but not running, starting it"
+        container.start
+        @running = true
+        return
+      elsif container.nil?
+        # No previous container exists, update previous membership info
+        cluster_state = update_membership(info)
       end
 
       cluster_size = info['grid']['initial_size']
       node_number = info['node_number']
       name = "node-#{info['node_number']}"
       grid_name = info['grid']['name']
-      weave_ip = "10.81.0.#{info['node_number']}"
       docker_ip = docker_gateway
 
       cmd = [
         '--name', name, '--data-dir', '/var/lib/etcd',
-        '--listen-client-urls', "http://127.0.0.1:2379,http://#{weave_ip}:2379,http://#{docker_ip}:2379",
+        '--listen-client-urls', "http://127.0.0.1:2379,http://#{weave_ip(info)}:2379,http://#{docker_ip}:2379",
         '--initial-cluster', initial_cluster(cluster_size).join(',')
       ]
       if node_number <= cluster_size
         cmd = cmd + [
-          '--listen-client-urls', "http://127.0.0.1:2379,http://#{weave_ip}:2379,http://#{docker_ip}:2379",
-          '--listen-peer-urls', "http://#{weave_ip}:2380",
-          '--advertise-client-urls', "http://#{weave_ip}:2379",
-          '--initial-advertise-peer-urls', "http://#{weave_ip}:2380",
+          '--listen-client-urls', "http://127.0.0.1:2379,http://#{weave_ip(info)}:2379,http://#{docker_ip}:2379",
+          '--listen-peer-urls', "http://#{weave_ip(info)}:2380",
+          '--advertise-client-urls', "http://#{weave_ip(info)}:2379",
+          '--initial-advertise-peer-urls', "http://#{weave_ip(info)}:2380",
           '--initial-cluster-token', grid_name,
-          '--initial-cluster', initial_cluster(cluster_size).join(','),
-          '--initial-cluster-state', 'new'
+          '--initial-cluster-state', cluster_state
         ]
-        info "starting etcd service as a cluster member"
+        info "starting etcd service as a cluster member with initial state: #{cluster_state}"
       else
         cmd = cmd + ['--proxy', 'on']
         info "starting etcd service as a proxy"
@@ -134,10 +141,66 @@ module Kontena::Launchers
         }
       )
       container.start
-      Celluloid::Notifications.publish('dns:add', {id: container.id, ip: weave_ip, name: 'etcd.kontena.local'})
+      Celluloid::Notifications.publish('dns:add', {id: container.id, ip: weave_ip(info), name: 'etcd.kontena.local'})
       info "started etcd service"
       @running = true
       container
+    end
+
+    # Removes possible previous member with the same IP
+    #
+    # @param [String] node weave ip
+    # @return [String] the state of the cluster member
+    def update_membership(info)
+      info "Checking if etcd previous membership needs to be updated"
+      tries = info['grid']['initial_size']
+      node_number = info['node_number']
+      peer_url = "http://#{weave_ip(info)}:2380"
+      client_url = "http://#{weave_ip(info)}:2379"
+
+      begin
+        etcd_host = "http://10.81.0.#{tries}:2379/v2/members"
+
+        info "Connecting to existing etcd at #{etcd_host}"
+        connection = Excon.new(etcd_host)
+        members = JSON.parse(connection.get().body)
+        peer_found = false
+        members['members'].each do |member|
+          if member['peerURLs'].include?(peer_url) && member['clientURLs'].include?(client_url)
+            info "Removing existing etcd membership info with id #{member['id']}"
+            result = connection.delete(:path => "/v2/members/#{member['id']}")
+            sleep 1
+            info "member delete result: #{result.inspect}"
+            info "Adding new etcd membership info with peer URL #{peer_url}"
+            result = connection.post(:body => JSON.generate({"peerURLs": [peer_url]}),
+                                      :headers => { "Content-Type" => "application/json" })
+            sleep 1
+            info "member add result: #{result.body}"
+            
+            return 'existing'
+          elsif member['peerURLs'].include?(peer_url) && !member['clientURLs'].include?(client_url)
+            peer_found = true
+          end
+        end
+
+        unless peer_found
+          info "Previous entry not found at all, adding"
+          result = connection.post(:body => JSON.generate({"peerURLs": [peer_url]}),
+                                  :headers => { "Content-Type" => "application/json" })
+          info "member add result: #{result.body}"
+        end
+        
+      rescue Excon::Errors::Error => exc
+        tries -= 1
+        if tries > 0
+          info "Retrying next etcd host"
+          retry
+        else
+          error "Cannot remove previous etcd membership info"
+          log_error exc
+        end
+      end
+      'new'
     end
 
     # @param [Integer] cluster_size
@@ -157,6 +220,12 @@ module Kontena::Launchers
       interface_ip('docker0')
     end
 
+    ##
+    # @param [Hash] node info
+    # @return [String] weave network ip of the node
+    def weave_ip(info)
+      "10.81.0.#{info['node_number']}"
+    end
     # @param [Exception] exc
     def log_error(exc)
       error "#{exc.class.name}: #{exc.message}"

--- a/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
+++ b/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
@@ -86,4 +86,199 @@ describe Kontena::Launchers::Etcd do
       subject.pull_image(image)
     end
   end
+
+  describe '#create_container' do
+    it 'returns if etcd already running' do
+      container = double
+      allow(Docker::Container).to receive(:get).and_return(container)
+      allow(container).to receive(:running?).and_return(true)
+      allow(container).to receive(:info).and_return({'Config' => {'Image' => 'etcd'}})
+      node_info = { }
+
+      subject.create_container('etcd', node_info)
+
+      expect(subject.instance_variable_get(:@running)).to eq(true)
+    end
+
+    it 'starts if etcd already exists but not running' do
+      container = double
+      allow(Docker::Container).to receive(:get).and_return(container)
+      allow(container).to receive(:running?).and_return(false)
+      allow(container).to receive(:info).and_return({'Config' => {'Image' => 'etcd'}})
+      expect(container).to receive(:start)
+      node_info = { }
+
+      subject.create_container('etcd', node_info)
+
+      expect(subject.instance_variable_get(:@running)).to eq(true)
+    end
+
+    it 'deletes and recreates the container' do
+      container = double
+      allow(Docker::Container).to receive(:get).and_return(container)
+      allow(container).to receive(:info).and_return({'Config' => {'Image' => 'foobar'}})
+      allow(subject.wrapped_object).to receive(:docker_gateway).and_return('172.17.0.1')
+      expect(container).to receive(:delete)
+      node_info = {
+        'node_number' => 1,
+        'grid' => {
+          'initial_size' => 3,
+          'name' => 'some_grid'
+        }
+      }
+      expected_cmd = [
+        '--name', 'node-1', '--data-dir', '/var/lib/etcd',
+        '--listen-client-urls', "http://127.0.0.1:2379,http://10.81.0.1:2379,http://172.17.0.1:2379",
+        '--initial-cluster', 'node-1=http://10.81.0.1:2380,node-2=http://10.81.0.2:2380,node-3=http://10.81.0.3:2380',
+        '--listen-client-urls', "http://127.0.0.1:2379,http://10.81.0.1:2379,http://172.17.0.1:2379",
+        '--listen-peer-urls', "http://10.81.0.1:2380",
+        '--advertise-client-urls', "http://10.81.0.1:2379",
+        '--initial-advertise-peer-urls', "http://10.81.0.1:2380",
+        '--initial-cluster-token', 'some_grid',
+        '--initial-cluster-state', 'new'
+      ]
+      etcd_container = double
+      expect(Docker::Container).to receive(:create).with(hash_including(
+        'name' => 'kontena-etcd',
+        'Image' => 'etcd',
+        'Cmd' => expected_cmd,
+        'HostConfig' => {
+          'NetworkMode' => 'host',
+          'RestartPolicy' => {'Name' => 'always'},
+          'VolumesFrom' => ['kontena-etcd-data']
+        })).and_return(etcd_container)
+      expect(etcd_container).to receive(:start)
+      allow(etcd_container).to receive(:id).and_return('12345')
+      expect(Celluloid::Notifications).to receive(:publish).with('dns:add', {id: etcd_container.id, ip: '10.81.0.1', name: 'etcd.kontena.local'})
+
+      subject.create_container('etcd', node_info)
+    end
+
+    it 'creates new container' do
+      container = double
+      allow(Docker::Container).to receive(:get).and_return(nil)
+      allow(subject.wrapped_object).to receive(:docker_gateway).and_return('172.17.0.1')
+      expect(subject.wrapped_object).to receive(:update_membership)
+      node_info = {
+        'node_number' => 1,
+        'grid' => {
+          'initial_size' => 3,
+          'name' => 'some_grid'
+        }
+      }
+      expected_cmd = [
+        '--name', 'node-1', '--data-dir', '/var/lib/etcd',
+        '--listen-client-urls', "http://127.0.0.1:2379,http://10.81.0.1:2379,http://172.17.0.1:2379",
+        '--initial-cluster', 'node-1=http://10.81.0.1:2380,node-2=http://10.81.0.2:2380,node-3=http://10.81.0.3:2380',
+        '--listen-client-urls', "http://127.0.0.1:2379,http://10.81.0.1:2379,http://172.17.0.1:2379",
+        '--listen-peer-urls', "http://10.81.0.1:2380",
+        '--advertise-client-urls', "http://10.81.0.1:2379",
+        '--initial-advertise-peer-urls', "http://10.81.0.1:2380",
+        '--initial-cluster-token', 'some_grid',
+        '--initial-cluster-state', 'existing'
+      ]
+      etcd_container = double
+      expect(Docker::Container).to receive(:create).with(hash_including(
+        'name' => 'kontena-etcd',
+        'Image' => 'etcd',
+        'Cmd' => expected_cmd,
+        'HostConfig' => {
+          'NetworkMode' => 'host',
+          'RestartPolicy' => {'Name' => 'always'},
+          'VolumesFrom' => ['kontena-etcd-data']
+        })).and_return(etcd_container)
+      expect(etcd_container).to receive(:start)
+      allow(etcd_container).to receive(:id).and_return('12345')
+      expect(Celluloid::Notifications).to receive(:publish).with('dns:add', {id: etcd_container.id, ip: '10.81.0.1', name: 'etcd.kontena.local'})
+
+      subject.create_container('etcd', node_info)
+    end
+
+    it 'deletes and recreates the container in proxy mode' do
+      container = double
+      allow(Docker::Container).to receive(:get).and_return(container)
+      allow(container).to receive(:info).and_return({'Config' => {'Image' => 'foobar'}})
+      allow(subject.wrapped_object).to receive(:docker_gateway).and_return('172.17.0.1')
+      expect(container).to receive(:delete)
+      node_info = {
+        'node_number' => 2,
+        'grid' => {
+          'initial_size' => 1,
+          'name' => 'some_grid'
+        }
+      }
+      expected_cmd = [
+        '--name', 'node-2', '--data-dir', '/var/lib/etcd',
+        '--listen-client-urls', "http://127.0.0.1:2379,http://10.81.0.2:2379,http://172.17.0.1:2379",
+        '--initial-cluster', 'node-1=http://10.81.0.1:2380',
+        '--proxy', 'on'
+      ]
+      etcd_container = double
+      expect(Docker::Container).to receive(:create).with(hash_including(
+        'name' => 'kontena-etcd',
+        'Image' => 'etcd',
+        'Cmd' => expected_cmd,
+        'HostConfig' => {
+          'NetworkMode' => 'host',
+          'RestartPolicy' => {'Name' => 'always'},
+          'VolumesFrom' => ['kontena-etcd-data']
+        })).and_return(etcd_container)
+      expect(etcd_container).to receive(:start)
+      allow(etcd_container).to receive(:id).and_return('12345')
+      expect(Celluloid::Notifications).to receive(:publish).with('dns:add', {id: etcd_container.id, ip: '10.81.0.2', name: 'etcd.kontena.local'})
+
+      subject.create_container('etcd', node_info)
+    end
+    
+  end
+
+  describe '#update_membership' do
+    it 'retries 3 times if Excon error connecting to etcd' do
+      excon = double
+      allow(Excon).to receive(:new).and_return(excon)
+      allow(excon).to receive(:get).and_raise(Excon::Errors::Error)
+      expect(excon).to receive(:get).exactly(3).times
+      node_info = {
+        'node_number' => 1,
+        'grid' => {
+          'initial_size' => 3
+        }
+      }
+      subject.update_membership(node_info)
+    end
+
+    it 'deletes and adds when matching peer found from etcd' do
+      excon = double
+      allow(Excon).to receive(:new).and_return(excon)
+      response = double
+      allow(excon).to receive(:get).and_return(response)
+      allow(response).to receive(:body).and_return('{"members":[{"id":"4e12ae023cc6f88d","name":"node-1","peerURLs":["http://10.81.0.1:2380"],"clientURLs":["http://10.81.0.1:2379"]}]}')
+      expect(excon).to receive(:delete).with(hash_including(:path => "/v2/members/4e12ae023cc6f88d"))
+      expect(excon).to receive(:post).with(hash_including(:body => '{"peerURLs":["http://10.81.0.1:2380"]}'))
+      node_info = {
+        'node_number' => 1,
+        'grid' => {
+          'initial_size' => 3
+        }
+      }
+      subject.update_membership(node_info)
+    end
+
+    it 'only adds when no matching peer found from etcd' do
+      excon = double
+      allow(Excon).to receive(:new).and_return(excon)
+      response = double
+      allow(excon).to receive(:get).and_return(response)
+      allow(response).to receive(:body).and_return('{"members":[{"id":"4e12ae023cc6f88d","name":"node-1","peerURLs":["http://10.81.0.1:2380"],"clientURLs":["http://10.81.0.1:2379"]}]}')
+      expect(excon).not_to receive(:delete)
+      expect(excon).to receive(:post).with(hash_including(:body => '{"peerURLs":["http://10.81.0.3:2380"]}'))
+      node_info = {
+        'node_number' => 3,
+        'grid' => {
+          'initial_size' => 3
+        }
+      }
+      subject.update_membership(node_info)
+    end
+  end
 end


### PR DESCRIPTION
Work-In-Progress

This PR adds functionality to handle etcd initial node replacing.

Uses the etcd members API to figure out if we are about to replace a member or if we are bootstrapping a new cluster.