### PR TITLE
Fix boot process / migration race condition

### DIFF
--- a/server/app/boot_jobs.rb
+++ b/server/app/boot_jobs.rb
@@ -3,8 +3,8 @@ require_relative 'services/worker_supervisor'
 require_relative 'services/mongodb/migrator'
 
 unless ENV['RACK_ENV'] == 'test'
+  MongoPubsub.start!(PubsubChannel.collection)
   JobSupervisor.run!
-  Mongodb::Migrator.new.migrate_async
 end
 
 WorkerSupervisor.run!

--- a/server/app/initializers/mongo_pubsub.rb
+++ b/server/app/initializers/mongo_pubsub.rb
@@ -1,5 +1,3 @@
 require_relative 'mongoid'
 require_relative '../services/mongo_pubsub'
 require_relative '../models/pubsub_channel'
-
-MongoPubsub.start!(PubsubChannel.collection) if ENV['RACK_ENV'] != 'test'

--- a/server/config/puma.rb
+++ b/server/config/puma.rb
@@ -1,3 +1,8 @@
 workers Integer(ENV['WEB_CONCURRENCY'] || 1)
 threads_count = Integer(ENV['MAX_THREADS'] || 8)
 threads threads_count, threads_count
+on_worker_boot do
+  require_relative '../app/boot'
+  require_relative '../app/services/mongodb/migrator'
+  Mongodb::Migrator.new.migrate
+end


### PR DESCRIPTION
Master bootup process has a race condition related to how database migrations are handled. This PR moves migrations to `on_worker_boot` puma hook that will block boot until migrations have completed. In a multi-master scenarios migration will acquire db lock before running migrations (same logic as before).