### PR TITLE
Allow to define app name in kontena.yml

### DIFF
--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -50,6 +50,21 @@ module Kontena::Cli::Apps
       ENV['grid'] = grid
     end
 
+    def service_prefix
+      @service_prefix ||= project_name || project_name_from_yaml(filename) || current_dir
+    end
+
+    def project_name_from_yaml(file)
+      reader = YAML::Reader.new(file, true)
+      outcome = reader.execute      
+      if outcome[:version] == '2'
+        outcome[:name]
+      else
+        nil
+      end
+    end
+
+
     # @return [String]
     def token
       @token ||= require_token

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -17,14 +17,13 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to start"
 
-    attr_reader :services, :service_prefix, :deploy_queue
+    attr_reader :services, :deploy_queue
 
     def execute
       require_api_url
       require_token
       require_config_file(filename)
-      @deploy_queue = []
-      @service_prefix = project_name || current_dir
+      @deploy_queue = []      
       @services = services_from_yaml(filename, service_list, service_prefix)
       process_docker_images(services) if !no_build?
       create_or_update_services(services)

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -15,12 +15,9 @@ module Kontena::Cli::Apps
     option ["-b", "--base-image"], "BASE_IMAGE_NAME", "Specify a docker base image name", default: "kontena/buildstep"
     option ["-p", "--project-name"], "NAME", "Specify an alternate project name (default: directory name)"
 
-    attr_reader :service_prefix
 
     def execute
       require 'highline/import'
-
-      @service_prefix = project_name || File.basename(Dir.getwd)
 
       if File.exist?('Dockerfile')
         puts 'Found Dockerfile'

--- a/cli/lib/kontena/cli/apps/list_command.rb
+++ b/cli/lib/kontena/cli/apps/list_command.rb
@@ -11,12 +11,11 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to start"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
 
-      @service_prefix = project_name || current_dir
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         show_services(services)

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -13,12 +13,11 @@ module Kontena::Cli::Apps
     option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     parameter "[SERVICE] ...", "Show only specified service logs"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
 
-      @service_prefix = project_name || current_dir
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         show_logs(services)

--- a/cli/lib/kontena/cli/apps/monitor_command.rb
+++ b/cli/lib/kontena/cli/apps/monitor_command.rb
@@ -11,12 +11,11 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to start"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
-
-      @service_prefix = project_name || current_dir
+            
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         show_monitor(services)

--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -11,14 +11,13 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Remove services"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_api_url
       require_token
       require_config_file(filename)
-
-      @service_prefix = project_name || current_dir
+      
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         remove_services(services)

--- a/cli/lib/kontena/cli/apps/restart_command.rb
+++ b/cli/lib/kontena/cli/apps/restart_command.rb
@@ -10,12 +10,11 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to start"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
 
-      @service_prefix = project_name || current_dir
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         restart_services(services)

--- a/cli/lib/kontena/cli/apps/scale_command.rb
+++ b/cli/lib/kontena/cli/apps/scale_command.rb
@@ -12,16 +12,14 @@ module Kontena::Cli::Apps
     parameter "SERVICE", "Service to show"
     parameter "INSTANCES", "Scales service to given number of instances"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
-      @service_prefix = project_name || current_dir
       yml_service = services_from_yaml(filename, [service], service_prefix)
       if yml_service[service]
         options = yml_service[service]
         abort("Service has already instances defined in #{filename}. Please update #{filename} and deploy service instead") if options['container_count']
-        @service_prefix = project_name || current_dir
         scale_service(require_token, prefixed_name(service), instances)
       else
         abort("Service not found")

--- a/cli/lib/kontena/cli/apps/show_command.rb
+++ b/cli/lib/kontena/cli/apps/show_command.rb
@@ -11,12 +11,11 @@ module Kontena::Cli::Apps
 
     parameter "SERVICE", "Service to show"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
 
-      @service_prefix = project_name || current_dir
       show_service(require_token, prefixed_name(service))
     end
   end

--- a/cli/lib/kontena/cli/apps/start_command.rb
+++ b/cli/lib/kontena/cli/apps/start_command.rb
@@ -11,12 +11,11 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to start"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
 
-      @service_prefix = project_name || current_dir
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         start_services(services)

--- a/cli/lib/kontena/cli/apps/stop_command.rb
+++ b/cli/lib/kontena/cli/apps/stop_command.rb
@@ -11,12 +11,11 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to stop"
 
-    attr_reader :services, :service_prefix
+    attr_reader :services
 
     def execute
       require_config_file(filename)
 
-      @service_prefix = project_name || current_dir
       @services = services_from_yaml(filename, service_list, service_prefix)
       if services.size > 0
         stop_services(services)

--- a/cli/spec/fixtures/kontena_v2.yml
+++ b/cli/spec/fixtures/kontena_v2.yml
@@ -1,4 +1,5 @@
 version: '2'
+name: test-project
 services:
   wordpress:
     extends:

--- a/cli/spec/kontena/cli/app/common_spec.rb
+++ b/cli/spec/kontena/cli/app/common_spec.rb
@@ -13,6 +13,10 @@ describe Kontena::Cli::Apps::Common do
     fixture('kontena.yml')
   end
 
+  let(:kontena_v2_yml) do
+    fixture('kontena_v2.yml')
+  end
+
   let(:docker_compose_yml) do
     fixture('docker-compose.yml')
   end
@@ -28,6 +32,29 @@ describe Kontena::Cli::Apps::Common do
         'ports' => ['80:80']
       }
     }
+  end
+
+  describe '#service_prefix' do
+    it 'returns given project name' do
+      allow(subject).to receive(:project_name).and_return('test')
+      expect(subject.service_prefix).to eq('test')
+    end
+
+    it 'returns app name from yaml if project name not given' do
+      allow(subject).to receive(:project_name).and_return(nil)
+      allow(subject).to receive(:filename).and_return('kontena.yml')
+      allow(File).to receive(:read).with("#{Dir.getwd}/docker-compose_v2.yml").and_return(docker_compose_yml)
+      allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_v2_yml)
+      expect(subject.service_prefix).to eq('test-project')
+    end
+
+    it 'returns current dir as default' do
+      allow(subject).to receive(:project_name).and_return(nil)
+      allow(subject).to receive(:filename).and_return('kontena.yml')
+      allow(subject).to receive(:project_name_from_yaml).and_return(nil)
+      allow(subject).to receive(:current_dir).and_return('working_dir')
+      expect(subject.service_prefix).to eq('working_dir')
+    end
   end
 
   describe '#load_from_yaml' do

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -119,6 +119,7 @@ describe Kontena::Cli::Apps::DeployCommand do
       end
 
       it 'reads given yml file' do
+        allow(subject).to receive(:project_name_from_yaml).and_return nil
         expect(File).to receive(:read).with("#{Dir.getwd}/custom.yml").and_return(kontena_yml)
         subject.run(["--file", "custom.yml"])
       end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -22,7 +22,6 @@ RSpec.configure do |config|
     allow(Dir).to receive(:home).and_return('/tmp/')
   end
 end
-RSpec::Expectations.configuration.warn_about_potential_false_positives = false
 
 require_relative 'support/client_helpers'
 require_relative 'support/fixtures_helpers'

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
     allow(Dir).to receive(:home).and_return('/tmp/')
   end
 end
+RSpec::Expectations.configuration.warn_about_potential_false_positives = false
 
 require_relative 'support/client_helpers'
 require_relative 'support/fixtures_helpers'


### PR DESCRIPTION
This PR allows to define app name in `kontena.yml`. It will be used if user has not given any `-p` option on app commands. If the app name is not defined in `kontena.yml` name of the current work dir is used.
```
version: '2'
name: todo-example
services:
  app:
    image: kontena/todo-example:latest
```

depends on #739 