### PR TITLE
Allow to use app name defined in yaml on app config command

### DIFF
--- a/cli/lib/kontena/cli/apps/config_command.rb
+++ b/cli/lib/kontena/cli/apps/config_command.rb
@@ -3,8 +3,7 @@ require 'pp'
 
 module Kontena::Cli::Apps
   class ConfigCommand < Clamp::Command
-    include Kontena::Cli::Common
-    include Kontena::Cli::GridOptions
+    include Kontena::Cli::Common    
     include Common
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
@@ -12,11 +11,8 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to view"
 
-    attr_reader :service_prefix
-
     def execute
       require_config_file(filename)
-      @service_prefix = project_name || current_dir
       services = services_from_yaml(filename, service_list, service_prefix)
       services.each do |name, config|
         config['cmd'] = config['cmd'].join(" ") if config['cmd']

--- a/cli/spec/kontena/cli/app/config_command_spec.rb
+++ b/cli/spec/kontena/cli/app/config_command_spec.rb
@@ -1,0 +1,78 @@
+require_relative "../../../spec_helper"
+require "kontena/cli/apps/config_command"
+require 'ruby_dig'
+
+describe Kontena::Cli::Apps::ConfigCommand do
+  include FixturesHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:kontena_yml) do
+    fixture('mysql.yml')
+  end
+
+  let(:yaml_with_app_name) do
+    {
+      'version' => '2',
+      'name' => 'myapp',
+      'services' => {
+        'mysql' => {
+          'image' => '$project-mysql:5.6'
+        }
+      }
+    }
+  end
+
+  let(:settings) do
+    {'current_server' => 'alias',
+     'servers' => [
+         {
+           'name' => 'some_master',
+           'url' => 'some_master'
+         }
+     ]
+    }
+  end
+
+  describe '#execute' do
+    before(:each) do
+      allow(subject).to receive(:settings).and_return(settings)
+      allow(subject).to receive(:current_dir).and_return("kontena-test")
+      allow(File).to receive(:exists?).and_return(true)
+      allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_yml)
+    end
+
+    it 'outputs service configs' do
+      valid_output = {
+        'services' => {
+          'mysql' => {
+            'image' => 'mysql:5.6',
+            'stateful' => false
+          }
+        }
+      }
+      expect {
+        subject.run([])
+      }.to output(valid_output.to_yaml).to_stdout
+    end
+
+    it 'uses app name from yaml as project variable' do
+
+      allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(yaml_with_app_name.to_yaml)
+      valid_output = {
+        'services' => {
+          'mysql' => {
+            'image' => 'myapp-mysql:5.6',
+            'stateful' => false
+          }
+        }
+      }
+      expect {
+        subject.run([])
+      }.to output(valid_output.to_yaml).to_stdout
+    end
+
+  end
+end


### PR DESCRIPTION
#751 implemented support to define app/stack name in kontena.yml. This PR enables this also on `kontena app config` command