### PR TITLE
Initial cli commands for stack API

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -5,6 +5,7 @@ module Kontena
       attr_reader :service_name,
                   :instance_number,
                   :deploy_rev,
+                  :service_revision,
                   :updated_at,
                   :labels,
                   :stateful,
@@ -38,6 +39,7 @@ module Kontena
         @service_name = attrs['service_name']
         @instance_number = attrs['instance_number'] || 1
         @deploy_rev = attrs['deploy_rev']
+        @service_revision = attrs['service_revision']
         @updated_at = attrs['updated_at']
         @labels = attrs['labels'] || {}
         @stateful = attrs['stateful'] || false
@@ -120,7 +122,8 @@ module Kontena
         labels['io.kontena.container.type'] = 'container'
         labels['io.kontena.container.name'] = self.name
         labels['io.kontena.container.pod'] = self.name
-        labels['io.kontena.container.deploy_rev'] = self.deploy_rev
+        labels['io.kontena.container.deploy_rev'] = self.deploy_rev.to_s
+        labels['io.kontena.container.service_revision'] = self.service_revision.to_s
         labels['io.kontena.service.instance_number'] = self.instance_number.to_s
         docker_opts['Labels'] = labels
         docker_opts['HostConfig'] = self.service_host_config

--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -45,6 +45,12 @@ module Kontena::Cli::Apps
       services
     end
 
+    def read_yaml(filename)
+      reader = YAML::Reader.new(filename)
+      outcome = reader.execute
+      outcome
+    end
+
     def set_env_variables(project, grid)
       ENV['project'] = project
       ENV['grid'] = grid
@@ -63,7 +69,6 @@ module Kontena::Cli::Apps
         nil
       end
     end
-
 
     # @return [String]
     def token

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -46,6 +46,7 @@ module Kontena
           puts "#{service['id']}:"
           puts "  status: #{service['state'] }"
           puts "  image: #{service['image']}"
+          puts "  revision: #{service['revision']}"
           puts "  stateful: #{service['stateful'] == true ? 'yes' : 'no' }"
           puts "  scaling: #{service['container_count'] }"
           puts "  strategy: #{service['strategy']}"
@@ -175,6 +176,7 @@ module Kontena
           result['containers'].each do |container|
             puts "    #{container['name']}:"
             puts "      rev: #{container['deploy_rev']}"
+            puts "      service_rev: #{container['service_rev']}"
             puts "      node: #{container['node']['name'] rescue 'unknown'}"
             puts "      dns: #{container['name']}.#{grid}.kontena.local"
             puts "      ip: #{container['overlay_cidr'].to_s.split('/')[0]}"

--- a/cli/lib/kontena/cli/stack_command.rb
+++ b/cli/lib/kontena/cli/stack_command.rb
@@ -12,7 +12,7 @@ class Kontena::Cli::StackCommand < Clamp::Command
   subcommand "show", "Show stack details", Kontena::Cli::Stacks::ShowCommand
   subcommand "update", "Update stack", Kontena::Cli::Stacks::UpdateCommand
   subcommand "deploy", "Deploy Kontena stack", Kontena::Cli::Stacks::DeployCommand
-  subcommand ["remove","rm"], "Remove services", Kontena::Cli::Stacks::RemoveCommand
+  subcommand ["remove","rm"], "Remove stack", Kontena::Cli::Stacks::RemoveCommand
   
   def execute
 

--- a/cli/lib/kontena/cli/stack_command.rb
+++ b/cli/lib/kontena/cli/stack_command.rb
@@ -1,0 +1,20 @@
+require_relative 'stacks/create_command'
+require_relative 'stacks/remove_command'
+require_relative 'stacks/deploy_command'
+require_relative 'stacks/update_command'
+require_relative 'stacks/list_command'
+require_relative 'stacks/show_command'
+
+class Kontena::Cli::StackCommand < Clamp::Command
+
+  subcommand "create", "Create stack", Kontena::Cli::Stacks::CreateCommand
+  subcommand ["ls", "list"], "List stacks", Kontena::Cli::Stacks::ListCommand
+  subcommand "show", "Show stack details", Kontena::Cli::Stacks::ShowCommand
+  subcommand "update", "Update stack", Kontena::Cli::Stacks::UpdateCommand
+  subcommand "deploy", "Deploy Kontena stack", Kontena::Cli::Stacks::DeployCommand
+  subcommand ["remove","rm"], "Remove services", Kontena::Cli::Stacks::RemoveCommand
+  
+  def execute
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -1,8 +1,3 @@
-#require 'yaml'
-
-#require_relative '../services/services_helper'
-#require_relative '../apps/common'
-#require_relative '../apps/service_generator_v2'
 require_relative '../apps/yaml/reader'
 
 module Kontena::Cli::Stacks

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -1,0 +1,44 @@
+#require 'yaml'
+
+#require_relative '../services/services_helper'
+#require_relative '../apps/common'
+#require_relative '../apps/service_generator_v2'
+require_relative '../apps/yaml/reader'
+
+module Kontena::Cli::Stacks
+  module Common
+    include Kontena::Cli::Apps::Common
+
+    def service_prefix
+      @service_prefix ||= project_name_from_yaml(filename)
+    end
+
+    def stack_from_yaml(filename)
+      set_env_variables(service_prefix, current_grid)
+      outcome = read_yaml(filename)
+      if outcome[:version] != '2'
+        STDERR.puts "Stack supported only in v2 YAML! Aborting.".colorize(:red)
+        abort
+      end
+      if outcome[:name].nil?
+        STDERR.puts "Stack MUST have name in YAML! Aborting.".colorize(:red)
+        abort
+      end
+      hint_on_validation_notifications(outcome[:notifications]) if outcome[:notifications].size > 0
+      abort_on_validation_errors(outcome[:errors]) if outcome[:errors].size > 0
+      kontena_services = generate_services(outcome[:services], outcome[:version])
+      # services now as hash, needs to be array in stacks API
+      services = []
+      kontena_services.each do |name, service|
+        service['name'] = prefixed_name(name)
+        services << service
+      end
+      stack = {
+        'name' => outcome[:name],
+        'services' => services
+      }
+      stack
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/create_command.rb
+++ b/cli/lib/kontena/cli/stacks/create_command.rb
@@ -1,0 +1,27 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class CreateCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena stack file', attribute_name: :filename, default: 'kontena.yml'
+
+    def execute
+      require_api_url
+      require_token
+      require_config_file(filename)
+      @stack = stack_from_yaml(filename)
+
+      create_stack
+    end
+
+    private
+
+    def create_stack
+      client(token).post("stacks/#{current_grid}", @stack)
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -1,0 +1,26 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class DeployCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    parameter "NAME", "Stack name"
+
+    def execute
+      require_api_url
+      require_token
+
+      deploy_stack(name)
+    end
+
+    private
+
+
+    def deploy_stack
+      client(token).post("stacks/#{current_grid}/#{name}/deploy", {})
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -1,0 +1,38 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class ListCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    COLUMNS = "%-30s %-10s %-10s".freeze
+
+    def execute
+      require_api_url
+      require_token
+
+      list_stacks
+    end
+
+    private
+
+    def list_stacks
+      response = client(token).get("stacks/#{current_grid}")
+      
+      titles = ['NAME', 'SERVICES', 'STATE']
+      puts COLUMNS % titles
+
+      response['stacks'].each do |stack|
+        vars = [
+          stack['name'],
+          stack['grid_services'].size,
+          stack['state']
+        ]
+
+        puts COLUMNS % vars
+      end
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/remove_command.rb
@@ -1,0 +1,26 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class RemoveCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    parameter "NAME", "Service name"
+
+    def execute
+      require_api_url
+      require_token
+
+      remove_stack(name)
+    end
+
+    private
+
+
+    def remove_stack(name)
+      client(token).delete("stacks/#{current_grid}/#{name}")
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -1,0 +1,38 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class ShowCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    parameter "NAME", "Service name"
+
+    def execute
+      require_api_url
+      require_token
+      
+      show_stack(name)
+      
+    end
+
+    private
+
+    def show_stack(name)
+      stack = client(token).get("stacks/#{current_grid}/#{name}")
+
+      puts stack
+
+      puts "#{stack['id']}:"
+      puts "  state: #{stack['state']}"
+      puts "  created_at: #{stack['created_at']}"
+      puts "  updated_at: #{stack['updated_at']}"
+      puts "  version: #{stack['version']}"
+      puts "  services:"
+      stack['grid_services'].each do |service|
+        puts "    id: #{service['id']}"
+      end
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/update_command.rb
+++ b/cli/lib/kontena/cli/stacks/update_command.rb
@@ -1,0 +1,27 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class UpdateCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena stack file', attribute_name: :filename, default: 'kontena.yml'
+
+    def execute
+      require_api_url
+      require_token
+      require_config_file(filename)
+      @stack = stack_from_yaml(filename)
+
+      update_stack
+    end
+
+    private
+
+    def update_stack
+      client(token).put("stacks/#{current_grid}/#{@stack['name']}", @stack)
+    end
+
+  end
+end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -23,11 +23,13 @@ require_relative 'cli/vault_command'
 require_relative 'cli/user_command'
 require_relative 'cli/plugin_command'
 require_relative 'cli/version_command'
+require_relative 'cli/stack_command'
 
 class Kontena::MainCommand < Kontena::Command
 
   subcommand "grid", "Grid specific commands", Kontena::Cli::GridCommand
   subcommand "app", "App specific commands", Kontena::Cli::AppCommand
+  subcommand "stack", "Stack specific commands", Kontena::Cli::StackCommand
   subcommand "service", "Service specific commands", Kontena::Cli::ServiceCommand
   subcommand "vault", "Vault specific commands", Kontena::Cli::VaultCommand
   subcommand "node", "Node specific commands", Kontena::Cli::NodeCommand

--- a/server/app/models/container.rb
+++ b/server/app/models/container.rb
@@ -18,6 +18,7 @@ class Container
   field :deleted_at, type: Time
   field :volumes, type: Array, default: []
   field :deploy_rev, type: String
+  field :service_rev, type: String
   field :container_type, type: String, default: 'container'
 
   validates_uniqueness_of :container_id, scope: [:host_node_id], allow_nil: true

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -33,7 +33,6 @@ class GridService
   field :deploy_requested_at, type: DateTime
   field :deployed_at, type: DateTime
   field :revision, type: Fixnum, default: 1
-  field :deploy_rev, type: String, default: '1'
   field :strategy, type: String, default: 'ha'
 
   belongs_to :grid

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -33,6 +33,7 @@ class GridService
   field :deploy_requested_at, type: DateTime
   field :deployed_at, type: DateTime
   field :revision, type: Fixnum, default: 1
+  field :deploy_rev, type: String, default: '1'
   field :strategy, type: String, default: 'ha'
 
   belongs_to :grid

--- a/server/app/models/stack.rb
+++ b/server/app/models/stack.rb
@@ -4,7 +4,7 @@ class Stack
   include Mongoid::Enum
 
   field :name, type: String
-  field :version, type: String
+  field :version, type: String, default: '1'
   enum :state, [:initialized, :deployed, :terminated]
 
   belongs_to :grid
@@ -20,6 +20,11 @@ class Stack
   # @return [String]
   def to_path
     "#{self.grid.try(:name)}/#{self.name}"
+  end
+
+  def increase_version
+    self.set(version: (self.version.to_i + 1))
+    self.version
   end
 
 end

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -139,7 +139,6 @@ module GridServices
       if self.secrets
         attributes[:secrets] = self.build_grid_service_secrets(self.grid_service.secrets.to_a)
       end
-
       grid_service.attributes = attributes
       if grid_service.changed?
         grid_service.revision += 1

--- a/server/app/mutations/stacks/update.rb
+++ b/server/app/mutations/stacks/update.rb
@@ -85,7 +85,8 @@ module Stacks
           add_error(:services, :invalid, "Service delete failed for service '#{service[:name]}': #{outcome.errors.message}")
         end
       end
-
+      self.stack.increase_version
+      self.stack.save
       self.stack.reload
     end
 

--- a/server/app/services/agent/container_info_mapper.rb
+++ b/server/app/services/agent/container_info_mapper.rb
@@ -113,6 +113,9 @@ module Agent
       if container.deploy_rev.nil? && labels['io.kontena.container.deploy_rev']
         attributes[:deploy_rev] = labels['io.kontena.container.deploy_rev']
       end
+      if labels['io.kontena.container.service_revision']
+        attributes[:service_rev] = labels['io.kontena.container.service_revision']
+      end
       if info['NetworkSettings']
         attributes[:network_settings] = self.parse_docker_network_settings(info['NetworkSettings'])
       end

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -29,6 +29,7 @@ module Docker
     def service_spec(instance_number, deploy_rev, creds = nil)
       spec = {
         service_name: grid_service.name,
+        service_revision: grid_service.revision,
         updated_at: grid_service.updated_at.to_s,
         instance_number: instance_number,
         image_name: grid_service.image_name,

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -70,7 +70,10 @@ class GridServiceDeployer
     self.grid_service.set_state('deploying')
     self.grid_service.set(:deployed_at => Time.now.utc)
     
-    deploy_rev = self.grid_service.revision.to_s
+    # Deploy revision needs to be unique per deployment, otherwise deployer cannot remove unnecessary containers
+    deploy_rev = (self.grid_service.deploy_rev.to_i + 1).to_s
+    self.grid_service.set(deploy_rev: deploy_rev)
+    
 
     deploy_futures = []
     total_instances = self.instance_count

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -70,11 +70,8 @@ class GridServiceDeployer
     self.grid_service.set_state('deploying')
     self.grid_service.set(:deployed_at => Time.now.utc)
     
-    # Deploy revision needs to be unique per deployment, otherwise deployer cannot remove unnecessary containers
-    deploy_rev = (self.grid_service.deploy_rev.to_i + 1).to_s
-    self.grid_service.set(deploy_rev: deploy_rev)
+    deploy_rev = Time.now.utc.to_s
     
-
     deploy_futures = []
     total_instances = self.instance_count
     total_instances.times do |i|

--- a/server/app/views/v1/containers/_container.json.jbuilder
+++ b/server/app/views/v1/containers/_container.json.jbuilder
@@ -31,6 +31,7 @@ json.deleted_at container.deleted_at
 json.status container.status
 json.state container.state
 json.deploy_rev container.deploy_rev
+json.service_rev container.service_rev
 json.image container.image
 json.env container.env
 json.volumes container.volumes

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -34,6 +34,18 @@ describe GridServices::Update do
       }.to change{ redis_service.reload.revision }.to(2)
     end
 
+    it 'updates image' do
+      redis_service.env = ['FOO=BAR', 'BAR=baz']
+      redis_service.save
+      expect {
+        described_class.new(
+            current_user: user,
+            grid_service: redis_service,
+            image: 'redis:3.0'
+        ).run
+      }.to change{ redis_service.reload.image_name }.to('redis:3.0')
+    end
+
     it 'does not update revision when nothing changes' do
       redis_service.env = ['FOO=bar']
       redis_service.save

--- a/server/spec/mutations/stacks/update_spec.rb
+++ b/server/spec/mutations/stacks/update_spec.rb
@@ -25,6 +25,16 @@ describe Stacks::Update do
       expect(stack.reload.grid_services.first.image_name).to eq('redis:3.0')
     end
 
+    it 'increases version automatically' do
+      services = [{grid: grid, name: 'redis', image: 'redis:3.0'}]
+      subject = described_class.new(current_user: user, stack: stack, services: services)
+      expect {
+        outcome = subject.run
+        expect(outcome.success?).to be_truthy
+      }.to change{stack.reload.version}.to eq('2')
+      
+    end
+
     it 'fails if stack is already terminated' do
       stack.state = :terminated
       subject = described_class.new(current_user: user, stack: stack)


### PR DESCRIPTION
This PR adds initial CLI commands for stacks API.

This also fixes a deploy revision related regression and now separates the deployment revision from the service version. Naturally there can be multiple deployments (re-balancing, interval deploy etc.) for a given service version and thus we need to separate these concepts.

We need to further work on the versioning when we actually enable the capability to deploy older version of service/stack.