### PR TITLE
Build args in v2 yaml

### DIFF
--- a/cli/lib/kontena/cli/apps/docker_helper.rb
+++ b/cli/lib/kontena/cli/apps/docker_helper.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Apps
             run_pre_build_hook(service['hooks']['pre_build'])
           end
           puts "Building image #{service['image'].colorize(:cyan)}"
-          build_docker_image(service['image'], service['build']['context'], dockerfile, no_cache, service['build']['args'])
+          build_docker_image(service, no_cache)
           puts "Pushing image #{service['image'].colorize(:cyan)} to registry"
           push_docker_image(service['image'])
         end
@@ -28,21 +28,22 @@ module Kontena::Cli::Apps
       !(/^[\w.\/\-:]+:?+[\w+.]+$/ =~ name).nil?
     end
 
-    # @param [String] name
-    # @param [String] path
-    # @param [String] dockerfile
+    # @param [Hash] service
     # @param [Boolean] no_cache
     # @return [Integer]
-    def build_docker_image(name, path, dockerfile, no_cache=false, args = {})
-      cmd = ["docker build -t #{name}"]
-      cmd << "-f #{File.join(File.expand_path(path), dockerfile)}" if dockerfile != "Dockerfile"
+    def build_docker_image(service, no_cache = false)
+      dockerfile = dockerfile = service['build']['dockerfile'] || 'Dockerfile'
+      build_context = service['build']['context']
+      cmd = ["docker build -t #{service['image']}"]
+      cmd << "-f #{File.join(File.expand_path(build_context), dockerfile)}" if dockerfile != "Dockerfile"
       cmd << "--no-cache" if no_cache
+      args = service['build']['args'] || {}
       args.each do |k, v|
         cmd << "--build-arg #{k}=#{v}"
       end
-      cmd << path
+      cmd << build_context
       ret = system(cmd.join(' '))
-      abort("Failed to build image #{name.colorize(:cyan)}") unless ret
+      abort("Failed to build image #{service['image'].colorize(:cyan)}") unless ret
       ret
     end
 

--- a/cli/lib/kontena/cli/apps/docker_helper.rb
+++ b/cli/lib/kontena/cli/apps/docker_helper.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Apps
             run_pre_build_hook(service['hooks']['pre_build'])
           end
           puts "Building image #{service['image'].colorize(:cyan)}"
-          build_docker_image(service['image'], service['build']['context'], dockerfile, no_cache)
+          build_docker_image(service['image'], service['build']['context'], dockerfile, no_cache, service['build']['args'])
           puts "Pushing image #{service['image'].colorize(:cyan)} to registry"
           push_docker_image(service['image'])
         end
@@ -33,10 +33,13 @@ module Kontena::Cli::Apps
     # @param [String] dockerfile
     # @param [Boolean] no_cache
     # @return [Integer]
-    def build_docker_image(name, path, dockerfile, no_cache=false)
+    def build_docker_image(name, path, dockerfile, no_cache=false, args = {})
       cmd = ["docker build -t #{name}"]
       cmd << "-f #{File.join(File.expand_path(path), dockerfile)}" if dockerfile != "Dockerfile"
       cmd << "--no-cache" if no_cache
+      args.each do |k, v|
+        cmd << "--build-arg #{k}=#{v}"
+      end
       cmd << path
       ret = system(cmd.join(' '))
       abort("Failed to build image #{name.colorize(:cyan)}") unless ret

--- a/cli/lib/kontena/cli/apps/service_generator_v2.rb
+++ b/cli/lib/kontena/cli/apps/service_generator_v2.rb
@@ -20,6 +20,7 @@ module Kontena::Cli::Apps
       unless options['build'].is_a?(Hash)
         options['build'] = { 'context' => options['build']}
       end
+      options['build']['args'] = parse_build_args(options['build']['args']) if options['build']['args']
       options['build']
     end
   end

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -89,6 +89,7 @@ module Kontena::Cli::Apps
       # @param [Hash] service_config
       def process_config(service_config)
         normalize_env_vars(service_config)
+        normalize_build_args(service_config)
         service_config = extend_config(service_config) if service_config.key?('extends')
         service_config
       end
@@ -143,6 +144,20 @@ module Kontena::Cli::Apps
       def normalize_env_vars(options)
         if options['environment'].is_a?(Hash)
           options['environment'] = options['environment'].map { |k, v| "#{k}=#{v}" }
+        end
+      end
+      
+      # @param [Hash] options - service config
+      def normalize_build_args(options)
+        if v2? && options.dig('build', 'args')
+          if options['build']['args'].is_a?(Array)
+            args = options['build']['args'].dup
+            options['build']['args'] = {}
+            args.each do |arg|
+              k,v = arg.split('=')
+              options['build']['args'][k] = v
+            end
+          end
         end
       end
     end

--- a/cli/lib/kontena/cli/apps/yaml/service_extender.rb
+++ b/cli/lib/kontena/cli/apps/yaml/service_extender.rb
@@ -21,6 +21,12 @@ module Kontena::Cli::Apps
           from['secrets'],
           service_config['secrets']
         )
+        build_args = extend_build_args(from.dig('build','args'), service_config.dig('build', 'args'))
+        unless build_args.empty?
+          service_config['build'] = {} unless service_config['build']
+          service_config['build']['args'] = build_args
+        end
+        
         from.merge(service_config)
       end
 
@@ -54,6 +60,16 @@ module Kontena::Cli::Apps
           end
         end
         secrets
+      end
+
+      def extend_build_args(from, to)
+        args = to || {}
+        if from
+          from.each do |k,v|
+            args[k] = v unless args.has_key?(k)
+          end
+        end
+        args
       end
     end
   end

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -32,6 +32,7 @@ module Kontena::Cli::Apps
             build.type?(Hash) > build.schema do
               key('context').required
               optional('dockerfile') { str? }
+              optional('args') { array? | type?(Hash)}
             end
           end
           optional('depends_on') { array? }

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -362,6 +362,25 @@ module Kontena
             'TB' => 1000 * 1000 * 1000 * 1000 * 1000
           }.each_pair { |e, s| return "#{(int.to_i / (s / 1000))}#{e}" if int < s }
         end
+
+        def parse_build_args(args)
+          build_args = {}
+          if args.kind_of?(Array)
+            args.each do |arg|
+              key, val = arg.split('=')
+              build_args[key] = val
+            end
+          elsif args.kind_of?(Hash)
+            build_args = build_args.merge(args)
+            build_args.each do |k, v|
+              if v.nil?
+                build_args[k] = ENV[k.to_s] # follow docker compose functionality here
+              end
+            end
+          end
+
+          build_args
+        end
       end
     end
   end

--- a/cli/spec/fixtures/kontena_build_v2.yaml
+++ b/cli/spec/fixtures/kontena_build_v2.yaml
@@ -1,0 +1,26 @@
+version: '2'
+name: test-project
+services:
+  mysql:
+    extends:
+      file: docker-compose.yml
+      service: mysql
+    stateful: true
+    environment:
+      - MYSQL_ROOT_PASSWORD=%{project}_secret
+
+  webapp:
+    image: webapp
+    build:
+      context: .
+      args:
+        - foo=bar
+        - baz=baf
+
+  some_app:
+    image: some_app
+    build:
+      context: .
+      args:
+        foo: bar
+        baz:

--- a/cli/spec/kontena/cli/app/docker_helper_spec.rb
+++ b/cli/spec/kontena/cli/app/docker_helper_spec.rb
@@ -103,4 +103,49 @@ describe Kontena::Cli::Apps::DockerHelper do
     end
   end
 
+  describe '#build_docker_image' do
+    it 'builds image' do
+      service = {
+        'build' => { 'context' => '.' },
+        'image' => 'test_service'
+      }
+      expect(subject).to receive(:system).with("docker build -t test_service ."). and_return(true)
+      subject.build_docker_image(service)
+    end
+
+    it 'builds image with no-cache' do
+      service = {
+        'build' => { 'context' => '.' },
+        'image' => 'test_service'
+      }
+      expect(subject).to receive(:system).with("docker build -t test_service --no-cache ."). and_return(true)
+      subject.build_docker_image(service, true)
+    end
+
+    it 'builds image with alternate dockerfile' do
+      service = {
+        'build' => { 'context' => '.', 'dockerfile' => 'other_dockerfile' },
+        'image' => 'test_service'
+      }
+      expected_path = File.join(File.expand_path('.'), 'other_dockerfile')
+      expect(subject).to receive(:system).with("docker build -t test_service -f #{expected_path} ."). and_return(true)
+      subject.build_docker_image(service)
+    end
+
+    it 'builds image' do
+      service = {
+        'build' => { 
+          'context' => '.',
+          'args' => {
+            'FOO' => 'bar',
+            'BAR' => 'foo'
+          }
+        },
+        'image' => 'test_service'
+      }
+      expect(subject).to receive(:system).with("docker build -t test_service --build-arg FOO=bar --build-arg BAR=foo ."). and_return(true)
+      subject.build_docker_image(service)
+    end
+  end
+
 end

--- a/cli/spec/kontena/cli/app/yaml/service_extender_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/service_extender_spec.rb
@@ -100,5 +100,29 @@ describe Kontena::Cli::Apps::YAML::ServiceExtender do
         expect(result['secrets']).to eq([to_secret, from_secret])
       end
     end
+
+    context 'build args' do
+      it 'inherits build args from upper level' do
+        from = { 'build' => { 'args' => {'foo' => 'bar'}} }
+        to = {}
+        result = described_class.new(to).extend(from)
+        expect(result['build']['args']).to eq({'foo' => 'bar'})
+      end
+
+      it 'overrides values' do
+        from = { 'build' => { 'args' => {'foo' => 'bar'}} }
+        to = { 'build' => { 'args' => {'foo' => 'baz'}} }
+        result = described_class.new(to).extend(from)
+        expect(result['build']['args']).to eq({'foo' => 'baz'})
+      end
+
+      it 'combines variables' do
+        from = { 'build' => { 'args' => {'foo' => 'bar'}} }
+        to = { 'build' => { 'args' => {'baz' => 'baf'}} }
+        result = described_class.new(to).extend(from)
+        expect(result['build']['args']).to eq({'foo' => 'bar', 'baz' => 'baf'})
+      end
+    end
+
   end
 end

--- a/cli/spec/kontena/cli/services/services_helper_spec.rb
+++ b/cli/spec/kontena/cli/services/services_helper_spec.rb
@@ -208,5 +208,20 @@ module Kontena::Cli::Services
         expect(subject.parse_relative_time("600")).to eq(600)
       end
     end
+
+    describe '#parse_build_args' do
+      it'parses array args' do
+        expect(subject.parse_build_args(['foo=bar', 'baz=baf'])).to eq({'foo' => 'bar', 'baz' => 'baf'})
+      end
+
+      it'parses hash args' do
+        expect(subject.parse_build_args({'foo' => 'bar', 'baz' => 'baf'})).to eq({'foo' => 'bar', 'baz' => 'baf'})
+      end
+
+      it'parses hash args and replaces empty value from env' do
+        expect(ENV).to receive(:[]).with('baz').and_return('baf')
+        expect(subject.parse_build_args({'foo' => 'bar', 'baz' => nil})).to eq({'foo' => 'bar', 'baz' => 'baf'})
+      end
+    end
   end
 end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -6,6 +6,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'clamp'
+require 'ruby_dig'
 require 'kontena/cli/common'
 require 'kontena/cli/grid_options'
 require 'kontena/client'

--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -44,6 +44,23 @@ build:
   context: .
   dockerfile: alternate-dockerfile
 ```
+Build arguments are supported in version 2 yaml format. They can be defined either as an array of strings or as hash:
+```
+build:
+  context: .
+  args:
+    - arg1=foo
+    - arg2=bar
+```
+```
+build:
+  context: .
+  args:
+    arg1: foo
+    arg2: bar
+    arg3:
+```
+Build arguments with only a key are resolved to their environment value on the machine the build is running on.
 
 #### dockerfile
 > **Note:** Version 1 only


### PR DESCRIPTION
This PR adds support for docker build args in v2 yaml. Follows docker-compose semantics and thus can be provided either as in array or hash form.


Fixes #780 