### PR TITLE
Stream only container events 

### DIFF
--- a/agent/lib/kontena/workers/event_worker.rb
+++ b/agent/lib/kontena/workers/event_worker.rb
@@ -24,7 +24,7 @@ module Kontena::Workers
     def stream_events
       info 'started to stream docker events'
       begin
-        Docker::Event.stream do |event|
+        Docker::Event.stream(query: {type: 'container'}) do |event|
           self.publish_event(event)
         end
       rescue Docker::Error::TimeoutError


### PR DESCRIPTION
Fixes flaky behaviour with docker >= 1.10.0