### PR TITLE
Update to dry-validation 0.8.0

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -28,7 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "highline"
   spec.add_runtime_dependency "shell-spinner"
   spec.add_runtime_dependency "ruby_dig"
-  spec.add_runtime_dependency "dry-validation", "0.7.4"
-  spec.add_runtime_dependency "dry-types", "0.7.1"
-  spec.add_runtime_dependency "dry-logic", "0.2.2"
+  spec.add_runtime_dependency "dry-validation", "~> 0.8"
 end

--- a/cli/lib/kontena/cli/apps/yaml/validations.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validations.rb
@@ -3,10 +3,12 @@ module Kontena::Cli::Apps::YAML
 
    def append_common_validations(base)
      base.optional('image').maybe(:str?)
+
      base.optional('extends').schema do
-       key('service').required(:str?)
-       optional('file') { str? }
-     end    
+       required('service').filled(:str?)
+       optional('file').value(:str?)
+     end
+
      base.optional('stateful') { bool? }
      base.optional('affinity') { array? { each { format?(/(?<=\!|\=)=/) } } }
      base.optional('cap_add') { array? | none? }
@@ -23,27 +25,31 @@ module Kontena::Cli::Apps::YAML
      base.optional('ports') { array? }
      base.optional('volumes') { array? }
      base.optional('volumes_from') { array? }
+
      base.optional('deploy').schema do
-       optional('strategy') { inclusion?(%w(ha daemon random)) }
+       optional('strategy').value(included_in?: %w(ha daemon random))
        optional('wait_for_port') { int? }
        optional('min_health') { float? }
        optional('interval') { format?(/^\d+(min|h|d|)$/) }
      end
+
      base.optional('hooks').schema do
        optional('post_start').each do
-         key('name').required
-         key('cmd').required
-         key('instances') { int? | eql?('*') }
+         required('name').filled
+         required('cmd').filled
+         required('instances') { int? | eql?('*') }
          optional('oneshot') { bool? }
        end
+
        optional('pre_build').each do
-         key('cmd').required
+         required('cmd').filled
        end
      end
+
      base.optional('secrets').each do
-       key('secret').required
-       key('name').required
-       key('type').required
+       required('secret').filled
+       required('name').filled
+       required('type').filled
      end
    end
 
@@ -59,7 +65,7 @@ module Kontena::Cli::Apps::YAML
    def validate_keys(service_config)
      errors = {}
      service_config.keys.each do |key|
-       error = validate_key(key)
+       error = validate_required(key)
        errors[key] = error if error
      end
      errors
@@ -67,7 +73,7 @@ module Kontena::Cli::Apps::YAML
 
    ##
    # @param [String] key
-   def validate_key(key)
+   def validate_required(key)
      if self.class::UNSUPPORTED_KEYS.include?(key)
        ['unsupported option']
      elsif !self.class::VALID_KEYS.include?(key)

--- a/cli/lib/kontena/cli/apps/yaml/validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Apps
     class Validator
       require_relative 'validations'
       include Validations
-      
+
       VALID_KEYS = %w(
       affinity build dockerfile cap_add cap_drop command deploy env_file environment extends external_links
       image links log_driver log_opt net pid ports volumes volumes_from cpu_shares
@@ -24,12 +24,12 @@ module Kontena::Cli::Apps
         base = self
         @yaml_schema = Dry::Validation.Schema do
           base.append_common_validations(self)
-          optional('build').maybe(:str?)
-          optional('dockerfile') { str? }
-          optional('net') { inclusion?(%w(host bridge)) }
-          optional('log_driver') { str? }
-          optional('log_opts') { type?(Hash) }
 
+          optional('build').maybe(:str?)
+          optional('dockerfile').value(:str?)
+          optional('net').value(included_in?: (%w(host bridge)))
+          optional('log_driver').value(:str?)
+          optional('log_opts').value(type?: Hash)
         end
       end
 

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -30,13 +30,13 @@ module Kontena::Cli::Apps
 
           rule(build_hash: ['build']) do |build|
             build.type?(Hash) > build.schema do
-              key('context').required
+              required('context').filled
               optional('dockerfile') { str? }
               optional('args') { array? | type?(Hash)}
             end
           end
           optional('depends_on') { array? }
-          optional('network_mode') { inclusion?(%w(host bridge)) }
+          optional('network_mode').value(included_in?: (%w(host bridge)))
           optional('logging').schema do
             optional('driver') { str? }
             optional('options') { type?(Hash) }


### PR DESCRIPTION
I haven't updated all rules to the new syntax, but basically in places where you have blocks w/o disjunctions you can just do `value(:some_predicate?)` and when it must be filled use `filled(:some_predicate?)` and when it can be nil do `maybe(:some_predicate?)`

Fixes #824