### PR TITLE
Allow to deploy service that is already in deploying state

### DIFF
--- a/server/app/mutations/grid_services/deploy.rb
+++ b/server/app/mutations/grid_services/deploy.rb
@@ -5,7 +5,7 @@ module GridServices
     class ExecutionError < StandardError
     end
 
-    VALID_STATES = %w(initialized running stopped)
+    VALID_STATES = %w(initialized running deploying stopped)
 
     required do
       model :grid_service
@@ -23,14 +23,13 @@ module GridServices
     end
 
     def execute
-      attrs = { deploy_requested_at: Time.now.utc, state: 'running' }
-      if self.force
-        attrs[:updated_at] = Time.now.utc
-      end
-      self.grid_service.set(attrs)
-      GridServiceDeploy.create(grid_service: self.grid_service)
+      attrs = { deploy_requested_at: Time.now.utc }
+      attrs[:state] = 'running' unless grid_service.deploying?
+      attrs[:updated_at] = Time.now.utc if force
+      grid_service.set(attrs)
+      GridServiceDeploy.create(grid_service: grid_service)
 
-      self.grid_service
+      grid_service
     end
   end
 end

--- a/server/spec/mutations/grid_services/deploy_spec.rb
+++ b/server/spec/mutations/grid_services/deploy_spec.rb
@@ -16,13 +16,6 @@ describe GridServices::Deploy do
   let(:subject) { described_class.new(current_user: user, grid_service: redis_service, strategy: 'ha')}
 
   describe '#run' do
-    it 'does not allow to deploy service that is already deploying' do
-      redis_service.set_state('deploying')
-      outcome = subject.run
-      expect(outcome.success?).to be_falsey
-      expect(outcome.errors.message['state']).not_to be_nil
-    end
-
     it 'does not allow to deploy service that is starting' do
       redis_service.set_state('starting')
       outcome = subject.run
@@ -49,6 +42,13 @@ describe GridServices::Deploy do
       outcome = subject.run
       expect(outcome.success?).to be_truthy
       expect(redis_service.reload.running?).to be_truthy
+    end
+
+    it 'allows to deploy service that is deploying' do
+      redis_service.set_state('deploying')
+      outcome = subject.run
+      expect(outcome.success?).to be_truthy
+      expect(redis_service.reload.deploying?).to be_truthy
     end
 
     it 'allows to deploy service that is stopped' do


### PR DESCRIPTION
0.13.3 has regression that blocks deploys if service is in deploying state.