### PR TITLE
Fix deploying registry on azure

### DIFF
--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -55,7 +55,7 @@ module Kontena::Cli::Registry
         env = [
             "REGISTRY_STORAGE=azure",
             "REGISTRY_STORAGE_AZURE_ACCOUNTNAME=#{azure_account_name}",
-            "REGISTRY_STORAGE_AZURE_ACCOUNTKEY=#{azure_account_key}"
+            "REGISTRY_STORAGE_AZURE_CONTAINER=#{azure_container_name}"
         ]
         secrets = [
           {secret: 'REGISTRY_STORAGE_AZURE_ACCOUNTKEY', name: 'REGISTRY_STORAGE_AZURE_ACCOUNTKEY', type: 'env'}


### PR DESCRIPTION
I believe there was a small mistake in #489 which makes deploying registry on azure impossible.

Also it should be `REGISTRY_STORAGE_AZURE_CONTAINER` and not like was before `REGISTRY_STORAGE_AZURE_CONTAINERNAME`.