### PR TITLE
Fix port definitions to include possibility to set bind IP

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -201,7 +201,7 @@ module Kontena
       def build_port_bindings
         bindings = {}
         self.ports.each do |p|
-          bindings["#{p['container_port']}/#{p['protocol']}"] = [{'HostPort' => p['node_port'].to_s}]
+          bindings["#{p['container_port']}/#{p['protocol']}"] = [{'HostIp' => p['ip'].to_s, 'HostPort' => p['node_port'].to_s}]
         end
         bindings
       end

--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -201,7 +201,8 @@ module Kontena
       def build_port_bindings
         bindings = {}
         self.ports.each do |p|
-          bindings["#{p['container_port']}/#{p['protocol']}"] = [{'HostIp' => p['ip'].to_s, 'HostPort' => p['node_port'].to_s}]
+          host_ip = p['ip'] || '0.0.0.0'
+          bindings["#{p['container_port']}/#{p['protocol']}"] = [{'HostIp' => host_ip.to_s, 'HostPort' => p['node_port'].to_s}]
         end
         bindings
       end

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -287,7 +287,7 @@ describe Kontena::Models::ServicePod do
   describe '#build_port_bindings' do
     let(:ports) do
       [
-        {'container_port' => 2379, 'node_port' => 12379, 'protocol' => 'tcp'},
+        {'ip' => '1.2.3.4', 'container_port' => 2379, 'node_port' => 12379, 'protocol' => 'tcp'},
         {'container_port' => 1194, 'node_port' => 1194, 'protocol' => 'udp'},
       ]
     end
@@ -299,8 +299,8 @@ describe Kontena::Models::ServicePod do
     it 'retuns correct hash when ports are defined' do
       data['ports'] = ports
       port_bindings = subject.build_port_bindings
-      expect(port_bindings['2379/tcp']).to eq([{'HostPort' => '12379'}])
-      expect(port_bindings['1194/udp']).to eq([{'HostPort' => '1194'}])
+      expect(port_bindings['2379/tcp']).to eq([{'HostIp' => '1.2.3.4', 'HostPort' => '12379'}])
+      expect(port_bindings['1194/udp']).to eq([{'HostIp' => '0.0.0.0', 'HostPort' => '1194'}])
     end
   end
 

--- a/cli/lib/kontena/cli/apps/service_generator.rb
+++ b/cli/lib/kontena/cli/apps/service_generator.rb
@@ -30,7 +30,7 @@ module Kontena::Cli::Apps
       data['container_count'] = options['instances']
       data['links'] = parse_links(options['links'] || [])
       data['external_links'] = parse_links(options['external_links'] || [])
-      data['ports'] = parse_ports(options['ports'] || [])
+      data['ports'] = parse_stringified_ports(options['ports'] || [])
       data['memory'] = parse_memory(options['mem_limit'].to_s) if options['mem_limit']
       data['memory_swap'] = parse_memory(options['memswap_limit'].to_s) if options['memswap_limit']
       data['cpu_shares'] = options['cpu_shares'] if options['cpu_shares']
@@ -81,16 +81,13 @@ module Kontena::Cli::Apps
 
     # @param [Array<String>] port_options
     # @return [Array<Hash>]
-    def parse_ports(port_options)
-      port_options.map{|p|
-        node_port, container_port, protocol = p.split(':')
-        if node_port.nil? || container_port.nil?
-          raise ArgumentError.new("Invalid port value #{p}")
-        end
+    def parse_stringified_ports(port_options)
+      parse_ports(port_options).map {|p|
         {
-            'container_port' => container_port,
-            'node_port' => node_port,
-            'protocol' => protocol || 'tcp'
+          'ip' => p[:ip],
+          'container_port' => p[:container_port],
+          'node_port' => p[:node_port],
+          'protocol' => p[:protocol]
         }
       }
     end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -251,14 +251,20 @@ module Kontena
         # @return [Array<Hash>]
         def parse_ports(port_options)
           port_options.map{|p|
-            node_port, container_port, protocol = p.split(':')
+            port, protocol = p.split('/')
+            protocol ||= 'tcp'
+            port_elements = port.split(':')
+            container_port = port_elements[-1]
+            node_port = port_elements[-2]
+            ip = port_elements[-3] || '0.0.0.0'
             if node_port.nil? || container_port.nil?
               raise ArgumentError.new("Invalid port value #{p}")
             end
             {
-                container_port: container_port,
-                node_port: node_port,
-                protocol: protocol || 'tcp'
+              ip: ip,
+              container_port: container_port,
+              node_port: node_port,
+              protocol: protocol 
             }
           }
         end

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -220,7 +220,7 @@ describe Kontena::Cli::Apps::DeployCommand do
           'stateful' => true,
           'strategy' => 'ha',
           'links' => [{ 'name' => 'kontena-test-mysql', 'alias' => 'mysql' }],
-          'ports' => [{ 'container_port' => '80', 'node_port' => '80', 'protocol' => 'tcp' }]
+          'ports' => [{ 'ip' => '0.0.0.0','container_port' => '80', 'node_port' => '80', 'protocol' => 'tcp' }]
         }
         expect(subject).to receive(:create_service).with('1234567', '1', hash_including(data))
 

--- a/cli/spec/kontena/cli/services/services_helper_spec.rb
+++ b/cli/spec/kontena/cli/services/services_helper_spec.rb
@@ -85,11 +85,45 @@ module Kontena::Cli::Services
 
       it 'returns hash of port options' do
         valid_result = [{
+          ip: '0.0.0.0',
+          container_port: '80',
+          node_port: '80',
+          protocol: 'tcp'
+        }]
+        port_options = subject.parse_ports(['80:80'])
+        expect(port_options).to eq(valid_result)
+      end
+
+      it 'returns hash of port options with protocol' do
+        valid_result = [{
+          ip: '0.0.0.0',
+          container_port: '80',
+          node_port: '80',
+          protocol: 'udp'
+        }]
+        port_options = subject.parse_ports(['80:80/udp'])
+        expect(port_options).to eq(valid_result)
+      end
+
+      it 'returns hash of port options with ip' do
+        valid_result = [{
+            ip: '1.2.3.4',
             container_port: '80',
             node_port: '80',
             protocol: 'tcp'
         }]
-        port_options = subject.parse_ports(['80:80'])
+        port_options = subject.parse_ports(['1.2.3.4:80:80'])
+        expect(port_options).to eq(valid_result)
+      end
+
+      it 'returns hash of port options with ip and protocol' do
+        valid_result = [{
+            ip: '1.2.3.4',
+            container_port: '80',
+            node_port: '80',
+            protocol: 'udp'
+        }]
+        port_options = subject.parse_ports(['1.2.3.4:80:80/udp'])
         expect(port_options).to eq(valid_result)
       end
     end

--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -274,7 +274,10 @@ Expose ports. Specify both ports (HOST:CONTAINER).
 ports:
   - "80:80"
   - "53160:53160/udp"
+  - "1.2.3.4:8443:443"
 ```
+
+**Note:** If you use bind IP in the port exposure definition make sure you use proper affinity rules to bind the service to a node where this address is available.
 
 #### privileged
 Give extended privileges to service.


### PR DESCRIPTION
This PR adds the possibility to use bind IP address in port expose settings. Scheduler will NOT make sure the address is actually available on the scheduled node so user has to use proper affinity rules to control this.

Fixes #795 