### PR TITLE
Test and bugfix cli app logs, with spec tests

### DIFF
--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -8,7 +8,9 @@ module Kontena::Cli::Apps
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
-    option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
+    option ["-l", "--lines"], "LINES", "How many lines to show", default: 100 do |s|
+      Integer(s)
+    end
     option "--since", "SINCE", "Show logs since given timestamp"
     option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     parameter "[SERVICE] ...", "Show only specified service logs"
@@ -30,14 +32,15 @@ module Kontena::Cli::Apps
     def show_logs(services)
       last_id = nil
       loop do
-        query_params = []
-        query_params << "from=#{last_id}" unless last_id.nil?
-        query_params << "limit=#{lines}"
-        query_params << "since=#{since}" if !since.nil? && last_id.nil?
+        query_params = {
+          'limit' => lines,
+        }
+        query_params['from'] = last_id unless last_id.nil?
+        query_params['since'] = since if !since.nil? && last_id.nil?
         logs = []
         services.each do |service_name, opts|
           service = get_service(token, prefixed_name(service_name)) rescue false
-          result = client(token).get("services/#{service['id']}/container_logs?#{query_params.join('&')}") if service
+          result = client(token).get("services/#{service['id']}/container_logs", query_params) if service
           logs = logs + result['logs'] if result && result['logs']
         end
         logs.sort!{|x,y| DateTime.parse(x['created_at']) <=> DateTime.parse(y['created_at'])}

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -42,14 +42,18 @@ module Kontena::Cli::Apps
         end
         logs.sort!{|x,y| DateTime.parse(x['created_at']) <=> DateTime.parse(y['created_at'])}
         logs.each do |log|
-          color = color_for_container(log['name'])
-          prefix = "#{log['created_at']} #{log['name']}:".colorize(color)
-          puts "#{prefix} #{log['data']}"
+          show_log(log)
           last_id = log['id']
         end
         break unless tail?
         sleep(2)
       end
+    end
+
+    def show_log(log)
+      color = color_for_container(log['name'])
+      prefix = "#{log['created_at']} #{log['name']}:".colorize(color)
+      puts "#{prefix} #{log['data']}"
     end
 
     def color_for_container(container_id)

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -57,9 +57,8 @@ module Kontena::Cli::Apps
 
         if service
           from = services_from[service['id']] if services_from
-          query_params = {
-            'limit' => lines,
-          }
+          query_params = { }
+          query_params['limit'] = lines if from.nil?
           query_params['since'] = since if !since.nil? && from.nil?
           query_params['from'] = from if !from.nil?
 

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -67,7 +67,7 @@ describe Kontena::Cli::Apps::LogsCommand do
           service: 'test-mysql',
           grid: 'testgrid',
 
-          'id' => '57cff2e8cfee65c8b6efc8bf',
+          'id' => '57cff2e8cfee65c8b6efc8bd',
           'name' => 'test-mysql-1',
           'created_at' => '2016-09-07T15:19:04.362690',
           'data' => "mysql log message 1",
@@ -76,7 +76,7 @@ describe Kontena::Cli::Apps::LogsCommand do
           service: 'test-wordpress',
           grid: 'testgrid',
 
-          'id' => '57cff2e8cfee65c8b6efc8be',
+          'id' => '57cff2e8cfee65c8b6efc8bf',
           'name' => 'test-wordpress-1',
           'created_at' => '2016-09-07T15:19:05.362690',
           'data' => "wordpress log message 1-1",
@@ -107,6 +107,13 @@ describe Kontena::Cli::Apps::LogsCommand do
 
         { 'logs' => logs.select{|log| log[:grid] == grid && log[:service] == service } }
       }
+
+      # collect show_log() output
+      @logs = []
+
+      allow(subject).to receive(:show_log) do |log|
+        @logs << log
+      end
     end
 
     it "we can get some mock service" do
@@ -117,12 +124,10 @@ describe Kontena::Cli::Apps::LogsCommand do
       expect(client.get('services/testgrid/test-wordpress/container_logs', {'limit' => 100})['logs']).to_not be_empty
     end
 
-    it "shows all service logs in time order" do
-      for log in logs do
-        expect(subject).to receive(:show_log).with(log).ordered
-      end
-
+    it "shows all service logs from the first loop in time order" do
       subject.show_logs services
+
+      expect(@logs).to eq logs
     end
   end
 end

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -1,0 +1,103 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/grid_options'
+require "kontena/cli/apps/logs_command"
+
+describe Kontena::Cli::Apps::LogsCommand do
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:client) do
+    double("client")
+  end
+
+  let(:token) do
+    "testtoken"
+  end
+
+  let(:current_grid) do
+    'testgrid'
+  end
+
+  let(:service_prefix) do
+    'test'
+  end
+
+  before (:each) do
+    allow(subject).to receive(:token) { token }
+    allow(subject).to receive(:client) { client }
+    allow(subject).to receive(:service_prefix) { service_prefix }
+  end
+
+  context 'with multiple services' do
+    let(:services) do
+      {
+          'wordpress' => {
+              'image' => 'wordpress:latest',
+              'links' => ['mysql:db'],
+              'ports' => ['80:80'],
+              'instances' => 2,
+              'deploy' => {
+                  'strategy' => 'ha'
+              }
+          },
+          'mysql' => {
+              'image' => 'mysql:5.6',
+              'stateful' => true
+          }
+      }
+    end
+
+    let(:wordpress_service) do
+      {
+        'id'  => 'testgrid/test-wordpress'
+      }
+    end
+
+    let (:wordpress_logs) do
+      [
+        {
+          'id' => '57cff2e8cfee65c8b6efc8be',
+          'name' => 'test-wordpress-1',
+          'created_at' => '2016-09-07T15:19:05.362690',
+          'data' => "wordpress log message 1-1",
+        },
+      ]
+    end
+
+    let (:mysql_service) do
+      {
+        'id' => 'testgrid/test-mysql'
+      }
+    end
+
+    let (:mysql_logs) do
+      [
+        {
+          'id' => '57cff2e8cfee65c8b6efc8bf',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:04.362690',
+          'data' => "mysql log message 1",
+        },
+      ]
+    end
+
+    before (:each) do
+      allow(subject).to receive(:services_from_yaml) { services }
+
+      allow(subject).to receive(:get_service).with(token, 'test-wordpress') { wordpress_service }
+      allow(subject).to receive(:get_service).with(token, 'test-mysql') { mysql_service }
+    end
+
+    it 'we can get some mock service' do
+      expect(subject.get_service('testtoken', 'test-mysql')).to eq mysql_service
+    end
+
+    it 'requests logs for each service' do
+      expect(client).to receive(:get).with('services/testgrid/test-wordpress/container_logs?limit=100') { { 'logs' => wordpress_logs } }
+      expect(client).to receive(:get).with('services/testgrid/test-mysql/container_logs?limit=100') { { 'logs' => mysql_logs } }
+
+      subject.show_logs services
+    end
+  end
+end

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -130,9 +130,11 @@ describe Kontena::Cli::Apps::LogsCommand do
 
       # mock container_logs
       allow(client).to receive(:get) do |url, params|
-        expect_params = { 'limit' => 100 }
-        expect_params['from'] = params['from'] if params['from']
-        expect(params).to eq expect_params
+        if params['from']
+          expect(params).to_not include('limit')
+        else
+          expect(params['limit']).to eq 100
+        end
 
         case url
         when 'services/testgrid/test-wordpress/container_logs'

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -60,6 +60,7 @@ describe Kontena::Cli::Apps::LogsCommand do
       }
     end
 
+    # globally ordered logs across multiple services
     let (:logs) do
       [
         {
@@ -90,12 +91,14 @@ describe Kontena::Cli::Apps::LogsCommand do
       allow(subject).to receive(:get_service).with(token, 'test-mysql') { mysql_service }
 
       # mock container_logs
-      allow(client).to receive(:get) { |url|
+      allow(client).to receive(:get) { |url, params|
+        expect(params).to eq({ 'limit' => 100 })
+
         case url
-        when 'services/testgrid/test-wordpress/container_logs?limit=100'
+        when 'services/testgrid/test-wordpress/container_logs'
             grid = 'testgrid'
             service = 'test-wordpress'
-        when 'services/testgrid/test-mysql/container_logs?limit=100'
+        when 'services/testgrid/test-mysql/container_logs'
             grid = 'testgrid'
             service = 'test-mysql'
         else
@@ -111,7 +114,7 @@ describe Kontena::Cli::Apps::LogsCommand do
     end
 
     it "we can get some mock logs" do
-      expect(client.get('services/testgrid/test-wordpress/container_logs?limit=100')['logs']).to_not be_empty
+      expect(client.get('services/testgrid/test-wordpress/container_logs', {'limit' => 100})['logs']).to_not be_empty
     end
 
     it "shows all service logs in time order" do

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -86,6 +86,17 @@ describe Kontena::Cli::Apps::LogsCommand do
         },
 
         # second loop
+        # pretend that the server got a test-mysql-1 log message after returning the test-mysql logs, but before returning the test-wordpress logs
+        {
+          service: 'test-mysql',
+          grid: 'testgrid',
+          loop: 2,
+
+          'id' => '57cff2e8cfee65c8b6efc8be',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:04.500000',
+          'data' => "mysql log message 2",
+        },
         {
           service: 'test-mysql',
           grid: 'testgrid',

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -97,6 +97,9 @@ describe Kontena::Cli::Apps::LogsCommand do
       expect(client).to receive(:get).with('services/testgrid/test-wordpress/container_logs?limit=100') { { 'logs' => wordpress_logs } }
       expect(client).to receive(:get).with('services/testgrid/test-mysql/container_logs?limit=100') { { 'logs' => mysql_logs } }
 
+      expect(subject).to receive(:show_log).with(mysql_logs[0]).ordered
+      expect(subject).to receive(:show_log).with(wordpress_logs[0]).ordered
+
       subject.show_logs services
     end
   end


### PR DESCRIPTION
Some bugfix work on `kontena app logs` to fix some issues, with spec tests and refactoring: 

* Add spec tests using a mock client implementation
* Refactor into separate `tail_logs()`, `show_logs()`, `get_logs()` and `show_log()` for easier testing
* Change `--tail` option to be an Integer
* Fix the incorrect use of `?limit=` even when tailing logs with `?from=`

    This would lead to skipped log lines if any service was logging more than `--limit` lines per the 2 second loop iteration

* Track per-service `?from=` offset when tailing

    This addresses a *potential* race condition where new service logs appear while looping through multiple `services/..../container_logs` requests for different services. Imagine the following scenario:

    * Service A has log messages 1...3
    * Service B has log messages 4..5
    * We request service A log messages -> 1..3
    * Service A gets a log message 6
    * Service B gets a log message 7
    * We request service B log messages -> 4..5,7
    * We enter the next loop iteration with `last_id=7`
    * Service A gets a log message 8
    * We request Service A logs with `?from=7` -> 8

    We have lost the Service A log message 6.

    Note that I have not actually tried to trigger such a race condition, this is just theoretical :)

Observe some `rspec spec/kontena/cli/app/logs_command_spec.rb -e 'tails'` mock client trace with the correct request options:

```
Randomized with seed 19971

GET services/testgrid/test-wordpress/container_logs {"limit"=>100}
GET services/testgrid/test-mysql/container_logs {"limit"=>100}
GET services/testgrid/test-wordpress/container_logs {"from"=>"57cff2e8cfee65c8b6efc8bf"}
GET services/testgrid/test-mysql/container_logs {"from"=>"57cff2e8cfee65c8b6efc8bd"}
GET services/testgrid/test-wordpress/container_logs {"from"=>"57cff2e8cfee65c8b6efc8c2"}
GET services/testgrid/test-mysql/container_logs {"from"=>"57cff2e8cfee65c8b6efc8c1"}
.

Finished in 0.01271 seconds (files took 0.30931 seconds to load)
1 example, 0 failures
```

If the commits look sane, I'll do a bit more integration testing against the server to make sure this works correctly.