### PR TITLE
Fix docker event stream filter params

### DIFF
--- a/agent/lib/kontena/workers/event_worker.rb
+++ b/agent/lib/kontena/workers/event_worker.rb
@@ -22,9 +22,10 @@ module Kontena::Workers
     end
 
     def stream_events
-      info 'started to stream docker events'
+      info 'started to stream docker container events'
+      filters = JSON.dump({type: ['container']})
       begin
-        Docker::Event.stream(query: {type: 'container'}) do |event|
+        Docker::Event.stream({filters: filters}) do |event|
           self.publish_event(event)
         end
       rescue Docker::Error::TimeoutError


### PR DESCRIPTION
Docker >= 1.10 accepts filters as json encoded value.