### PR TITLE
Do not silently swallow exceptions in cli logs commands

### DIFF
--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -64,6 +64,7 @@ module Kontena::Cli::Grids
         )
       rescue => exc
         retry if exc.cause.is_a?(EOFError) # Excon wraps the EOFerror into SocketError
+        raise
       end
     end
   end

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -71,6 +71,7 @@ module Kontena::Cli::Services
         )
       rescue => exc
         retry if exc.cause.is_a?(EOFError) # Excon wraps the EOFerror into SocketError
+        raise
       end
     end
   end


### PR DESCRIPTION
`kontena service logs --tail ...` and `kontena grid logs --tail` currently exit silently on any errors in `stream_logs`. Re-raise any non-retried exceptions instead for easier debugging of any potential logs streaming issues.