### PR TITLE
Fix automatic scale down on too many instances

### DIFF
--- a/server/app/jobs/service_balancer_job.rb
+++ b/server/app/jobs/service_balancer_job.rb
@@ -157,6 +157,7 @@ class ServiceBalancerJob
       :'state.running' => true,
       :deleted_at.gt => grace_period_for_service(service).ago
     ).count
+    return false if offline_count == 0
 
     (running_count + offline_count) >= desired_count
   end

--- a/server/spec/jobs/service_balancer_job_spec.rb
+++ b/server/spec/jobs/service_balancer_job_spec.rb
@@ -115,6 +115,13 @@ describe ServiceBalancerJob do
         expect(subject.all_instances_exist?(service)).to eq(false)
       end
 
+      it 'returns false if service has too many instances' do
+        service.containers.create!(name: "test-1", state: {running: true})
+        service.containers.create!(name: "test-1", state: {running: true})
+        service.containers.create!(name: "test-2", state: {running: true})
+        expect(subject.all_instances_exist?(service)).to eq(false)
+      end
+
       it 'returns true if containers are marked as deleted and are within grace period' do
         service.containers.create!(
           name: "test-1", state: {running: true}, deleted_at: 5.seconds.ago


### PR DESCRIPTION
This PR fixes situation where node has been down so long that master looses track of "offline" service instances.