### PR TITLE
New more object oriented config handler

### DIFF
--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -1,0 +1,477 @@
+require 'ostruct'
+require 'singleton'
+require 'forwardable'
+require 'json'
+require 'logger'
+
+module Kontena
+  module Cli
+    # Helper to access and update the CLI configuration file.
+    #
+    # Also provides a "fake" config hash that behaves just like the file based
+    # config when ENV-variables are used instead of config file.
+    class Config < OpenStruct
+      include Singleton
+
+      attr_accessor :logger
+      attr_accessor :current_server
+      attr_reader :current_account
+
+      def self.reset_instance
+        Singleton.send :__init__, self
+        self
+      end
+
+      class TokenExpiredError < StandardError;  end
+
+      def initialize
+        @logger = Logger.new(STDOUT)
+        @logger.level = ENV["DEBUG"].nil? ? Logger::INFO : Logger::DEBUG
+        @logger.progname = 'CONFIG'
+        load_settings_from_env || load_settings_from_config_file
+
+        logger.debug "Configuration loaded with #{servers.count} servers."
+        logger.debug "Current master: #{current_server || '(not selected)'}"
+        logger.debug "Current grid: #{current_grid || '(not selected)'}"
+      end
+
+      # Craft a regular looking configuration based on ENV variables
+      def load_settings_from_env
+        return nil unless ENV['KONTENA_URL']
+        logger.debug 'Loading configuration from ENV'
+        servers << Server.new(
+          url: ENV['KONTENA_URL'], 
+          name: 'default',
+          token: Token.new(access_token: ENV['KONTENA_TOKEN']),
+          grid: ENV['KONTENA_GRID'],
+          parent_type: :master,
+          parent_name: 'default'
+        )
+        accounts << Account.new(
+          url: ENV['AUTH_API_URL'] || 'https://auth.kontena.io',
+          name: 'kontena',
+          token: Token.new(access_token: ENV['KONTENA_ACCOUNT_TOKEN'], parent_type: :account, parent_name: 'default')
+        )
+
+        self.current_master  = 'default'
+        self.current_account = 'kontena'
+      end
+
+      def extract_token!(hash={})
+        Token.new(
+          access_token: hash.delete('token'),
+          refresh_token: hash.delete('refresh_token'),
+          expires_at: hash.delete('token_expires_at').to_i
+        )
+      end
+
+      # Load configuration from default location ($HOME/.kontena_client.json)
+      def load_settings_from_config_file
+        settings = config_file_available? ? parse_config_file : default_settings
+
+        Array(settings['servers']).each do |server_data|
+          if server_data['token']
+            token = extract_token!(server_data)
+            token.parent_type = :master
+            token.parent_name = server_data['name']
+            server = Server.new(server_data)
+            server.token = token
+          else
+            server = Server.new(server_data)
+          end
+          servers << server
+        end
+
+        self.current_server = settings['current_server']
+
+        Array(settings['accounts']).each do |account_data|
+          if account_data['token']
+            token = extract_token!(account_data)
+            token.parent_type = :account
+            token.parent_name = account_data['name']
+            account = Account.new(account_data)
+            account.token = token
+          else
+            account = Account.new(account_data)
+          end
+          accounts << account
+        end
+
+        accounts << Account.new(kontena_account_data) unless find_account('kontena')
+        accounts << Account.new(master_account_data)  unless find_account('master')
+
+        self.current_account = settings['current_account'] || 'kontena'
+      end
+
+      def kontena_account_data
+        {
+          name: 'kontena',
+          url: 'https://auth.kontena.io',
+          token_endpoint: '/v1/oauth2/token',
+          authorization_endpoint: '/v1/authorizations',
+          token_verify_path: '/v1/authorizations',
+        }
+      end
+
+      def master_account_data
+        {
+          name: 'master',
+          token_endpoint: '/oauth2/token',
+          authorization_endpoint: '/oauth2/authorize',
+          redirection_endpoint: '/cb',
+          token_verify_path: '/v1/user'
+        }
+      end
+
+      # Verifies access to existing configuration file
+      #
+      # @return [Boolean]
+      def config_file_available?
+        File.exist?(config_filename) && File.readable?(config_filename)
+      end
+
+      # Default settings hash, used when configuration file does not exist.
+      #
+      # @return [Hash]
+      def default_settings
+        logger.debug 'Configuration file not found, using default settings.'
+        {
+          'current_server' => 'default',
+          'servers' => []
+        }
+      end
+
+      # Converts old style settings hash into modern one
+      #
+      # @param [Hash] settings_hash
+      # @return [Hash] migrated_settings_hash
+      def migrate_legacy_settings(settings)
+        logger.debug "Migrating from legacy style configuration"
+        {
+          'current_server' => 'default',
+          'servers' => [ 
+            settings['server'].merge(
+              'name' => 'default',
+              'account' => 'kontena'
+            )
+          ],
+          'accounts' => [ kontena_account_data ]
+        }
+      end
+
+      # Read, parse and migrate the configuration file
+      #
+      # @return [Hash] config_data
+      def parse_config_file
+        logger.debug "Loading configuration from #{config_filename}"
+        settings = JSON.load(File.read(config_filename))
+        if settings.has_key?('server')
+          settings = migrate_legacy_settings(settings)
+        else
+          settings
+        end
+      end
+
+      # Return the configuration file path. You can override the default
+      # by using KONTENA_CONFIG environment variable.
+      #
+      # @return [String] path
+      def config_filename
+        @config_filename ||= ENV['KONTENA_CONFIG'] || default_config_filename
+      end
+
+      # Generate the default configuration filename
+      def default_config_filename
+        File.join(Dir.home, '.kontena_client.json')
+      end
+
+      # List of configured servers
+      #
+      # @return [Array]
+      def servers
+        @servers ||= []
+      end
+
+      # List of configured accounts
+      #
+      # @return [Array]
+      def accounts
+        @accounts ||= []
+      end
+
+      # Add a new server to the configuration
+      #
+      # @param [Hash] server_data
+      def add_server(data)
+        token = Token.new(
+          access_token: data.delete('token'),
+          refresh_token: data.delete('refresh_token'),
+          expires_at: data.delete('token_expires_at')
+        )
+        server = Server.new(data.merge(token: token))
+        if (existing_index = find_server_index(server.name))
+          servers[existing_index] = server
+        else
+          servers << server
+        end
+        write
+      end
+
+      # Search the server list for a server by field(s) and value(s).
+      # @example
+      #   find_server_by(url: 'https://localhost', token: 'abcd')
+      # @param [Hash] search_criteria
+      # @return [Server, NilClass]
+      def find_server_by(criteria = {})
+        servers.find{|s| criteria.none? {|k,v| v != s[k]}}
+      end
+
+      # Search the server list for a server by field(s) and value(s)
+      # and return its index.
+      #
+      # @example
+      #   find_server_index(url: 'https://localhost')
+      # @param [Hash] search_criteria
+      # @return [Fixnum, NilClass]
+      def find_server_index_by(criteria = {})
+        servers.find_index{|s| criteria.none? {|k,v| v != s[k]}}
+      end
+
+      # Shortcut to find_server_by(name: name)
+      #
+      # @param [String] server_name
+      # @return [Server, NilClass]
+      def find_server(name)
+        find_server_by(name: name)
+      end
+
+      # Shortcut to find_server_index_by(name: name)
+      #
+      # @param [String] server_name
+      # @return [Fixnum, NilClass]
+      def find_server_index(name)
+        find_server_index_by(name: name)
+      end
+
+      def find_account(name)
+        accounts.find{|a| a['name'] == name.to_s}
+      end
+
+      def find_account_index(name)
+        accounts.find_index{|a| a['name'] == name.to_s}
+      end
+
+      # Currently selected master's configuration data
+      #
+      # @return [Server]
+      def current_master
+        return servers[@current_master_index] if @current_master_index
+        return nil unless current_server
+        @current_master_index = find_server_index(current_server)
+        servers[@current_master_index] if @current_master_index
+      end
+
+      # Raises unless current master has token.
+      #
+      # @return [Token] current_master_token
+      # @raise [ArgumentError] if no token available
+      def require_current_master_token
+        require_current_master
+        token = current_master.token
+        if token && token.access_token 
+          return token unless token.expired?
+          raise TokenExpiredError, "The access token has expired and need to be refreshed."
+        end
+        raise ArgumentError, "You are not logged into a Kontena Master. Use: kontena login"
+      end
+
+      # Raises unless current master is selected.
+      #
+      # @return [Server] current_master
+      # @raise [ArgumentError] if no account is selected
+      def require_current_master
+        return current_master if current_master
+        raise ArgumentError, "You are not logged into a Kontena Master. Use: kontena login"
+      end
+
+      # Raises unless current account is selected.
+      #
+      # @return [Account] current_account
+      # @raise [ArgumentError] if no account is selected
+      def require_current_account
+        return @current_account if @current_account
+        raise ArgumentError, "You are not logged into an authorization provider. Use: kontena auth login"
+      end
+
+      # Set the current master.
+      #
+      # @param [String] server_name
+      # @raise [ArgumentError] if server by that name doesn't exist
+      def current_master=(name)
+        @current_master_index = nil
+        if name.nil?
+          self.current_server = nil
+        else
+          index = find_server_index(name.respond_to?(:name) ? name.name : name)
+          if index
+            self.current_server = servers[index].name
+          else
+            raise ArgumentError, "Server '#{name}' does not exist, can't add as current master."
+          end
+        end
+      end
+
+      # Raises unless current grid is selected.
+      #
+      # @return [String] current_grid_name
+      # @raise [ArgumentError] if no grid is selected
+      def require_current_grid
+        return current_grid if current_grid
+        raise ArgumentError, "You have not selected a grid. Use: kontena grid"
+      end
+      # Name of the currently selected grid. Can override using 
+      # KONTENA_GRID environment variable.
+      #
+      # @return [String, NilClass]
+      def current_grid
+        ENV['KONTENA_GRID'] || (current_master && current_master.grid)
+      end
+
+      # Set the current grid name.
+      #
+      # @param [String] grid_name
+      # @raise [ArgumentError] if current master hasn't been selected
+      def current_grid=(name)
+        if current_master
+          current_master.grid = name
+        else
+          raise ArgumentError, "Current master not selected, can't set grid."
+        end
+      end
+
+      def current_account=(name)
+        if name.nil?
+          @current_account = nil
+        elsif name == 'master'
+          raise ArgumentError, "The master account can not be used as current account."
+        else
+          account = find_account(name.respond_to?(:name) ? name.name : name)
+          if account
+            @current_account = account
+          else
+            raise ArgumentError, "Account '#{name}' not found in configuration"
+          end
+        end
+      end
+
+      # Generate a hash from the current configuration.
+      #
+      # @return [Hash]
+      def to_hash
+        {
+          current_server: self.current_server,
+          current_account: self.current_account ? self.current_account.name : nil,
+          servers: servers.map(&:to_h),
+          accounts: accounts.map(&:to_h)
+        }
+      end
+
+      # Generate a JSON string from the current configuration
+      #
+      # @return [String]
+      def to_json
+        JSON.pretty_generate(to_hash)
+      end
+
+      # Write the current configuration to config file. 
+      # Does nothing if using settings from environment variables.
+      def write
+        return nil if ENV['KONTENA_URL']
+        logger.debug "Writing configuration to #{config_filename}"
+        File.write(config_filename, to_json)
+      end
+
+      class << self
+        extend Forwardable
+        def_delegators :instance, *Config.instance_methods(false)
+      end
+
+      module TokenSerializer
+        # Modified to_h to handle token data serialization
+        #
+        # @return [Hash]
+        def to_h
+          token = delete_field(:token) if respond_to?(:token)
+          result = super
+          if token
+            self.token = token
+            result.merge!(token.to_h)
+          end
+          result
+        end
+      end
+
+      module ConfigurationInstance
+        def config
+          Kontena::Cli::Config.instance
+        end
+      end
+
+      class Account < OpenStruct
+        include TokenSerializer
+        include ConfigurationInstance
+
+        # Strip token info from master-account, the token is saved with the server.
+        def to_h
+          if self.name == 'master'
+            super.to_h.reject do |k,_|
+              [:url, :token, :refresh_token, :token_expires_at].include?(k)
+            end
+          else
+            super
+          end
+        end
+      end
+
+      class Server < OpenStruct
+        include TokenSerializer
+        include ConfigurationInstance
+      end
+
+      class Token < OpenStruct
+        include ConfigurationInstance
+
+        # Hash representation of token data
+        #
+        # @return [Hash]
+        def to_h
+          {
+            token: self.access_token,
+            token_expires_at: self.expires_at,
+            refresh_token: self.refresh_token
+          }.merge(self.respond_to?(:username) ? {username: self.username} : {})
+        end
+
+        def expires?
+          expires_at.nil? ? false : expires_at.to_i > 0
+        end
+
+        def expired?
+          expires? && expires_at && expires_at.to_i < Time.now.utc.to_i
+        end
+
+        def parent
+          return nil unless parent_type
+          return nil unless parent_name
+          if parent_type == :master
+            config.find_server(parent_name)
+          elsif parent_type == :account
+            config.find_account(parent_name)
+          else
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/master/current_command.rb
+++ b/cli/lib/kontena/cli/master/current_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Master
     option ["--name"], :flag, "Show name only", default: false
 
     def execute
-      master = current_master
+      master = require_current_master
 
       if name?
         puts master['name']

--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Master
     parameter "NAME", "Master name to use"
 
     def execute
-      master = find_master_by_name(name)
+      master = config.find_server(name)
       if !master.nil?
         self.current_master = master['name']
         puts "Using master: #{master['name'].cyan} (#{master['url']})"
@@ -24,13 +24,6 @@ module Kontena::Cli::Master
         abort "Could not resolve master by name [#{name}]. For a list of known masters please run: kontena master list".colorize(:red)
       end
     end
-
-    def find_master_by_name(name)
-      settings['servers'].each do |server|
-        return server if server['name'] == name
-      end
-    end
-
   end
 
 end

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -12,8 +12,9 @@ module Kontena
     # Initialize api client
     #
     # @param [String] api_url
+    # @param [String,Hash,Kontena::Cli::Config::Token] token
     # @param [Hash] default_headers
-    def initialize(api_url, default_headers = {})
+    def initialize(api_url, token = nil, default_headers = {})
       Excon.defaults[:ssl_verify_peer] = false if ignore_ssl_errors?
       @http_client = Excon.new(api_url)
       @default_headers = {
@@ -21,6 +22,14 @@ module Kontena
         'Content-Type' => 'application/json',
         'User-Agent' => "kontena-cli/#{Kontena::Cli::VERSION}"
       }.merge(default_headers)
+
+      if token 
+        if token.kind_of?(String)
+          token = { 'access_token' => token }
+        end
+        @default_headers.merge!('Authorization' => "Bearer #{token}")
+      end
+
       @api_url = api_url
       @path_prefix = '/v1/'
     end

--- a/cli/spec/kontena/cli/app/scale_spec.rb
+++ b/cli/spec/kontena/cli/app/scale_spec.rb
@@ -42,7 +42,7 @@ describe Kontena::Cli::Apps::ScaleCommand do
 
     it 'scales given service' do
       allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_yml_no_instances)
-      expect(subject).to receive(:scale_service).with('1234567','kontena-test-wordpress',3)
+      expect(subject).to receive(:scale_service).with(duck_type(:access_token),'kontena-test-wordpress',3)
       subject.run(['wordpress', 3])
     end
 

--- a/cli/spec/kontena/cli/master/current_command_spec.rb
+++ b/cli/spec/kontena/cli/master/current_command_spec.rb
@@ -2,52 +2,31 @@ require_relative "../../../spec_helper"
 require 'kontena/cli/master/current_command'
 
 describe Kontena::Cli::Master::CurrentCommand do
-  let(:settings) do
-    {'current_server' => 'alias',
-      'servers' => [
-        {'name' => 'some_master', 'url' => 'some_master'},
-        {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
-      ]
-    }
-  end
-
+  include ClientHelpers
+  
   let(:subject) { described_class.new(File.basename($0)) }
 
   describe '#execute' do
     it 'puts master name and URL' do
-      allow(subject).to receive(:settings).and_return(settings)
-
       expect {
         subject.run([])
       }.to output(/alias.*someurl/).to_stdout
     end
 
     it 'only outputs name if name-flag is set' do
-      allow(subject).to receive(:settings).and_return(settings)
-
       expect {
         subject.run(['--name'])
       }.to output("alias\n").to_stdout
     end
 
     it 'does not raise error when logged in' do
-      allow(subject).to receive(:settings).and_return(settings)
-
       expect {
         subject.run([])
       }.to_not raise_error
     end
 
     it 'raises error when not logged in' do
-      allow(subject).to receive(:settings).and_return(
-        {
-            'current_server' => nil,
-            'servers' => [
-                {'name' => 'some_master', 'url' => 'some_master'},
-                {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
-            ]
-        }
-      )
+      expect(subject.config).to receive(:current_master).and_return(nil)
 
       expect {
         subject.run([])

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -3,33 +3,20 @@ require 'kontena/cli/master/use_command'
 
 describe Kontena::Cli::Master::UseCommand do
 
+  include ClientHelpers
+
   let(:subject) do
     described_class.new(File.basename($0))
   end
 
-  let(:client) { spy(:client) }
-
-  let(:valid_settings) do
-    {'current_server' => 'alias',
-     'servers' => [
-         {'name' => 'some_master', 'url' => 'some_master'},
-         {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
-     ]
-    }
-  end
-
   describe '#use' do
     it 'should update current master' do
-      allow(subject).to receive(:client).and_return(client)
-      allow(subject).to receive(:settings).and_return(valid_settings)
       expect(subject).to receive(:current_master=).with('some_master')
       subject.run(['some_master'])
     end
 
     it 'should fetch grid list from master' do
       allow(subject).to receive(:require_token).and_return('token')
-      allow(subject).to receive(:client).and_return(client)
-      allow(subject).to receive(:settings).and_return(valid_settings)
       expect(subject).to receive(:current_master=).with('some_master')
       expect(client).to receive(:get).with('grids')
       subject.run(['some_master'])

--- a/cli/spec/kontena/cli/master/users/invite_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/invite_command_spec.rb
@@ -4,27 +4,13 @@ require 'kontena/cli/master/users/invite_command'
 
 describe Kontena::Cli::Master::Users::InviteCommand do
 
+  include ClientHelpers
+
   let(:subject) do
     described_class.new(File.basename($0))
   end
 
-  let(:valid_settings) do
-    {'current_server' => 'alias',
-     'servers' => [
-         {'name' => 'some_master', 'url' => 'some_master'},
-         {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
-     ]
-    }
-  end
-
-  let(:client) { spy(:client) }
-
   describe "#invite" do
-    before(:each) do
-      allow(subject).to receive(:client).and_return(client)
-      allow(subject).to receive(:settings).and_return(valid_settings)
-    end
-
     it 'makes invitation request for all given users' do
       expect(client).to receive(:post).with("users", {email: 'john@example.org'}).once
       expect(client).to receive(:post).with("users", {email: 'jane@example.org'}).once

--- a/cli/spec/kontena/cli/master/users/roles/add_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/roles/add_command_spec.rb
@@ -4,27 +4,13 @@ require 'kontena/cli/master/users/roles/add_command'
 
 describe Kontena::Cli::Master::Users::Roles::AddCommand do
 
+  include ClientHelpers
+
   let(:subject) do
     described_class.new(File.basename($0))
   end
 
-  let(:client) { spy(:client) }
-
-  let(:valid_settings) do
-    {'current_server' => 'alias',
-     'servers' => [
-         {'name' => 'some_master', 'url' => 'some_master'},
-         {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
-     ]
-    }
-  end
-
   describe "#add-role" do
-    before(:each) do
-      allow(subject).to receive(:client).and_return(client)
-      allow(subject).to receive(:settings).and_return(valid_settings)
-    end
-
     it 'makes add role request for all given users' do
       expect(client).to receive(:post).with("users/john@example.org/roles", {role: 'role'}).once
       expect(client).to receive(:post).with("users/jane@example.org/roles", {role: 'role'}).once

--- a/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
@@ -4,25 +4,14 @@ require 'kontena/cli/master/users/roles/remove_command'
 
 describe Kontena::Cli::Master::Users::Roles::RemoveCommand do
 
+  include ClientHelpers
+
   let(:subject) do
     described_class.new(File.basename($0))
   end
 
-  let(:valid_settings) do
-    {'current_server' => 'alias',
-     'servers' => [
-         {'name' => 'some_master', 'url' => 'some_master'},
-         {'name' => 'alias', 'url' => 'someurl', 'token' => '123456'}
-     ]
-    }
-  end
-
-  let(:client) { spy(:client) }
-
   describe "#remove-role" do
     before(:each) do
-      allow(subject).to receive(:client).and_return(client)
-      allow(subject).to receive(:settings).and_return(valid_settings)
       allow(subject).to receive(:confirm).and_return(true)
     end
 

--- a/cli/spec/kontena/cli/services/restart_command_spec.rb
+++ b/cli/spec/kontena/cli/services/restart_command_spec.rb
@@ -22,7 +22,7 @@ describe Kontena::Cli::Services::RestartCommand do
     end
 
     it 'triggers restart command' do
-      expect(subject).to receive(:restart_service).with(token, 'service')
+      expect(subject).to receive(:restart_service)
       subject.run(['service'])
     end
   end

--- a/cli/spec/kontena/cli/services/update_command_spec.rb
+++ b/cli/spec/kontena/cli/services/update_command_spec.rb
@@ -23,28 +23,28 @@ describe Kontena::Cli::Services::UpdateCommand do
     end
 
     it 'sends update command' do
-      expect(subject).to receive(:update_service).with(token, 'service', {privileged: false})
+      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', {privileged: false})
       subject.run(['service'])
     end
 
     it 'sends --cap-add' do
-      expect(subject).to receive(:update_service).with(token, 'service', hash_including(cap_add: ['NET_ADMIN']))
+      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', hash_including(cap_add: ['NET_ADMIN']))
       subject.run(['--cap-add', 'NET_ADMIN', 'service'])
     end
 
     it 'sends --cap-drop' do
-      expect(subject).to receive(:update_service).with(token, 'service', hash_including(cap_drop: ['MKNOD']))
+      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', hash_including(cap_drop: ['MKNOD']))
       subject.run(['--cap-drop', 'MKNOD', 'service'])
     end
 
     it 'sends --log-driver' do
-      expect(subject).to receive(:update_service).with(token, 'service', hash_including(log_driver: 'syslog'))
+      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', hash_including(log_driver: 'syslog'))
       subject.run(['--log-driver', 'syslog', 'service'])
     end
 
     it 'sends --log-opt' do
       expect(subject).to receive(:update_service).with(
-        token, 'service', hash_including(log_opts: {
+        duck_type(:access_token), 'service', hash_including(log_opts: {
           'gelf-address'  => 'udp://log_forwarder-logstash_internal:12201'
         })
       )

--- a/cli/spec/kontena/config_spec.rb
+++ b/cli/spec/kontena/config_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../spec_helper'
+
+# Lots of coverage already in Common spec
+describe Kontena::Cli::Config do
+
+  context 'base' do
+    let(:subject) { described_class.instance }
+
+    before(:each) do
+      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:write).and_return(true)
+      subject.class.reset_instance
+      subject.servers << Kontena::Cli::Config::Server.new(
+        url: 'http://localhost',
+        name: 'test',
+        token: Kontena::Cli::Config::Token.new(access_token: 'abcd')
+      )
+    end
+
+    it 'finds a server by name' do
+      expect(subject.find_server('test').url).to eq 'http://localhost'
+    end
+
+    it 'finds a server by url' do
+      expect(subject.find_server_by(url: 'http://localhost').name).to eq 'test'
+    end
+
+    it 'returns current master' do
+      subject.current_master = 'test'
+      expect(subject.current_master.name).to eq 'test'
+    end
+
+    it 'returns an array of servers' do
+      expect(subject.servers).to be_kind_of(Array)
+      expect(subject.servers.first.url).to match /^http/
+    end
+
+    it 'returns an array of accounts' do
+      expect(subject.accounts).to be_kind_of(Array)
+    end
+
+    it 'adds default accounts' do
+      expect(subject.find_account('kontena').name).to eq 'kontena'
+      expect(subject.find_account('master').name).to eq 'master'
+    end
+
+    it 'sets and returns current grid' do
+      subject.current_master = 'test'
+      subject.current_grid = 'foo'
+      expect(subject.current_master.grid).to eq 'foo'
+      expect(subject.current_grid).to eq 'foo'
+    end
+  end
+
+  describe 'Token' do
+    let(:subject) { Kontena::Cli::Config::Token.new(access_token: 'abcd', expires_at: Time.now.utc - 100) }
+
+    it 'knows when a token is expired' do
+      expect(subject.expired?).to be_truthy
+      subject.expires_at = Time.now.utc + 100
+      expect(subject.expired?).to be_falsey
+    end
+  end
+end
+

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -22,6 +22,15 @@ RSpec.configure do |config|
   config.order = 'random'
   config.before(:each) do
     allow(Dir).to receive(:home).and_return('/tmp/')
+    allow(ENV).to receive(:[]).with(anything).and_call_original
+    allow(ENV).to receive(:[]).with('DEBUG').and_call_original
+    Kontena::Cli::Config.reset_instance
+  end
+  
+  config.after(:each) do
+    RSpec::Mocks.space.proxy_for(File).reset
+    RSpec::Mocks.space.proxy_for(Kontena::Cli::Config).reset
+    File.unlink(Kontena::Cli::Config.default_config_filename) if File.exist?(Kontena::Cli::Config.default_config_filename)
   end
 end
 

--- a/cli/spec/support/client_helpers.rb
+++ b/cli/spec/support/client_helpers.rb
@@ -15,17 +15,23 @@ module ClientHelpers
 
     base.let(:settings) do
       {'current_server' => 'alias',
+       'current_account' => 'kontena',
        'servers' => [
            {'name' => 'some_master', 'url' => 'some_master'},
-           {'name' => 'alias', 'url' => 'someurl', 'token' => token}
+           {'name' => 'alias', 'url' => 'someurl', 'token' => token, 'account' => 'master'}
        ]
       }
     end
 
     base.before(:each) do
-      allow(subject).to receive(:client).with(token).and_return(client)
+      RSpec::Mocks.space.proxy_for(File).reset
+      allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:current_grid).and_return('test-grid')
-      allow(subject).to receive(:settings).and_return(settings)
+      allow(File).to receive(:exist?).with(File.join(Dir.home, '.kontena_client.json')).and_return(true)
+      allow(File).to receive(:readable?).with(File.join(Dir.home, '.kontena_client.json')).and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(File.join(Dir.home, '.kontena_client.json')).and_return(JSON.dump(settings))
+      Kontena::Cli::Config.reset_instance
     end
   end
 end


### PR DESCRIPTION
You can now do things like `config.current_master.grid = 'foo'` or
`config.find_server('foo').url = 'https://foo'`

Config handling is now done in it's own Kontena::Cli::Config instead of in Kontena::Cli::Common.
