### PR TITLE
Support for tagging master and nodes on AWS

### DIFF
--- a/cli/lib/kontena/cli/master/aws/create_command.rb
+++ b/cli/lib/kontena/cli/master/aws/create_command.rb
@@ -21,6 +21,7 @@ module Kontena::Cli::Master::Aws
     option "--auth-provider-url", "AUTH_PROVIDER_URL", "Define authentication provider url (optional)"
     option "--associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
     option "--security-groups", "SECURITY GROUPS", "Comma separated list of security groups (names) where the new instance will be attached (default: create 'kontena_master' group if not already existing)"
+    option "--tag", "TAG", "Tag(s) for the new master", multivalued: true
 
 
     def execute
@@ -41,7 +42,8 @@ module Kontena::Cli::Master::Aws
           vault_iv: vault_iv || SecureRandom.hex(24),
           mongodb_uri: mongodb_uri,
           associate_public_ip: associate_public_ip?,
-          security_groups: security_groups
+          security_groups: security_groups,
+          tags: tag_list
       )
     end
   end

--- a/cli/lib/kontena/cli/nodes/aws/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/aws/create_command.rb
@@ -16,6 +16,7 @@ module Kontena::Cli::Nodes::Aws
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
     option "--associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: false, attribute_name: :associate_public_ip
     option "--security-groups", "SECURITY GROUPS", "Comma separated list of security groups (names) where the new instance will be attached (default: create grid specific group if not already existing)"
+    option "--tag", "TAG", "Tag(s) for the new node", multivalued: true
 
     def execute
       require_api_url
@@ -37,7 +38,8 @@ module Kontena::Cli::Nodes::Aws
           version: version,
           key_pair: key_pair,
           associate_public_ip: associate_public_ip?,
-          security_groups: security_groups
+          security_groups: security_groups,
+          tags: tag_list
       )
     end
   end

--- a/cli/lib/kontena/machine/aws/common.rb
+++ b/cli/lib/kontena/machine/aws/common.rb
@@ -33,7 +33,25 @@ module Kontena
           ec2.vpcs({filters: [{name: "is-default", values: ["true"]}]}).first
         end
 
-        
+        ##
+        #
+        # @param tag_list [Array] array of string where each string looks like 'key=value'
+        # @param ec2_instance [] the instance to add tags to
+        # @param name [String] name of the instance
+        def add_tags(tag_list, ec2_instance, name)
+          tags = [
+            {key: 'Name', value: name}
+          ]
+          if tag_list && !tag_list.empty?
+            tag_list.each { |tag|
+              key, value = tag.split('=')
+              tags << {key: key, value: value}
+            }
+          end
+          ec2_instance.create_tags({
+            tags: tags
+          })
+        end        
 
         ##
         # Resolves givne list of group names into group ids

--- a/cli/lib/kontena/machine/aws/master_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/master_provisioner.rb
@@ -84,11 +84,8 @@ module Kontena
              }
             ]
           }).first
-          ec2_instance.create_tags({
-            tags: [
-              {key: 'Name', value: name}
-            ]
-          })
+
+          add_tags(opts[:tags], ec2_instance, name)
           
           ShellSpinner "Creating AWS instance #{name.colorize(:cyan)} " do
             sleep 5 until ec2_instance.reload.state.name == 'running'

--- a/cli/lib/kontena/machine/aws/node_provisioner.rb
+++ b/cli/lib/kontena/machine/aws/node_provisioner.rb
@@ -78,12 +78,9 @@ module Kontena
              }
             ]
           }).first
-          ec2_instance.create_tags({
-            tags: [
-              {key: 'Name', value: name},
-              {key: 'kontena_grid', value: opts[:grid]}
-            ]
-          })
+
+          opts[:tags] << "kontena_grid=#{opts[:grid]}"
+          add_tags(opts[:tags], ec2_instance, name)
 
           ShellSpinner "Creating AWS instance #{name.colorize(:cyan)} " do
             sleep 5 until ec2_instance.reload.state.name == 'running'


### PR DESCRIPTION
This PR adds support for tagging instances (both master and nodes) on AWS. Adds following options:
```
kontena node aws create --access-key access_key --secret-key secret \
--key-pair testing --region eu-central-1 --zone a \
--tag tag1=foo --tag tag2=bar
```

Fixes #762 