### PR TITLE
Handle malformed YAML files in a sane way

### DIFF
--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -62,12 +62,7 @@ module Kontena::Cli::Apps
 
     def project_name_from_yaml(file)
       reader = YAML::Reader.new(file, true)
-      outcome = reader.execute
-      if outcome[:version].to_i == 2
-        outcome[:name]
-      else
-        nil
-      end
+      reader.stack_name
     end
 
     # @return [String]

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -214,11 +214,7 @@ module Kontena::Cli::Apps
             options['build']['args'][k] = v
           end
         end
-      end
-
-      def abort_on_malformed_options(file, service_name)
-        #abort("Service '#{service_name}' contains malformed options #{file}".colorize(:red))
-      end
+      end      
     end
   end
 end

--- a/cli/lib/kontena/cli/apps/yaml/validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator.rb
@@ -44,7 +44,7 @@ module Kontena::Cli::Apps
 
         yaml.each do |service, options|
           unless options.is_a?(Hash)
-            result[:errors] << { service => ['contains malformed options'] }
+            result[:errors] << { service => { 'options' => 'must be a mapping not a string'}  }
             next
           end
           key_errors = validate_keys(options)

--- a/cli/lib/kontena/cli/apps/yaml/validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator.rb
@@ -44,7 +44,7 @@ module Kontena::Cli::Apps
 
         yaml.each do |service, options|
           unless options.is_a?(Hash)
-            result[:errors] << { service => { 'options' => 'must be a mapping not a string'}  }
+            result[:errors] << { service => { 'options' => 'must be a mapping not a string'}  }            
             next
           end
           key_errors = validate_keys(options)

--- a/cli/lib/kontena/cli/apps/yaml/validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator.rb
@@ -43,6 +43,10 @@ module Kontena::Cli::Apps
         }
 
         yaml.each do |service, options|
+          unless options.is_a?(Hash)
+            result[:errors] << { service => ['contains malformed options'] }
+            next
+          end
           key_errors = validate_keys(options)
           option_errors = validate_options(options)
           result[:errors] << { service => option_errors.messages } if option_errors.failure?

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -55,7 +55,7 @@ module Kontena::Cli::Apps
         if yaml.key?('services')
           yaml['services'].each do |service, options|
             unless options.is_a?(Hash)
-              result[:errors] << { service => { 'config' => 'contains malformed options'} }
+              result[:errors] << { service => { 'options' => 'must be a mapping not a string'} }
               next
             end
             key_errors = validate_keys(options)

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -54,6 +54,10 @@ module Kontena::Cli::Apps
         }
         if yaml.key?('services')
           yaml['services'].each do |service, options|
+            unless options.is_a?(Hash)
+              result[:errors] << { service => { 'config' => 'contains malformed options'} }
+              next
+            end
             key_errors = validate_keys(options)
             option_errors = validate_options(options)
             result[:errors] << { service => option_errors.messages } if option_errors.failure?

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -53,7 +53,7 @@ module Kontena::Cli::Apps
           notifications: []
         }
         if yaml.key?('services')
-          yaml['services'].each do |service, options|
+          yaml['services'].each do |service, options|            
             unless options.is_a?(Hash)
               result[:errors] << { service => { 'options' => 'must be a mapping not a string'} }
               next

--- a/cli/spec/fixtures/kontena-malformed-yaml.yml
+++ b/cli/spec/fixtures/kontena-malformed-yaml.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  wordpress:
+    build: .
+      context: .
+      dockerfile: Dockerfile.alternative

--- a/cli/spec/fixtures/kontena-not-hash-service-config.yml
+++ b/cli/spec/fixtures/kontena-not-hash-service-config.yml
@@ -1,0 +1,3 @@
+version: '2'
+services:
+  wordpress: 'service config cannot be string'    

--- a/cli/spec/kontena/cli/app/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/reader_spec.rb
@@ -429,4 +429,30 @@ describe Kontena::Cli::Apps::YAML::Reader do
       end
     end
   end
+
+  describe '#stack_name' do
+    it 'returns nil for v1' do
+      allow(File).to receive(:read)
+        .with(absolute_yaml_path('kontena.yml'))
+        .and_return(fixture('kontena.yml'))
+      name = subject.stack_name
+      expect(name).to be_nil
+    end
+
+    it 'returns name for v2 if defined' do
+      allow(File).to receive(:read)
+        .with(absolute_yaml_path('kontena.yml'))
+        .and_return(fixture('kontena_v2.yml'))
+      name = subject.stack_name
+      expect(name).to eq('test-project')
+    end
+
+    it 'returns nil for v2 if not defined' do
+      allow(File).to receive(:read)
+        .with(absolute_yaml_path('kontena.yml'))
+        .and_return(fixture('docker-compose.yml'))
+      name = subject.stack_name
+      expect(name).to be_nil
+    end
+  end
 end

--- a/cli/spec/kontena/cli/app/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/reader_spec.rb
@@ -156,6 +156,28 @@ describe Kontena::Cli::Apps::YAML::Reader do
     end
   end
 
+  context 'when yaml file is malformed' do
+    it 'exits the execution' do
+      allow(File).to receive(:read)
+        .with(absolute_yaml_path)
+        .and_return(fixture('kontena-malformed-yaml.yml'))
+      expect {
+        subject.execute
+      }.to raise_error(SystemExit)
+    end
+  end
+
+  context 'when service config is not hash' do
+    it 'returns error' do
+      allow(File).to receive(:read)
+        .with(absolute_yaml_path)
+        .and_return(fixture('kontena-not-hash-service-config.yml'))
+
+      outcome = subject.execute
+      expect(outcome[:errors].size).to eq(1)
+    end
+  end
+
   describe '#v2?' do
     context 'version 1' do
       it 'returns false' do


### PR DESCRIPTION
When YAML files are malformed Kontena does not handle them very well atm. This PR will catch those errors and outputs error message instead:

When YAML file is not well structured for example:
```
version: '2'
services:
  wordpress:
    build: .
      context: .
      dockerfile: Dockerfile.alternative
```

Instead of this output
```
Kontena error: (<unknown>): mapping values are not allowed in this context at line 5 column 14
Rerun the command with environment DEBUG=true set to get the full exception
```

The following output is displayed:
```
Error while parsing ./kontena/cli/spec/fixtures/kontena-malformed-yaml.yml (<unknown>): mapping values are not allowed in this context at line 5 column 14
```

Also when service level config is not Hash previously the following output was displayed
```
Kontena error: undefined method `dig' for "service config cannot be string":String
Rerun the command with environment DEBUG=true set to get the full exception
```

With this PR the output will look like this:
```
YAML validation failed! Aborting.
./kontena/cli/spec/fixtures/kontena-not-hash-service-config.yml:
  wordpress:
    - options: "must be a mapping not a string"
```