### PR TITLE
Use correct IP address on quick start guide

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -143,8 +143,8 @@ After the deploy is finished you can verify it using
 $ kontena app show wordpress
 ```
 
-It should show details of the service. If you view node details (`$ kontena node show <node>`), you can pick the private IP address of the node and verify in a browser that application is responding.
-**Note:** This is only the special case on the Vagrant setup, normally you can just pick the public IP of the service from the application details.
+It should show details of the service. If you view the node details (`$ kontena node show <node>`), you can pick the private IP address of the node and verify in a browser that application is responding.
+**Note:** This is only the special case for the Vagrant setup, normally you can just pick the public IP of the service from the application details.
 
 If you need more complex examples, please see the following examples:
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -143,7 +143,8 @@ After the deploy is finished you can verify it using
 $ kontena app show wordpress
 ```
 
-It should show details of the service. You can pick the private ip address of the service and verify in a browser that application is responding.
+It should show details of the service. If you view node details (`$ kontena node show <node>`), you can pick the private IP address of the node and verify in a browser that application is responding.
+**Note:** This is only the special case on the Vagrant setup, normally you can just pick the public IP of the service from the application details.
 
 If you need more complex examples, please see the following examples:
 


### PR DESCRIPTION
This PR fixes Quick Start guide where currently user is asked to pick up the private IP address of the service. He/she should use private IP address of the node instead.

Fixes #976