### PR TITLE
Allow to use numeric version value in kontena.yml

### DIFF
--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -33,7 +33,7 @@ module Kontena::Cli::Apps
     # @return [Hash]
     def generate_services(yaml_services, version)
       services = {}
-      if version == '2'
+      if version.to_i == 2
         generator_klass = ServiceGeneratorV2
       else
         generator_klass = ServiceGenerator
@@ -63,7 +63,7 @@ module Kontena::Cli::Apps
     def project_name_from_yaml(file)
       reader = YAML::Reader.new(file, true)
       outcome = reader.execute
-      if outcome[:version] == '2'
+      if outcome[:version].to_i == 2
         outcome[:name]
       else
         nil

--- a/cli/spec/fixtures/kontena_numeric_version.yml
+++ b/cli/spec/fixtures/kontena_numeric_version.yml
@@ -1,0 +1,9 @@
+version: 2
+name: foo
+
+services:
+  bar:
+    image: konttisample
+    build:
+      context: .
+      dockerfile: Dockerfile

--- a/cli/spec/kontena/cli/app/common_spec.rb
+++ b/cli/spec/kontena/cli/app/common_spec.rb
@@ -13,6 +13,10 @@ describe Kontena::Cli::Apps::Common do
     fixture('kontena.yml')
   end
 
+  let(:kontena_numeric_version_yml) do
+    fixture('kontena_numeric_version.yml')
+  end
+
   let(:kontena_v2_yml) do
     fixture('kontena_v2.yml')
   end
@@ -61,7 +65,7 @@ describe Kontena::Cli::Apps::Common do
     end
   end
 
-  describe '#load_from_yaml' do
+  describe '#services_from_yaml' do
     before(:each) do
       allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_yml)
       allow(File).to receive(:read).with("#{Dir.getwd}/health.yml").and_return(health_yml)
@@ -95,6 +99,13 @@ describe Kontena::Cli::Apps::Common do
       services = subject.services_from_yaml('health.yml',['web'],'')
       expect(services['web']).not_to be_nil
       expect(services['web']['health_check']).not_to be_nil
+    end
+
+    it 'allows version to be numeric' do
+      allow(File).to receive(:read).with("#{Dir.getwd}/kontena-numeric-version.yml").and_return(kontena_numeric_version_yml)
+      services = subject.services_from_yaml('kontena-numeric-version.yml', [], '')
+      expect(services.dig('bar', 'build', 'context')).to eq(Dir.pwd)
+      expect(services.dig('bar', 'build', 'dockerfile')).to eq('Dockerfile')
     end
   end
 end


### PR DESCRIPTION
This PR fixes error when using numeric value of version in kontena.yml, like the following

```
version: 2
name: foo

services:
  bar:
    image: konttisample
    build:
      context: .
      dockerfile: Dockerfile
```

Previously version was not recognised correctly when generating service config for the YAML file and build options get corrupted. This PR fixes this situation by casting version value to integer before selecting the service generator class.

Fixes #986 