### PR TITLE
Fix race condition in DNS add

### DIFF
--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -20,7 +20,7 @@ module Kontena
         begin
           dns_client.put(
             path: "/name/#{container_id}/#{ip}",
-            body: URI.encode_www_form('fqdn' => name, 'check-alive' => 'true'),
+            body: URI.encode_www_form('fqdn' => name),
             headers: { "Content-Type" => "application/x-www-form-urlencoded" }
           )
         rescue Docker::Error::NotFoundError


### PR DESCRIPTION
This PR fixes a race condition with weave dns adding. 

Docker start event is emitted before the actual process in the container is started thus the status of the container is not changed to running. Only after the process itself is started the status is changed. This causes a race condition with Weave DNS as it checks whether the container is running while we add the DNS entries after receiving the start event. This essentially removes all DNS entries of a restarting container. :(

The timing difference in Docker seems to be more significant(around 200ms) on environments where devicemapper is used thus making this hard to reproduce on setup without it. On local CentOS vagrant box with devicemapper+docker setup this was easy to reproduce.