### PR TITLE
CLI: Reimplement app logs, with spec tests

### DIFF
--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -1,9 +1,12 @@
 require_relative 'common'
+require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Apps
   class LogsCommand < Clamp::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
+    include Kontena::Cli::Helpers::LogHelper
+
     include Common
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
@@ -13,60 +16,48 @@ module Kontena::Cli::Apps
     option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     parameter "[SERVICE] ...", "Show only specified service logs"
 
-    attr_reader :services
-
     def execute
       require_config_file(filename)
 
-      @services = services_from_yaml(filename, service_list, service_prefix)
-      if services.size > 0
-        show_logs(services)
-      elsif !service_list.empty?
-        puts "No such service: #{service_list.join(', ')}".colorize(:red)
+      services = services_from_yaml(filename, service_list, service_prefix)
+
+      if services.empty? && !service_list.empty?
+        signal_error "No such service: #{service_list.join(', ')}"
+      elsif services.empty?
+        signal_error "No services for application"
       end
 
-    end
+      query_services = services.map{|service_name, opts| prefixed_name(service_name)}.join ','
+      query_params = {
+        services: query_services,
+        limit: lines,
+      }
+      query_params[:since] = since if since
 
-    def show_logs(services)
-      last_id = nil
-      loop do
-        query_params = []
-        query_params << "from=#{last_id}" unless last_id.nil?
-        query_params << "limit=#{lines}"
-        query_params << "since=#{since}" if !since.nil? && last_id.nil?
-        logs = []
-        services.each do |service_name, opts|
-          service = get_service(token, prefixed_name(service_name)) rescue false
-          result = client(token).get("services/#{service['id']}/container_logs?#{query_params.join('&')}") if service
-          logs = logs + result['logs'] if result && result['logs']
-        end
-        logs.sort!{|x,y| DateTime.parse(x['created_at']) <=> DateTime.parse(y['created_at'])}
-        logs.each do |log|
-          color = color_for_container(log['name'])
-          prefix = "#{log['created_at']} #{log['name']}:".colorize(color)
-          puts "#{prefix} #{log['data']}"
-          last_id = log['id']
-        end
-        break unless tail?
-        sleep(2)
+      if tail?
+        tail_logs(services, query_params)
+      else
+        show_logs(services, query_params)
       end
     end
 
-    def color_for_container(container_id)
-      color_maps[container_id] = colors.shift unless color_maps[container_id]
-      color_maps[container_id].to_sym
-    end
-
-    def color_maps
-      @color_maps ||= {}
-    end
-
-    def colors
-      if(@colors.nil? || @colors.size == 0)
-        @colors = [:green, :magenta, :yellow, :cyan, :red,
-                   :light_green, :light_yellow, :ligh_magenta, :light_cyan, :light_red]
+    def tail_logs(services, query_params)
+      stream_logs("grids/#{current_grid}/container_logs", query_params) do |log|
+        show_log(log)
       end
-      @colors
+    end
+
+    def show_logs(services, query_params)
+      result = client(token).get("grids/#{current_grid}/container_logs", query_params)
+      result['logs'].each do |log|
+        show_log(log)
+      end
+    end
+
+    def show_log(log)
+      color = color_for_container(log['name'])
+      prefix = "#{log['created_at']} #{log['name']}:".colorize(color)
+      puts "#{prefix} #{log['data']}"
     end
   end
 end

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -1,0 +1,133 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/grid_options'
+require "kontena/cli/apps/logs_command"
+
+describe Kontena::Cli::Apps::LogsCommand do
+  include FixturesHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:client) do
+    double("client")
+  end
+
+  let(:token) do
+    "testtoken"
+  end
+
+  let(:current_grid) do
+  'test-grid'
+end
+
+  let(:service_prefix) do
+    'test'
+  end
+
+  before (:each) do
+    allow(subject).to receive(:token) { token }
+    allow(subject).to receive(:client) { client }
+    allow(subject).to receive(:service_prefix) { service_prefix }
+    allow(subject).to receive(:current_grid) { current_grid }
+  end
+
+  context 'with multiple services' do
+    let(:kontena_yml) do
+      fixture('kontena.yml')
+    end
+
+    let(:docker_compose_yml) do
+      fixture('docker-compose.yml')
+    end
+
+    # globally ordered logs across multiple services
+    let (:logs) do
+      [
+        {
+          'id' => '57cff2e8cfee65c8b6efc8bd',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:04.362690',
+          'data' => "mysql log message 1",
+        },
+        {
+          'id' => '57cff2e8cfee65c8b6efc8be',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:04.500000',
+          'data' => "mysql log message 2",
+        },
+        {
+          'id' => '57cff2e8cfee65c8b6efc8bf',
+          'name' => 'test-wordpress-1',
+          'created_at' => '2016-09-07T15:19:05.362690',
+          'data' => "wordpress log message 1-1",
+        },
+        {
+          'id' => '57cff2e8cfee65c8b6efc8c1',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:06.100000',
+          'data' => "mysql log message 3",
+        },
+        {
+          'id' => '57cff2e8cfee65c8b6efc8c2',
+          'name' => 'test-wordpress-1',
+          'created_at' => '2016-09-07T15:19:07.100000',
+          'data' => "wordpress log message 1-2",
+        },
+      ]
+    end
+
+    before (:each) do
+      # mock kontena.yml services
+      expect(subject).to receive(:require_config_file).with("kontena.yml")
+      allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_yml)
+      allow(File).to receive(:read).with("#{Dir.getwd}/docker-compose.yml").and_return(docker_compose_yml)
+
+      # collect show_log() output
+      @logs = []
+
+      allow(subject).to receive(:show_log) do |log|
+        @logs << log
+      end
+    end
+
+    it "shows all service logs" do
+      expect(client).to receive(:get).with('grids/test-grid/container_logs', {
+        services: 'test-wordpress,test-mysql',
+        limit: '100',
+      }) { { 'logs' => logs } }
+
+      subject.run([])
+
+      expect(@logs).to eq logs
+    end
+
+    it "shows logs for one service" do
+      mysql_logs = logs.select{|log| log['name'] =~ /test-mysql-/ }
+
+      expect(client).to receive(:get).with('grids/test-grid/container_logs', {
+        services: 'test-mysql',
+        limit: '100',
+      }) { { 'logs' => mysql_logs } }
+
+      subject.run(["mysql"])
+
+      expect(@logs).to eq mysql_logs
+    end
+
+    it "shows logs since time" do
+      since = '2016-09-07T15:19:05.362690'
+      since_logs = logs.select{|log| log['created_at'] > since }
+
+      expect(client).to receive(:get).with('grids/test-grid/container_logs', {
+        services: 'test-wordpress,test-mysql',
+        limit: '100',
+        since: since,
+      }) { { 'logs' => since_logs } }
+
+      subject.run(["--since=#{since}"])
+
+      expect(@logs).to eq since_logs
+    end
+  end
+end


### PR DESCRIPTION
Reimplement `kontena app logs` using `Kontena::Cli::Helpers::LogHelper` with the server `/v1/grids/.../container_logs?services=...` API. This is version 2 of #984.

This resolves several issues with the earlier implementation: 

* The incorrect use of `?limit=` even when tailing logs with `?from=` would lead to skipped log lines if any service was logging more than `--limit` lines per the 2 second loop iteration
* A *potential* race condition where new service logs appear while looping through multiple `services/..../container_logs` requests for different services.

This changes the behavior of `--lines`, which now limits the total number of output lines across all services. Previously `--lines` applied per service, which could give up to (limit)*(number of services) lines of output. The previous behavior is probably somewhat confusing, as you would get a long history of output from quiet services, intermingled with only very recent output from chatty services.

Summary of changes:

* Add spec tests using a mock client implementation
* Add `LogHelper#stream_logs()` method
* Refactor `LogsCommand` into separate `tail_logs()`, `show_logs()`, `show_log()` for easier testing
* Change `--tail` option to be an Integer
* Change `kontena grid logs` to also use the `LogHelper#stream_logs()` method

TODO is to verify that the various server-side logs endpoints all behave similarly enough to use the same CLI `LogHelper` implementation for all cli logs commands, and add tests for `LogHelper#stream_logs`.