### PR TITLE
Use region as az in DO

### DIFF
--- a/cli/lib/kontena/machine/digital_ocean/node_provisioner.rb
+++ b/cli/lib/kontena/machine/digital_ocean/node_provisioner.rb
@@ -47,7 +47,7 @@ module Kontena
           ShellSpinner "Waiting for node #{droplet.name.colorize(:cyan)} join to grid #{opts[:grid].colorize(:cyan)} " do
             sleep 2 until node = droplet_exists_in_grid?(opts[:grid], droplet)
           end
-          set_labels(node, ["region=#{opts[:region]}"])
+          set_labels(node, ["region=#{opts[:region]}", "az=#{opts[:region]}"])
         end
 
         def user_data(vars)


### PR DESCRIPTION
This PR adds automatic az labeling based on DO region as DO does not support actual az's.

Fixes #718 