### PR TITLE
Notify grid nodes when node information is updated

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -168,7 +168,7 @@ module Kontena::NetworkAdapters
 
       weave = nil
       peer_ips = info['peer_ips'] || []
-      trusted_subnets = info['grid']['trusted_subnets']
+      trusted_subnets = info.dig('grid', 'trusted_subnets')
       until weave && weave.running? do
         exec_params = [
           '--local', 'launch-router', '--ipalloc-range', '', '--dns-domain', 'kontena.local',
@@ -199,8 +199,8 @@ module Kontena::NetworkAdapters
 
     # @param [Array<String>] peer_ips
     def connect_peers(peer_ips)
-      self.exec(['--local', 'connect', '--replace'] + peer_ips) if peer_ips.size > 0
       if peer_ips.size > 0
+        self.exec(['--local', 'connect', '--replace'] + peer_ips)
         info "router connected to peers #{peer_ips.join(', ')}"
       else
         info "router does not have any known peers"

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -16,6 +16,7 @@ module Kontena::NetworkAdapters
 
     def initialize(autostart = true)
       @images_exist = false
+      @started = false
       info 'initialized'
       subscribe('agent:node_info', :on_node_info)
       async.ensure_images if autostart
@@ -47,6 +48,11 @@ module Kontena::NetworkAdapters
     # @return [Boolean]
     def images_exist?
       @images_exist == true
+    end
+
+    # @return [Boolean]
+    def already_started?
+      @started == true
     end
 
     # @param [Hash] opts
@@ -162,15 +168,13 @@ module Kontena::NetworkAdapters
 
       weave = nil
       peer_ips = info['peer_ips'] || []
+      trusted_subnets = info['grid']['trusted_subnets']
       until weave && weave.running? do
         exec_params = [
           '--local', 'launch-router', '--ipalloc-range', '', '--dns-domain', 'kontena.local',
           '--password', ENV['KONTENA_TOKEN']
         ]
-        if info['grid']['trusted_subnets']
-          exec_params += ['--trusted-subnets', info['grid']['trusted_subnets'].join(',')]
-        end
-        exec_params += peer_ips
+        exec_params += ['--trusted-subnets', trusted_subnets.join(',')] if trusted_subnets
         self.exec(exec_params)
         weave = Docker::Container.get('weave') rescue nil
         wait = Time.now.to_f + 10.0
@@ -181,25 +185,36 @@ module Kontena::NetworkAdapters
         end
       end
 
-      if peer_ips.size > 0
-        info "router started with peers #{peer_ips.join(', ')}"
-      else
-        info "router started without known peers"
-      end
-      if info['grid']['trusted_subnets']
-        info "using trusted subnets: #{info['grid']['trusted_subnets'].join(',')}"
-      end
+      connect_peers(peer_ips)
+      info "using trusted subnets: #{trusted_subnets.join(',')}" if trusted_subnets && !already_started?
 
+      post_start(info) unless already_started?
+
+      @started = true
+      info
+    rescue => exc
+      error "#{exc.class.name}: #{exc.message}"
+      debug exc.backtrace.join("\n")
+    end
+
+    # @param [Array<String>] peer_ips
+    def connect_peers(peer_ips)
+      self.exec(['--local', 'connect', '--replace'] + peer_ips) if peer_ips.size > 0
+      if peer_ips.size > 0
+        info "router connected to peers #{peer_ips.join(', ')}"
+      else
+        info "router does not have any known peers"
+      end
+    end
+
+    # @param [Hash] info
+    def post_start(info)
       if info['node_number']
         weave_bridge = "10.81.0.#{info['node_number']}/19"
         self.exec(['--local', 'expose', "ip:#{weave_bridge}"])
         info "bridge exposed: #{weave_bridge}"
       end
       Celluloid::Notifications.publish('network_adapter:start', info)
-      info
-    rescue => exc
-      error "#{exc.class.name}: #{exc.message}"
-      debug exc.backtrace.join("\n")
     end
 
     private

--- a/server/app/mutations/host_nodes/common.rb
+++ b/server/app/mutations/host_nodes/common.rb
@@ -1,0 +1,20 @@
+module HostNodes
+  module Common
+
+    # @param [Grid] grid
+    def notify_grid(grid)
+      Celluloid::Future.new {
+        grid.host_nodes.connected.each do |node|
+          notify_node(grid, node)
+        end
+      }
+    end
+
+    # @param [Grid] grid
+    # @param [HostNode] node
+    def notify_node(grid, node)
+      plugger = Agent::NodePlugger.new(grid, node)
+      plugger.send_node_info
+    end
+  end
+end

--- a/server/app/mutations/host_nodes/remove.rb
+++ b/server/app/mutations/host_nodes/remove.rb
@@ -1,7 +1,8 @@
 module HostNodes
   class Remove < Mutations::Command
     include Workers
-    
+    include Common
+
     required do
       model :host_node
     end
@@ -12,6 +13,7 @@ module HostNodes
 
       if grid
         worker(:grid_scheduler).async.perform(grid.id)
+        notify_grid(grid)
       end
     end
   end

--- a/server/app/mutations/host_nodes/update.rb
+++ b/server/app/mutations/host_nodes/update.rb
@@ -1,6 +1,9 @@
+require_relative 'common'
 
 module HostNodes
   class Update < Mutations::Command
+
+    include Common
 
     required do
       model :host_node
@@ -10,6 +13,8 @@ module HostNodes
     def execute
       self.host_node.labels = self.labels if self.labels
       self.host_node.save
+
+      notify_grid(self.host_node.grid)
 
       self.host_node
     end

--- a/server/spec/api/v1/nodes_spec.rb
+++ b/server/spec/api/v1/nodes_spec.rb
@@ -1,7 +1,8 @@
 require_relative '../../spec_helper'
 
 describe '/v1/grids' do
-
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
   let(:grid) { Grid.create!(name: 'test') }
   let(:request_headers) do
     {

--- a/server/spec/mutations/host_nodes/common_spec.rb
+++ b/server/spec/mutations/host_nodes/common_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../spec_helper'
+
+describe HostNodes::Common do
+  let(:grid) { Grid.create!(name: 'test') }
+  let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA', connected: true) }
+  let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB', connected: true) }
+  let(:node_c) { HostNode.create!(name: 'node-c', grid: grid, node_id: 'CC', connected: false) }
+  let(:described_class) {
+    Class.new do
+      include HostNodes::Common
+    end
+  }
+
+  describe '#notify_grid' do
+    it 'returns future' do
+      expect(subject.notify_grid(grid).class).to eq(Celluloid::Future)
+    end
+
+    it 'notifies all connected nodes' do
+      node_a; node_b; node_c
+      expect(subject).to receive(:notify_node).once.with(grid, node_a)
+      expect(subject).to receive(:notify_node).once.with(grid, node_b)
+      expect(subject).not_to receive(:notify_node).with(grid, node_c)
+      future = subject.notify_grid(grid)
+      future.value
+    end
+  end
+end

--- a/server/spec/mutations/host_nodes/common_spec.rb
+++ b/server/spec/mutations/host_nodes/common_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
 
 describe HostNodes::Common do
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
   let(:grid) { Grid.create!(name: 'test') }
   let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA', connected: true) }
   let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB', connected: true) }

--- a/server/spec/mutations/host_nodes/remove_spec.rb
+++ b/server/spec/mutations/host_nodes/remove_spec.rb
@@ -9,21 +9,24 @@ describe HostNodes::Remove do
   let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB') }
 
   describe '#run' do
+    let(:subject) { described_class.new(host_node: node_a) }
+    before(:each) { allow(subject).to receive(:worker).and_return(spy(:worker)) }
+
     it 'removes node' do
       node_a; node_b
       expect {
-        described_class.new(
-          host_node: node_a,
-        ).run
+        subject.run
       }.to change{ grid.host_nodes.count }.by(-1)
     end
 
+    it 'triggers grid_scheduler worker' do
+      expect(subject).to receive(:worker).once.with(:grid_scheduler)
+      subject.run
+    end
+
     it 'notifies grid nodes' do
-      mutation = described_class.new(
-        host_node: node_a,
-      )
-      expect(mutation).to receive(:notify_grid).once.with(grid)
-      mutation.run
+      expect(subject).to receive(:notify_grid).once.with(grid)
+      subject.run
     end
   end
 end

--- a/server/spec/mutations/host_nodes/remove_spec.rb
+++ b/server/spec/mutations/host_nodes/remove_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../../spec_helper'
+
+describe HostNodes::Remove do
+  let(:grid) { Grid.create!(name: 'test') }
+  let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA') }
+  let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB') }
+
+  describe '#run' do
+    it 'removes node' do
+      node_a; node_b
+      expect {
+        described_class.new(
+          host_node: node_a,
+        ).run
+      }.to change{ grid.host_nodes.count }.by(-1)
+    end
+
+    it 'notifies grid nodes' do
+      mutation = described_class.new(
+        host_node: node_a,
+      )
+      expect(mutation).to receive(:notify_grid).once.with(grid)
+      mutation.run
+    end
+  end
+end

--- a/server/spec/mutations/host_nodes/remove_spec.rb
+++ b/server/spec/mutations/host_nodes/remove_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
 
 describe HostNodes::Remove do
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
   let(:grid) { Grid.create!(name: 'test') }
   let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA') }
   let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB') }

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
 
 describe HostNodes::Update do
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
   let(:grid) { Grid.create!(name: 'test') }
   let(:node) { HostNode.create!(name: 'node-1', grid: grid, node_id: 'AA') }
 

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../spec_helper'
+
+describe HostNodes::Update do
+  let(:grid) { Grid.create!(name: 'test') }
+  let(:node) { HostNode.create!(name: 'node-1', grid: grid, node_id: 'AA') }
+
+  describe '#run' do
+    it 'updates node labels' do
+      node.labels = []
+      labels = ['foo=bar', 'bar=baz']
+      expect {
+        described_class.new(
+          host_node: node,
+          labels: labels
+        ).run
+      }.to change{ node.labels }.from([]).to(labels)
+    end
+
+    it 'notifies grid nodes' do
+      mutation = described_class.new(
+        host_node: node,
+        labels: []
+      )
+      expect(mutation).to receive(:notify_grid).once.with(grid)
+      mutation.run
+    end
+  end
+end


### PR DESCRIPTION
Notify all connected grid nodes when node information (currently only labels) are changed. Changing node information might have effect on how network and other stuff is configured.