### PR TITLE
Generate yaml v2 formatted files on app init command

### DIFF
--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -56,7 +56,7 @@ module Kontena::Cli::Apps
 
     def project_name_from_yaml(file)
       reader = YAML::Reader.new(file, true)
-      outcome = reader.execute      
+      outcome = reader.execute
       if outcome[:version] == '2'
         outcome[:name]
       else
@@ -100,10 +100,8 @@ module Kontena::Cli::Apps
     def app_json
       if !@app_json && File.exist?('app.json')
         @app_json = JSON.parse(File.read('app.json'))
-      else
-        @app_json = {}
       end
-      @app_json
+      @app_json ||= {}
     end
 
     def display_notifications(messages, color = :yellow)

--- a/cli/lib/kontena/cli/apps/docker_compose_generator.rb
+++ b/cli/lib/kontena/cli/apps/docker_compose_generator.rb
@@ -14,33 +14,45 @@ module Kontena::Cli::Apps
     def generate(procfile, addons, env_file)
       if procfile.keys.size > 0
         # generate services found in Procfile
-        docker_compose = {}
-        procfile.keys.each do |service|
-          docker_compose[service] = {'build' => '.' }
+        docker_compose = {
+          'version' => '2'
+        }
+        services = {}
+        procfile.each do |service, command|
+          services[service] = {'build' => '.' }
           if app_json && service == 'web' # Heroku generates PORT env variable so should we do too
-            docker_compose[service]['environment'] = ['PORT=5000']
-            docker_compose[service]['ports'] = ['5000:5000']
+            services[service]['environment'] = ['PORT=5000']
+            services[service]['ports'] = ['5000:5000']
           end
-          docker_compose[service]['command'] = "/start #{service}" if service != 'web'
-          docker_compose[service]['env_file'] = env_file if env_file
+          services[service]['command'] =  "/start #{service}" if service != 'web'
+          services[service]['env_file'] = env_file if env_file
 
           # generate addon services
           addons.each do |addon|
             addon_service = addon.split(":")[0]
             addon_service.slice!('heroku-')
             if valid_addons.has_key?(addon_service)
-              docker_compose[service]['links'] = [] unless docker_compose[service]['links']
-              docker_compose[service]['links'] << "#{addon_service}:#{addon_service}"
-              docker_compose[service]['environment'] = [] unless docker_compose[service]['environment']
-              docker_compose[service]['environment'] += valid_addons[addon_service]['environment']
-              docker_compose[addon_service] = {'image' => valid_addons[addon_service]['image']}
+              services[service]['links'] = [] unless services[service]['links']
+              services[service]['links'] << "#{addon_service}:#{addon_service}"
+              services[service]['environment'] = [] unless services[service]['environment']
+              services[service]['environment'] += valid_addons[addon_service]['environment']
+              services[addon_service] = {'image' => valid_addons[addon_service]['image']}
             end
           end
         end
+        docker_compose['services'] = services
       else
         # no Procfile found, create dummy web service
-        docker_compose = {'web' => { 'build' => '.'}}
-        docker_compose['web']['env_file'] = env_file if env_file
+        docker_compose = {
+          'version' => '2',
+          'services' => {
+            'web' => {
+              'build' => '.'
+            }
+          }
+        }
+
+        docker_compose['services']['web']['env_file'] = env_file if env_file
       end
       # create docker-compose.yml file
       create_yml(docker_compose, docker_compose_file)

--- a/cli/spec/fixtures/app.json
+++ b/cli/spec/fixtures/app.json
@@ -1,0 +1,42 @@
+{
+  "name": "Small Sharp Tool",
+  "description": "This app does one little thing, and does it well.",
+  "keywords": [
+    "productivity",
+    "HTML5",
+    "scalpel"
+  ],
+  "website": "https://small-sharp-tool.com/",
+  "repository": "https://github.com/jane-doe/small-sharp-tool",
+  "logo": "https://small-sharp-tool.com/logo.svg",
+  "success_url": "/welcome",
+  "scripts": {
+    "postdeploy": "bundle exec rake bootstrap"
+  },
+  "env": {
+    "SECRET_TOKEN": {
+      "description": "A secret key for verifying the integrity of signed cookies.",
+      "generator": "secret"
+    },
+    "WEB_CONCURRENCY": {
+      "description": "The number of processes to run.",
+      "value": "5"
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 2,
+      "size": "Performance-M"
+    }
+  },
+  "image": "heroku/ruby",
+  "addons": [
+    "openredis",
+    "mongolab:shared-single-small"
+  ],
+  "buildpacks": [
+    {
+      "url": "https://github.com/stomita/heroku-buildpack-phantomjs"
+    }
+  ]
+}

--- a/cli/spec/kontena/cli/app/init_command_spec.rb
+++ b/cli/spec/kontena/cli/app/init_command_spec.rb
@@ -1,0 +1,110 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/apps/init_command'
+
+describe Kontena::Cli::Apps::InitCommand do
+  include FixturesHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:app_json) do
+    fixture('app.json')
+  end
+
+  before(:each) do
+    allow(File).to receive(:exist?).and_return false
+    allow(subject).to receive(:create_yml).and_return nil
+    allow(subject).to receive(:create_dockerfile?).and_return false
+    allow(subject).to receive(:create_env_file).and_return nil
+    allow(subject).to receive(:create_docker_compose_yml?).and_return false
+    allow(Kontena::Cli::Apps::KontenaYmlGenerator).to receive(:new).and_return spy
+  end
+
+  describe '#execute' do
+    it 'detects Dockerfile' do
+      expect(File).to receive(:exist?).with('Dockerfile').once.and_return true
+      subject.run([])
+    end
+
+    it 'reads Procfile' do
+      allow(File).to receive(:exist?).with('Procfile').once.and_return true
+      expect(File).to receive(:read).with('Procfile').once.and_return 'web: bundle exec rails s'
+      subject.run([])
+    end
+
+    it 'reads app.json file' do
+      allow(File).to receive(:exist?).with('app.json').once.and_return true
+      expect(File).to receive(:read).with('app.json').once.and_return '{}'
+      subject.run([])
+    end
+
+    it 'asks creation of docker-compose.yml' do
+      expect(subject).to receive(:create_docker_compose_yml?).and_return false
+      subject.run([])
+    end
+
+    it 'creates docker-compose.yml if accepted' do
+      allow(subject).to receive(:create_docker_compose_yml?).and_return true
+      generator = spy
+      generator_klass = Kontena::Cli::Apps::DockerComposeGenerator
+      expect(generator_klass).to receive(:new).with('docker-compose.yml').and_return(generator)
+      expect(generator).to receive(:generate).with({}, [], nil)
+      subject.run([])
+    end
+
+    it 'passes Procfile services to docker-compose.yml creation' do
+      allow(File).to receive(:exist?).with('Procfile').once.and_return true
+      allow(File).to receive(:read).with('Procfile').once.and_return 'web: bundle exec rails s'
+      allow(subject).to receive(:create_docker_compose_yml?).and_return true
+      generator = spy
+      generator_klass = Kontena::Cli::Apps::DockerComposeGenerator
+      expect(generator_klass).to receive(:new).with('docker-compose.yml').and_return(generator)
+      expect(generator).to receive(:generate).with({ 'web' => 'bundle exec rails s' }, [], nil)
+      subject.run([])
+    end
+
+    it 'passes app.json options to docker-compose.yml creation' do
+      expect(File).to receive(:exist?).with('app.json').and_return true
+      expect(File).to receive(:read).with('app.json').and_return app_json
+      allow(subject).to receive(:create_docker_compose_yml?).and_return true
+      generator = spy
+      generator_klass = Kontena::Cli::Apps::DockerComposeGenerator
+      expect(generator_klass).to receive(:new).with('docker-compose.yml').and_return(generator)
+      expect(generator).to receive(:generate).with({}, ["openredis","mongolab:shared-single-small"], nil)
+      subject.run([])
+    end
+
+    it 'creates .env file' do
+      allow(File).to receive(:exist?).with('app.json').and_return true
+      allow(File).to receive(:read).with('app.json').and_return app_json
+      allow(subject).to receive(:create_docker_compose_yml?).and_return true
+      generator = spy
+      generator_klass = Kontena::Cli::Apps::DockerComposeGenerator
+      allow(generator_klass).to receive(:new).with('docker-compose.yml').and_return(generator)
+      app_env = JSON.parse(app_json)['env']
+      expect(subject).to receive(:create_env_file).with(app_env).and_return nil
+      subject.run([])
+    end
+
+    it 'creates kontena.yml from docker-compose.yml' do
+      allow(File).to receive(:exist?).with('docker-compose.yml').and_return true
+      generator = spy
+      generator_klass = Kontena::Cli::Apps::KontenaYmlGenerator
+      expect(generator_klass).to receive(:new).with(nil, 'cli').and_return(generator)
+      expect(generator).to receive(:generate_from_compose_file).with('docker-compose.yml')
+      subject.run([])
+    end
+
+    context 'when docker-compose.yml not created' do
+      it 'creates dummy kontena.yml' do
+        allow(File).to receive(:exist?).with('docker-compose.yml').and_return false
+        generator = spy
+        generator_klass = Kontena::Cli::Apps::KontenaYmlGenerator
+        expect(generator_klass).to receive(:new).with(nil, 'cli').and_return(generator)
+        expect(generator).to receive(:generate).with({}, [], nil)
+        subject.run([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR updates `kontena app init` command to generate yaml v2 formatted `docker-compose.yml` and `kontena.yml` files.

Also fixes #784 