### PR TITLE
Fix deploy interval handling in app yaml parsing

### DIFF
--- a/cli/lib/kontena/cli/apps/service_generator.rb
+++ b/cli/lib/kontena/cli/apps/service_generator.rb
@@ -52,6 +52,7 @@ module Kontena::Cli::Apps
       deploy = {}
       deploy['wait_for_port'] = deploy_opts['wait_for_port'] if deploy_opts.has_key?('wait_for_port')
       deploy['min_health'] = deploy_opts['min_health'] if deploy_opts.has_key?('min_health')
+      deploy['interval'] = parse_relative_time(deploy_opts['interval']) if deploy_opts.has_key?('interval')
       unless deploy.empty?
         data['deploy_opts'] = deploy
       end

--- a/cli/lib/kontena/cli/apps/yaml/validations.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validations.rb
@@ -27,6 +27,7 @@ module Kontena::Cli::Apps::YAML
        optional('strategy') { inclusion?(%w(ha daemon random)) }
        optional('wait_for_port') { int? }
        optional('min_health') { float? }
+       optional('interval') { format?(/^\d+(min|h|d|)$/) }
      end
      base.optional('hooks').schema do
        optional('post_start').each do

--- a/cli/spec/kontena/cli/app/service_generator_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_spec.rb
@@ -324,6 +324,17 @@ describe Kontena::Cli::Apps::ServiceGenerator do
         expect(result['strategy']).to eq('daemon')
       end
 
+      it 'sets interval if deploy.interval is defined' do
+        data = {
+          'image' => 'foo/bar:latest',
+          'deploy' => {
+            'interval' => '1min'
+          }
+        }
+        result = subject.send(:parse_data, data)
+        expect(result['deploy_opts']['interval']).to eq(60)
+      end
+
       it 'does not return deploy_opts if no deploy options are defined' do
         data = {
           'image' => 'foo/bar:latest'

--- a/cli/spec/kontena/cli/app/yaml/validator_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_spec.rb
@@ -62,6 +62,26 @@ describe Kontena::Cli::Apps::YAML::Validator do
       end
     end
 
+    context 'deploy' do
+      it 'validates interval' do
+        
+        result = subject.validate_options('deploy' => {'interval' => '1xyz'})
+        expect(result.messages.key?('deploy')).to be_truthy
+
+        result = subject.validate_options('deploy' => {'interval' => '1min'})
+        expect(result.messages.key?('deploy')).to be_falsey
+
+        result = subject.validate_options('deploy' => {'interval' => '1h'})
+        expect(result.messages.key?('deploy')).to be_falsey
+
+        result = subject.validate_options('deploy' => {'interval' => '1d'})
+        expect(result.messages.key?('deploy')).to be_falsey
+
+        result = subject.validate_options('deploy' => {'interval' => '100'})
+        expect(result.messages.key?('deploy')).to be_falsey
+      end
+    end
+
     context 'command' do
       it 'is optional' do
         result = subject.validate_options({})


### PR DESCRIPTION
This PR fixes regression of app yaml parsing losing deploy interval definition.


fixes #819 