### PR TITLE
Fix build context parsing

### DIFF
--- a/cli/lib/kontena/cli/apps/service_generator_v2.rb
+++ b/cli/lib/kontena/cli/apps/service_generator_v2.rb
@@ -17,6 +17,9 @@ module Kontena::Cli::Apps
     end
 
     def parse_build_options(options)
+      unless options['build'].is_a?(Hash)
+        options['build'] = { 'context' => options['build']}
+      end
       options['build']
     end
   end

--- a/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
@@ -46,4 +46,25 @@ describe Kontena::Cli::Apps::ServiceGeneratorV2 do
       }])
     end
   end
+
+  describe '#parse_build_options' do
+    it 'returns hash' do
+      data = {
+        'build' => '.',
+        'image' => 'myapp'
+      }
+      result = subject.send(:parse_build_options, data)
+      expect(result).to eq({ 'context' => '.' })
+
+      data = {
+        'build' => {
+          'context' => '.',
+          'dockerfile' => 'alternate-dockerfile'
+         }
+      }
+
+      result = subject.send(:parse_build_options, data)
+      expect(result).to eq(data['build'])
+    end
+  end
 end

--- a/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
@@ -48,23 +48,27 @@ describe Kontena::Cli::Apps::ServiceGeneratorV2 do
   end
 
   describe '#parse_build_options' do
-    it 'returns hash' do
-      data = {
-        'build' => '.',
-        'image' => 'myapp'
-      }
-      result = subject.send(:parse_build_options, data)
-      expect(result).to eq({ 'context' => '.' })
-
-      data = {
-        'build' => {
-          'context' => '.',
-          'dockerfile' => 'alternate-dockerfile'
-         }
-      }
-
-      result = subject.send(:parse_build_options, data)
-      expect(result).to eq(data['build'])
+    context 'when build option is a string' do
+      it 'converts build option to hash' do
+        data = {
+          'build' => '.',
+          'image' => 'myapp'
+        }
+        result = subject.send(:parse_build_options, data)
+        expect(result).to eq({ 'context' => '.' })
+      end
+    end
+    context 'when build options is a hash' do
+      it 'uses it as build options' do
+        data = {
+          'build' => {
+            'context' => '.',
+            'dockerfile' => 'alternate-dockerfile'
+           }
+        }
+        result = subject.send(:parse_build_options, data)
+        expect(result).to eq(data['build'])
+      end
     end
   end
 end


### PR DESCRIPTION
In YAML version 2 build context can be either string or hash. This PR takes both options into an account.