### PR TITLE
Fix app remove command (regression caused by #696)

### DIFF
--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -29,7 +29,7 @@ module Kontena::Cli::Apps
 
     private
     def remove_services(services)
-      services.find_all {|service_name, options| options[:links] && options[:links].size > 0 }.each do |service_name, options|
+      services.find_all {|service_name, options| options['links'] && options['links'].size > 0 }.each do |service_name, options|
         delete(service_name, options, false)
         services.delete(service_name)
       end


### PR DESCRIPTION
#696 changed internal service config handling so that config hashes will have stringified keys. This PR takes that into an account also when removing linked services.