### PR TITLE
Fix weave slow start after node reboot

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -10,7 +10,7 @@ module Kontena::NetworkAdapters
     include Kontena::Helpers::IfaceHelper
     include Kontena::Logging
 
-    WEAVE_VERSION = ENV['WEAVE_VERSION'] || '1.6.0'
+    WEAVE_VERSION = ENV['WEAVE_VERSION'] || '1.5.2'
     WEAVE_IMAGE = ENV['WEAVE_IMAGE'] || 'weaveworks/weave'
     WEAVEEXEC_IMAGE = ENV['WEAVEEXEC_IMAGE'] || 'weaveworks/weaveexec'
 


### PR DESCRIPTION
Fixes #915 by downgrading Weave to 1.5.2.