### PR TITLE
Use host network in cadvisor

### DIFF
--- a/agent/lib/kontena/launchers/cadvisor.rb
+++ b/agent/lib/kontena/launchers/cadvisor.rb
@@ -72,6 +72,7 @@ module Kontena::Launchers
         'Volumes' => volume_mappings,
         'HostConfig' => {
           'Binds' => volume_binds,
+          'NetworkMode' => 'host',
           'PidMode' => 'host',
           'Privileged' => true,
           'RestartPolicy' => {'Name' => 'always'}


### PR DESCRIPTION
Fixes custom cadvisor images not exposing port properly to agent