### PR TITLE
Implement kontena app config command

### DIFF
--- a/cli/lib/kontena/cli/app_command.rb
+++ b/cli/lib/kontena/cli/app_command.rb
@@ -1,5 +1,6 @@
 require_relative 'apps/init_command'
 require_relative 'apps/build_command'
+require_relative 'apps/config_command'
 require_relative 'apps/deploy_command'
 require_relative 'apps/start_command'
 require_relative 'apps/stop_command'
@@ -15,6 +16,7 @@ class Kontena::Cli::AppCommand < Clamp::Command
 
   subcommand "init", "Init Kontena application", Kontena::Cli::Apps::InitCommand
   subcommand "build", "Build Kontena services", Kontena::Cli::Apps::BuildCommand
+  subcommand "config", "View service configurations", Kontena::Cli::Apps::ConfigCommand
   subcommand "deploy", "Deploy Kontena services", Kontena::Cli::Apps::DeployCommand
   subcommand "scale", "Scale services", Kontena::Cli::Apps::ScaleCommand
   subcommand "start", "Start services", Kontena::Cli::Apps::StartCommand

--- a/cli/lib/kontena/cli/apps/config_command.rb
+++ b/cli/lib/kontena/cli/apps/config_command.rb
@@ -1,0 +1,29 @@
+require_relative 'common'
+require 'pp'
+
+module Kontena::Cli::Apps
+  class ConfigCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
+
+    parameter "[SERVICE] ...", "Services to view"
+
+    attr_reader :service_prefix
+
+    def execute
+      require_config_file(filename)
+      @service_prefix = project_name || current_dir
+      services = services_from_yaml(filename, service_list, service_prefix)
+      services.each do |name, config|
+        config['cmd'] = config['cmd'].join(" ") if config['cmd']
+        config.delete_if {|key, value| value.nil? || (value.respond_to?(:empty?) && value.empty?) }
+      end
+      services = { 'services' => services }
+      puts services.to_yaml
+    end
+  end
+end

--- a/cli/lib/kontena/scripts/completer
+++ b/cli/lib/kontena/scripts/completer
@@ -144,7 +144,7 @@ if words.size > 0
       completion.push %w(add list delete)
     when 'app'
       completion.clear
-      sub_commands = %w(init build deploy start stop remove rm ps list
+      sub_commands = %w(init build config deploy start stop remove rm ps list
                         logs monitor show)
       if words[1]
         completion.push(sub_commands) unless sub_commands.include?(words[1])


### PR DESCRIPTION
This PR implements `kontena app config` command. Command is identical to `docker-compose config` command. It validates YAML files and displays service configs:

```
$ kontena app config
---
services:
  app:
    image: kontena/todo-example:latest
    env:
    - MONGODB_URI=mongodb://todo-mongodb.kontena.local/todo_production
    links:
    - name: mongodb
      alias: mongodb
    ports:
    - container_port: '9292'
      node_port: '9292'
      protocol: tcp
    cmd: bundle exec puma -p 9292 -e production
    stateful: false
    build:
      context: "."
  mongodb:
    image: mongo:3.2
    cmd: mongod --smallfiles
    stateful: false
```