### PR TITLE
Fix/nil on cpu usage and refactor stats worker

### DIFF
--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -68,9 +68,9 @@ module Kontena::Workers
 
       current_stat = container[:stats][-1]
 
-      num_cores = current_stat[:cpu][:usage][:per_cpu_usage].count
-      raw_cpu_usage = current_stat[:cpu][:usage][:total] - prev_stat[:cpu][:usage][:total]
-      interval_in_ns = get_interval(current_stat[:timestamp], prev_stat[:timestamp])
+      num_cores = current_stat.dig(:cpu, :usage, :per_cpu_usage).count rescue 1 # Need to default to something
+      raw_cpu_usage = current_stat.dig(:cpu, :usage, :total) - prev_stat.dig(:cpu, :usage, :total)
+      interval_in_ns = get_interval(current_stat.dig(:timestamp), prev_stat.dig(:timestamp))
 
       event = {
         event: 'container:stats'.freeze,

--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -1,5 +1,3 @@
-require 'pp'
-
 module Kontena::Workers
   class StatsWorker
     include Celluloid
@@ -93,7 +91,8 @@ module Kontena::Workers
 
       current_stat = container.dig(slice_key, :stats, -1)
       # Need to default to something usable in calculations
-      num_cores = current_stat.dig(:cpu, :usage, :per_cpu_usage).count rescue 1 
+      cpu_usages = current_stat.dig(:cpu, :usage, :per_cpu_usage)
+      num_cores = cpu_usages ? cpu_usages.count : 1
       raw_cpu_usage = current_stat.dig(:cpu, :usage, :total) - prev_stat.dig(:cpu, :usage, :total)
       interval_in_ns = get_interval(current_stat.dig(:timestamp), prev_stat.dig(:timestamp))
 

--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -1,3 +1,5 @@
+require 'pp'
+
 module Kontena::Workers
   class StatsWorker
     include Celluloid
@@ -46,68 +48,75 @@ module Kontena::Workers
     end
 
     def collect_stats
+      info 'starting collection'
       begin
-        data = fetch_stats
-        if data
-          debug "total stats size: #{data.values.size}"
-          data.values.each do |container|
-            self.send_container_stats(container)
-            sleep 0.5
-          end
+        Docker::Container.all.each do |container|
+          data = self.collect_container_stats(container.id)
+          send_container_stats(data) if data
+          sleep 0.5
         end
       rescue => exc
         error "error on stats fetching: #{exc.message}"
+        error exc.backtrace.join("\n")
+      end
+    end
+
+
+    def collect_container_stats(container_id)
+      retries = 3
+      begin
+        response = client.get(:path => "/api/v1.2/docker/#{container_id}")
+        if response.status == 200
+          JSON.parse(response.body, symbolize_names: true) rescue nil
+        else
+          error "failed to fetch cadvisor stats: #{response.status} #{response.body}"
+          nil
+        end
+      rescue => exc
+        retries -= 1
+        if retries > 0
+          retry
+        end
+        error "error getting container(#{container_id}) stats. #{exc.class.name}: #{exc.message}"
+        nil
       end
     end
 
     ##
     # @param [Hash] container
     def send_container_stats(container)
-      prev_stat = container[:stats][-2]
+      # when single container stats are used cadvisor "prefixes" all the data with some stupid system slice sutff
+      slice_key = container.keys[0]
+
+      prev_stat = container.dig(slice_key, :stats)[-2] if container
       return if prev_stat.nil?
 
-      current_stat = container[:stats][-1]
-
-      num_cores = current_stat.dig(:cpu, :usage, :per_cpu_usage).count rescue 1 # Need to default to something
+      current_stat = container.dig(slice_key, :stats, -1)
+      # Need to default to something usable in calculations
+      num_cores = current_stat.dig(:cpu, :usage, :per_cpu_usage).count rescue 1 
       raw_cpu_usage = current_stat.dig(:cpu, :usage, :total) - prev_stat.dig(:cpu, :usage, :total)
       interval_in_ns = get_interval(current_stat.dig(:timestamp), prev_stat.dig(:timestamp))
 
       event = {
         event: 'container:stats'.freeze,
         data: {
-          id: container[:aliases][1],
-          spec: container[:spec],
+          id: container.dig(slice_key, :aliases, 1),
+          spec: container.dig(slice_key, :spec),
           cpu: {
             usage: raw_cpu_usage,
             usage_pct: (((raw_cpu_usage / interval_in_ns ) / num_cores ) * 100).round(2)
           },
           memory: {
-            usage: current_stat[:memory][:usage],
-            working_set: current_stat[:memory][:working_set]
+            usage: current_stat.dig(:memory, :usage),
+            working_set: current_stat.dig(:memory, :working_set)
           },
           filesystem: current_stat[:filesystem],
           diskio: current_stat[:diskio],
           network: current_stat[:network]
         }
       }
-
       self.queue << event
-      send_statsd_metrics(container[:aliases][0], event[:data])
-    end
-
-    ##
-    # Fetch stats from cAdvisor
-    #
-    def fetch_stats
-      resp = client.get
-      if resp.status == 200
-        JSON.parse(resp.body, symbolize_names: true) rescue nil
-      else
-        error "failed to fetch cadvisor stats: #{resp.status} #{resp.body}"
-      end
-    rescue => exc
-      error "failed to fetch cadvisor stats: #{exc.message}"
-      nil
+      send_statsd_metrics(container.dig(slice_key, :aliases, 0), event[:data])
     end
 
     def client

--- a/agent/spec/fixtures/container_stats.json
+++ b/agent/spec/fixtures/container_stats.json
@@ -1,0 +1,76 @@
+{
+	"/system.slice/docker-dcc8a5ef41be9527779a6e81589f5a09d792653fb7f1c3213ee4537381ec1b07.scope": {
+		"id": "a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e",
+		"name": "/system.slice/docker-a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e.scope",
+		"aliases": [
+			"weave",
+			"a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e"
+		],
+		"namespace": "docker",
+		"labels": {
+			"works.weave.role": "system"
+		},
+		"spec": "spec",
+		"stats": [{
+			"timestamp": "2016-05-31T08:46:40.31624557Z",
+			"cpu": {
+				"usage": {
+					"total": 100000000,
+					"per_cpu_usage": [
+						100000000
+					],
+					"user": 100000000,
+					"system": 100000000
+				},
+				"load_average": 0
+			},
+			"diskio": {},
+			"memory": {
+				"usage": 123248640,
+				"cache": 11108352,
+				"rss": 112140288,
+				"working_set": 121257984
+			},
+			"network": {
+				"name": "eth0",
+				"rx_bytes": 274156082
+			},
+			"filesystem": [{
+				"device": "/dev/sda9",
+				"type": "vfs",
+				"capacity": 16718393344,
+				"usage": 18911232
+			}]
+		}, {
+			"timestamp": "2016-05-31T08:47:15.906910438Z",
+			"cpu": {
+				"usage": {
+					"total": 200000000,
+					"per_cpu_usage": [
+						200000000
+					],
+					"user": 200000000,
+					"system": 200000000
+				},
+				"load_average": 0
+			},
+			"diskio": {},
+			"memory": {
+				"usage": 1024,
+				"cache": 11108352,
+				"rss": 112140288,
+				"working_set": 2048
+			},
+			"network": {
+				"name": "eth0",
+				"rx_bytes": 274156226
+			},
+			"filesystem": [{
+				"device": "/dev/sda9",
+				"type": "vfs",
+				"capacity": 16718393344,
+				"usage": 18911232
+			}]
+		}]
+	}
+}

--- a/agent/spec/lib/helpers/fixtures_helpers.rb
+++ b/agent/spec/lib/helpers/fixtures_helpers.rb
@@ -1,0 +1,7 @@
+module FixturesHelpers
+  FIXTURES_PATH = File.dirname(__FILE__) + '/../../fixtures/'
+
+  def fixture(file)
+    IO.read(FIXTURES_PATH+file)
+  end
+end

--- a/agent/spec/lib/kontena/workers/stats_workers_spec.rb
+++ b/agent/spec/lib/kontena/workers/stats_workers_spec.rb
@@ -76,4 +76,137 @@ describe Kontena::Workers::StatsWorker do
       subject.send_statsd_metrics('foobar', event)
     end
   end
+
+describe '#send_container_stats' do
+    let(:event) do
+      {
+        "id": "a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e",
+        "name": "/system.slice/docker-a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e.scope",
+        "aliases": [
+          "weave",
+          "a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e"
+        ],
+        "namespace": "docker",
+        "labels": {
+          "works.weave.role": "system"
+        },
+        "spec": "spec",
+        "stats": [
+          {
+            "timestamp": "2016-05-31T08:46:40.31624557Z",
+            "cpu": {
+              "usage": {
+                "total": 10,
+                "per_cpu_usage": [
+                  10
+                ],
+                "user": 10,
+                "system": 10
+              },
+              "load_average": 0
+            },
+            "diskio": {
+            },
+            "memory": {
+              "usage": 123248640,
+              "cache": 11108352,
+              "rss": 112140288,
+              "working_set": 121257984
+            },
+            "network": {
+              "name": "eth0",
+              "rx_bytes": 274156082
+            },
+            "filesystem": [
+              {
+                "device": "/dev/sda9",
+                "type": "vfs",
+                "capacity": 16718393344,
+                "usage": 18911232
+              }
+            ],
+          },
+          {
+            "timestamp": "2016-05-31T08:47:15.906910438Z",
+            "cpu": {
+              "usage": {
+                "total": 20,
+                "per_cpu_usage": [
+                  20
+                ],
+                "user": 20,
+                "system": 20
+              },
+              "load_average": 0
+            },
+            "diskio": {},
+            "memory": {
+              "usage": 1024,
+              "cache": 11108352,
+              "rss": 112140288,
+              "working_set": 2048,
+            },
+            "network": {
+              "name": "eth0",
+              "rx_bytes": 274156226
+            },
+            "filesystem": [
+              {
+                "device": "/dev/sda9",
+                "type": "vfs",
+                "capacity": 16718393344,
+                "usage": 18911232
+              }
+            ]
+          }
+        ]
+      }
+    end
+
+    it 'sends container stats' do
+      #allow(subject.wrapped_object).to receive(:statsd).and_return(statsd)
+      #expect(statsd).to receive(:gauge)
+      expect(subject.wrapped_object).to receive(:send_statsd_metrics).with('weave', hash_including({
+          id: 'a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e',
+          spec: 'spec',
+          cpu: {
+            usage: 10,
+            usage_pct: 0.0
+          },
+          memory: {
+            usage: 1024,
+            working_set: 2048
+          },
+          filesystem: event.dig(:stats, -1, :filesystem),
+          diskio: event.dig(:stats, -1, :diskio),
+          network: event.dig(:stats, -1, :network)
+        }
+      ))
+      subject.send_container_stats(event)
+    end
+
+    it 'does not fail on missing stats' do
+      #allow(subject.wrapped_object).to receive(:statsd).and_return(statsd)
+      #expect(statsd).to receive(:gauge)
+      event[:stats][-1][:cpu][:usage][:per_cpu_usage] = nil
+      expect(subject.wrapped_object).to receive(:send_statsd_metrics).with('weave', hash_including({
+          id: 'a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e',
+          spec: 'spec',
+          cpu: {
+            usage: 10,
+            usage_pct: 0.0
+          },
+          memory: {
+            usage: 1024,
+            working_set: 2048
+          },
+          filesystem: event.dig(:stats, -1, :filesystem),
+          diskio: event.dig(:stats, -1, :diskio),
+          network: event.dig(:stats, -1, :network)
+        }
+      ))
+      subject.send_container_stats(event)
+    end
+  end
+
 end


### PR DESCRIPTION
Fix possible error relating to missing per cpu stats as reported in #678.

Refactored the stats worker to fetch single container stats as cAdvisor throws errors on all containers if one single container fails when getting stats for all containers on same call.

ping @jakolehm 