### PR TITLE
Replug agent on successfull ping

### DIFF
--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -62,4 +62,29 @@ describe WebsocketBackend do
       sleep 0.05
     end
   end
+
+  describe '#on_pong' do
+    let(:client) do
+      { id: 'node_id', ws: spy(:ws) }
+    end
+
+    let(:grid) do
+      Grid.create!(name: 'test')
+    end
+
+    let(:node) do
+      HostNode.create!(name: 'test-node', node_id: 'aa', grid: grid)
+    end
+
+    it 'calls on_close if client is not found' do
+      expect(subject).to receive(:on_close).with(client[:ws])
+      subject.on_pong(client)
+    end
+
+    it 'triggers agent plug' do
+      expect(Agent::NodePlugger).to receive(:new).and_return(spy)
+      client[:id] = node.node_id
+      subject.on_pong(client)
+    end
+  end
 end


### PR DESCRIPTION
This PR improves situation where agent is somehow unplugged by any of the master instances and after that currently connected master instance sees that agent is still connected (by ping/pong).