### PR TITLE
Fix wait service deploy to finish

### DIFF
--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -202,6 +202,7 @@ module Kontena
         # @param [String] name
         def wait_for_deploy_to_finish(token, name)
           ShellSpinner " " do
+            sleep 1 # wait for master to process deploy request and change state to 'deploying'
             until client(token).get("services/#{name}")['state'] != 'deploying' do
               sleep 1
             end


### PR DESCRIPTION
When deploying a service/app, service state is not changed immediately to `deploying`, that's why we need to wait a bit before starting to poll service state.