### PR TITLE
Handle env_file on YAML file parsing

### DIFF
--- a/cli/lib/kontena/cli/apps/service_generator.rb
+++ b/cli/lib/kontena/cli/apps/service_generator.rb
@@ -26,7 +26,7 @@ module Kontena::Cli::Apps
       data = {}
       data['container_count'] = options['instances']
       data['image'] = parse_image(options['image'])
-      data['env'] = merge_env_vars(options)
+      data['env'] = options['environment'] if options['environment']
       data['container_count'] = options['instances']
       data['links'] = parse_links(options['links'] || [])
       data['external_links'] = parse_links(options['external_links'] || [])
@@ -71,24 +71,6 @@ module Kontena::Cli::Apps
         data['health_check'] = health_check
       end
       data
-    end
-
-    # @param [Hash] options
-    def merge_env_vars(options)
-      return options['environment'] unless options['env_file']
-
-      options['env_file'] = [options['env_file']] if options['env_file'].is_a?(String)
-      options['environment'] = [] unless options['environment']
-      options['env_file'].each do |env_file|
-        options['environment'].concat(read_env_file(env_file))
-      end
-      options['environment'].uniq {|s| s.split('=').first}
-    end
-
-
-    # @param [String] path
-    def read_env_file(path)
-      File.readlines(path).delete_if { |line| line.start_with?('#') || line.strip.empty? }
     end
 
     # @param [Array<String>] port_options

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -89,6 +89,7 @@ module Kontena::Cli::Apps
       # @param [Hash] service_config
       def process_config(service_config)
         normalize_env_vars(service_config)
+        merge_env_vars(service_config)
         normalize_build_args(service_config)
         service_config = extend_config(service_config) if service_config.key?('extends')
         service_config
@@ -146,7 +147,26 @@ module Kontena::Cli::Apps
           options['environment'] = options['environment'].map { |k, v| "#{k}=#{v}" }
         end
       end
-      
+
+      # @param [Hash] options
+      def merge_env_vars(options)
+        return options['environment'] unless options['env_file']
+
+        options['env_file'] = [options['env_file']] if options['env_file'].is_a?(String)
+        options['environment'] = [] unless options['environment']
+        options['env_file'].each do |env_file|
+          options['environment'].concat(read_env_file(env_file))
+        end
+        options.delete('env_file')
+        options['environment'].uniq! { |s| s.split('=').first }
+      end
+
+
+      # @param [String] path
+      def read_env_file(path)
+        File.readlines(path).delete_if { |line| line.start_with?('#') || line.strip.empty? }.map { |line| line.strip }
+      end
+
       # @param [Hash] options - service config
       def normalize_build_args(options)
         if v2? && options.dig('build', 'args')

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -164,7 +164,7 @@ module Kontena::Cli::Apps
 
       # @param [String] path
       def read_env_file(path)
-        File.readlines(path).delete_if { |line| line.start_with?('#') || line.strip.empty? }.map { |line| line.strip }
+        File.readlines(path).map { |line| line.strip }.delete_if { |line| line.start_with?('#') || line.empty? }
       end
 
       # @param [Hash] options - service config

--- a/cli/spec/fixtures/kontena-with-env-file.yml
+++ b/cli/spec/fixtures/kontena-with-env-file.yml
@@ -1,0 +1,18 @@
+wordpress:
+  extends:
+    file: docker-compose.yml
+    service: wordpress
+  stateful: true
+  env_file: .env
+  environment:
+    WORDPRESS_DB_PASSWORD: %{project}_secret
+  instances: 2
+  deploy:
+    strategy: ha
+mysql:
+  extends:
+    file: docker-compose.yml
+    service: mysql
+  stateful: true
+  environment:
+    - MYSQL_ROOT_PASSWORD=%{project}_secret

--- a/cli/spec/kontena/cli/app/service_generator_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_spec.rb
@@ -6,12 +6,6 @@ describe Kontena::Cli::Apps::ServiceGenerator do
     described_class.new({})
   end
 
-  let(:env_file) do
-    'APIKEY=12345
-MYSQL_ROOT_PASSWORD=secret
-WP_ADMIN_PASSWORD=verysecret'.split(/\r?\n/)
-  end
-
   describe '#parse_data' do
     context 'volumes' do
       it 'returns volumes if set' do
@@ -387,50 +381,5 @@ WP_ADMIN_PASSWORD=verysecret'.split(/\r?\n/)
         expect(result['secrets']).to be_nil
       end
     end
-  end
-
-  describe '#read_env_file' do
-    before(:each) do
-      allow(File).to receive(:readlines).with('.env').and_return(env_file)
-    end
-    it 'reads given file' do
-      expect(File).to receive(:readlines).with('.env').and_return(env_file)
-      subject.send(:read_env_file, '.env')
-    end
-
-    it 'returns array' do
-      variables = subject.send(:read_env_file, '.env')
-      expect(variables).to eq([
-        'APIKEY=12345',
-        'MYSQL_ROOT_PASSWORD=secret',
-        'WP_ADMIN_PASSWORD=verysecret'
-        ])
-    end
-
-    it 'discards comment lines' do
-      result = env_file
-      result << "#COMMENTLINE"
-      allow(File).to receive(:readlines).with('.env').and_return(result)
-
-      variables = subject.send(:read_env_file, '.env')
-      expect(variables).to eq([
-        'APIKEY=12345',
-        'MYSQL_ROOT_PASSWORD=secret',
-        'WP_ADMIN_PASSWORD=verysecret'
-        ])
-    end
-
-    it 'discards empty lines' do
-      result = env_file
-      result << '
-'
-      allow(File).to receive(:readlines).with('.env').and_return(result)
-      variables = subject.send(:read_env_file, '.env')
-      expect(variables).to eq([
-        'APIKEY=12345',
-        'MYSQL_ROOT_PASSWORD=secret',
-        'WP_ADMIN_PASSWORD=verysecret'
-        ])
-    end
-  end
+  end  
 end


### PR DESCRIPTION
Currently environment variables are merged with variables from env_file after the YAML file is read and parsed. It means that the path of the env_file is related to directory where the command is executed not the directory of YAML file. For example this will fail if some service has `env_file:  .env` definition: 

`$ kontena app config -f ./subfolder/kontena.yml`

This PR moves env_file parsing to YAML reading phase and env_files are read correctly.