### PR TITLE
Default to fullchain certificate with options for cert only or chain

### DIFF
--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -6,6 +6,7 @@ module Kontena::Cli::Certificate
 
 
     option '--secret-name', 'SECRET_NAME', 'The name for the secret to store the certificate in'
+    option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain, chain or cert', default: 'fullchain'
     parameter "DOMAIN ...", "Domain(s) to get certificate for"
 
 

--- a/docs/using-kontena/certificates.md
+++ b/docs/using-kontena/certificates.md
@@ -74,6 +74,12 @@ Certificate:
                 DNS:www.example.com, DNS:example.com
 ```
 
+By default Kontena stores the full chain version of the certificate. This is because LE intermediaries are not trusted by all client libraries (some Rubies, Docker, wget, ...). You can control the type of certificate stored by this command line option:
+```
+--cert-type CERT_TYPE    The type of certificate to get: fullchain, chain or cert (default: "fullchain")
+```
+
+
 ## Secrets
 
 Kontena LE integration stores all certificate information securely in [Kontena Vault](vault.md). Upon receiving a certificate from LetsEncrypt Kontena stores three secrets in the vault:


### PR DESCRIPTION
This PR changes certificate management to default to using fullchain certificates as plain certs of LE are not overly trusted with all client libraries. (some rubies, docker, wget, ...). Also adds cli options to get either chain, fullchain or plain cert.

