### PR TITLE
Add option to associate public ip for VPC

### DIFF
--- a/cli/lib/kontena/cli/master/aws/create_command.rb
+++ b/cli/lib/kontena/cli/master/aws/create_command.rb
@@ -19,7 +19,7 @@ module Kontena::Cli::Master::Aws
     option "--mongodb-uri", "URI", "External MongoDB uri (optional)"
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--auth-provider-url", "AUTH_PROVIDER_URL", "Define authentication provider url (optional)"
-    option "--associate_public_ip_address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
+    option "--associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
 
 
     def execute

--- a/cli/lib/kontena/cli/master/aws/create_command.rb
+++ b/cli/lib/kontena/cli/master/aws/create_command.rb
@@ -19,6 +19,8 @@ module Kontena::Cli::Master::Aws
     option "--mongodb-uri", "URI", "External MongoDB uri (optional)"
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--auth-provider-url", "AUTH_PROVIDER_URL", "Define authentication provider url (optional)"
+    option "--associate_public_ip_address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
+
 
     def execute
       require 'kontena/machine/aws'
@@ -36,7 +38,8 @@ module Kontena::Cli::Master::Aws
           auth_server: auth_provider_url,
           vault_secret: vault_secret || SecureRandom.hex(24),
           vault_iv: vault_iv || SecureRandom.hex(24),
-          mongodb_uri: mongodb_uri
+          mongodb_uri: mongodb_uri,
+          associate_public_ip: associate_public_ip?
       )
     end
   end

--- a/cli/lib/kontena/cli/nodes/aws/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/aws/create_command.rb
@@ -14,6 +14,7 @@ module Kontena::Cli::Nodes::Aws
     option "--type", "SIZE", "Instance type", default: 't2.small'
     option "--storage", "STORAGE", "Storage size (GiB)", default: '30'
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
+    option "--associate_public_ip_address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
 
     def execute
       require_api_url
@@ -33,7 +34,8 @@ module Kontena::Cli::Nodes::Aws
           subnet: subnet_id,
           storage: storage,
           version: version,
-          key_pair: key_pair
+          key_pair: key_pair,
+          associate_public_ip: associate_public_ip?
       )
     end
   end

--- a/cli/lib/kontena/cli/nodes/aws/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/aws/create_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Nodes::Aws
     option "--type", "SIZE", "Instance type", default: 't2.small'
     option "--storage", "STORAGE", "Storage size (GiB)", default: '30'
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
-    option "--associate_public_ip_address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
+    option "--associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
 
     def execute
       require_api_url

--- a/cli/lib/kontena/machine/aws/node_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/node_provisioner.rb
@@ -54,9 +54,7 @@ module Kontena
             min_count: 1,
             max_count: 1,
             instance_type: opts[:type],
-            security_group_ids: [security_group.group_id],
             key_name: opts[:key_pair],
-            subnet_id: subnet.subnet_id,
             user_data: Base64.encode64(user_data(userdata_vars)),
             block_device_mappings: [
               {
@@ -67,6 +65,15 @@ module Kontena
                   volume_type: 'gp2'
                 }
               }
+            ],
+            network_interfaces: [
+             {
+               device_index: 0,
+               subnet_id: subnet.subnet_id,
+               groups: [security_group.group_id],
+               associate_public_ip_address: opts[:associate_public_ip],
+               delete_on_termination: true
+             }
             ]
           }).first
           ec2_instance.create_tags({

--- a/docs/getting-started/installing/master.md
+++ b/docs/getting-started/installing/master.md
@@ -42,6 +42,7 @@ Options:
     --vault-iv VAULT_IV           Initialization vector for Vault (default: generate random iv)
     --version VERSION             Define installed Kontena version (default: "latest")
     --auth-provider-url AUTH_PROVIDER_URL Define authentication provider url (optional)
+    --associate-public-ip-address Flag to associate public IP address in VPC that does not do it automatically 
 ```
 
 ### Microsoft Azure

--- a/docs/getting-started/installing/nodes.md
+++ b/docs/getting-started/installing/nodes.md
@@ -40,6 +40,7 @@ Options:
     --type SIZE                   Instance type (default: "t2.small")
     --storage STORAGE             Storage size (GiB) (default: "30")
     --version VERSION             Define installed Kontena version (default: "latest")
+    --associate-public-ip         Flag to associate public IP address in VPC that does not do it automatically
 ```
 
 ### Microsoft Azure

--- a/docs/getting-started/installing/nodes.md
+++ b/docs/getting-started/installing/nodes.md
@@ -40,7 +40,7 @@ Options:
     --type SIZE                   Instance type (default: "t2.small")
     --storage STORAGE             Storage size (GiB) (default: "30")
     --version VERSION             Define installed Kontena version (default: "latest")
-    --associate-public-ip         Flag to associate public IP address in VPC that does not do it automatically
+    --associate-public-ip-address Flag to associate public IP address in VPC that does not do it automatically
 ```
 
 ### Microsoft Azure


### PR DESCRIPTION
This PR adds option to associate public IP for instances in VPC networks which do not automatically assign public IPs.

Fixes #766 #761 

ping @jakolehm 