### PR TITLE
Fix possible agent ws ping_timer race condition

### DIFF
--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -52,6 +52,7 @@ module Kontena
 
     def connect
       return if connecting?
+      @connected = false
       @connecting = true
       info "connecting to master at #{api_uri}"
       headers = {

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -115,9 +115,9 @@ module Kontena
       @connecting = false
       @ws = nil
       if event.code == 4001
-        handle_invalid_token(event)
+        handle_invalid_token
       elsif event.code == 4010
-        handle_invalid_version(event)
+        handle_invalid_version
       end
       Celluloid::Notifications.publish('websocket:disconnect', event)
       info "connection closed with code: #{event.code}"
@@ -125,14 +125,12 @@ module Kontena
       error exc.message
     end
 
-    # @param [Faye::WebSocket::API::Event] event
-    def handle_invalid_token(event)
+    def handle_invalid_token
       error 'master does not accept our token, shutting down ...'
       EM.next_tick { abort('Shutting down ...') }
     end
 
-    # @param [Faye::WebSocket::API::Event] _
-    def handle_invalid_version(_)
+    def handle_invalid_version
       agent_version = Kontena::Agent::VERSION
       error "master does not accept our version (#{agent_version}), shutting down ..."
       EM.next_tick { abort("Shutting down ...") }

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -1,5 +1,3 @@
-require 'cgi'
-require 'socket'
 require_relative 'logging'
 require_relative 'rpc_server'
 
@@ -9,7 +7,12 @@ module Kontena
 
     KEEPALIVE_TIME = 30
 
-    attr_reader :api_uri, :api_token, :ws
+    attr_reader :api_uri,
+                :api_token,
+                :ws,
+                :rpc_server,
+                :ping_timer
+
     delegate :on, to: :ws
 
     ##
@@ -18,21 +21,21 @@ module Kontena
     def initialize(api_uri, api_token)
       @api_uri = api_uri
       @api_token = api_token.to_s
-      @subscribers = {}
       @rpc_server = Kontena::RpcServer.new
       @abort = false
       info "initialized with token #{@api_token[0..10]}..."
       @connected = false
       @connecting = false
+      @ping_timer = nil
     end
 
     def ensure_connect
       EM::PeriodicTimer.new(1) {
-        self.connect unless connected?
+        connect unless connected?
       }
       EM::PeriodicTimer.new(KEEPALIVE_TIME) {
         if connected?
-          EM.next_tick{ self.verify_connection }
+          EM.next_tick { verify_connection }
         end
       }
     end
@@ -61,13 +64,13 @@ module Kontena
       Celluloid::Notifications.publish('websocket:connect', self)
 
       @ws.on :open do |event|
-        self.on_open(event)
+        on_open(event)
       end
       @ws.on :message do |event|
-        self.on_message(@ws, event)
+        on_message(@ws, event)
       end
       @ws.on :close do |event|
-        self.on_close(event)
+        on_close(event)
       end
       @ws.on :error do |event|
         error "connection closed with error: #{event.message}"
@@ -77,61 +80,61 @@ module Kontena
     ##
     # @param [String, Array] msg
     def send_message(msg)
-      EM.next_tick {
-        @ws.send(msg)
-      }
+      EM.next_tick { ws.send(msg) }
     end
 
-    # @param [Faye::WebSocket::Api::Event] event
+    # @param [Faye::WebSocket::API::Event] event
     def on_open(event)
+      ping_timer.cancel if ping_timer
       info 'connection established'
       @connected = true
       @connecting = false
     end
 
     # @param [Faye::WebSocket::Client] ws
-    # @param [Faye::WebSocket::Api::Event] event
+    # @param [Faye::WebSocket::API::Event] event
     def on_message(ws, event)
       data = MessagePack.unpack(event.data.pack('c*'))
       if request_message?(data)
         EM.defer {
-          response = @rpc_server.handle_request(data)
-          self.send_message(MessagePack.dump(response).bytes)
+          response = rpc_server.handle_request(data)
+          send_message(MessagePack.dump(response).bytes)
         }
       elsif notification_message?(data)
         EM.defer {
-          @rpc_server.handle_notification(data)
+          rpc_server.handle_notification(data)
         }
       end
     end
 
-    # @param [Faye::WebSocket::Api::Event] event
+    # @param [Faye::WebSocket::API::Event] event
     def on_close(event)
+      ping_timer.cancel if ping_timer
       @connected = false
       @connecting = false
       @ws = nil
       if event.code == 4001
-        self.handle_invalid_token(event)
+        handle_invalid_token(event)
       elsif event.code == 4010
-        self.handle_invalid_version(event)
+        handle_invalid_version(event)
       end
       Celluloid::Notifications.publish('websocket:disconnect', event)
       info "connection closed with code: #{event.code}"
     rescue => exc
-      logger.error(LOG_NAME) { exc.message }
+      error exc.message
     end
 
-    # @param [Faye::WebSocket::Api::Event] event
+    # @param [Faye::WebSocket::API::Event] event
     def handle_invalid_token(event)
-      error "master does not accept our token, shutting down ..."
-      EM.next_tick{ abort("Shutting down ...") }
+      error 'master does not accept our token, shutting down ...'
+      EM.next_tick { abort('Shutting down ...') }
     end
 
-    # @param [Faye::WebSocket::Api::Event] event
-    def handle_invalid_version(event)
+    # @param [Faye::WebSocket::API::Event] _
+    def handle_invalid_version(_)
       agent_version = Kontena::Agent::VERSION
       error "master does not accept our version (#{agent_version}), shutting down ..."
-      EM.next_tick{ abort("Shutting down ...") }
+      EM.next_tick { abort("Shutting down ...") }
     end
 
     # @param [Array] msg
@@ -152,15 +155,13 @@ module Kontena
     end
 
     def verify_connection
-      timer = EM::Timer.new(2) do
+      @ping_timer = EM::Timer.new(2) do
         if @connected
-          info "did not receive pong, closing connection"
-          self.ws.close(1000)
+          info 'did not receive pong, closing connection'
+          ws.close(1000)
         end
       end
-      self.ws.ping {
-        timer.cancel
-      }
+      ws.ping { @ping_timer.cancel }
     rescue => exc
       error exc.message
     end

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -89,13 +89,13 @@ describe Kontena::WebsocketClient do
 
     it 'handles 4001 error code' do
       event = Faye::WebSocket::API::CloseEvent.new('close', code: 4001)
-      expect(subject).to receive(:handle_invalid_token).once.with(event)
+      expect(subject).to receive(:handle_invalid_token).once
       subject.on_close(event)
     end
 
     it 'handles 4010 error code' do
       event = Faye::WebSocket::API::CloseEvent.new('close', code: 4010)
-      expect(subject).to receive(:handle_invalid_version).once.with(event)
+      expect(subject).to receive(:handle_invalid_version).once
       subject.on_close(event)
     end
 

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -4,7 +4,10 @@ describe Kontena::WebsocketClient do
 
   let(:subject) { described_class.new('', '')}
 
-  before(:each) { Celluloid.boot }
+  before(:each) {
+    Celluloid.boot
+    allow(subject).to receive(:host_id).and_return('ABCD')
+  }
   after(:each) { Celluloid.shutdown }
 
   around(:each) do |example|
@@ -26,10 +29,66 @@ describe Kontena::WebsocketClient do
   end
 
   describe '#on_open' do
-    it 'sets state to connected' do
+    it 'sets connected to true' do
       expect(subject.connected?).to be_falsey
       subject.on_open(spy)
       expect(subject.connected?).to be_truthy
+    end
+
+    it 'sets connecting to false' do
+      subject.connect
+      expect(subject.connecting?).to be_truthy
+      subject.on_open(spy)
+      expect(subject.connecting?).to be_falsey
+    end
+
+    it 'cancels ping timer' do
+      timer = spy(:timer)
+      allow(subject).to receive(:ping_timer).and_return(timer)
+      expect(timer).to receive(:cancel)
+      subject.on_open(spy)
+    end
+  end
+
+  describe '#on_close' do
+    let(:event) { Faye::WebSocket::API::CloseEvent.new('close', {}) }
+
+    it 'publishes event' do
+      expect(Celluloid::Notifications).to receive(:publish)
+      subject.on_close(event)
+    end
+
+    it 'sets connected to false' do
+      subject.on_open(spy)
+      expect {
+        subject.on_close(event)
+      }.to change{ subject.connected? }.from(true).to(false)
+    end
+
+    it 'sets connecting to false' do
+      subject.connect
+      expect {
+        subject.on_close(event)
+      }.to change{ subject.connecting? }.from(true).to(false)
+    end
+
+    it 'handles 4001 error code' do
+      event = Faye::WebSocket::API::CloseEvent.new('close', code: 4001)
+      expect(subject).to receive(:handle_invalid_token).once.with(event)
+      subject.on_close(event)
+    end
+
+    it 'handles 4010 error code' do
+      event = Faye::WebSocket::API::CloseEvent.new('close', code: 4010)
+      expect(subject).to receive(:handle_invalid_version).once.with(event)
+      subject.on_close(event)
+    end
+
+    it 'cancels ping timer' do
+      timer = spy(:timer)
+      allow(subject).to receive(:ping_timer).and_return(timer)
+      expect(timer).to receive(:cancel)
+      subject.on_close(event)
     end
   end
 

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -28,6 +28,21 @@ describe Kontena::WebsocketClient do
     end
   end
 
+  describe '#connect' do
+    it 'sets connecting to true' do
+      expect {
+        subject.connect
+      }.to change{ subject.connecting? }.from(false).to(true)
+    end
+
+    it 'sets connected to false' do
+      subject.on_open(spy)
+      expect {
+        subject.connect
+      }.to change{ subject.connected? }.from(true).to(false)
+    end
+  end
+
   describe '#on_open' do
     it 'sets connected to true' do
       expect(subject.connected?).to be_falsey


### PR DESCRIPTION
In some really rare conditions agent might drop connection and loose track of connection status. This stops connection retries and agent is "offline" until it's restarted.