### PR TITLE
Support for LE certificates

### DIFF
--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -1,0 +1,23 @@
+
+module Kontena::Cli::Certificate
+  class AuthorizeCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+
+
+    parameter "DOMAIN", "Domain to authorize"
+
+    def execute
+      require_api_url
+      token = require_token
+
+      data = {domain: domain}
+      response = client(token).post("certificates/#{current_grid}/authorize", data)
+      puts "Authorization successfully created. Use the following details to create necessary validations:"
+      puts "Record name:#{response['record_name']}"
+      puts "Record type:#{response['record_type']}"
+      puts "Record content:#{response['record_content']}"
+
+    end
+  end
+end

--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -1,0 +1,25 @@
+
+module Kontena::Cli::Certificate
+  class GetCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+
+
+    option '--secret-name', 'SECRET_NAME', 'The name for the secret to store the certificate in'
+    parameter "DOMAIN ...", "Domain(s) to get certificate for"
+
+
+    def execute
+      require_api_url
+      token = require_token
+      secret = secret_name || "LE_CERTIFICATE_#{domain_list[0].gsub('.', '_')}"
+      data = {domains: domain_list, secret_name: secret}
+      response = client(token).post("certificates/#{current_grid}/certificate", data)
+      puts "Certificate successfully received and stored into vault with keys:"
+      response.each do |secret|
+        puts secret.colorize(:green)
+      end
+      puts "Use the #{secret}_BUNDLE with Kontena loadbalancer!"
+    end
+  end
+end

--- a/cli/lib/kontena/cli/certificate/register_command.rb
+++ b/cli/lib/kontena/cli/certificate/register_command.rb
@@ -1,0 +1,19 @@
+
+module Kontena::Cli::Certificate
+  class RegisterCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+
+
+    parameter "EMAIL", "Email to register"
+
+    def execute
+      require_api_url
+      token = require_token
+
+      data = {email: email}
+      response = client(token).post("certificates/#{current_grid}/register", data)
+      puts 'Email registered to LetsEncrypt'
+    end
+  end
+end

--- a/cli/lib/kontena/cli/certificate_command.rb
+++ b/cli/lib/kontena/cli/certificate_command.rb
@@ -1,0 +1,14 @@
+require_relative 'certificate/register_command'
+require_relative 'certificate/authorize_command'
+require_relative 'certificate/get_command'
+
+class Kontena::Cli::CertificateCommand < Clamp::Command
+
+
+  subcommand "register", "Register to LetsEncrypt", Kontena::Cli::Certificate::RegisterCommand
+  subcommand "authorize", "Create DNS authorization for domain", Kontena::Cli::Certificate::AuthorizeCommand
+  subcommand "get", "Get certificate for domain", Kontena::Cli::Certificate::GetCommand
+
+  def execute
+  end
+end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -24,6 +24,7 @@ require_relative 'cli/user_command'
 require_relative 'cli/plugin_command'
 require_relative 'cli/version_command'
 require_relative 'cli/stack_command'
+require_relative 'cli/certificate_command'
 
 class Kontena::MainCommand < Kontena::Command
 
@@ -32,6 +33,7 @@ class Kontena::MainCommand < Kontena::Command
   subcommand "stack", "Stack specific commands", Kontena::Cli::StackCommand
   subcommand "service", "Service specific commands", Kontena::Cli::ServiceCommand
   subcommand "vault", "Vault specific commands", Kontena::Cli::VaultCommand
+  subcommand "certificate", "LE Certificate specific commands", Kontena::Cli::CertificateCommand
   subcommand "node", "Node specific commands", Kontena::Cli::NodeCommand
   subcommand "master", "Master specific commands", Kontena::Cli::MasterCommand
   subcommand "vpn", "VPN specific commands", Kontena::Cli::VpnCommand

--- a/docs/using-kontena/README.md
+++ b/docs/using-kontena/README.md
@@ -12,3 +12,4 @@ toc_link: false
 * [Services](services.md)
 * [Users](users.md)
 * [VPN Access](vpn-access.md)
+* [Certificates](certificates.md)

--- a/docs/using-kontena/certificates.md
+++ b/docs/using-kontena/certificates.md
@@ -73,3 +73,12 @@ Certificate:
             X509v3 Subject Alternative Name: 
                 DNS:www.example.com, DNS:example.com
 ```
+
+## Secrets
+
+Kontena LE integration stores all certificate information securely in [Kontena Vault](vault.md). Upon receiving a certificate from LetsEncrypt Kontena stores three secrets in the vault:
+**LE_CERTIFICATE_`<domain_name>`_PRIVATE_KEY** Private key of the certificate
+**LE_CERTIFICATE_`<domain_name>`_CERTIFICATE** The actual certificate
+**LE_CERTIFICATE_`<domain_name>`_BUNDLE** Bundle of the certificate and private key, suitable to use with [Kontena Loadbalancer](loadbalancer.md).
+
+These can be used with any software that can utilize secrets from environment using normal [secret integration](vault.md#using-secrets-with-applications).

--- a/docs/using-kontena/certificates.md
+++ b/docs/using-kontena/certificates.md
@@ -1,0 +1,75 @@
+---
+title: Load Balancer
+toc_order: 6
+---
+
+# Kontena Certificates
+
+Kontena integrates natively with [LetsEncrypt](letsencrypt.org) to bring easy to use certificate management for your services.
+
+Certificate management is integrated with Kontena [vault](vault.md) to handle certificates with proper security constraints.
+
+## Register for LE
+
+To be able to use LetsEncrypt one must first register as user. 
+```
+kontena certificate register <you@example.com>
+```
+
+By default this creates a new private key to be used with LE to identify the client.
+
+**Note:** If you have already registered with other means and have existing private key you wish to use you can import it into vault using specific name `LE_PRIVATE_KEY`
+```
+$ kontena vault write LE_PRIVATE_KEY "$(cat priv_key.pem)"
+```
+
+The email is needed for Let's Encrypt to notify when certificates are about to expire. This registration is neede only once per grid.
+
+## Create domain authorization
+
+To be able to request certificates for a domain one must first prove that you are in charge of tht domain. For this Kontena certificate management support DNS based authorization.
+
+```
+$ kontena certificate authorize api.example.com
+Record name:_acme-challenge
+Record type:TXT
+Record content:5m1FCaNvneLduTN4AcPqAbyuQhBQA4ESisAQfEYvXIE
+```
+
+To verify that you really control the requested domain, create a DNS TXT record for domain `_acme-challenge.api.example.com` with content specified in the response.
+
+## Get actual certificate
+
+Once you have created the necessary DNS proofs of domain control you can request the actual certificate.
+
+```
+$ kontena certificate get --secret-name SSL_CERT_LE_TEST api.example.com
+Certificate successfully received and stored into vault with key SSL_CERT_LE_TEST
+```
+
+Kontena automatically stores the certificate into secure vault in a format where it can be used for SSL termination with our loadbalancer. If you omit the secret-name option Kontena automatically generates the name using the domain name.
+
+LetsEncrypt does NOT support wildcard certificates. In many cases there's a need to server multiple sites behind one certificate and for that LE supports a concept called subject alternative names (SAN). To obtain a certificate for multiple DNS names just specify them in the request:
+```
+$ kontena certificate get --secret-name SSL_CERT_LE_TEST example.com www.example.com
+Certificate successfully received and stored into vault with key SSL_CERT_LE_TEST
+```
+**Note:** For each of the domains in the certificate request you have to complete the domain authorization first! The first domain in the list becomes the common name and others are used as alternative names:
+```
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            fa:2c:99:7a:4e:76:10:97:fe:b9:7b:28:4a:c3:44:7a:fe:b1
+    Signature Algorithm: sha256WithRSAEncryption
+        Issuer: CN=Fake LE Intermediate X1
+        Validity
+            Not Before: Jul  1 06:31:00 2016 GMT
+            Not After : Sep 29 06:31:00 2016 GMT
+        Subject: CN=example.com
+        Subject Public Key Info:
+        ...
+        X509v3 extensions:
+            X509v3 Subject Alternative Name: 
+                DNS:www.example.com, DNS:example.com
+```

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -17,7 +17,9 @@ gem 'httpclient', '~> 2.3'
 gem 'authority'
 gem 'ruby_dig'
 gem 'rollbar', require: false
-gem "mongoid-enum"
+gem 'mongoid-enum'
+gem 'acme-client'
+gem 'json-jwt', '= 1.5.2'
 
 group :development, :test do
   gem 'dotenv'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -1,6 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    acme-client (0.3.4)
+      faraday (~> 0.9, >= 0.9.1)
+      json-jwt (~> 1.2, >= 1.2.3)
     activemodel (4.1.14)
       activesupport (= 4.1.14)
       builder (~> 3.1)
@@ -14,6 +17,7 @@ GEM
     authority (3.1.0)
       activesupport (>= 3.0.0)
       rake (>= 0.8.7)
+    bindata (2.3.1)
     bson (3.2.6)
     builder (3.2.2)
     celluloid (0.16.0)
@@ -29,6 +33,8 @@ GEM
     docile (1.1.5)
     dotenv (1.0.2)
     eventmachine (1.0.8)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     faye-websocket (0.10.2)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
@@ -40,11 +46,17 @@ GEM
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
     json (1.8.3)
+    json-jwt (1.5.2)
+      activesupport
+      bindata
+      multi_json (>= 1.3)
+      securecompare
+      url_safe_base64
     listen (2.8.3)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    minitest (5.8.3)
+    minitest (5.9.0)
     mongoid (4.0.2)
       activemodel (~> 4.0)
       moped (~> 2.0.0)
@@ -61,7 +73,8 @@ GEM
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
     msgpack (0.7.4)
-    multi_json (1.10.1)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
     mutations (0.7.2)
       activesupport
     optionable (0.2.0)
@@ -95,6 +108,7 @@ GEM
     rspec-support (3.1.2)
     ruby_dig (0.0.2)
     safe_yaml (1.0.4)
+    securecompare (1.0.0)
     simplecov (0.9.2)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -111,6 +125,7 @@ GEM
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    url_safe_base64 (0.2.2)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -122,12 +137,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acme-client
   activesupport (~> 4.1.14)
   authority
   celluloid (~> 0.16.0)
   dotenv
   faye-websocket (~> 0.10.0)
   httpclient (~> 2.3)
+  json-jwt (= 1.5.2)
   mongoid (~> 4.0.0)
   mongoid-enum
   mongoid-rspec (~> 2.1.0)

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -29,6 +29,7 @@ class Grid
   has_many :registries, dependent: :delete
   has_many :overlay_cidrs, dependent: :delete
   has_many :stacks, dependent: :destroy
+  has_many :grid_domain_authorizations, dependent: :delete
   has_and_belongs_to_many :users
 
   index({ name: 1 }, { unique: true })

--- a/server/app/models/grid_domain_authorization.rb
+++ b/server/app/models/grid_domain_authorization.rb
@@ -1,0 +1,23 @@
+class GridDomainAuthorization
+  include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Enum
+
+  belongs_to :grid
+
+  enum :state, [:created, :requested, :validated], default: :created
+  field :domain, type: String
+  field :challenge, type: Hash
+  field :challenge_opts, type: Hash # TODO encrypt?
+
+  index({ grid_id: 1 })
+  index({ domain: 1 })
+  index({ grid_id: 1, domain: 1 }, {unique: true})
+
+  validates_uniqueness_of :domain, scope: [:grid_id]
+
+  # @return [String]
+  def to_path
+    "#{self.grid.try(:name)}/#{self.name}"
+  end
+end

--- a/server/app/mutations/grid_certificates/authorize_domain.rb
+++ b/server/app/mutations/grid_certificates/authorize_domain.rb
@@ -1,0 +1,38 @@
+require 'acme-client'
+require 'openssl'
+
+require_relative 'common'
+require_relative '../../services/logging'
+
+module GridCertificates
+  class AuthorizeDomain < Mutations::Command
+    include Common
+    include Logging
+
+    required do
+      model :grid, class: Grid
+      string :domain
+    end
+
+    def execute
+
+      authorization = acme_client(self.grid).authorize(domain: self.domain)
+      challenge = authorization.dns01
+      challenge_opts = {
+        'record_name' => challenge.record_name,
+        'record_type' => challenge.record_type,
+        'record_content' => challenge.record_content
+      }
+      authz = get_authz_for_domain(self.grid, self.domain)
+      if authz
+        authz.state = :created
+        authz.update_attributes(grid: self.grid, domain: self.domain, challenge: challenge.to_h, challenge_opts: challenge_opts)
+      else
+        authz = GridDomainAuthorization.new(grid: self.grid, domain: self.domain, challenge: challenge.to_h, challenge_opts: challenge_opts)
+      end
+      
+      authz.save
+      authz
+    end
+  end
+end

--- a/server/app/mutations/grid_certificates/common.rb
+++ b/server/app/mutations/grid_certificates/common.rb
@@ -1,0 +1,51 @@
+require 'openssl'
+require 'acme-client'
+
+require_relative '../../services/logging'
+
+module GridCertificates
+  module Common
+
+    include Logging
+
+    LE_PRIVATE_KEY = 'LE_PRIVATE_KEY'.freeze
+
+    ACME_ENDPOINT = 'https://acme-v01.api.letsencrypt.org/'.freeze
+
+    def acme_client(grid)
+      client = Acme::Client.new(private_key: acme_private_key(grid), 
+                                endpoint: acme_endpoint, 
+                                connection_options: { request: { open_timeout: 5, timeout: 5 } })
+      client
+    end
+
+    def acme_private_key(grid)
+      le_secret = grid.grid_secrets.where(name: LE_PRIVATE_KEY).first
+      if le_secret.nil?
+        info 'LE private key does not yet exist, creating...'
+        private_key = OpenSSL::PKey::RSA.new(4096)
+        outcome = GridSecrets::Create.run(grid: grid, name: LE_PRIVATE_KEY, value: private_key.to_pem)
+        unless outcome.success?
+          return nil # TODO Or raise something?
+        end
+      else
+        private_key = OpenSSL::PKey::RSA.new(le_secret.value)
+      end
+
+      private_key
+    end
+
+    def domain_to_vault_key(domain)
+      domain.sub('.', '_')
+    end
+
+    def get_authz_for_domain(grid, domain)
+      grid.grid_domain_authorizations.find_by(domain: domain)
+    end
+
+    def acme_endpoint
+      ENV['ACME_ENDPOINT'] || ACME_ENDPOINT
+    end
+
+  end
+end

--- a/server/app/mutations/grid_certificates/get_certificate.rb
+++ b/server/app/mutations/grid_certificates/get_certificate.rb
@@ -1,0 +1,113 @@
+require 'timeout'
+
+require_relative 'common'
+require_relative '../../services/logging'
+
+module GridCertificates
+  class GetCertificate < Mutations::Command
+    include Common
+    include Logging
+
+    LE_CERT_PREFIX = 'LE_CERTIFICATE'.freeze
+    
+
+    required do
+      model :grid, class: Grid
+      string :secret_name
+      
+      array :domains do
+        string
+      end
+    end
+
+
+    def validate
+      self.domains.each do |domain|
+        domain_authz = get_authz_for_domain(self.grid, domain)
+
+        if domain_authz
+          # Check that the expected DNS record is already in place
+          unless validate_dns_record(domain, domain_authz.challenge_opts['record_content'])
+            add_error(:dns_record, :invalid, "Expected DNS record not present for domain #{domain}")
+          end
+        else
+          add_error(:authorization, :not_found, "Domain authorization not found for domain #{domain}")
+        end
+
+      end
+    end
+
+    def execute
+
+      csr = Acme::Client::CertificateRequest.new(names: self.domains)
+      client = acme_client(self.grid)
+
+      self.domains.each do |domain|
+        domain_authz = get_authz_for_domain(self.grid, domain)
+
+        challenge = client.challenge_from_hash(domain_authz.challenge)
+        if domain_authz.state == :created
+          info 'requesting verification'
+          success = challenge.request_verification
+          if success
+            domain_authz.state = :requested
+            domain_authz.save
+          end
+        end
+
+        Timeout::timeout(30) {
+          info 'waiting for DNS validation...'
+          sleep 1 until challenge.verify_status == 'valid'
+          info 'DNS validation complete'
+        }
+
+        domain_authz.state = :validated
+        domain_authz.save
+  
+      end
+      
+      certificate = client.new_certificate(csr)
+      cert_priv_key = certificate.request.private_key.to_pem
+      cert = certificate.to_pem
+      
+      secrets = []
+      secrets << upsert_secret("#{self.secret_name}_PRIVATE_KEY", cert_priv_key)
+      secrets << upsert_secret("#{self.secret_name}_CERTIFICATE", cert_priv_key)
+      secrets << upsert_secret("#{self.secret_name}_BUNDLE", [cert, cert_priv_key].join)
+
+      secrets
+    rescue Timeout::Error
+      warn 'timeout while waiting for DNS verfication status'
+      add_error(:challenge_verify, :timeout, 'Challenge verification timeout')
+    rescue Acme::Client::Error => exc
+      error "#{exc.class.name}: #{exc.message}"
+      error exc.backtrace.join("\n") if exc.backtrace
+      add_error(:acme_client, :error, exc.message)
+    end
+
+    def upsert_secret(name, value)
+      cert_secret = self.grid.grid_secrets.find_by(name: name)
+      if cert_secret
+        outcome = GridSecrets::Update.run(grid_secret: cert_secret, value: value)
+      else
+        outcome = GridSecrets::Create.run(grid: self.grid, name: name, value: value)
+      end
+
+      unless outcome.success?
+        add_error(:cert_store, :failure, "Certificate storing to vault failed: #{outcome.errors.message}")
+        return
+      end
+      outcome.result
+    end
+
+    def validate_dns_record(domain, expected_record)
+      resolv = Resolv::DNS.new()
+      info "validating domain:_acme-challenge.#{domain}"
+      resource = resolv.getresource("_acme-challenge.#{domain}", Resolv::DNS::Resource::IN::TXT)
+      info "got record: #{resource.strings}, expected: #{expected_record}"
+      expected_record == resource.strings[0]
+    rescue
+      false
+    end
+  end
+end

--- a/server/app/mutations/grid_certificates/register.rb
+++ b/server/app/mutations/grid_certificates/register.rb
@@ -1,0 +1,29 @@
+require 'acme-client'
+require 'openssl'
+
+require_relative 'common'
+require_relative '../../services/logging'
+
+module GridCertificates
+  class Register < Mutations::Command
+    include Common
+    include Logging
+
+    required do
+      model :grid, class: Grid
+      string :email
+    end
+
+    def validate
+      
+    end
+
+    def execute
+
+      registration = acme_client(self.grid).register(contact: "mailto:#{email}")
+      registration.agree_terms
+    rescue Acme::Client::Error => exc
+      add_error(:acme, :error, exc.message)
+    end
+  end
+end

--- a/server/app/routes/v1/certificates_api.rb
+++ b/server/app/routes/v1/certificates_api.rb
@@ -1,0 +1,92 @@
+module V1
+  class CertificatesApi < Roda
+    include OAuth2TokenVerifier
+    include CurrentUser
+    include RequestHelpers
+    include Auditor
+
+    plugin :multi_route
+
+    route do |r|
+      validate_access_token
+      require_current_user
+
+      ##
+      # @param [String] name
+      # @return [Grid]
+      def load_grid(name)
+        @grid = current_user.accessible_grids.find_by(name: name)
+        halt_request(404, {error: 'Not found'}) unless @grid
+      end
+
+      def authorize_domain(data)
+        data[:grid] = @grid
+        outcome = GridCertificates::AuthorizeDomain.run(data)
+        if outcome.success?
+          @authorization = outcome.result
+          response.status = 201
+          {
+            'record_name' => @authorization.challenge_opts['record_name'],
+            'record_type' => @authorization.challenge_opts['record_type'],
+            'record_content' => @authorization.challenge_opts['record_content']
+          }
+          
+        else
+          response.status = 422
+          {error: outcome.errors.message}
+        end
+      end
+
+      def get_certificate(data)
+        data[:grid] = @grid
+        outcome = GridCertificates::GetCertificate.run(data)
+        if outcome.success?
+          @cert_secrets = outcome.result
+          response.status = 201
+          
+          @cert_secrets.collect { |s| s.name}
+        else
+          response.status = 422
+          {error: outcome.errors.message}
+        end
+      end
+
+      def register(data)
+        data[:grid] = @grid
+        outcome = GridCertificates::Register.run(data)
+        if outcome.success?
+          response.status = 201
+          {}
+        else
+          response.status = 422
+          {error: outcome.errors.message}
+        end
+      end
+
+      # /v1/certificates/:grid/
+      r.on ':grid' do |grid|
+        
+        load_grid(grid)
+
+        r.post do
+
+          r.on 'authorize' do
+            data = parse_json_body
+            authorize_domain(data)
+          end
+
+          r.on 'certificate' do
+            data = parse_json_body
+            get_certificate(data)
+          end
+
+          r.on 'register' do
+            data = parse_json_body
+            register(data)
+          end
+        end
+      end
+      
+    end
+  end
+end

--- a/server/app/views/v1/certificates/authorization.json.jbuilder
+++ b/server/app/views/v1/certificates/authorization.json.jbuilder
@@ -1,0 +1,1 @@
+json.record_content authorization.record_content

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,6 +6,9 @@ api:
   environment:
     - RACK_ENV=production
     - MONGODB_URI=mongodb://mongodb:27017/kontena_development
+    - VAULT_KEY=jkfldsjkflsdajfaklsjfklasdjfklas
+    - VAULT_IV=kfsdfopweu09fewjlhfksdjifjpoweop
+    - ACME_ENDPOINT=https://acme-staging.api.letsencrypt.org/
   links:
    - mongodb
 mongodb:

--- a/server/server.rb
+++ b/server/server.rb
@@ -74,6 +74,10 @@ class Server < Roda
       r.on('stacks') do
         r.run V1::StacksApi
       end
+
+      r.on('certificates') do
+        r.run V1::CertificatesApi
+      end
     end
   end
 end

--- a/server/spec/models/grid_domain_authorization_spec.rb
+++ b/server/spec/models/grid_domain_authorization_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../spec_helper'
+
+describe GridDomainAuthorization do
+  it { should have_fields(:domain).of_type(String)}
+  it { should have_fields(:challenge, :challenge_opts).of_type(Hash) }
+
+  
+end

--- a/server/spec/mutations/grid_certificates/authorize_domain_spec.rb
+++ b/server/spec/mutations/grid_certificates/authorize_domain_spec.rb
@@ -1,0 +1,63 @@
+require_relative '../../spec_helper'
+
+describe GridCertificates::AuthorizeDomain do
+
+  let(:subject) { described_class.new(grid: grid, domain: 'example.com') }
+  
+  let(:grid) {
+    grid = Grid.create!(name: 'test-grid')
+    grid
+  }
+
+  let(:authz) {
+    challenge_opts = {
+      'record_name' => '_acme-challenge',
+      'record_content' => '1234567890'
+    }
+    authz = GridDomainAuthorization.create(grid: grid, domain: 'example.com', challenge: {}, challenge_opts: challenge_opts)
+    authz
+  }
+  
+  describe '#validate' do
+
+  end
+
+  describe '#execute' do
+    it 'sends verification request and creates new authorization' do
+      acme = double
+      allow(subject).to receive(:acme_client).and_return(acme)
+      auth = double({dns01: double(
+        {
+          record_name: '_acme_challenge',
+          record_type: 'TXT',
+          record_content: '123456789',
+          to_h: {}
+        })})
+      expect(acme).to receive(:authorize).with(domain: 'example.com').and_return(auth)
+
+      expect {
+        subject.execute  
+      }.to change{GridDomainAuthorization.count}.by(1)
+      
+    end
+
+    it 'sends verification request and updates authorization' do
+      acme = double
+      allow(subject).to receive(:acme_client).and_return(acme)
+      auth = double({dns01: double(
+        {
+          record_name: '_acme_challenge',
+          record_type: 'TXT',
+          record_content: '123456789',
+          to_h: {}
+        })})
+      expect(acme).to receive(:authorize).with(domain: 'example.com').and_return(auth)
+
+      expect {
+        subject.execute  
+      }.to change{authz.reload.updated_at}
+      
+    end
+  end
+
+end

--- a/server/spec/mutations/grid_certificates/get_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/get_certificate_spec.rb
@@ -1,0 +1,143 @@
+require_relative '../../spec_helper'
+
+describe GridCertificates::GetCertificate do
+
+  let(:subject) { described_class.new(grid: grid, secret_name: 'secret', domains: ['example.com']) }
+  
+  let(:grid) {
+    grid = Grid.create!(name: 'test-grid')
+    grid
+  }
+
+  let(:authz) {
+    challenge_opts = {
+      'record_name' => '_acme-challenge',
+      'record_content' => '1234567890'
+    }
+    authz = GridDomainAuthorization.create(grid: grid, domain: 'example.com', challenge: {}, challenge_opts: challenge_opts)
+    authz
+  }
+  
+  describe '#validate' do
+    it 'validates domain authorization existence' do
+      subject.validate
+      expect(subject.has_errors?).to be_truthy
+    end
+
+    it 'fails validation in domain challenge' do
+      authz
+      expect(subject).to receive(:validate_dns_record).and_return(false)
+      subject.validate
+      expect(subject.has_errors?).to be_truthy
+    end
+
+    it 'validates domain challenge' do
+      authz
+      expect(subject).to receive(:validate_dns_record).and_return(true)
+      outcome = subject.validate
+      expect(subject.has_errors?).to be_truthy
+    end
+
+  end
+
+  describe '#execute' do
+    it 'sends verification request' do
+      authz
+      acme = double
+      allow(subject).to receive(:acme_client).and_return(acme)
+      challenge = double
+      expect(acme).to receive(:challenge_from_hash).and_return(challenge)
+      expect(acme).to receive(:new_certificate).and_return(
+        double({
+          to_pem: 'pem_cert',
+          request: double(
+            {
+              private_key: double({to_pem: 'private_key'})
+            }
+          )
+        }))
+      expect(challenge).to receive(:request_verification).and_return(true)
+      expect(challenge).to receive(:verify_status).and_return('valid')
+      expect(subject).to receive(:upsert_secret).exactly(3).times.and_return(double({success?: true}))
+
+      subject.execute
+    end
+
+    it 'adds error if verification timeouts' do
+      authz
+      acme = double
+      allow(subject).to receive(:acme_client).and_return(acme)
+      challenge = double
+      expect(acme).to receive(:challenge_from_hash).and_return(challenge)
+      expect(challenge).to receive(:request_verification).and_return(true)
+      expect(challenge).to receive(:verify_status).and_raise(Timeout::Error)
+      expect(subject).to receive(:add_error)
+
+      subject.execute
+    end
+
+    it 'adds error if acme client errors' do
+      authz
+      acme = double
+      allow(subject).to receive(:acme_client).and_return(acme)
+      challenge = double
+      expect(acme).to receive(:challenge_from_hash).and_return(challenge)
+      expect(challenge).to receive(:request_verification).and_raise(Acme::Client::Error)
+      expect(subject).to receive(:add_error)
+
+      subject.execute
+    end
+
+
+  end
+
+
+  describe '#validate_dns_record' do
+    it 'returns false when wrong content in DNS record' do
+      resolv = double
+      allow(Resolv::DNS).to receive(:new).and_return(resolv)
+      expect(resolv).to receive(:getresource).with("_acme-challenge.example.com", Resolv::DNS::Resource::IN::TXT).and_return(double(strings: ['dsdsdsdsds']))
+      expect(subject.validate_dns_record('example.com', '1234567890')).to be_falsey
+      
+    end
+
+    it 'returns false when DNS Failure' do
+      resolv = double
+      allow(Resolv::DNS).to receive(:new).and_return(resolv)
+      expect(resolv).to receive(:getresource).with("_acme-challenge.example.com", Resolv::DNS::Resource::IN::TXT).and_raise(Resolv::ResolvError)
+      expect(subject.validate_dns_record('example.com', '1234567890')).to be_falsey
+      
+    end
+
+    it 'returns true when correct content in DNS record' do
+      resolv = double
+      allow(Resolv::DNS).to receive(:new).and_return(resolv)
+      expect(resolv).to receive(:getresource).with("_acme-challenge.example.com", Resolv::DNS::Resource::IN::TXT).and_return(double(strings: ['1234567890']))
+      expect(subject.validate_dns_record('example.com', '1234567890')).to be_truthy
+      
+    end
+  end
+
+  describe '#upsert_secret' do
+    it 'creates new secret' do
+      expect(GridSecrets::Create).to receive(:run).and_return(double({success?: true, result: double}))
+      subject.upsert_secret('foo', 'cert_content')
+    end
+
+    it 'updates secret' do
+      secret = GridSecret.create!(name: 'secret', value: 'secret')
+      grid.grid_secrets << secret
+      expect(GridSecrets::Update).to receive(:run).and_return(double({success?: true, result: double}))
+      
+      subject.upsert_secret('secret', 'cert_content')
+      
+    end
+
+    it 'adds error if secret upsert fails' do
+      expect(GridSecrets::Create).to receive(:run).and_return(double({success?: false, errors: double({message:'error'})}))
+      expect(subject).to receive(:add_error)
+      subject.upsert_secret('foo', 'cert_content')
+    end
+  end
+
+end

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 ENV['RACK_ENV'] = 'test'
 ENV['VAULT_KEY'] = SecureRandom.base64(64)
 ENV['VAULT_IV'] = SecureRandom.base64(64)
+ENV['ACME_ENDPOINT'] = 'https://acme-staging.api.letsencrypt.org/'
 require 'dotenv'
 Dotenv.load
 


### PR DESCRIPTION
This PR adds support for managing LE certificates with vault.

The docs explain the usage pattern but in nutshell we utilize the DNS challenge and do the verification and certificate request in two steps.

The registration step creates private key, if not imported into vault before, and associates it with a email address to be used as identity for LE.

WIP flag still as there's some cleanup and refactoring needed. 

ping @jakolehm @nevalla 

fixes #704 