### PR TITLE
Fix cli log stream buffer mem leak

### DIFF
--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -5,6 +5,7 @@ module Kontena::Cli::Helpers
     # @return [Hash,NilClass]
     def buffered_log_json(chunk)
       @buffer = '' if @buffer.nil?
+      return if @buffer.empty? && chunk.strip.empty?
       begin
         orig_chunk = chunk
         unless @buffer.empty?

--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -1,0 +1,49 @@
+module Kontena::Cli::Helpers
+  module LogHelper
+
+    # @param [String] chunk
+    # @return [Hash,NilClass]
+    def buffered_log_json(chunk)
+      @buffer = '' if @buffer.nil?
+      begin
+        orig_chunk = chunk
+        unless @buffer.empty?
+          chunk = @buffer + chunk
+        end
+        unless chunk.empty?
+          log = JSON.parse(chunk)
+        end
+        @buffer = ''
+        log
+      rescue => exc
+        if @buffer.bytesize > 1024 * 10
+          @buffer = ''
+        else
+          @buffer << orig_chunk
+        end
+        nil
+      end
+    end
+
+    # @param [String] container_id
+    # @return [Symbol]
+    def color_for_container(container_id)
+      color_maps[container_id] = colors.shift unless color_maps[container_id]
+      color_maps[container_id].to_sym
+    end
+
+    # @return [Hash]
+    def color_maps
+      @color_maps ||= {}
+    end
+
+    # @return [Array<Symbol>]
+    def colors
+      if(@colors.nil? || @colors.size == 0)
+        @colors = [:green, :yellow, :magenta, :cyan, :red,
+          :light_green, :light_yellow, :ligh_magenta, :light_cyan, :light_red]
+      end
+      @colors
+    end
+  end
+end

--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -16,11 +16,7 @@ module Kontena::Cli::Helpers
         @buffer = ''
         log
       rescue => exc
-        if @buffer.bytesize > 1024 * 10
-          @buffer = ''
-        else
-          @buffer << orig_chunk
-        end
+        @buffer << orig_chunk
         nil
       end
     end

--- a/cli/spec/kontena/cli/helpers/log_helper_spec.rb
+++ b/cli/spec/kontena/cli/helpers/log_helper_spec.rb
@@ -16,7 +16,7 @@ describe Kontena::Cli::Helpers::LogHelper do
       expect(log).to eq(chunk)
     end
 
-    it 'combines two part json chunks to valid json' do
+    it 'combines multi part json chunks to valid json' do
       chunk1 = '{"foo": "'
       chunk2 = 'bar'
       chunk3 = '"}'
@@ -26,6 +26,18 @@ describe Kontena::Cli::Helpers::LogHelper do
       expect(log).to be_nil
       log = subject.buffered_log_json(chunk3)
       expect(log).to eq({"foo" => "bar"})
+    end
+
+    it 'handles big log messages' do
+      chunk1 = '{"foo": "' << "lol" * 10000
+      chunk2 = 'lol'
+      chunk3 = 'lol"}'
+      log = subject.buffered_log_json(chunk1)
+      expect(log).to be_nil
+      log = subject.buffered_log_json(chunk2)
+      expect(log).to be_nil
+      log = subject.buffered_log_json(chunk3)
+      expect(log).to eq(JSON.parse(chunk1 + chunk2 + chunk3))
     end
 
     it 'returns nil on invalid json' do

--- a/cli/spec/kontena/cli/helpers/log_helper_spec.rb
+++ b/cli/spec/kontena/cli/helpers/log_helper_spec.rb
@@ -1,0 +1,36 @@
+require_relative "../../../spec_helper"
+require "kontena/cli/helpers/log_helper"
+
+describe Kontena::Cli::Helpers::LogHelper do
+
+  let(:described_class) do
+    Class.new do
+      include Kontena::Cli::Helpers::LogHelper
+    end
+  end
+
+  describe '#buffered_log_json' do
+    it 'returns has on valid json' do
+      chunk = {"foo" => "bar"}
+      log = subject.buffered_log_json(chunk.to_json)
+      expect(log).to eq(chunk)
+    end
+
+    it 'combines two part json chunks to valid json' do
+      chunk1 = '{"foo": "'
+      chunk2 = 'bar'
+      chunk3 = '"}'
+      log = subject.buffered_log_json(chunk1)
+      expect(log).to be_nil
+      log = subject.buffered_log_json(chunk2)
+      expect(log).to be_nil
+      log = subject.buffered_log_json(chunk3)
+      expect(log).to eq({"foo" => "bar"})
+    end
+
+    it 'returns nil on invalid json' do
+      log = subject.buffered_log_json('{"foo": "')
+      expect(log).to be_nil
+    end
+  end
+end

--- a/cli/spec/kontena/cli/helpers/log_helper_spec.rb
+++ b/cli/spec/kontena/cli/helpers/log_helper_spec.rb
@@ -6,6 +6,10 @@ describe Kontena::Cli::Helpers::LogHelper do
   let(:described_class) do
     Class.new do
       include Kontena::Cli::Helpers::LogHelper
+
+      def buffer
+        @buffer
+      end
     end
   end
 
@@ -38,6 +42,12 @@ describe Kontena::Cli::Helpers::LogHelper do
       expect(log).to be_nil
       log = subject.buffered_log_json(chunk3)
       expect(log).to eq(JSON.parse(chunk1 + chunk2 + chunk3))
+    end
+
+    it 'does not append to buffer if buffer is empty and chunk has just whitespace' do
+      log = subject.buffered_log_json(' ')
+      expect(log).to be_nil
+      expect(subject.buffer).to eq('')
     end
 
     it 'returns nil on invalid json' do


### PR DESCRIPTION
Memory leak happens only when kontena cli gets partial json chunks from a log stream. This PR fixes partial json buffering and adds failsafety so that buffer cannot ever grow infinitely.

Fixes #963 