### PR TITLE
Verify Upcloud API access

### DIFF
--- a/cli/lib/kontena/machine/upcloud/master_provisioner.rb
+++ b/cli/lib/kontena/machine/upcloud/master_provisioner.rb
@@ -35,6 +35,8 @@ module Kontena
             end
           end
 
+          abort_unless_api_access
+
           abort('CoreOS template not found on Upcloud') unless coreos_template = find_template('CoreOS Stable')
           abort('Server plan not found on Upcloud') unless plan = find_plan(opts[:plan])
           abort('Zone not found on Upcloud') unless zone_exist?(opts[:zone])

--- a/cli/lib/kontena/machine/upcloud/node_destroyer.rb
+++ b/cli/lib/kontena/machine/upcloud/node_destroyer.rb
@@ -18,6 +18,9 @@ module Kontena
         end
 
         def run!(grid, name)
+
+          abort_unless_api_access
+
           servers = get('server')
           unless servers && servers.has_key?(:servers)
             abort('Upcloud API error')

--- a/cli/lib/kontena/machine/upcloud/node_provisioner.rb
+++ b/cli/lib/kontena/machine/upcloud/node_provisioner.rb
@@ -34,6 +34,8 @@ module Kontena
             grid_token: opts[:grid_token],
           }
 
+          abort_unless_api_access
+          
           abort('CoreOS template not found on Upcloud') unless coreos_template = find_template('CoreOS Stable')
           abort('Server plan not found on Upcloud') unless plan = find_plan(opts[:plan])
           abort('Zone not found on Upcloud') unless zone_exist?(opts[:zone])

--- a/cli/lib/kontena/machine/upcloud/node_restarter.rb
+++ b/cli/lib/kontena/machine/upcloud/node_restarter.rb
@@ -17,6 +17,8 @@ module Kontena
         end
 
         def run!(name)
+          abort_unless_api_access
+
           servers = get('server')
           unless servers && servers.has_key?(:servers)
             abort('Upcloud API error')

--- a/cli/lib/kontena/machine/upcloud/upcloud_common.rb
+++ b/cli/lib/kontena/machine/upcloud/upcloud_common.rb
@@ -35,6 +35,19 @@ module Kontena
           get("server/#{id}").fetch(:server, nil)
         end
 
+        def api_access?
+          response = get('account')
+          response.kind_of?(Hash) && response.has_key?(:account)
+        rescue
+          false
+        end
+
+        def abort_unless_api_access
+          unless api_access?
+            abort('Upcloud API authentication failed. Check that API access is enabled for the user.')
+          end
+        end
+
         [:get, :post, :delete].each do |http_method|
           define_method http_method do |path, opts={}|
             response = client.send(
@@ -59,12 +72,3 @@ module Kontena
     end
   end
 end
-
-class Testing
-  include Kontena::Machine::Upcloud::UpcloudCommon
-  def initialize(user, pass)
-    @username = user
-    @password = pass
-  end
-end
-


### PR DESCRIPTION
Fail gracefully if Upcloud API access fails due to wrong username and password or if API access is not enabled for the user.

