### PR TITLE
Cookie lb support

### DIFF
--- a/agent/lib/kontena/load_balancers/configurer.rb
+++ b/agent/lib/kontena/load_balancers/configurer.rb
@@ -45,12 +45,14 @@ module Kontena::LoadBalancers
           virtual_path = env_hash['KONTENA_LB_VIRTUAL_PATH'] || '/'
         end
         keep_virtual_path = env_hash['KONTENA_LB_KEEP_VIRTUAL_PATH']
+        cookie = env_hash['KONTENA_LB_COOKIE']
         set("#{etcd_path}/services/#{service_name}/balance", balance)
         set("#{etcd_path}/services/#{service_name}/health_check_uri", check_uri)
         set("#{etcd_path}/services/#{service_name}/custom_settings", custom_settings)
         set("#{etcd_path}/services/#{service_name}/virtual_hosts", virtual_hosts)
         set("#{etcd_path}/services/#{service_name}/virtual_path", virtual_path)
         set("#{etcd_path}/services/#{service_name}/keep_virtual_path", keep_virtual_path)
+        set("#{etcd_path}/services/#{service_name}/cookie", cookie)
         rmdir("#{etcd_path}/tcp-services/#{service_name}") rescue nil
       else
         external_port = env_hash['KONTENA_LB_EXTERNAL_PORT'] || '5000'

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -88,6 +88,20 @@ describe Kontena::LoadBalancers::Configurer do
       subject.ensure_config(container)
     end
 
+    it 'sets cookie' do
+      container.env_hash['KONTENA_LB_COOKIE'] = ''
+      expect(etcd).to receive(:set).
+        with("#{etcd_prefix}/lb/services/test-api/cookie", {value: ''})
+      subject.ensure_config(container)
+    end
+
+    it 'removes cookie setting' do
+      container.env_hash.delete('KONTENA_LB_COOKIE')
+      expect(etcd).to receive(:delete).
+        with("#{etcd_prefix}/lb/services/test-api/cookie")
+      subject.ensure_config(container)
+    end
+
     it 'sets http check uri' do
       container.labels['io.kontena.health_check.uri'] = '/health'
       expect(etcd).to receive(:set).

--- a/docs/using-kontena/loadbalancer.md
+++ b/docs/using-kontena/loadbalancer.md
@@ -152,4 +152,5 @@ These options are defined on the services that are balanced through lb.
 * `KONTENA_LB_VIRTUAL_PATH`: path that is used to match request, example "/api" (only for http mode)
 * `KONTENA_LB_KEEP_VIRTUAL_PATH`: if set to true, virtual path will be kept in request path (only for http mode)
 * `KONTENA_LB_CUSTOM_SETTINGS`: extra settings, each line will be appended to either related backend section or listen session in the HAProxy configuration file
+* `KONTENA_LB_COOKIE`: Enables cookie based session stickyness. With empty value defaults to LB set cookie. Can be customized to utilize application cookies. See details at [HAProxy docs](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie)
 


### PR DESCRIPTION
This PR adds support for cookie based stickyness on loadbalancer.

Needs still docs, will add in coming commit

fixes #799 
requires https://github.com/kontena/kontena-loadbalancer/pull/18