### PR TITLE
Take az into account in ha scheduling strategy

### DIFF
--- a/docs/using-kontena/deploy.md
+++ b/docs/using-kontena/deploy.md
@@ -9,7 +9,7 @@ Kontena can use different scheduling algorithms when deploying services to more 
 
 ### High Availability (HA)
 
-Service with `ha` strategy will deploy its instances to different host nodes. This means that the service instances will be spread across all nodes.
+Service with `ha` strategy will deploy its instances to different host nodes. This means that the service instances will be spread across all availability zones/nodes. Availability zones are resolved from node labels, for example `az=a1` means that node belongs to availability zone `a1`.
 
 ```
 deploy:

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -97,7 +97,7 @@ class HostNode
   # @return [String]
   def region
     if @region.nil?
-      @region = 'default'
+      @region = 'default'.freeze
       self.labels.to_a.each do |label|
         if match = label.match(/^region=(.+)/)
           @region = match[1]
@@ -110,6 +110,19 @@ class HostNode
   def initial_member?
     return true if self.node_number <= self.grid.initial_size
     false
+  end
+
+  # @return [String]
+  def availability_zone
+    if @availability_zone.nil?
+      @availability_zone = 'default'.freeze
+      self.labels.to_a.each do |label|
+        if match = label.match(/^az=(.+)/)
+          @availability_zone = match[1]
+        end
+      end
+    end
+    @availability_zone
   end
 
   private

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -174,4 +174,20 @@ describe HostNode do
       expect(subject.region).to eq('ams2')
     end
   end
+
+  describe '#availability_zone' do
+    it 'returns default if az is not found from labels' do
+      expect(subject.availability_zone).to eq('default')
+    end
+
+    it 'returns default if labels is nil' do
+      allow(subject).to receive(:labels).and_return(nil)
+      expect(subject.availability_zone).to eq('default')
+    end
+
+    it 'returns availability_zone from labels' do
+      subject.labels = ['foo=bar', 'az=b']
+      expect(subject.availability_zone).to eq('b')
+    end
+  end
 end

--- a/server/spec/services/scheduler/strategy/high_availability_spec.rb
+++ b/server/spec/services/scheduler/strategy/high_availability_spec.rb
@@ -4,11 +4,21 @@ describe Scheduler::Strategy::HighAvailability do
 
   let(:grid) { Grid.create(name: 'test') }
 
+  let(:availability_zones) { %w(a b c) }
   let(:nodes) do
     nodes = []
-    nodes << HostNode.create!(node_id: 'node1', name: 'node-1', connected: true, grid: grid)
-    nodes << HostNode.create!(node_id: 'node2', name: 'node-2', connected: true, grid: grid)
-    nodes << HostNode.create!(node_id: 'node3', name: 'node-3', connected: true, grid: grid)
+    availability_zones.each do |az|
+      2.times do |i|
+        instance = i + 1
+        nodes << HostNode.create!(
+          node_id: "node#{instance}",
+          name: "node-#{instance}",
+          connected: true,
+          grid: grid,
+          labels: ['region=eu-west-1', "az=#{az}"]
+        )
+      end
+    end
     nodes
   end
 
@@ -22,11 +32,11 @@ describe Scheduler::Strategy::HighAvailability do
 
   describe '#find_node' do
     context 'stateful service' do
-      it 'returns node that does not yet have service instance' do
-        nodes[1].schedule_counter = 1
-        expect(subject.find_node(stateful_service, 2, nodes)).not_to eq(nodes[1])
-        nodes[0].schedule_counter = 1
-        expect(subject.find_node(stateful_service, 3, nodes)).to eq(nodes[2])
+      it 'returns node from az that does not yet have service instance' do
+        nodes[2].schedule_counter = 1 # az=b
+        expect(['a', 'c']).to include(subject.find_node(stateful_service, 2, nodes).availability_zone)
+        nodes[1].schedule_counter = 1 # az=a
+        expect(['c']).to include(subject.find_node(stateful_service, 3, nodes).availability_zone)
       end
 
       it 'returns node that has data volume container' do
@@ -42,12 +52,53 @@ describe Scheduler::Strategy::HighAvailability do
     end
 
     context 'stateless service' do
-      it 'returns node that does not yet have service instance' do
-        nodes[1].schedule_counter = 1
-        expect(subject.find_node(stateful_service, 2, nodes)).not_to eq(nodes[1])
-        nodes[0].schedule_counter = 1
-        expect(subject.find_node(stateful_service, 3, nodes)).to eq(nodes[2])
+      it 'returns node from az that does not yet have service instance' do
+        nodes[2].schedule_counter = 1 # az=b
+        expect(['a', 'c']).to include(subject.find_node(stateless_service, 2, nodes).availability_zone)
+        nodes[1].schedule_counter = 1 # az=a
+        expect(['c']).to include(subject.find_node(stateless_service, 3, nodes).availability_zone)
       end
+    end
+  end
+
+  describe '#instance_rank' do
+    let(:node) { nodes[0] }
+
+    it 'returns zero rank if instance is not already scheduled to node' do
+      stateless_service.containers.create!(name: "#{stateless_service.name}-2", host_node: nodes[2])
+      expect(subject.instance_rank(node, stateless_service, 1)).to eq(0.0)
+    end
+
+    it 'returns negative rank if instance is already scheduled to node' do
+      stateless_service.containers.create!(name: "#{stateless_service.name}-2", host_node: node)
+      expect(subject.instance_rank(node, stateless_service, 2) < 0.0).to be_truthy
+    end
+  end
+
+  describe '#memory_rank' do
+    let(:node) { nodes[0] }
+
+    it 'returns 0.0 if node has no memory stats' do
+      expect(subject.memory_rank(node)).to eq(0.0)
+    end
+
+    it 'returns rank based on memory usage' do
+      node.host_node_stats.create!(memory: {'used' => 256.megabytes})
+      node.mem_total = 1.gigabytes
+      expect(subject.memory_rank(node)).to eq(0.25)
+    end
+  end
+
+  describe '#availability_zone_count' do
+    it 'returns schedule count for az' do
+      node1 = nodes[0]
+      node2 = nodes[1]
+      node3 = nodes[2]
+      node1.schedule_counter = 2
+      node2.schedule_counter = 2
+      node3.set(labels: ['region=eu-west-1', 'az=b'])
+      expect(subject.availability_zone_count(node1, nodes)).to eq(4)
+      expect(subject.availability_zone_count(node3, nodes)).to eq(0)
     end
   end
 end


### PR DESCRIPTION
This PR implements logic that will spread service instances across availability zones by default.