### PR TITLE
Index GridServiceDeploy#created_at/started_at fields

### DIFF
--- a/server/app/models/grid_service_deploy.rb
+++ b/server/app/models/grid_service_deploy.rb
@@ -6,6 +6,8 @@ class GridServiceDeploy
   field :finished_at, type: DateTime
 
   index({ grid_service_id: 1 })
+  index({ created_at: 1 })
+  index({ started_at: 1 })
 
   belongs_to :grid_service
 end

--- a/server/db/migrations/11_add_indexes_to_grid_service_deploy.rb
+++ b/server/db/migrations/11_add_indexes_to_grid_service_deploy.rb
@@ -1,0 +1,5 @@
+class AddIndexesToGridServiceDeploy < Mongodb::Migration
+  def self.up
+    GridServiceDeploy.create_indexes
+  end
+end

--- a/server/spec/models/grid_service_deploy.rb
+++ b/server/spec/models/grid_service_deploy.rb
@@ -4,4 +4,7 @@ describe GridServiceDeploy do
   it { should be_timestamped_document }
   it { should have_fields(:started_at, :finished_at).of_type(DateTime) }
   it { should belong_to(:grid_service) }
+  it { should have_index_for(grid_service_id: 1) }
+  it { should have_index_for(created_at: 1) }
+  it { should have_index_for(started_at: 1) }
 end


### PR DESCRIPTION
Otherwise db start to take hit after deployment count goes high.