### PR TITLE
Fix server log stream thread leak

### DIFF
--- a/server/app/routes/v1/grids/grid_container_logs.rb
+++ b/server/app/routes/v1/grids/grid_container_logs.rb
@@ -48,6 +48,7 @@ V1::GridsApi.route('grid_container_logs') do |r|
           logs.each do |log|
             out << render('container_logs/_container_log', {locals: {log: log}})
           end
+          out << ' ' if logs.size == 0
           first_run = false
           sleep 0.5 if logs.size == 0
           from = logs.last.id if logs.last

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -86,10 +86,10 @@ module V1
                 else
                   logs = scope.to_a.reverse
                 end
-
                 logs.each do |log|
                   out << render('container_logs/_container_log', {locals: {log: log}})
                 end
+                out << ' ' if logs.size == 0
                 first_run = false
 
                 sleep 0.5 if logs.size == 0


### PR DESCRIPTION
Thread leak happens only when stream is closed from the client side and no log items are coming in from the database. This PR fixes this situation by appending empty strings to the output that will trigger socket close eventually.