### PR TITLE
Fix HostNode#initial_member? error when node_number is nil

### DIFF
--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -108,6 +108,7 @@ class HostNode
   end
 
   def initial_member?
+    return false if self.node_number.nil?
     return true if self.node_number <= self.grid.initial_size
     false
   end

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -70,6 +70,10 @@ describe HostNode do
     it 'returns false if not initial_member' do
       expect(node_2.initial_member?).to be_falsey
     end
+
+    it 'returns false if node_number is not set' do
+      expect(subject.initial_member?).to be_falsey
+    end
   end
 
   describe '#attributes_from_docker' do


### PR DESCRIPTION
`HostNode#initial_member?` throws error if `HostNode#node_number` is not yet set. This PR fixes this by returning false is node_number is not set.