### PR TITLE
Initial health check for remote services

### DIFF
--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -27,6 +27,7 @@ require_relative 'kontena/workers/stats_worker'
 require_relative 'kontena/workers/event_worker'
 require_relative 'kontena/workers/weave_worker'
 require_relative 'kontena/workers/image_cleanup_worker'
+require_relative 'kontena/workers/health_check_worker'
 
 require_relative 'kontena/load_balancers/configurer'
 require_relative 'kontena/load_balancers/registrator'

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -77,6 +77,11 @@ module Kontena
         type: Kontena::Workers::ImageCleanupWorker,
         as: :image_cleanup_worker
       )
+      @supervisor.supervise(
+        type: Kontena::Workers::HealthCheckWorker,
+        as: :health_check_worker,
+        args: [@queue]
+      )
     end
 
     def supervise_lb

--- a/agent/lib/kontena/helpers/port_helper.rb
+++ b/agent/lib/kontena/helpers/port_helper.rb
@@ -1,0 +1,20 @@
+  module Kontena
+    module Helpers
+      module PortHelper
+
+        def container_port_open?(ip, port, timeout = 2.0)
+          Timeout::timeout(timeout) do
+            begin
+              TCPSocket.new(ip, port).close
+              true
+            rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+              false
+            end
+          end
+        rescue Timeout::Error
+          false
+        end
+
+      end
+    end
+  end

--- a/agent/lib/kontena/image_puller.rb
+++ b/agent/lib/kontena/image_puller.rb
@@ -26,9 +26,11 @@ module Kontena
       retries = 0
       begin
         Docker::Image.create({'fromImage' => image}, creds)
+        info "pulled image: #{image}"
       rescue => exc
         retries += 1
         if retries < 10
+          warn "image pull failed: #{exc.message}. Retrying still for #{10 - retries} times."
           sleep 0.1
           retry
         end

--- a/agent/lib/kontena/load_balancers/configurer.rb
+++ b/agent/lib/kontena/load_balancers/configurer.rb
@@ -30,6 +30,7 @@ module Kontena::LoadBalancers
     def ensure_config(container)
       name = container.labels['io.kontena.load_balancer.name']
       service_name = container.labels['io.kontena.service.name']
+      check_uri = container.labels['io.kontena.health_check.uri']
       etcd_path = "#{ETCD_PREFIX}/#{name}"
       env_hash = container.env_hash
 
@@ -45,6 +46,7 @@ module Kontena::LoadBalancers
         end
         keep_virtual_path = env_hash['KONTENA_LB_KEEP_VIRTUAL_PATH']
         set("#{etcd_path}/services/#{service_name}/balance", balance)
+        set("#{etcd_path}/services/#{service_name}/health_check_uri", check_uri)
         set("#{etcd_path}/services/#{service_name}/custom_settings", custom_settings)
         set("#{etcd_path}/services/#{service_name}/virtual_hosts", virtual_hosts)
         set("#{etcd_path}/services/#{service_name}/virtual_path", virtual_path)

--- a/agent/lib/kontena/rpc/agent_api.rb
+++ b/agent/lib/kontena/rpc/agent_api.rb
@@ -1,6 +1,9 @@
+require_relative '../helpers/port_helper'
+
 module Kontena
   module Rpc
     class AgentApi
+      include Kontena::Helpers::PortHelper
 
       # @param [Hash] data
       def master_info(data)
@@ -21,16 +24,7 @@ module Kontena
       # @param [Float] timeout
       # @return [Hash]
       def port_open?(ip, port, timeout = 2.0)
-        Timeout::timeout(timeout) do
-          begin
-            TCPSocket.new(ip, port).close
-            {open: true}
-          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
-            {open: false}
-          end
-        end
-      rescue Timeout::Error
-        {open: false}
+        {open: container_port_open?(ip, port, timeout)}
       end
 
       private

--- a/agent/lib/kontena/rpc/docker_container_api.rb
+++ b/agent/lib/kontena/rpc/docker_container_api.rb
@@ -11,6 +11,7 @@ module Kontena
     #
     class DockerContainerApi
       include Kontena::Helpers::IfaceHelper
+      include Kontena::Logging
 
       ##
       # @param [String] id

--- a/agent/lib/kontena/workers/container_health_check_worker.rb
+++ b/agent/lib/kontena/workers/container_health_check_worker.rb
@@ -1,0 +1,92 @@
+require_relative '../helpers/port_helper'
+
+module Kontena::Workers
+  class ContainerHealthCheckWorker
+    include Celluloid
+    include Kontena::Logging
+    include Kontena::Helpers::PortHelper
+
+    HEALTHY_STATUSES = [200]
+
+    finalizer :log_exit
+
+    # @param [Docker::Container] container
+    # @param [Queue] queue
+    def initialize(container, queue)
+      @container = container
+      @queue = queue
+      info "starting to watch health of container #{container.name}"
+    end
+
+    
+    def start
+      labels = @container.json['Config']['Labels']
+      uri = labels['io.kontena.health_check.uri']
+      interval = labels['io.kontena.health_check.interval'].to_i
+      initial_delay = labels['io.kontena.health_check.initial_delay'].to_i
+      timeout = labels['io.kontena.health_check.timeout'].to_i
+      port = labels['io.kontena.health_check.port'].to_i
+      protocol = labels['io.kontena.health_check.protocol']
+      ip, _ = @container.overlay_cidr.split('/')
+
+      sleep initial_delay # to allow container to startup properly
+
+      every(interval) do
+        if protocol == 'http'
+          msg = check_http_status(ip, port, uri, timeout)
+        elsif
+          msg = check_tcp_status(ip, port, timeout)
+        end
+        @queue << msg
+      end
+      
+    end
+
+    def check_http_status(ip, port, uri, timeout)
+      url = "http://#{ip}:#{port}#{uri}"
+      debug "checking health for container: #{@container.name} using url: #{url}"
+      msg = {
+        event: 'container:health'.freeze,
+        data: {
+          'status' => 'unhealthy',
+          'status_code' => '',
+          'id' => @container.id
+        }
+      }
+      begin
+        response = Excon.get(url, :connect_timeout => timeout)
+        debug "got status: #{response.status}"
+        msg[:data]['status'] = HEALTHY_STATUSES.include?(response.status) ? 'healthy' : 'unhealthy'
+        msg[:data]['status_code'] = response.status
+      rescue => exc
+        msg[:data]['status'] = 'unhealthy'
+      end
+      msg
+    end
+
+    def check_tcp_status(ip, port, timeout)
+      debug "checking health for container: #{@container.name} using tcp ip and port: #{ip}:#{port}"
+      msg = {
+        event: 'container:health'.freeze,
+        data: {
+          'status' => 'unhealthy',
+          'status_code' => '',
+          'id' => @container.id
+        }
+      }
+      begin
+        response = container_port_open?(ip, port, timeout)
+        debug "got status: #{response}"
+        msg[:data]['status'] = response ? 'healthy' : 'unhealthy'
+        msg[:data]['status_code'] = response ? 'open' : 'closed'
+      rescue => exc
+        msg[:data]['status'] = 'unhealthy'
+      end
+      msg
+    end
+
+    def log_exit
+      debug "stopped to check status from %s" % [@container.name]
+    end
+  end
+end

--- a/agent/lib/kontena/workers/health_check_worker.rb
+++ b/agent/lib/kontena/workers/health_check_worker.rb
@@ -1,0 +1,80 @@
+require_relative 'container_health_check_worker'
+
+module Kontena::Workers
+  class HealthCheckWorker
+    include Celluloid
+    include Celluloid::Notifications
+    include Kontena::Logging
+
+    attr_reader :queue, :etcd, :workers
+
+    finalizer :terminate_workers
+
+    START_EVENTS = ['start']
+    STOP_EVENTS = ['die']
+    ETCD_PREFIX = '/kontena/log_worker/containers'
+
+    ##
+    # @param [Queue] queue
+    # @param [Boolean] autostart
+    def initialize(queue, autostart = true)
+      @queue = queue
+      @queue_processing = false
+      @workers = {}
+      subscribe('container:event', :on_container_event)
+      info 'initialized'
+
+      async.start if autostart
+    end
+
+    def start
+      Docker::Container.all.each do |container|
+        self.start_container_check(container)
+      end
+    end
+
+    def stop
+      @workers.keys.dup.each do |id|
+        self.stop_container_check(id)
+      end
+    rescue => exc
+      error "#{exc.class.name}: #{exc.message}"
+    end
+
+    # @param [Docker::Container] container
+    def start_container_check(container)
+      return if container.nil? || container.labels['io.kontena.health_check.uri'].nil?
+
+      exclusive {
+        unless workers[container.id]
+          workers[container.id] = ContainerHealthCheckWorker.new(container, queue)
+          workers[container.id].async.start
+        end
+      }
+    rescue => exc
+      error "#{exc.class.name}: #{exc.message}"
+    end
+
+    # @param [String] container_id
+    def stop_container_check(container_id)
+      worker = workers.delete(container_id)
+      if worker
+        # we have to use kill because worker is blocked by log stream
+        Celluloid::Actor.kill(worker) if worker.alive?
+      end
+    end
+
+    # @param [String] topic
+    # @param [Docker::Event] event
+    def on_container_event(topic, event)
+      if STOP_EVENTS.include?(event.status)
+        stop_container_check(event.id)
+      elsif START_EVENTS.include?(event.status)
+        container = Docker::Container.get(event.id) rescue nil
+        if container
+          start_container_check(container)
+        end
+      end
+    end
+  end
+end

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -88,6 +88,20 @@ describe Kontena::LoadBalancers::Configurer do
       subject.ensure_config(container)
     end
 
+    it 'sets http check uri' do
+      container.labels['io.kontena.health_check.uri'] = '/health'
+      expect(etcd).to receive(:set).
+        with("#{etcd_prefix}/lb/services/test-api/health_check_uri", {value: '/health'})
+      subject.ensure_config(container)
+    end
+
+    it 'removes http check uri' do
+      container.labels.delete('io.kontena.health_check.uri')
+      expect(etcd).to receive(:delete).
+        with("#{etcd_prefix}/lb/services/test-api/health_check_uri")
+      subject.ensure_config(container)
+    end
+
     it 'removes tcp-services' do
       expect(subject.wrapped_object).to receive(:rmdir).
         with("#{etcd_prefix}/lb/tcp-services/test-api")

--- a/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
@@ -1,0 +1,101 @@
+require_relative '../../../spec_helper'
+
+describe Kontena::Workers::ContainerHealthCheckWorker do
+
+  let(:container) { spy(:container) }
+  let(:queue) { Queue.new }
+  let(:subject) { described_class.new(container, queue) }
+
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
+  describe '#start' do
+    it 'checks status' do
+      json = {
+        'Config' => {
+          'Labels' => {
+            'io.kontena.health_check.protocol' => 'http',
+            'io.kontena.health_check.uri' => '/',
+            'io.kontena.health_check.port' => '8080',
+            'io.kontena.health_check.timeout' => '10',
+            'io.kontena.health_check.interval' => '30',
+            'io.kontena.health_check.initial_delay' => '20',
+          }
+        }
+      }
+      allow(container).to receive(:json).and_return(json)
+      expect(subject.wrapped_object).to receive(:every).with(30).and_yield
+      expect(subject.wrapped_object).to receive(:sleep).with(20)
+      expect(subject.wrapped_object).to receive(:check_http_status).and_return({})
+      expect {
+        subject.start
+      }.to change {queue.size}.by (1)
+    end
+  end
+
+  describe '#check_http_status' do
+    
+    it 'returns healthy status' do
+      response = double
+      allow(response).to receive(:status).and_return(200)
+      expect(Excon).to receive(:get).with('http://1.2.3.4:8080/health', connect_timeout: 10).and_return(response)
+      health_status = subject.check_http_status('1.2.3.4', 8080, '/health', 10)
+      expect(health_status[:data]['status']).to eq('healthy')
+      expect(health_status[:data]['status_code']).to eq(200)
+    end
+    
+    it 'returns unhealthy status when response status not 200' do
+      response = double
+      allow(response).to receive(:status).and_return(500)
+      expect(Excon).to receive(:get).with('http://1.2.3.4:8080/health', connect_timeout: 10).and_return(response)
+      health_status = subject.check_http_status('1.2.3.4', 8080, '/health', 10)
+      expect(health_status[:data]['status']).to eq('unhealthy')
+      expect(health_status[:data]['status_code']).to eq(500)
+    end
+
+    it 'returns unhealthy status when connection timeouts' do
+      expect(Excon).to receive(:get).with('http://1.2.3.4:8080/health', connect_timeout: 10).and_raise(Excon::Errors::Timeout)
+      health_status = subject.check_http_status('1.2.3.4', 8080, '/health', 10)
+      expect(health_status[:data]['status']).to eq('unhealthy')
+    end
+
+    it 'returns unhealthy status when connection fails with weird error' do
+      expect(Excon).to receive(:get).with('http://1.2.3.4:8080/health', connect_timeout: 10).and_raise(Excon::Errors::Error)
+      health_status = subject.check_http_status('1.2.3.4', 8080, '/health', 10)
+      expect(health_status[:data]['status']).to eq('unhealthy')
+    end
+
+  end
+
+  describe '#check_tcp_status' do
+    
+    it 'returns healthy status' do
+      socket = spy
+      expect(TCPSocket).to receive(:new).with('1.2.3.4', 3306).and_return(socket)
+      health_status = subject.check_tcp_status('1.2.3.4', 3306, 10)
+      expect(health_status[:data]['status']).to eq('healthy')
+      expect(health_status[:data]['status_code']).to eq('open')
+    end
+    
+    it 'returns unhealthy status when cannot open socket' do
+      expect(TCPSocket).to receive(:new).with('1.2.3.4', 3306).and_raise(Errno::ECONNREFUSED)
+      health_status = subject.check_tcp_status('1.2.3.4', 3306, 10)
+      expect(health_status[:data]['status']).to eq('unhealthy')
+      expect(health_status[:data]['status_code']).to eq('closed')
+    end
+
+    it 'returns unhealthy status when connection timeouts' do
+      expect(TCPSocket).to receive(:new).with('1.2.3.4', 3306) {sleep 1.5}
+      health_status = subject.check_tcp_status('1.2.3.4', 3306, 1)
+      expect(health_status[:data]['status']).to eq('unhealthy')
+      expect(health_status[:data]['status_code']).to eq('closed')
+    end
+
+    it 'returns unhealthy status when connection fails with weird error' do
+      expect(TCPSocket).to receive(:new).with('1.2.3.4', 3306).and_raise(Excon::Errors::Error)
+      health_status = subject.check_tcp_status('1.2.3.4', 3306, 10)
+      expect(health_status[:data]['status']).to eq('unhealthy')
+    end
+
+  end
+end

--- a/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
@@ -1,0 +1,85 @@
+require_relative '../../../spec_helper'
+
+describe Kontena::Workers::HealthCheckWorker do
+
+  let(:queue) { Queue.new }
+  let(:subject) { described_class.new(queue, false) }
+  let(:container) { spy(:container, id: 'foo', labels: {'io.kontena.health_check.uri' => '/'}) }
+  let(:container_not_to_check) { spy(:container, id: 'foo', labels: {}) }
+
+
+  before(:each) do
+    Celluloid.boot
+  end
+
+  after(:each) { Celluloid.shutdown }
+
+  describe '#start' do
+
+    it 'starts container checks' do
+      allow(Docker::Container).to receive(:all).and_return([container, container_not_to_check])
+      expect(subject.wrapped_object).to receive(:start_container_check).twice
+      subject.start
+    end
+  end
+
+  describe '#stop' do
+    it 'stops all checks' do
+      worker = spy(:worker, :alive? => true)
+      subject.workers[container.id] = worker
+      expect(subject.wrapped_object).to receive(:stop_container_check).once.with(container.id)
+      subject.stop
+    end
+  end
+
+  describe '#start_container_check' do
+    it 'does nothing if worker actor already exist' do
+      expect(Kontena::Workers::ContainerHealthCheckWorker).not_to receive(:new)
+      subject.workers[container.id] = spy(:container_log_worker)
+      subject.start_container_check(container)
+    end
+
+    it 'does nothing if health check not needed' do
+      expect(Kontena::Workers::ContainerHealthCheckWorker).not_to receive(:new)
+      subject.workers[container.id] = spy(:container_log_worker)
+      subject.start_container_check(container_not_to_check)
+    end
+
+    it 'creates new container_health_check_worker actor' do
+      worker = spy(:container_log_worker)
+      expect(Kontena::Workers::ContainerHealthCheckWorker).to receive(:new).and_return(worker)
+      subject.start_container_check(container)
+    end
+  end
+
+  describe '#stop_container_check' do
+    it 'terminates worker if it exist' do
+      worker = spy(:worker, :alive? => true)
+      subject.workers[container.id] = worker
+      expect(Celluloid::Actor).to receive(:kill).with(worker)
+      subject.stop_container_check(container.id)
+    end
+  end
+
+  describe '#on_container_event' do
+    it 'stops check on die' do
+      expect(subject.wrapped_object).to receive(:stop_container_check).once.with('foo')
+      subject.on_container_event('topic', double(:event, id: 'foo', status: 'die'))
+      sleep 0.01
+    end
+
+    it 'starts check on start' do
+      allow(Docker::Container).to receive(:get).and_return(container)
+      allow(subject.wrapped_object).to receive(:queue_processing?).and_return(true)
+      expect(subject.wrapped_object).to receive(:start_container_check).once.with(container)
+      subject.on_container_event('topic', double(:event, id: 'foo', status: 'start'))
+    end
+
+    it 'does not start check on create' do
+      allow(Docker::Container).to receive(:get).and_return(container)
+      allow(subject.wrapped_object).to receive(:queue_processing?).and_return(true)
+      expect(subject.wrapped_object).not_to receive(:start_container_check)
+      subject.on_container_event('topic', double(:event, id: 'foo', status: 'create'))
+    end
+  end
+end

--- a/cli/lib/kontena/cli/apps/service_generator.rb
+++ b/cli/lib/kontena/cli/apps/service_generator.rb
@@ -59,6 +59,17 @@ module Kontena::Cli::Apps
       data['hooks'] = options['hooks'] || {}
       data['secrets'] = options['secrets'] if options['secrets']
       data['build'] = parse_build_options(options) if options['build']
+      health_check = {}
+      health_opts = options['health_check'] || {}
+      health_check['protocol'] = health_opts['protocol'] if health_opts.has_key?('protocol')
+      health_check['uri'] = health_opts['uri'] if health_opts.has_key?('uri')
+      health_check['port'] = health_opts['port'] if health_opts.has_key?('port')
+      health_check['timeout'] = health_opts['timeout'] if health_opts.has_key?('timeout')
+      health_check['interval'] = health_opts['interval'] if health_opts.has_key?('interval')
+      health_check['initial_delay'] = health_opts['initial_delay'] if health_opts.has_key?('initial_delay')
+      unless health_check.empty?
+        data['health_check'] = health_check
+      end
       data
     end
 

--- a/cli/lib/kontena/cli/apps/yaml/validations.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validations.rb
@@ -45,6 +45,14 @@ module Kontena::Cli::Apps::YAML
        key('name').required
        key('type').required
      end
+     base.optional('health_check').schema do
+      key('protocol') { format?(/^(http|tcp)$/) }
+      key('port') { int? }
+      optional('uri') { format?(/\/[\S]*/) }
+      optional('timeout') { int? }
+      optional('interval') { int? }
+      optional('initial_delay') { int? }
+     end
    end
 
    ##

--- a/cli/lib/kontena/cli/apps/yaml/validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Apps
       VALID_KEYS = %w(
       affinity build dockerfile cap_add cap_drop command deploy env_file environment extends external_links
       image links log_driver log_opt net pid ports volumes volumes_from cpu_shares
-      mem_limit memswap_limit privileged stateful user instances hooks secrets
+      mem_limit memswap_limit privileged stateful user instances hooks secrets health_check
       ).freeze
 
       UNSUPPORTED_KEYS = %w(

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Apps
       VALID_KEYS = %w(
       affinity build cap_add cap_drop command deploy depends_on env_file environment extends external_links
       image links logging network_mode pid ports volumes volumes_from cpu_shares
-      mem_limit memswap_limit privileged stateful user instances hooks secrets
+      mem_limit memswap_limit privileged stateful user instances hooks secrets health_check
       ).freeze
 
       UNSUPPORTED_KEYS = %w(

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -34,6 +34,12 @@ module Kontena::Cli::Services
     option "--deploy-interval", "TIME", "Auto-deploy with given interval (format: <number><unit>, where unit = min, h, d)"
     option "--pid", "PID", "Pid namespace to use"
     option "--secret", "SECRET", "Import secret from Vault (format: <secret>:<name>:<env>)", multivalued: true
+    option "--health-check-uri", "HEALTH CHECK URI", "URI path for HTTP health check"
+    option "--health-check-timeout", "HEALTH CHECK TIMEOUT", "Timeout for health check"
+    option "--health-check-interval", "HEALTH CHECK INTERVAL", "Interval for health check"
+    option "--health-check-initial-delay", "HEALTH CHECK INITIAL DELAY", "Initial delay for health check"
+    option "--health-check-port", "HEALTH CHECK PORT", "Port for health check"
+    option "--health-check-protocol", "HEALTH CHECK PROTOCOL", "Protocol of health check"
 
     def execute
       require_api_url
@@ -82,6 +88,16 @@ module Kontena::Cli::Services
       end
       if deploy_interval
         data[:deploy_opts][:interval] = parse_relative_time(deploy_interval)
+      end
+      if health_check_port
+        data[:health_check] = { 
+          protocol: health_check_protocol,
+          uri: health_check_uri, 
+          port: health_check_port, 
+          timeout: health_check_timeout, 
+          interval: health_check_interval,
+          initial_delay: health_check_initial_delay
+        }
       end
       data[:pid] = pid if pid
       data

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -12,8 +12,8 @@ module Kontena::Cli::Services
 
       grids = client(token).get("grids/#{current_grid}/services")
       services = grids['services'].sort_by{|s| s['updated_at'] }.reverse
-      titles = ['NAME', 'INSTANCES', 'STATEFUL', 'STATE', 'EXPOSED PORTS']
-      puts "%-60s %-10s %-8s %-10s %-50s" % titles
+      titles = ['NAME', 'INSTANCES', 'STATEFUL', 'STATE', 'HEALTH', 'EXPOSED PORTS']
+      puts "%-60s %-10s %-8s %-10s %-10s %-50s" % titles
       services.each do |service|
         stateful = service['stateful'] ? 'yes' : 'no'
         running = service['instances']['running']
@@ -22,14 +22,28 @@ module Kontena::Cli::Services
         ports = service['ports'].map{|p|
           "#{p['ip']}:#{p['node_port']}->#{p['container_port']}/#{p['protocol']}"
         }.join(", ")
+        health = 'unknown'
+        if service['health_status']
+          icon = "■"
+          healthy = service.dig('health_status', 'healthy')
+          total = service.dig('health_status', 'total')
+          color = :green
+          if healthy == 0
+            color = :red
+          elsif healthy > 0 && healthy < total
+            color = :yellow
+          end
+          health = "■".colorize(color)
+        end 
         vars = [
           service['name'],
           instances,
           stateful,
           service['state'],
+          health,
           ports
         ]
-        puts "%-60.60s %-10.10s %-8s %-10s %-50s" % vars
+        puts "%-60.60s %-10.10s %-8s %-10s %-10s %-50s" % vars
       end
     end
   end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -170,6 +170,22 @@ module Kontena
             puts "  pid: #{service['pid']}"
           end
 
+          if service['health_check']
+            puts "  health check:"
+            puts "    protocol: #{service['health_check']['protocol']}"
+            puts "    uri: #{service['health_check']['uri']}" if service['health_check']['protocol'] == 'http'
+            puts "    port: #{service['health_check']['port']}"
+            puts "    timeout: #{service['health_check']['timeout']}"
+            puts "    interval: #{service['health_check']['interval']}"
+            puts "    initial_delay: #{service['health_check']['initial_delay']}"
+          end
+          
+          if service['health_status']
+            puts "  health status:"
+            puts "    healthy: #{service['health_status']['healthy']}"
+            puts "    total: #{service['health_status']['total']}"
+          end
+
           puts "  instances:"
           result = client(token).get("services/#{parse_service_id(service_id)}/containers")
           result['containers'].each do |container|

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -31,6 +31,12 @@ module Kontena::Cli::Services
     option "--deploy-interval", "TIME", "Auto-deploy with given interval (format: <number><unit>, where unit = min, h, d)"
     option "--pid", "PID", "Pid namespace to use"
     option "--secret", "SECRET", "Import secret from Vault (format: <secret>:<name>:<type>)", multivalued: true
+    option "--health-check-uri", "HEALTH CHECK URI", "URI path for HTTP health check"
+    option "--health-check-timeout", "HEALTH CHECK TIMEOUT", "Timeout for HTTP health check"
+    option "--health-check-interval", "HEALTH CHECK INTERVAL", "Interval for HTTP health check"
+    option "--health-check-initial-delay", "HEALTH CHECK INITIAL DELAY", "Initial for HTTP health check"
+    option "--health-check-port", "HEALTH CHECK PORT", "Port for HTTP health check"
+    option "--health-check-protocol", "HEALTH CHECK PROTOCOL", "Protocol of health check"
 
     def execute
       require_api_url
@@ -69,6 +75,16 @@ module Kontena::Cli::Services
       data[:deploy_opts][:wait_for_port] = deploy_wait_for_port.to_i if deploy_wait_for_port
       if deploy_interval
         data[:deploy_opts][:interval] = parse_relative_time(deploy_interval)
+      end
+      if health_check_port
+        data[:health_check] = { 
+          protocol: health_check_protocol,
+          uri: health_check_uri, 
+          port: health_check_port, 
+          timeout: health_check_timeout, 
+          interval: health_check_interval,
+          initial_delay: health_check_initial_delay
+        }
       end
       data.delete(:deploy_opts) if data[:deploy_opts].empty?
       data[:pid] = pid if pid

--- a/cli/spec/fixtures/health.yml
+++ b/cli/spec/fixtures/health.yml
@@ -1,0 +1,26 @@
+web:
+  image: nginx
+  stateful: false
+  health_check:
+    protocol: http
+    port: 80
+    interval: 20
+    uri: /
+    initial_delay: 10
+    timeout: 2
+
+
+mysql:
+  image: mysql
+  stateful: false
+  deploy:
+    strategy: ha
+    wait_for_port: 3306
+  environment:
+    - MYSQL_ALLOW_EMPTY_PASSWORD=true
+  health_check:
+    protocol: tcp
+    port: 3306
+    interval: 20
+    initial_delay: 10
+    timeout: 2

--- a/cli/spec/kontena/cli/app/common_spec.rb
+++ b/cli/spec/kontena/cli/app/common_spec.rb
@@ -25,6 +25,10 @@ describe Kontena::Cli::Apps::Common do
     fixture('mysql.yml')
   end
 
+  let(:health_yml) do
+    fixture('health.yml')
+  end
+
   let(:services) do
     {
       'wordpress' => {
@@ -60,6 +64,7 @@ describe Kontena::Cli::Apps::Common do
   describe '#load_from_yaml' do
     before(:each) do
       allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_yml)
+      allow(File).to receive(:read).with("#{Dir.getwd}/health.yml").and_return(health_yml)
       allow(File).to receive(:read).with("#{Dir.getwd}/docker-compose.yml").and_return(docker_compose_yml)
     end
 
@@ -84,6 +89,12 @@ describe Kontena::Cli::Apps::Common do
       services = subject.services_from_yaml('kontena.yml',['wordpress'],'')
       expect(services['wordpress']).not_to be_nil
       expect(services.size).to eq(1)
+    end
+
+    it 'populates health check' do
+      services = subject.services_from_yaml('health.yml',['web'],'')
+      expect(services['web']).not_to be_nil
+      expect(services['web']['health_check']).not_to be_nil
     end
   end
 end

--- a/cli/spec/kontena/cli/app/yaml/validator_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_spec.rb
@@ -279,5 +279,36 @@ describe Kontena::Cli::Apps::YAML::Validator do
         end
       end
     end
+
+    context 'validates health_check' do
+      it 'validates health_check' do
+        result = subject.validate_options('health_check' => {})
+        expect(result.messages.key?('health_check')).to be_truthy        
+      end
+
+      it 'validates health_check port ' do
+        result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 'abc'})
+        expect(result.messages.key?('health_check')).to be_truthy
+
+        result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 8080})
+        expect(result.messages.key?('health_check')).to be_falsey
+      end
+
+      it 'validates health_check uri' do
+        result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 8080, 'uri' => 'foobar'})
+        expect(result.messages.key?('health_check')).to be_truthy
+
+        result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 8080, 'uri' => '/health/foo/bar'})
+        expect(result.messages.key?('health_check')).to be_falsey
+      end
+
+      it 'validates health_check protocol' do
+        result = subject.validate_options('health_check' => { 'protocol' => 'foo', 'port' => 8080, 'uri' => 'foobar'})
+        expect(result.messages.key?('health_check')).to be_truthy
+
+        result = subject.validate_options('health_check' => { 'protocol' => 'tcp', 'port' => 3306 })
+        expect(result.messages.key?('health_check')).to be_falsey
+      end
+    end
   end
 end

--- a/server/app/models/container.rb
+++ b/server/app/models/container.rb
@@ -20,6 +20,9 @@ class Container
   field :deploy_rev, type: String
   field :container_type, type: String, default: 'container'
 
+  field :health_status, type: String
+  field :health_status_at, type: Time
+
   validates_uniqueness_of :container_id, scope: [:host_node_id], allow_nil: true
 
   belongs_to :grid

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -47,6 +47,7 @@ class GridService
   embeds_many :hooks, class_name: 'GridServiceHook'
   embeds_many :secrets, class_name: 'GridServiceSecret'
   embeds_one :deploy_opts, class_name: 'GridServiceDeployOpt', autobuild: true
+  embeds_one :health_check, class_name: 'GridServiceHealthCheck'
 
   index({ grid_id: 1 })
   index({ name: 1 })
@@ -203,5 +204,15 @@ class GridService
     return true if self.net.to_s.match(/^container:.+/)
 
     false
+  end
+
+  def health_status
+    healthy = 0
+
+    self.containers.each do |c|
+      healthy += 1 if c.health_status == 'healthy'
+    end
+
+    {healthy: healthy, total: self.containers.count}
   end
 end

--- a/server/app/models/grid_service_health_check.rb
+++ b/server/app/models/grid_service_health_check.rb
@@ -1,0 +1,13 @@
+class GridServiceHealthCheck
+  include Mongoid::Document
+
+  field :uri, type: String, default: '/'
+  field :timeout, type: Fixnum, default: 10
+  field :interval, type: Fixnum, default: 60
+  field :initial_delay, type: Fixnum, default: 10
+  field :protocol, type: String
+  field :port, type: Fixnum
+
+  embedded_in :grid_service
+
+end

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -99,6 +99,18 @@ module GridServices
           end
         end
       end
+      hash :health_check do
+        required do
+          integer :port
+          string :protocol, matches: /^(http|tcp)$/
+        end
+        optional do
+          string :uri
+          integer :timeout, default: 10
+          integer :interval, default: 60
+          integer :initial_delay, default: 10
+        end
+      end
     end
 
     def validate
@@ -114,6 +126,9 @@ module GridServices
       end
       if self.strategy && !self.strategies[self.strategy]
         add_error(:strategy, :invalid_strategy, 'Strategy not supported')
+      end
+      if self.health_check && self.health_check[:interval] < self.health_check[:timeout]
+        add_error(:health_check, :invalid, 'Interval has to be bigger than timeout')
       end
     end
 

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -90,6 +90,18 @@ module GridServices
           end
         end
       end
+      hash :health_check do
+        required do
+          integer :port
+          string :protocol, matches: /^(http|tcp)$/
+        end
+        optional do
+          string :uri
+          integer :timeout, default: 10
+          integer :interval, default: 60
+          integer :initial_delay, default: 10
+        end
+      end
     end
 
     def validate
@@ -103,6 +115,9 @@ module GridServices
 
       if self.strategy && !self.strategies[self.strategy]
         add_error(:strategy, :invalid_strategy, 'Strategy not supported')
+      end
+      if self.health_check && self.health_check[:interval] < self.health_check[:timeout]
+        add_error(:health_check, :invalid, 'Interval has to be bigger than timeout')
       end
     end
 

--- a/server/app/services/agent/message_handler.rb
+++ b/server/app/services/agent/message_handler.rb
@@ -60,6 +60,8 @@ module Agent
           self.on_container_log(grid, message['node_id'], data['data'])
         when 'container:stats'.freeze
           self.on_container_stat(grid, data['data'])
+        when 'container:health'.freeze
+          self.on_container_health(grid, data['data'])
         else
           error "unknown event: #{message}"
       end
@@ -158,6 +160,23 @@ module Agent
           db_session[:container_stats].insert(@stats.dup)
           @stats.clear
         end
+      end
+    end
+
+    ##
+    # @param [Grid] grid
+    # @param [Hash] data
+    def on_container_health(grid, data)
+      container = Container.find_by(
+        grid_id: grid.id, container_id: data['id']
+      )
+      if container
+        container.update_attributes(
+          health_status: data['status'],
+          health_status_at: Time.now
+        )
+      else
+        warn "health status update failed, could not find container for id: #{data['id']}"
       end
     end
 

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -135,6 +135,14 @@ module Docker
         labels['io.kontena.load_balancer.internal_port'] = internal_port
         labels['io.kontena.load_balancer.mode'] = mode
       end
+      if grid_service.health_check
+        labels['io.kontena.health_check.uri'] = grid_service.health_check.uri
+        labels['io.kontena.health_check.protocol'] = grid_service.health_check.protocol
+        labels['io.kontena.health_check.interval'] = grid_service.health_check.interval.to_s
+        labels['io.kontena.health_check.timeout'] = grid_service.health_check.timeout.to_s
+        labels['io.kontena.health_check.initial_delay'] = grid_service.health_check.initial_delay.to_s
+        labels['io.kontena.health_check.port'] = grid_service.health_check.port.to_s
+      end
       labels
     end
 

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -34,3 +34,14 @@ json.instances do
 end
 json.hooks grid_service.hooks.as_json(only: [:name, :type, :cmd, :oneshot])
 json.revision grid_service.revision
+if grid_service.health_check
+	json.health_check do
+		json.protocol grid_service.health_check.protocol
+		json.uri grid_service.health_check.uri
+		json.port grid_service.health_check.port
+		json.timeout grid_service.health_check.timeout
+		json.initial_delay grid_service.health_check.initial_delay
+		json.interval grid_service.health_check.interval
+	end
+	json.health_status grid_service.health_status
+end

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -72,6 +72,16 @@ describe '/v1/services' do
       get "/v1/services/#{redis_service.to_path}", nil, request_headers
       expect(response.status).to eq(403)
     end
+
+    it 'returns health status' do
+      redis_service.health_check = GridServiceHealthCheck.new(port: 5000)
+      redis_service.save
+      container = redis_service.containers.create!(name: 'redis-1', container_id: 'aaa', health_status: 'healthy')
+      get "/v1/services/#{redis_service.to_path}", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['health_status']['total']).to eq(1)
+      expect(json_response['health_status']['healthy']).to eq(1)
+    end
   end
 
   describe 'PUT /:id' do

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -161,4 +161,19 @@ describe GridService do
       expect(subject.load_balancer?).to eq(false)
     end
   end
+
+  describe '#health_status' do
+    it 'returns health status' do
+      healthy_container = grid_service.containers.create!(name: 'redis-1')
+      healthy_container.update_attribute(:health_status, 'healthy')
+      unhealthy_container = grid_service.containers.create!(name: 'redis-2')
+      unhealthy_container.update_attribute(:health_status, 'unhealthy')
+
+      expect(grid_service.health_status).to eq({healthy: 1, total: 2})
+    end
+
+    it 'returns nil if container is not found' do
+      expect(grid_service.container_by_name('not_found')).to be_nil
+    end
+  end
 end

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -291,5 +291,60 @@ describe GridServices::Create do
       ).run
       expect(outcome.result.revision).to eq(1)
     end
+    
+    it 'saves health_check' do
+      outcome = described_class.new(
+          current_user: user,
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          health_check: {
+            protocol: 'http',
+            uri: '/health',
+            interval: 120,
+            timeout: 5,
+            initial_delay: 10,
+            port: 5000
+          }
+      ).run
+      expect(outcome.result.health_check).not_to be_nil
+      expect(outcome.result.health_check.uri).to eq('/health')
+    end
+
+    it 'fails to save health_check, no port defined' do
+      outcome = described_class.new(
+          current_user: user,
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          health_check: {
+            uri: '/health',
+            interval: 120,
+            timeout: 5,
+            initial_delay: 10
+          }
+      ).run
+      expect(outcome.success?).to be(false)
+    end
+
+    it 'fails to save health_check, interval < timeout' do
+      outcome = described_class.new(
+          current_user: user,
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          health_check: {
+            protocol: 'tcp',
+            interval: 10,
+            timeout: 50,
+            initial_delay: 10,
+            port: 1234
+          }
+      ).run
+      expect(outcome.success?).to be(false)
+    end
   end
 end

--- a/server/spec/services/agent/message_handler_spec.rb
+++ b/server/spec/services/agent/message_handler_spec.rb
@@ -164,4 +164,20 @@ describe Agent::MessageHandler do
       }.to change{ node.host_node_stats.count }.by(1)
     end
   end
+
+  describe '#on_container_health' do
+    it 'updates health status' do
+      container_id = SecureRandom.hex(16)
+      container = grid.containers.new(name: 'foo-1')
+      container.update_attribute(:container_id, container_id)
+
+      expect {
+        subject.on_container_health(grid, {
+            'id' => container_id,
+            'status' => 'healthy'
+          }
+        )
+      }.to change {container.reload.health_status}.to eq('healthy')
+    end
+  end
 end

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -154,6 +154,16 @@ describe Docker::ServiceCreator do
         expect(labels).to include('io.kontena.load_balancer.internal_port' => '80')
         expect(labels).to include('io.kontena.load_balancer.mode' => 'http')
       end
+
+      it 'includes health check labels if defined' do
+        service.health_check = GridServiceHealthCheck.new(uri: '/', port: 80, protocol: 'http')
+        expect(labels).to include('io.kontena.health_check.protocol' => 'http')
+        expect(labels).to include('io.kontena.health_check.uri' => '/')
+        expect(labels).to include('io.kontena.health_check.port' => '80')
+        expect(labels).to include('io.kontena.health_check.interval' => '60')
+        expect(labels).to include('io.kontena.health_check.timeout' => '10')
+        expect(labels).to include('io.kontena.health_check.initial_delay' => '10')
+      end
     end
   end
 end


### PR DESCRIPTION
This PR implements initial HTTP health checks for services. The status check results are stored per instance (container). The status is not acted upon by the scheduler it is only informatory to the user at this point.

Creating a service with health check looks like this: 
```
kontena service create --instances 2 --health-check-port 80 --health-check-interval 20 --health-check-timeout 2 --health-check-uri / nginx nginx
```

And with kontena.yml:
```
web:
  image: nginx
  stateful: false
  health_check:
    protocol: http
    port: 80
    interval: 20
    uri: /
    initial_delay: 10
    timeout: 2


mysql:
  image: mysql
  stateful: false
  deploy:
    strategy: ha
    wait_for_port: 3306
  environment:
    - MYSQL_ALLOW_EMPTY_PASSWORD=true
  health_check:
    protocol: tcp
    port: 3306
    interval: 20
    initial_delay: 10
    timeout: 2
```
Both http and tcp protocols are supported. When http is used, currently only 200 status code is translated into healthy service. When tcp is used, successful port opening test will translate into healthy service.

The initial delay parameter is used to allow decent time for the service in the container to startup after which the health checks are started.

The health status is "aggregated" into service listing as color code:
<img width="903" alt="screen shot 2016-06-17 at 14 12 13" src="https://cloud.githubusercontent.com/assets/3205505/16151083/a0e14a64-34a3-11e6-9ed9-470bc3f1a675.png">


Code needs still some polishing and tuning thus the WIP flag. :)


fixes #658 