### PR TITLE
Support for callbacks when running cli commands.

### DIFF
--- a/cli/lib/kontena/callback.rb
+++ b/cli/lib/kontena/callback.rb
@@ -1,0 +1,47 @@
+class Kontena::Callback
+
+  attr_reader :command
+
+  def initialize(command)
+    @command = command
+  end
+
+  # Register callback for command types it is supposed to run with.
+  def self.command_types(*cmd_types)
+    return @command_types if cmd_types.empty?
+
+    # In case you call command_types([array, items, here]) instead of command_types(array, items, here)
+    cmd_types = cmd_types.first if cmd_types.first.kind_of?(Array)
+
+    unless cmd_types.first.kind_of?(Hash)
+      cmd_types = Array(cmd_types).map{ |cmd_type| [cmd_type, :all] }.to_h
+    end
+
+    # Finally it should be normalized into a hash that looks like :cmd_class => :cmd_type, :app => :init, :grid => :all
+    cmd_types.first.each do |cmd_class, cmd_type|
+      Kontena::Callback.callbacks[cmd_class] ||= {}
+      Kontena::Callback.callbacks[cmd_class][cmd_type] ||= []
+      Kontena::Callback.callbacks[cmd_class][cmd_type] << self
+    end
+  end
+
+  def self.callbacks
+    @@callbacks ||= {}
+  end
+
+  def self.run_callbacks(cmd_type, state, obj)
+    [cmd_type.last, :all].compact.uniq.each do |cmd|
+      callbacks.fetch(cmd_type.first, {}).fetch(cmd, []).each do |klass|
+        if klass.instance_methods.include?(state)
+          cb = klass.new(obj)
+          if cb.send(state).kind_of?(FalseClass)
+            ENV["DEBUG"] && puts("Execution aborted by #{klass}")
+            exit 1
+          end
+        end
+      end
+    end
+  end
+end
+
+Dir[File.expand_path('../callbacks/**/*.rb', __FILE__)].sort_by{ |file| File.basename(file) }.each { |file| require file }

--- a/cli/lib/kontena/cli/app_command.rb
+++ b/cli/lib/kontena/cli/app_command.rb
@@ -12,7 +12,7 @@ require_relative 'apps/monitor_command'
 require_relative 'apps/show_command'
 require_relative 'apps/scale_command'
 
-class Kontena::Cli::AppCommand < Clamp::Command
+class Kontena::Cli::AppCommand < Kontena::Command
 
   subcommand "init", "Init Kontena application", Kontena::Cli::Apps::InitCommand
   subcommand "build", "Build Kontena services", Kontena::Cli::Apps::BuildCommand

--- a/cli/lib/kontena/cli/apps/build_command.rb
+++ b/cli/lib/kontena/cli/apps/build_command.rb
@@ -2,7 +2,7 @@ require_relative 'common'
 require_relative 'docker_helper'
 
 module Kontena::Cli::Apps
-  class BuildCommand < Clamp::Command
+  class BuildCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
     include DockerHelper

--- a/cli/lib/kontena/cli/apps/config_command.rb
+++ b/cli/lib/kontena/cli/apps/config_command.rb
@@ -2,7 +2,7 @@ require_relative 'common'
 require 'pp'
 
 module Kontena::Cli::Apps
-  class ConfigCommand < Clamp::Command
+  class ConfigCommand < Kontena::Command
     include Kontena::Cli::Common    
     include Common
 

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -3,7 +3,7 @@ require_relative 'common'
 require_relative 'docker_helper'
 
 module Kontena::Cli::Apps
-  class DeployCommand < Clamp::Command
+  class DeployCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -6,7 +6,7 @@ require_relative 'kontena_yml_generator'
 
 
 module Kontena::Cli::Apps
-  class InitCommand < Clamp::Command
+  class InitCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/apps/list_command.rb
+++ b/cli/lib/kontena/cli/apps/list_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class LogsCommand < Clamp::Command
+  class LogsCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/monitor_command.rb
+++ b/cli/lib/kontena/cli/apps/monitor_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class MonitorCommand < Clamp::Command
+  class MonitorCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/restart_command.rb
+++ b/cli/lib/kontena/cli/apps/restart_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class RestartCommand < Clamp::Command
+  class RestartCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/apps/scale_command.rb
+++ b/cli/lib/kontena/cli/apps/scale_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class ScaleCommand < Clamp::Command
+  class ScaleCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/show_command.rb
+++ b/cli/lib/kontena/cli/apps/show_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class ShowCommand < Clamp::Command
+  class ShowCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/start_command.rb
+++ b/cli/lib/kontena/cli/apps/start_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class StartCommand < Clamp::Command
+  class StartCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/apps/stop_command.rb
+++ b/cli/lib/kontena/cli/apps/stop_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Apps
-  class StopCommand < Clamp::Command
+  class StopCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -1,6 +1,6 @@
 
 module Kontena::Cli::Certificate
-  class AuthorizeCommand < Clamp::Command
+  class AuthorizeCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -1,6 +1,6 @@
 
 module Kontena::Cli::Certificate
-  class GetCommand < Clamp::Command
+  class GetCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/certificate/register_command.rb
+++ b/cli/lib/kontena/cli/certificate/register_command.rb
@@ -1,6 +1,6 @@
 
 module Kontena::Cli::Certificate
-  class RegisterCommand < Clamp::Command
+  class RegisterCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/certificate_command.rb
+++ b/cli/lib/kontena/cli/certificate_command.rb
@@ -2,7 +2,7 @@ require_relative 'certificate/register_command'
 require_relative 'certificate/authorize_command'
 require_relative 'certificate/get_command'
 
-class Kontena::Cli::CertificateCommand < Clamp::Command
+class Kontena::Cli::CertificateCommand < Kontena::Command
 
 
   subcommand "register", "Register to LetsEncrypt", Kontena::Cli::Certificate::RegisterCommand

--- a/cli/lib/kontena/cli/container_command.rb
+++ b/cli/lib/kontena/cli/container_command.rb
@@ -1,7 +1,7 @@
 require_relative 'containers/exec_command'
 require_relative 'containers/inspect_command'
 
-class Kontena::Cli::ContainerCommand < Clamp::Command
+class Kontena::Cli::ContainerCommand < Kontena::Command
 
   subcommand "exec", "Execute command inside a container", Kontena::Cli::Containers::ExecCommand
   subcommand "inspect", "Inspect the container", Kontena::Cli::Containers::InspectCommand

--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -2,7 +2,7 @@ require_relative '../grid_options'
 require_relative './containers_helper'
 
 module Kontena::Cli::Containers
-  class ExecCommand < Clamp::Command
+  class ExecCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ContainersHelper

--- a/cli/lib/kontena/cli/containers/inspect_command.rb
+++ b/cli/lib/kontena/cli/containers/inspect_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Containers
-  class InspectCommand < Clamp::Command
+  class InspectCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/etcd/get_command.rb
+++ b/cli/lib/kontena/cli/etcd/get_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Etcd
-  class GetCommand < Clamp::Command
+  class GetCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/etcd/list_command.rb
+++ b/cli/lib/kontena/cli/etcd/list_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Etcd
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/etcd/mkdir_command.rb
+++ b/cli/lib/kontena/cli/etcd/mkdir_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Etcd
-  class MkdirCommand < Clamp::Command
+  class MkdirCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/etcd/remove_command.rb
+++ b/cli/lib/kontena/cli/etcd/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Etcd
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/etcd/set_command.rb
+++ b/cli/lib/kontena/cli/etcd/set_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Etcd
-  class SetCommand < Clamp::Command
+  class SetCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/etcd_command.rb
+++ b/cli/lib/kontena/cli/etcd_command.rb
@@ -4,7 +4,7 @@ require_relative 'etcd/mkdir_command'
 require_relative 'etcd/list_command'
 require_relative 'etcd/remove_command'
 
-class Kontena::Cli::EtcdCommand < Clamp::Command
+class Kontena::Cli::EtcdCommand < Kontena::Command
 
   subcommand "get", "Get the current value for a single key", Kontena::Cli::Etcd::GetCommand
   subcommand "set", "Set a value on the specified key", Kontena::Cli::Etcd::SetCommand

--- a/cli/lib/kontena/cli/external_registries/add_command.rb
+++ b/cli/lib/kontena/cli/external_registries/add_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::ExternalRegistries
-  class AddCommand < Clamp::Command
+  class AddCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/external_registries/delete_command.rb
+++ b/cli/lib/kontena/cli/external_registries/delete_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::ExternalRegistries
-  class DeleteCommand < Clamp::Command
+  class DeleteCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/external_registries/list_command.rb
+++ b/cli/lib/kontena/cli/external_registries/list_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::ExternalRegistries
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/external_registries/remove_command.rb
+++ b/cli/lib/kontena/cli/external_registries/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::ExternalRegistries
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "NAME", "External registry name to remove"

--- a/cli/lib/kontena/cli/external_registry_command.rb
+++ b/cli/lib/kontena/cli/external_registry_command.rb
@@ -3,7 +3,7 @@ require_relative 'external_registries/list_command'
 require_relative 'external_registries/delete_command'
 require_relative 'external_registries/remove_command'
 
-class Kontena::Cli::ExternalRegistryCommand < Clamp::Command
+class Kontena::Cli::ExternalRegistryCommand < Kontena::Command
 
   subcommand "add", "Add external Docker image registry", Kontena::Cli::ExternalRegistries::AddCommand
   subcommand ["list", "ls"], "List external Docker image registries", Kontena::Cli::ExternalRegistries::ListCommand

--- a/cli/lib/kontena/cli/grid_command.rb
+++ b/cli/lib/kontena/cli/grid_command.rb
@@ -12,7 +12,7 @@ require_relative 'grids/user_command'
 require_relative 'grids/cloud_config_command'
 require_relative 'grids/trusted_subnet_command'
 
-class Kontena::Cli::GridCommand < Clamp::Command
+class Kontena::Cli::GridCommand < Kontena::Command
 
   subcommand ["list","ls"], "List all grids", Kontena::Cli::Grids::ListCommand
   subcommand "create", "Create a new grid", Kontena::Cli::Grids::CreateCommand

--- a/cli/lib/kontena/cli/grids/audit_log_command.rb
+++ b/cli/lib/kontena/cli/grids/audit_log_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class AuditLogCommand < Clamp::Command
+  class AuditLogCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/cloud_config_command.rb
+++ b/cli/lib/kontena/cli/grids/cloud_config_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class CloudConfigCommand < Clamp::Command
+  class CloudConfigCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class CreateCommand < Clamp::Command
+  class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/current_command.rb
+++ b/cli/lib/kontena/cli/grids/current_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class CurrentCommand < Clamp::Command
+  class CurrentCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/env_command.rb
+++ b/cli/lib/kontena/cli/grids/env_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class EnvCommand < Clamp::Command
+  class EnvCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/list_command.rb
+++ b/cli/lib/kontena/cli/grids/list_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Grids
-  class LogsCommand < Clamp::Command
+  class LogsCommand < Kontena::Command
     include Kontena::Cli::Common
 
     option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false

--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/show_command.rb
+++ b/cli/lib/kontena/cli/grids/show_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class ShowCommand < Clamp::Command
+  class ShowCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Grids
   require_relative 'trusted_subnets/add_command'
   require_relative 'trusted_subnets/remove_command'
 
-  class TrustedSubnetCommand < Clamp::Command
+  class TrustedSubnetCommand < Kontena::Command
     subcommand ["list", "ls"], "List trusted subnets", TrustedSubnets::ListCommand
     subcommand "add", "Add trusted subnet", TrustedSubnets::AddCommand
     subcommand ["remove", "rm"], "Remove trusted subnet", TrustedSubnets::RemoveCommand

--- a/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Grids::TrustedSubnets
-  class AddCommand < Clamp::Command
+  class AddCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "NAME", "Grid name"

--- a/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Grids::TrustedSubnets
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "NAME", "Grid name"

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Grids::TrustedSubnets
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "NAME", "Grid name"

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class UpdateCommand < Clamp::Command
+  class UpdateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/use_command.rb
+++ b/cli/lib/kontena/cli/grids/use_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Grids
-  class UseCommand < Clamp::Command
+  class UseCommand < Kontena::Command
     include Kontena::Cli::Common
     include Common
 

--- a/cli/lib/kontena/cli/grids/user_command.rb
+++ b/cli/lib/kontena/cli/grids/user_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Grids
   require_relative 'users/add_command'
   require_relative 'users/remove_command'
 
-  class UserCommand < Clamp::Command
+  class UserCommand < Kontena::Command
     subcommand ["list", "ls"], "List grid users", Users::ListCommand
     subcommand "add", "Add user to grid", Users::AddCommand
     subcommand ["remove", "rm"], "Remove user from grid", Users::RemoveCommand

--- a/cli/lib/kontena/cli/grids/users/add_command.rb
+++ b/cli/lib/kontena/cli/grids/users/add_command.rb
@@ -1,7 +1,7 @@
 require_relative '../common'
 
 module Kontena::Cli::Grids::Users
-  class AddCommand < Clamp::Command
+  class AddCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Grids::Common

--- a/cli/lib/kontena/cli/grids/users/list_command.rb
+++ b/cli/lib/kontena/cli/grids/users/list_command.rb
@@ -1,7 +1,7 @@
 require_relative '../common'
 
 module Kontena::Cli::Grids::Users
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::Grids::Common
 

--- a/cli/lib/kontena/cli/grids/users/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/users/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative '../common'
 
 module Kontena::Cli::Grids::Users
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Grids::Common

--- a/cli/lib/kontena/cli/login_command.rb
+++ b/cli/lib/kontena/cli/login_command.rb
@@ -1,4 +1,4 @@
-class Kontena::Cli::LoginCommand < Clamp::Command
+class Kontena::Cli::LoginCommand < Kontena::Command
   include Kontena::Cli::Common
 
   parameter "URL", "Kontena Master URI"

--- a/cli/lib/kontena/cli/logout_command.rb
+++ b/cli/lib/kontena/cli/logout_command.rb
@@ -1,4 +1,4 @@
-class Kontena::Cli::LogoutCommand < Clamp::Command
+class Kontena::Cli::LogoutCommand < Kontena::Command
   include Kontena::Cli::Common
 
   def execute

--- a/cli/lib/kontena/cli/master/current_command.rb
+++ b/cli/lib/kontena/cli/master/current_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Master
-  class CurrentCommand < Clamp::Command
+  class CurrentCommand < Kontena::Command
     include Kontena::Cli::Common
 
     option ["--name"], :flag, "Show name only", default: false

--- a/cli/lib/kontena/cli/master/list_command.rb
+++ b/cli/lib/kontena/cli/master/list_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Master
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
 
     def execute

--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Master
-  class UseCommand < Clamp::Command
+  class UseCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "NAME", "Master name to use"

--- a/cli/lib/kontena/cli/master/users/invite_command.rb
+++ b/cli/lib/kontena/cli/master/users/invite_command.rb
@@ -1,7 +1,7 @@
 require_relative '../../common'
 
 module Kontena::Cli::Master::Users
-  class InviteCommand < Clamp::Command
+  class InviteCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "EMAIL ...", "List of emails"

--- a/cli/lib/kontena/cli/master/users/list_command.rb
+++ b/cli/lib/kontena/cli/master/users/list_command.rb
@@ -1,7 +1,7 @@
 require_relative '../../common'
 
 module Kontena::Cli::Master::Users
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
 
     def execute

--- a/cli/lib/kontena/cli/master/users/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative '../../common'
 
 module Kontena::Cli::Master::Users
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "EMAIL ...", "List of emails"

--- a/cli/lib/kontena/cli/master/users/role_command.rb
+++ b/cli/lib/kontena/cli/master/users/role_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Master::Users
   require_relative 'roles/add_command'
   require_relative 'roles/remove_command'
 
-  class RoleCommand < Clamp::Command
+  class RoleCommand < Kontena::Command
     subcommand "add", "Add role to user", Roles::AddCommand
     subcommand ["remove", "rm"], "Remove role from user", Roles::RemoveCommand
   end

--- a/cli/lib/kontena/cli/master/users/roles/add_command.rb
+++ b/cli/lib/kontena/cli/master/users/roles/add_command.rb
@@ -1,7 +1,7 @@
 require_relative '../../../common'
 
 module Kontena::Cli::Master::Users::Roles
-  class AddCommand < Clamp::Command
+  class AddCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "ROLE", "Role name"

--- a/cli/lib/kontena/cli/master/users/roles/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/roles/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative '../../../common'
 
 module Kontena::Cli::Master::Users::Roles
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "ROLE", "Role name"

--- a/cli/lib/kontena/cli/master/users_command.rb
+++ b/cli/lib/kontena/cli/master/users_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Master
   require_relative 'users/list_command'
   require_relative 'users/role_command'
 
-  class UsersCommand < Clamp::Command
+  class UsersCommand < Kontena::Command
     subcommand "invite", "Invite user to Kontena Master", Users::InviteCommand
     subcommand ["remove", "rm"], "Remove user from Kontena Master", Users::RemoveCommand
     subcommand ["list", "ls"], "List users", Users::ListCommand

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -3,7 +3,7 @@ require_relative 'master/list_command'
 require_relative 'master/users_command'
 require_relative 'master/current_command'
 
-class Kontena::Cli::MasterCommand < Clamp::Command
+class Kontena::Cli::MasterCommand < Kontena::Command
 
   subcommand ["list", "ls"], "List masters where client has logged in", Kontena::Cli::Master::ListCommand
   subcommand "use", "Switch to use selected master", Kontena::Cli::Master::UseCommand

--- a/cli/lib/kontena/cli/node_command.rb
+++ b/cli/lib/kontena/cli/node_command.rb
@@ -5,7 +5,7 @@ require_relative 'nodes/update_command'
 require_relative 'nodes/ssh_command'
 require_relative 'nodes/label_command'
 
-class Kontena::Cli::NodeCommand < Clamp::Command
+class Kontena::Cli::NodeCommand < Kontena::Command
 
   subcommand ["list","ls"], "List grid nodes", Kontena::Cli::Nodes::ListCommand
   subcommand "show", "Show node", Kontena::Cli::Nodes::ShowCommand

--- a/cli/lib/kontena/cli/nodes/label_command.rb
+++ b/cli/lib/kontena/cli/nodes/label_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Nodes
   require_relative 'labels/add_command'
   require_relative 'labels/remove_command'
 
-  class LabelCommand < Clamp::Command
+  class LabelCommand < Kontena::Command
 
     subcommand "add", "Add label to node", Labels::AddCommand
     subcommand ["remove", "rm"], "Remove label from node", Labels::RemoveCommand

--- a/cli/lib/kontena/cli/nodes/labels/add_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/add_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Nodes::Labels
-  class AddCommand < Clamp::Command
+  class AddCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "NODE_ID", "Node id"

--- a/cli/lib/kontena/cli/nodes/labels/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Nodes::Labels
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "NODE_ID", "Node id"

--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Nodes
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Nodes
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Nodes
-  class ShowCommand < Clamp::Command
+  class ShowCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::BytesHelper

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Nodes
-  class SshCommand < Clamp::Command
+  class SshCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/nodes/update_command.rb
+++ b/cli/lib/kontena/cli/nodes/update_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Nodes
-  class UpdateCommand < Clamp::Command
+  class UpdateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/plugin_command.rb
+++ b/cli/lib/kontena/cli/plugin_command.rb
@@ -3,7 +3,7 @@ require_relative 'plugins/search_command'
 require_relative 'plugins/install_command'
 require_relative 'plugins/uninstall_command'
 
-class Kontena::Cli::PluginCommand < Clamp::Command
+class Kontena::Cli::PluginCommand < Kontena::Command
 
   subcommand ["list","ls"], "List plugins", Kontena::Cli::Plugins::ListCommand
   subcommand "search", "Search plugins", Kontena::Cli::Plugins::SearchCommand

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -1,7 +1,7 @@
 require 'open3'
 
 module Kontena::Cli::Plugins
-  class InstallCommand < Clamp::Command
+  class InstallCommand < Kontena::Command
     include Kontena::Util
 
     parameter 'NAME', 'Plugin name'

--- a/cli/lib/kontena/cli/plugins/list_command.rb
+++ b/cli/lib/kontena/cli/plugins/list_command.rb
@@ -1,6 +1,6 @@
 
 module Kontena::Cli::Plugins
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
 
     def execute
       titles = ['NAME', 'VERSION', 'DESCRIPTION']

--- a/cli/lib/kontena/cli/plugins/search_command.rb
+++ b/cli/lib/kontena/cli/plugins/search_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Plugins
-  class SearchCommand < Clamp::Command
+  class SearchCommand < Kontena::Command
 
     parameter '[NAME]', 'Search text'
 

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -1,7 +1,7 @@
 require 'open3'
 
 module Kontena::Cli::Plugins
-  class UninstallCommand < Clamp::Command
+  class UninstallCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter 'NAME', 'Plugin name'

--- a/cli/lib/kontena/cli/register_command.rb
+++ b/cli/lib/kontena/cli/register_command.rb
@@ -1,4 +1,4 @@
-class Kontena::Cli::RegisterCommand < Clamp::Command
+class Kontena::Cli::RegisterCommand < Kontena::Command
   include Kontena::Cli::Common
 
   option "--auth-provider-url", "AUTH_PROVIDER_URL", "Auth provider URL"

--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -1,7 +1,7 @@
 require 'shell-spinner'
 
 module Kontena::Cli::Registry
-  class CreateCommand < Clamp::Command
+  class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/registry/delete_command.rb
+++ b/cli/lib/kontena/cli/registry/delete_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Registry
-  class DeleteCommand < Clamp::Command
+  class DeleteCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/registry/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Registry
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced

--- a/cli/lib/kontena/cli/registry_command.rb
+++ b/cli/lib/kontena/cli/registry_command.rb
@@ -2,7 +2,7 @@ require_relative 'registry/create_command'
 require_relative 'registry/delete_command'
 require_relative 'registry/remove_command'
 
-class Kontena::Cli::RegistryCommand < Clamp::Command
+class Kontena::Cli::RegistryCommand < Kontena::Command
 
   subcommand "create", "Create Docker image registry service", Kontena::Cli::Registry::CreateCommand
   subcommand ["remove","rm"], "Remove Docker image registry service", Kontena::Cli::Registry::RemoveCommand

--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -20,7 +20,7 @@ require_relative 'services/secret_command'
 require_relative 'services/link_command'
 require_relative 'services/unlink_command'
 
-class Kontena::Cli::ServiceCommand < Clamp::Command
+class Kontena::Cli::ServiceCommand < Kontena::Command
 
   subcommand ["list","ls"], "List services", Kontena::Cli::Services::ListCommand
   subcommand "create", "Create a new service", Kontena::Cli::Services::CreateCommand

--- a/cli/lib/kontena/cli/services/container_command.rb
+++ b/cli/lib/kontena/cli/services/container_command.rb
@@ -1,6 +1,6 @@
 require_relative 'containers/exec_command'
 
-class Kontena::Cli::ContainerCommand < Clamp::Command
+class Kontena::Cli::ContainerCommand < Kontena::Command
 
   subcommand "exec", "Execute command inside a container", Kontena::Cli::Containers::ExecCommand
 

--- a/cli/lib/kontena/cli/services/containers_command.rb
+++ b/cli/lib/kontena/cli/services/containers_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class ContainersCommand < Clamp::Command
+  class ContainersCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class CreateCommand < Clamp::Command
+  class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/delete_command.rb
+++ b/cli/lib/kontena/cli/services/delete_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class DeleteCommand < Clamp::Command
+  class DeleteCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class DeployCommand < Clamp::Command
+  class DeployCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/env_command.rb
+++ b/cli/lib/kontena/cli/services/env_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Services
   require_relative 'envs/list_command'
   require_relative 'envs/remove_command'
 
-  class EnvCommand < Clamp::Command
+  class EnvCommand < Kontena::Command
     subcommand ["list", "ls"], "List service environment variables", Envs::ListCommand
     subcommand "add", "Add environment variable", Envs::AddCommand
     subcommand ["remove", "rm"], "Remove environment variable", Envs::RemoveCommand

--- a/cli/lib/kontena/cli/services/envs/add_command.rb
+++ b/cli/lib/kontena/cli/services/envs/add_command.rb
@@ -1,7 +1,7 @@
 require_relative '../services_helper'
 
 module Kontena::Cli::Services::Envs
-  class AddCommand < Clamp::Command
+  class AddCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper

--- a/cli/lib/kontena/cli/services/envs/list_command.rb
+++ b/cli/lib/kontena/cli/services/envs/list_command.rb
@@ -1,7 +1,7 @@
 require_relative '../services_helper'
 
 module Kontena::Cli::Services::Envs
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper

--- a/cli/lib/kontena/cli/services/envs/remove_command.rb
+++ b/cli/lib/kontena/cli/services/envs/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative '../services_helper'
 
 module Kontena::Cli::Services::Envs
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper

--- a/cli/lib/kontena/cli/services/link_command.rb
+++ b/cli/lib/kontena/cli/services/link_command.rb
@@ -2,7 +2,7 @@ require_relative '../grid_options'
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class LinkCommand < Clamp::Command
+  class LinkCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class LogsCommand < Clamp::Command
+  class LogsCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/monitor_command.rb
+++ b/cli/lib/kontena/cli/services/monitor_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class MonitorCommand < Clamp::Command
+  class MonitorCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/restart_command.rb
+++ b/cli/lib/kontena/cli/services/restart_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class RestartCommand < Clamp::Command
+  class RestartCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/scale_command.rb
+++ b/cli/lib/kontena/cli/services/scale_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class ScaleCommand < Clamp::Command
+  class ScaleCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/secret_command.rb
+++ b/cli/lib/kontena/cli/services/secret_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Services
   require_relative 'secrets/link_command'
   require_relative 'secrets/unlink_command'
 
-  class SecretCommand < Clamp::Command
+  class SecretCommand < Kontena::Command
     subcommand "link", "Link secret from Vault", Secrets::LinkCommand
     subcommand "unlink", "Unlink secret from Vault", Secrets::UnlinkCommand
   end

--- a/cli/lib/kontena/cli/services/secrets/link_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/link_command.rb
@@ -1,7 +1,7 @@
 require_relative '../services_helper'
 
 module Kontena::Cli::Services::Secrets
-  class LinkCommand < Clamp::Command
+  class LinkCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper

--- a/cli/lib/kontena/cli/services/secrets/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/unlink_command.rb
@@ -1,7 +1,7 @@
 require_relative '../services_helper'
 
 module Kontena::Cli::Services::Secrets
-  class UnlinkCommand < Clamp::Command
+  class UnlinkCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper

--- a/cli/lib/kontena/cli/services/show_command.rb
+++ b/cli/lib/kontena/cli/services/show_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class ShowCommand < Clamp::Command
+  class ShowCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/start_command.rb
+++ b/cli/lib/kontena/cli/services/start_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class StartCommand < Clamp::Command
+  class StartCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/stats_command.rb
+++ b/cli/lib/kontena/cli/services/stats_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class StatsCommand < Clamp::Command
+  class StatsCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/stop_command.rb
+++ b/cli/lib/kontena/cli/services/stop_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class StopCommand < Clamp::Command
+  class StopCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/unlink_command.rb
@@ -2,7 +2,7 @@ require_relative '../grid_options'
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class UnlinkCommand < Clamp::Command
+  class UnlinkCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -1,7 +1,7 @@
 require_relative 'services_helper'
 
 module Kontena::Cli::Services
-  class UpdateCommand < Clamp::Command
+  class UpdateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper

--- a/cli/lib/kontena/cli/stack_command.rb
+++ b/cli/lib/kontena/cli/stack_command.rb
@@ -5,7 +5,7 @@ require_relative 'stacks/update_command'
 require_relative 'stacks/list_command'
 require_relative 'stacks/show_command'
 
-class Kontena::Cli::StackCommand < Clamp::Command
+class Kontena::Cli::StackCommand < Kontena::Command
 
   subcommand "create", "Create stack", Kontena::Cli::Stacks::CreateCommand
   subcommand ["ls", "list"], "List stacks", Kontena::Cli::Stacks::ListCommand

--- a/cli/lib/kontena/cli/stacks/create_command.rb
+++ b/cli/lib/kontena/cli/stacks/create_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Stacks
-  class CreateCommand < Clamp::Command
+  class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Stacks
-  class DeployCommand < Clamp::Command
+  class DeployCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Stacks
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/stacks/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/remove_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Stacks
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Stacks
-  class ShowCommand < Clamp::Command
+  class ShowCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/stacks/update_command.rb
+++ b/cli/lib/kontena/cli/stacks/update_command.rb
@@ -1,7 +1,7 @@
 require_relative 'common'
 
 module Kontena::Cli::Stacks
-  class UpdateCommand < Clamp::Command
+  class UpdateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common

--- a/cli/lib/kontena/cli/user/forgot_password_command.rb
+++ b/cli/lib/kontena/cli/user/forgot_password_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::User
-  class ForgotPasswordCommand < Clamp::Command
+  class ForgotPasswordCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "EMAIL", "Email address"

--- a/cli/lib/kontena/cli/user/reset_password_command.rb
+++ b/cli/lib/kontena/cli/user/reset_password_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::User
-  class ResetPasswordCommand < Clamp::Command
+  class ResetPasswordCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "TOKEN", "Password reset token"

--- a/cli/lib/kontena/cli/user/verify_command.rb
+++ b/cli/lib/kontena/cli/user/verify_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::User
-  class VerifyCommand < Clamp::Command
+  class VerifyCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter "TOKEN", "Kontena verify token"

--- a/cli/lib/kontena/cli/user_command.rb
+++ b/cli/lib/kontena/cli/user_command.rb
@@ -2,7 +2,7 @@ require_relative 'user/verify_command'
 require_relative 'user/forgot_password_command'
 require_relative 'user/reset_password_command'
 
-class Kontena::Cli::UserCommand < Clamp::Command
+class Kontena::Cli::UserCommand < Kontena::Command
 
   subcommand "verify", "Verify user account", Kontena::Cli::User::VerifyCommand
   subcommand "forgot-password", "Request password reset for Kontena account", Kontena::Cli::User::ForgotPasswordCommand

--- a/cli/lib/kontena/cli/vault/list_command.rb
+++ b/cli/lib/kontena/cli/vault/list_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vault
-  class ListCommand < Clamp::Command
+  class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/vault/read_command.rb
+++ b/cli/lib/kontena/cli/vault/read_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vault
-  class ReadCommand < Clamp::Command
+  class ReadCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vault
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vault
-  class UpdateCommand < Clamp::Command
+  class UpdateCommand < Kontena::Command
     include Kontena::Cli::Common
 
     parameter 'NAME', 'Secret name'

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vault
-  class WriteCommand < Clamp::Command
+  class WriteCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/vault_command.rb
+++ b/cli/lib/kontena/cli/vault_command.rb
@@ -4,7 +4,7 @@ require_relative 'vault/read_command'
 require_relative 'vault/remove_command'
 require_relative 'vault/update_command'
 
-class Kontena::Cli::VaultCommand < Clamp::Command
+class Kontena::Cli::VaultCommand < Kontena::Command
 
   subcommand ["list", "ls"], "List secrets", Kontena::Cli::Vault::ListCommand
   subcommand "write", "Write a secret", Kontena::Cli::Vault::WriteCommand

--- a/cli/lib/kontena/cli/version_command.rb
+++ b/cli/lib/kontena/cli/version_command.rb
@@ -1,6 +1,6 @@
 require_relative 'version'
 
-class Kontena::Cli::VersionCommand < Clamp::Command
+class Kontena::Cli::VersionCommand < Kontena::Command
   include Kontena::Cli::Common
 
   def execute

--- a/cli/lib/kontena/cli/vpn/config_command.rb
+++ b/cli/lib/kontena/cli/vpn/config_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vpn
-  class ConfigCommand < Clamp::Command
+  class ConfigCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/vpn/create_command.rb
+++ b/cli/lib/kontena/cli/vpn/create_command.rb
@@ -1,7 +1,7 @@
 require 'shell-spinner'
 
 module Kontena::Cli::Vpn
-  class CreateCommand < Clamp::Command
+  class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/vpn/delete_command.rb
+++ b/cli/lib/kontena/cli/vpn/delete_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vpn
-  class DeleteCommand < Clamp::Command
+  class DeleteCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 

--- a/cli/lib/kontena/cli/vpn/remove_command.rb
+++ b/cli/lib/kontena/cli/vpn/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Vpn
-  class RemoveCommand < Clamp::Command
+  class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced

--- a/cli/lib/kontena/cli/vpn_command.rb
+++ b/cli/lib/kontena/cli/vpn_command.rb
@@ -3,7 +3,7 @@ require_relative 'vpn/config_command'
 require_relative 'vpn/remove_command'
 require_relative 'vpn/delete_command'
 
-class Kontena::Cli::VpnCommand < Clamp::Command
+class Kontena::Cli::VpnCommand < Kontena::Command
 
   subcommand "create", "Create VPN service", Kontena::Cli::Vpn::CreateCommand
   subcommand "config", "Show/Export VPN config", Kontena::Cli::Vpn::ConfigCommand

--- a/cli/lib/kontena/cli/whoami_command.rb
+++ b/cli/lib/kontena/cli/whoami_command.rb
@@ -1,4 +1,4 @@
-class Kontena::Cli::WhoamiCommand < Clamp::Command
+class Kontena::Cli::WhoamiCommand < Kontena::Command
   include Kontena::Cli::Common
 
   option '--bash-completion-path', :flag, 'Show bash completion path', hidden: true

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -1,4 +1,75 @@
 require 'clamp'
+require_relative 'callback'
 
 class Kontena::Command < Clamp::Command
+
+  attr_accessor :arguments
+  attr_reader :result
+  attr_reader :exit_code
+
+  def self.inherited(where)
+    name_parts = where.name.split('::')[-2, 2]
+
+    unless name_parts.nil?
+      # 1: Remove trailing 'Command' from for example AuthCommand
+      # 2: Convert the string from CamelCase to under_score
+      # 3: Convert the string into a symbol
+      #
+      # In comes: ['ExternalRegistry', 'UseCommand']
+      # Out goes: [:external_registry, :use]
+      name_parts = name_parts.map { |np|
+        np.gsub(/Command$/, '').
+        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+        gsub(/([a-z\d])([A-Z])/,'\1_\2').
+        tr("-", "_").
+        downcase.
+        to_sym
+      }
+      where.command_type(*name_parts)
+    end
+
+    # Run all #after_load callbacks for this command.
+    [name_parts.last, :all].compact.uniq.each do |cmd_type|
+      if Kontena::Callback.callbacks.fetch(name_parts.first, {}).fetch(cmd_type, nil)
+        Kontena::Callback.callbacks[name_parts.first][cmd_type].each do |cb|
+          if cb.instance_methods.include?(:after_load)
+            cb.new(where).after_load
+          end
+        end
+      end
+    end
+  end
+
+  def self.command_type(cmd_class = nil, cmd_type = nil)
+    unless cmd_class
+      return nil unless @command_class
+      return [@command_class, @command_type]
+    end
+    @command_class = cmd_class
+    @command_type = cmd_type
+    [@command_class, @command_type]
+  end
+
+  def run_callbacks(state)
+    if self.class.respond_to?(:command_type) && !self.class.command_type.nil?
+      Kontena::Callback.run_callbacks(self.class.command_type, state, self)
+    end
+  end
+
+  def run(arguments)
+    ENV["DEBUG"] && puts("Running #{self} -- callback command type = #{Hash[self.class.command_type.first, self.class.command_type.last]}")
+    @arguments = arguments
+    run_callbacks :before_parse
+    parse @arguments
+    run_callbacks :before
+    begin
+      @result = execute
+      @exit_code = @result.kind_of?(FalseClass) ? 1 : 0
+    rescue SystemExit => exc
+      @result = exc.status == 0
+      @exit_code = exc.status
+    end
+    run_callbacks :after
+    exit @exit_code 
+  end
 end

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -1,6 +1,7 @@
 module Kontena; end
 
 require 'ruby_dig'
+require_relative 'kontena/command'
 require_relative 'kontena/client'
 require_relative 'kontena/plugin_manager'
 require_relative 'kontena/main_command'

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -7,6 +7,7 @@
 
 require 'clamp'
 require 'ruby_dig'
+require 'kontena/command'
 require 'kontena/cli/common'
 require 'kontena/cli/grid_options'
 require 'kontena/client'


### PR DESCRIPTION
Adds callback support to Kontena::Command

Types of callbacks:
 - after_load runs after command is loaded. With this you can for
   example add parameters. Example:
```ruby
   def after_load
     command.class_eval do
       option ["--auth-token"], '[AUTH_TOKEN]', 'Use authentication
       token'
     end
   end
```
 - before runs before command's #execute method
 - after runs after command's #execute method
 - before_parse runs before command line parameters are parsed.

Here is an example of a callback that runs after provisioning a master and suggests inviting yourself as a regular user if you are currently using the master's local "admin" account:

```ruby
class SuggestInvitingYourself < Kontena::Callback

  include Kontena::Cli::Common

  # Runs for all commands that are something like:
  # Kontena::Cli::Vagrant::Master::CreateCommand
  command_types :master =>  :create

  # Runs after the original command's #execute method
  def after
    # .command is an accessor to the original command instance.
    # command.exit_code is 1 when the original command exited with "exit(1)"
    return nil unless command.exit_code == 0

    if current_master && current_master.username.to_s == 'admin'
      puts
      puts "Protip:"
      puts "  You are currently using Kontena Master administrator account."
      puts "  Consider inviting yourself as a regular user and using the"
      puts "  returned invite code to authenticate. Use:"
      puts "    kontena master users invite your@email.address.example.com"
      puts "    kontena auth master --join <invite_code>"
      puts
    end
  end
end
```