### PR TITLE
Improved VPN creation for non-public environments

### DIFF
--- a/cli/spec/kontena/cli/vpn/create_command_spec.rb
+++ b/cli/spec/kontena/cli/vpn/create_command_spec.rb
@@ -1,0 +1,116 @@
+require_relative "../../../spec_helper"
+require "kontena/cli/vpn/create_command"
+
+describe Kontena::Cli::Vpn::CreateCommand do
+  
+  include ClientHelpers
+
+  let(:subject) { described_class.new(File.basename($0)) }
+
+  describe '#execute' do
+    it 'should abort if vpn already exists' do
+      expect(client).to receive(:get).with("services/test-grid/vpn").and_return({vpn: true})
+
+      expect {
+        subject.execute
+      }.to raise_error SystemExit
+    end
+
+    
+  end
+
+  describe '#find_node' do
+
+    it 'should abort if no online nodes exists' do
+      expect(client).to receive(:get).with("grids/test-grid/nodes").and_return(
+        { 
+          'nodes' => [
+            {'connected' => false}, 
+            {'connected' => false, 'public_ip' => '1.2.3.4'}
+          ]
+        })
+
+      expect {
+        subject.find_node(token, nil)
+      }.to raise_error SystemExit
+    end
+
+    it 'should return first online node with public ip' do
+      expect(client).to receive(:get).with("grids/test-grid/nodes").and_return(
+        { 
+          'nodes' => [
+            {'connected' => true}, 
+            {'connected' => true, 'public_ip' => '1.2.3.4'}
+          ]
+        })
+
+      node = subject.find_node(token, nil)
+      expect(node['public_ip']).to eq('1.2.3.4')
+    end
+
+    it 'should return preferred node' do
+      expect(client).to receive(:get).with("grids/test-grid/nodes").and_return(
+        { 
+          'nodes' => [
+            {'connected' => true}, 
+            {'name' => 'preferred', 'connected' => true, 'public_ip' => '1.2.3.4'}
+          ]
+        })
+
+      node = subject.find_node(token, 'preferred')
+      expect(node['name']).to eq('preferred')
+    end
+
+    it 'should abort if no online nodes exists' do
+      expect(client).to receive(:get).with("grids/test-grid/nodes").and_return(
+        { 
+          'nodes' => [
+            {'connected' => true}, 
+            {'name' => 'preferred', 'connected' => true, 'public_ip' => '1.2.3.4'}
+          ]
+        })
+
+      expect {
+        subject.find_node(token, 'foobar')
+      }.to raise_error SystemExit
+    end
+
+  end
+
+  describe '#node_vpn_ip' do
+
+    it 'return ip when set' do
+      allow(subject).to receive(:ip).and_return('1.2.3.4')
+
+      expect(subject.node_vpn_ip(nil)).to eq('1.2.3.4')
+    end
+
+    it 'return public ip when set on node' do
+      allow(subject).to receive(:ip).and_return(nil)
+      node = {
+        'public_ip' => '8.8.8.8',
+        'private_ip' => '10.1.1.2'
+      }
+      expect(subject.node_vpn_ip(node)).to eq('8.8.8.8')
+    end
+
+    it 'return private ip when public not set on node' do
+      allow(subject).to receive(:ip).and_return(nil)
+      node = {
+        'private_ip' => '10.1.1.2'
+      }
+      expect(subject.node_vpn_ip(node)).to eq('10.1.1.2')
+    end
+
+    it 'return private on vagrant nodes' do
+      allow(subject).to receive(:ip).and_return(nil)
+      node = {
+        'public_ip' => '8.8.8.8',
+        'private_ip' => '10.1.1.2',
+        'labels' => ['provider=vagrant']
+      }
+      expect(subject.node_vpn_ip(node)).to eq('10.1.1.2')
+    end
+
+  end
+end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -7,6 +7,7 @@
 
 require 'clamp'
 require 'kontena/cli/common'
+require 'kontena/cli/grid_options'
 require 'kontena/client'
 
 RSpec.configure do |config|

--- a/docs/using-kontena/vpn-access.md
+++ b/docs/using-kontena/vpn-access.md
@@ -28,9 +28,17 @@ You should use the Kontena's built-in VPN access if you want to:
 
 ```
 $ kontena vpn create
+Usage:
+    kontena vpn create [OPTIONS]
+
+Options:
+    --node NODE                   Node name where VPN is deployed
+    --ip IP                       Node ip-address to use in VPN service configuration
 ```
 
-> VPN service uses port 1194 (udp), remember to open it to nodes if you are using firewall
+Use the `--node` and/or `--ip` option to override automatic node selection and IP detection in private network setups.
+
+> VPN service uses port 1194 (udp), remember to open it to nodes if you are using firewall!
 
 
 #### Export VPN Configuration:
@@ -44,5 +52,5 @@ $ kontena vpn config > /path/to/kontena.ovpn
 #### Delete VPN Service:
 
 ```
-$ kontena vpn delete
+$ kontena vpn remove
 ```


### PR DESCRIPTION
This PR improves VPN creation logic for environments where there are no public IPs for nodes. If the `--node` option is provided and if node does not have any public IP the VPN creation fallbacks to nodes private IP.

Fixes #786 

ping @jakolehm 