### PR TITLE
PoC: shutdown gracefully on SIGTERM

### DIFF
--- a/agent/bin/kontena-agent
+++ b/agent/bin/kontena-agent
@@ -35,4 +35,5 @@ agent = Kontena::Agent.new(
 )
 agent.connect!
 
-sleep
+sleep 0.1 until $AGENT_STOP_SLEEPING
+puts "exiting.."

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -12,6 +12,13 @@ module Kontena
       self.supervise_network_adapter
       self.supervise_lb
       self.supervise_workers
+
+      Signal.trap('SIGTERM') {
+        10.times { puts "AGENT STOPPING EVENT MACHINE" }
+
+        EM.stop
+        $AGENT_STOP_SLEEPING = true
+      }
     end
 
     # Connect to master server

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -1,5 +1,10 @@
 class RpcServer
 
+  Signal.trap('SIGTERM') {
+    10.times { puts "SERVER STOPPING EVENT MACHINE" }
+    EM.stop
+  }
+  
   HANDLERS = {
   }
 


### PR DESCRIPTION
When developing locally for example with #935, shutting down api and agent take time because api or agent don't shutdown gracefully on SIGTERM -- docker-compose will eventially SIGKILL them.

I don't know enough of the codebase to make a real pull-request of this, but something like this patch should be done?

As it is now:
![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/3893/17974064/475d58f4-6aed-11e6-8a0d-36b5c9ab51cc.gif)

With this PoC patch:
![ezgif com-video-to-gif 2](https://cloud.githubusercontent.com/assets/3893/17974074/4b33dcbe-6aed-11e6-800d-b54328a0be7f.gif)
