### PR TITLE
Enable security group setting for master and nodes in AWS

### DIFF
--- a/cli/lib/kontena/cli/master/aws/create_command.rb
+++ b/cli/lib/kontena/cli/master/aws/create_command.rb
@@ -20,6 +20,7 @@ module Kontena::Cli::Master::Aws
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--auth-provider-url", "AUTH_PROVIDER_URL", "Define authentication provider url (optional)"
     option "--associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
+    option "--security-groups", "SECURITY GROUPS", "Comma separated list of security groups (names) where the new instance will be attached (default: create 'kontena_master' group if not already existing)"
 
 
     def execute
@@ -39,7 +40,8 @@ module Kontena::Cli::Master::Aws
           vault_secret: vault_secret || SecureRandom.hex(24),
           vault_iv: vault_iv || SecureRandom.hex(24),
           mongodb_uri: mongodb_uri,
-          associate_public_ip: associate_public_ip?
+          associate_public_ip: associate_public_ip?,
+          security_groups: security_groups
       )
     end
   end

--- a/cli/lib/kontena/cli/nodes/aws/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/aws/create_command.rb
@@ -15,6 +15,7 @@ module Kontena::Cli::Nodes::Aws
     option "--storage", "STORAGE", "Storage size (GiB)", default: '30'
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
+    option "--security-groups", "SECURITY GROUPS", "Comma separated list of security groups (names) where the new instance will be attached (default: create grid specific group if not already existing)"
 
     def execute
       require_api_url
@@ -35,7 +36,8 @@ module Kontena::Cli::Nodes::Aws
           storage: storage,
           version: version,
           key_pair: key_pair,
-          associate_public_ip: associate_public_ip?
+          associate_public_ip: associate_public_ip?,
+          security_groups: security_groups
       )
     end
   end

--- a/cli/lib/kontena/machine/aws/common.rb
+++ b/cli/lib/kontena/machine/aws/common.rb
@@ -32,6 +32,26 @@ module Kontena
         def default_vpc
           ec2.vpcs({filters: [{name: "is-default", values: ["true"]}]}).first
         end
+
+        
+
+        ##
+        # Resolves givne list of group names into group ids
+        # @param [String] comma separated list of group names
+        # @return [Array]
+        def resolve_security_groups_to_ids(group_list, vpc_id)
+          ids = group_list.split(',').map { |group|  
+            sg = ec2.security_groups({
+            filters: [
+                {name: 'group-name', values: [group]},
+                {name: 'vpc-id', values: [vpc_id]}
+              ]
+            }).first
+
+            sg ? sg.group_id : nil
+          }
+          ids.compact
+        end
       end
     end
   end

--- a/cli/lib/kontena/machine/aws/node_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/node_provisioner.rb
@@ -31,9 +31,11 @@ module Kontena
 
           opts[:vpc] = default_vpc.vpc_id unless opts[:vpc]
 
-          security_group = ensure_security_group(opts[:grid], opts[:vpc])
+          security_groups = opts[:security_groups] ? 
+              resolve_security_groups_to_ids(opts[:security_groups], opts[:vpc]) : 
+              ensure_security_group(opts[:grid], opts[:vpc])
+              
           name = opts[:name ] || generate_name
-
 
           if opts[:subnet].nil?
             subnet = default_subnet(opts[:vpc], region+opts[:zone])
@@ -70,7 +72,7 @@ module Kontena
              {
                device_index: 0,
                subnet_id: subnet.subnet_id,
-               groups: [security_group.group_id],
+               groups: security_groups,
                associate_public_ip_address: opts[:associate_public_ip],
                delete_on_termination: true
              }
@@ -96,21 +98,18 @@ module Kontena
 
         ##
         # @param [String] grid
-        # @return [Aws::EC2::SecurityGroup]
+        # @return [Array] Security group id in array
         def ensure_security_group(grid, vpc_id)
           group_name = "kontena_grid_#{grid}"
-          sg = ec2.security_groups({
-            filters: [
-              {name: 'group-name', values: [group_name]},
-              {name: 'vpc-id', values: [vpc_id]}
-            ]
-          }).first
-          unless sg
+          group_id = resolve_security_groups_to_ids(group_name, vpc_id)
+
+          if group_id.empty?
             ShellSpinner "Creating AWS security group" do
               sg = create_security_group(group_name, vpc_id)
+              group_id = [sg.group_id]
             end
           end
-          sg
+          group_id
         end
 
         ##

--- a/docs/getting-started/installing/master.md
+++ b/docs/getting-started/installing/master.md
@@ -43,6 +43,7 @@ Options:
     --version VERSION             Define installed Kontena version (default: "latest")
     --auth-provider-url AUTH_PROVIDER_URL Define authentication provider url (optional)
     --associate-public-ip-address Flag to associate public IP address in VPC that does not do it automatically 
+    --security-groups             Comma separated list of security group names to which the new master will be attached
 ```
 
 ### Microsoft Azure

--- a/docs/getting-started/installing/nodes.md
+++ b/docs/getting-started/installing/nodes.md
@@ -41,6 +41,7 @@ Options:
     --storage STORAGE             Storage size (GiB) (default: "30")
     --version VERSION             Define installed Kontena version (default: "latest")
     --associate-public-ip-address Flag to associate public IP address in VPC that does not do it automatically
+    --security-groups             Comma separated list of security group names to which the new master will be attached
 ```
 
 ### Microsoft Azure


### PR DESCRIPTION
This PR enables setting existing security groups for both master and nodes.