### PR TITLE
cli: handle invalid master name gracefully and improved formatting

### DIFF
--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -11,8 +11,6 @@ module Kontena::Cli::Master
         self.current_master = master['name']
         puts "Using master: #{master['name'].cyan} (#{master['url']})"
         puts "Using grid: #{current_grid.cyan}" if current_grid
-      else
-        puts "Could not resolve master with name: #{name}".colorize(:red)
 
         grids = client(require_token).get('grids')['grids']
         if grids.size > 1
@@ -23,8 +21,8 @@ module Kontena::Cli::Master
             puts "  * #{grid['name']}"
           end
         end
-
-        abort
+      else
+        abort "Could not resolve master with name: #{name}".colorize(:red)
       end
     end
 

--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -5,29 +5,26 @@ module Kontena::Cli::Master
     parameter "NAME", "Master name to use"
 
     def execute
-      master = find_master_by_name(name)
-      if !master.nil?
+      master = settings['servers'].find { |s| s['name'] == name }
+
+      if master
         self.current_master = master['name']
         puts "Using master: #{master['name'].cyan} (#{master['url']})"
         puts "Using grid: #{current_grid.cyan}" if current_grid
+      else
+        puts "Could not resolve master with name: #{name}".colorize(:red)
+
         grids = client(require_token).get('grids')['grids']
         if grids.size > 1
           puts ""
-          puts "You have access to following grids and can switch between them using 'kontena grid use <name>'"
+          puts "You have access to following grids:"
           puts ""
           grids.each do |grid|
             puts "  * #{grid['name']}"
           end
-          puts ""
         end
-      else
-        abort "Could not resolve master by name [#{name}]. For a list of known masters please run: kontena master list".colorize(:red)
-      end
-    end
 
-    def find_master_by_name(name)
-      settings['servers'].each do |server|
-        return server if server['name'] == name
+        abort
       end
     end
 

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -26,13 +26,13 @@ describe Kontena::Cli::Master::UseCommand do
       subject.run(['some_master'])
     end
 
-    it 'should fetch grid list from master' do
+    it 'should fetch grid list from master if invalid master name given' do
       allow(subject).to receive(:require_token).and_return('token')
       allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:settings).and_return(valid_settings)
       expect(subject).to receive(:current_master=).with('some_master')
       expect(client).to receive(:get).with('grids')
-      subject.run(['some_master'])
+      subject.run(['not_existing'])
     end
   end
 end

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -26,13 +26,18 @@ describe Kontena::Cli::Master::UseCommand do
       subject.run(['some_master'])
     end
 
-    it 'should fetch grid list from master if invalid master name given' do
+    it 'should fetch grid list from master' do
       allow(subject).to receive(:require_token).and_return('token')
       allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:settings).and_return(valid_settings)
       expect(subject).to receive(:current_master=).with('some_master')
       expect(client).to receive(:get).with('grids')
-      subject.run(['not_existing'])
+      subject.run(['some_master'])
+    end
+
+    it 'should abort with error message if master is not configured' do
+      expect { subject.run(['not_existing']) }.to raise_error(
+        SystemExit, /Could not resolve master with name: not_existing/)
     end
   end
 end


### PR DESCRIPTION
Before:
```
➜  ~ kontena master use invalid_name
Kontena error: no implicit conversion of String into Integer
Rerun the command with environment DEBUG=true set to get the full exception

```
After:
```
➜  ~ kontena master use invalid_name
Could not resolve master with name: invalid_name

You have access to following grids:

  * gcp-1
  * gcp-2
➜  ~ kontena master use gcp-1
Using master: gcp-1 (https://master.kontena.com)
Using grid: gcp-1
```