### PR TITLE
Fix custom cadvisor image volume mappings

### DIFF
--- a/agent/lib/kontena/launchers/cadvisor.rb
+++ b/agent/lib/kontena/launchers/cadvisor.rb
@@ -69,13 +69,9 @@ module Kontena::Launchers
           '--storage_duration=2m',
           '--housekeeping_interval=30s'
         ],
-        'Volumes' => {
-          '/host' => {},
-        },
+        'Volumes' => volume_mappings,
         'HostConfig' => {
-          'Binds' => [
-            '/:/host:rw'
-          ],
+          'Binds' => volume_binds,
           'PidMode' => 'host',
           'Privileged' => true,
           'RestartPolicy' => {'Name' => 'always'}
@@ -88,6 +84,41 @@ module Kontena::Launchers
     def log_error(exc)
       error "#{exc.class.name}: #{exc.message}"
       error exc.backtrace.join("\n")
+    end
+
+    # @return [Hash]
+    def volume_mappings
+      if default_image?
+        {
+          '/host' => {}
+        }
+      else
+        {
+          '/rootfs' => {},
+          '/var/run' => {},
+          '/sys' => {},
+          '/var/lib/docker' => {}
+        }
+      end
+    end
+
+    # @return [Array<String>]
+    def volume_binds
+      if default_image?
+        ['/:/host:rw']
+      else
+        [
+          '/:/rootfs:ro',
+          '/var/run:/var/run',
+          '/sys:/sys:ro',
+          '/var/lib/docker:/var/lib/docker:ro'
+        ]
+      end
+    end
+
+    # @return [Boolean]
+    def default_image?
+      CADVISOR_IMAGE == 'kontena/cadvisor'
     end
   end
 end

--- a/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
+++ b/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
@@ -31,4 +31,27 @@ describe Kontena::Launchers::Cadvisor do
       sleep 0.01
     end
   end
+
+  describe '#volume_mappings' do
+    it 'returns only one mapping by default (for nsenter)' do
+      expect(subject.volume_mappings.keys).to eq(['/host'])
+    end
+
+    it 'returns cadvisor default mappings when custom image is used' do
+      allow(subject.wrapped_object).to receive(:default_image?).and_return(false)
+      expect(subject.volume_mappings.keys).to eq(['/rootfs', '/var/run', '/sys', '/var/lib/docker'])
+    end
+  end
+
+  describe '#default_image?' do
+    it 'returns true when kontena/cadvisor is used' do
+      stub_const("#{described_class.name}::CADVISOR_IMAGE", 'kontena/cadvisor')
+      expect(subject.default_image?).to be_truthy
+    end
+
+    it 'returns false when custom image is used' do
+      stub_const("#{described_class.name}::CADVISOR_IMAGE", 'google/cadvisor')
+      expect(subject.default_image?).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Now it's (again) possible to define custom cadvisor image for the kontena agent using `CADVISOR_IMAGE` and  `CADVISOR_VERSION` environment variables. This allows agent to collect statistics for example in Docker for Mac by switching cadvisor to official image.

Fixes #934 