### PR TITLE
Catch service remove timeout error and rollback to prev state

### DIFF
--- a/server/app/jobs/grid_service_remove_worker.rb
+++ b/server/app/jobs/grid_service_remove_worker.rb
@@ -10,19 +10,25 @@ class GridServiceRemoveWorker
 
   # @param [GridService] grid_service
   def remove_grid_service(grid_service)
-    prev_state = grid_service.state
-    grid_service.set_state('deleting')
-    grid_service.containers.scoped.each do |container|
-      terminate_from_node(container.host_node, container.name)
+    begin
+      prev_state = grid_service.state
+      grid_service.set_state('deleting')
+      grid_service.containers.scoped.each do |container|
+        terminate_from_node(container.host_node, container.name)
+      end
+
+      wait_instance_removal(grid_service, grid_service.containers.scoped.count * 30)
+
+      grid_service.destroy
+    rescue Timeout::Error
+      grid_service.set_state(prev_state)
     end
-
-    wait_instance_removal(grid_service)
-
-    grid_service.destroy
   end
 
-  def wait_instance_removal(grid_service)
-    Timeout::timeout(10) do
+  # @param [GridService] grid_service
+  # @param [Integer] timeout
+  def wait_instance_removal(grid_service, timeout)
+    Timeout::timeout(timeout) do
       sleep 1 until grid_service.reload.containers.scoped.count == 0
     end
   end

--- a/server/app/jobs/grid_service_remove_worker.rb
+++ b/server/app/jobs/grid_service_remove_worker.rb
@@ -1,5 +1,6 @@
 class GridServiceRemoveWorker
   include Celluloid
+  include Logging
 
   def perform(grid_service_id)
     grid_service = GridService.find_by(id: grid_service_id)
@@ -21,6 +22,7 @@ class GridServiceRemoveWorker
 
       grid_service.destroy
     rescue Timeout::Error
+      error "service remove timed out #{grid_service.to_path}"
       grid_service.set_state(prev_state)
     end
   end

--- a/server/spec/jobs/grid_service_remove_worker.rb
+++ b/server/spec/jobs/grid_service_remove_worker.rb
@@ -32,5 +32,14 @@ describe GridServiceRemoveWorker do
       expect(Docker::ServiceTerminator).to receive(:new).twice.and_return(spy)
       subject.perform(service.id)
     end
+
+    it 'handles timeout properly' do
+      service # instantiate
+      service.set_state('running')
+      allow(subject.wrapped_object).to receive(:wait_instance_removal).and_raise(Timeout::Error)
+      expect {
+        subject.perform(service.id)
+      }.not_to change{ service.reload.state }
+    end
   end
 end


### PR DESCRIPTION
In some cases service remove might timeout and this leaves service to "deleting" state. This PR fixes these situations by dynamically adjusting timeout / rollbacking service state.

Fixes #828 