### PR TITLE
Agent version publishing and showing on cli

### DIFF
--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -1,7 +1,8 @@
 require 'net/http'
+require 'vmstat'
+
 require_relative '../helpers/node_helper'
 require_relative '../helpers/iface_helper'
-require 'vmstat'
 
 module Kontena::Workers
   class NodeInfoWorker
@@ -60,6 +61,7 @@ module Kontena::Workers
       info 'publishing node information'
       docker_info['PublicIp'] = self.public_ip
       docker_info['PrivateIp'] = self.private_ip
+      docker_info['AgentVersion'] = Kontena::Agent::VERSION
       event = {
           event: 'node:info',
           data: docker_info

--- a/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
@@ -99,6 +99,12 @@ describe Kontena::Workers::NodeInfoWorker do
       info = subject.queue.pop
       expect(info[:data]['PrivateIp']).to eq('192.168.66.2')
     end
+
+    it 'contains agent_version' do
+      subject.publish_node_info
+      info = subject.queue.pop
+      expect(info[:data]['AgentVersion']).to match(/\d+\.\d+\.\d+/)
+    end
   end
 
   describe '#publish_node_stats' do
@@ -108,6 +114,7 @@ describe Kontena::Workers::NodeInfoWorker do
       }.to change{ subject.queue.length }.by(1)
     end
   end
+
 
   describe '#public_ip' do
     it 'returns ip from env if set' do

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -14,6 +14,7 @@ module Kontena::Cli::Nodes
       node = client(token).get("grids/#{current_grid}/nodes/#{node_id}")
       puts "#{node['name']}:"
       puts "  id: #{node['id']}"
+      puts "  agent version: #{node['agent_version']}"
       puts "  connected: #{node['connected'] ? 'yes': 'no'}"
       puts "  last connect: #{node['updated_at']}"
       puts "  last seen: #{node['last_seen_at']}"

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -23,6 +23,7 @@ class HostNode
   field :public_ip, type: String
   field :private_ip, type: String
   field :last_seen_at, type: Time
+  field :agent_version, type: String
 
   attr_accessor :schedule_counter
 
@@ -60,7 +61,8 @@ class HostNode
       cpus: attrs['NCPU'],
       swap_limit: attrs['SwapLimit'],
       public_ip: attrs['PublicIp'],
-      private_ip: attrs['PrivateIp']
+      private_ip: attrs['PrivateIp'],
+      agent_version: attrs['AgentVersion']
     }
     if self.name.nil?
       self.name = attrs['Name']

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -14,6 +14,7 @@ json.mem_limit node.mem_limit
 json.cpus node.cpus
 json.public_ip node.public_ip
 json.private_ip node.private_ip
+json.agent_version node.agent_version
 json.peer_ips node.grid.host_nodes.ne(id: node.id).map{|n|
   if n.region == node.region
     n.private_ip

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -96,6 +96,12 @@ describe HostNode do
         subject.attributes_from_docker({'Labels' => ['foo=bar']})
       }.not_to change{ subject.labels }
     end
+
+    it 'sets agent_version' do
+      expect {
+        subject.attributes_from_docker({'AgentVersion' => '1.2.3'})
+      }.to change{ subject.agent_version }.to('1.2.3')
+    end
   end
 
   describe '#save!' do


### PR DESCRIPTION
This PR adds agent version publishing and showing on cli.
```
kontena node show dev
dev:
  id: 66CY:NUJZ:TKPN:RD2Y:AVHH:FWGQ:OHZE:U4GH:FBM3:K723:6XTQ:VNPJ
  agent version:0.13.2
  connected: yes
```
Fixes #649 