### PR TITLE
CLI: Refactor logs commands, add container logs command

### DIFF
--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -11,9 +11,6 @@ module Kontena::Cli::Apps
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
-    option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
-    option "--since", "SINCE", "Show logs since given timestamp"
-    option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
     parameter "[SERVICE] ...", "Show only specified service logs"
 
     def execute
@@ -30,34 +27,11 @@ module Kontena::Cli::Apps
       query_services = services.map{|service_name, opts| prefixed_name(service_name)}.join ','
       query_params = {
         services: query_services,
-        limit: lines,
       }
-      query_params[:since] = since if since
 
-      if tail?
-        tail_logs(services, query_params)
-      else
-        show_logs(services, query_params)
-      end
-    end
-
-    def tail_logs(services, query_params)
-      stream_logs("grids/#{current_grid}/container_logs", query_params) do |log|
+      show_logs("grids/#{current_grid}/container_logs", query_params) do |log|
         show_log(log)
       end
-    end
-
-    def show_logs(services, query_params)
-      result = client(token).get("grids/#{current_grid}/container_logs", query_params)
-      result['logs'].each do |log|
-        show_log(log)
-      end
-    end
-
-    def show_log(log)
-      color = color_for_container(log['name'])
-      prefix = "#{log['created_at']} #{log['name']}:".colorize(color)
-      puts "#{prefix} #{log['data']}"
     end
   end
 end

--- a/cli/lib/kontena/cli/container_command.rb
+++ b/cli/lib/kontena/cli/container_command.rb
@@ -1,10 +1,12 @@
 require_relative 'containers/exec_command'
 require_relative 'containers/inspect_command'
+require_relative 'containers/logs_command'
 
 class Kontena::Cli::ContainerCommand < Clamp::Command
 
   subcommand "exec", "Execute command inside a container", Kontena::Cli::Containers::ExecCommand
   subcommand "inspect", "Inspect the container", Kontena::Cli::Containers::InspectCommand
+  subcommand "logs", "Show container logs", Kontena::Cli::Containers::LogsCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/containers/logs_command.rb
+++ b/cli/lib/kontena/cli/containers/logs_command.rb
@@ -1,0 +1,22 @@
+require_relative '../grid_options'
+require_relative '../helpers/log_helper'
+
+module Kontena::Cli::Containers
+  class LogsCommand < Clamp::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Kontena::Cli::Helpers::LogHelper
+
+    parameter "CONTAINER_ID", "Container id"
+
+    def execute
+      require_api_url
+
+      service_name = container_id.match(/(.+)-(\d+)/)[1] rescue nil
+
+      show_logs("containers/#{current_grid}/#{service_name}/#{container_id}/logs") do |log|
+        show_log(log)
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -1,9 +1,46 @@
 module Kontena::Cli::Helpers
   module LogHelper
 
+    def self.included(base)
+      if base.respond_to?(:option)
+        base.option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
+        base.option "--lines", "LINES", "Number of lines to show from the end of the logs", default: 100 do |s|
+          Integer(s)
+        end
+        base.option "--since", "SINCE", "Show logs since given timestamp"
+      end
+    end
+
+    # @return [String]
+    def token
+      @token ||= require_token
+    end
+
+    def show_logs(url, query_params = { }, &block)
+      if tail?
+        stream_logs(url, query_params, &block)
+      else
+        get_logs(url, query_params, &block)
+      end
+    end
+
+    def get_logs(url, query_params)
+      query_params[:limit] = lines if lines
+      query_params[:since] = since if since
+
+      result = client(token).get(url, query_params)
+      result['logs'].each do |log|
+        yield log
+      end
+    end
+
     # @param [String] url
     # @param [Hash] query_params
     def stream_logs(url, query_params)
+      query_params[:limit] = lines if lines
+      query_params[:since] = since if since
+      query_params[:follow] = 1
+
       last_seen = nil
       streamer = lambda do |chunk, remaining_bytes, total_bytes|
         log = buffered_log_json(chunk)
@@ -14,7 +51,6 @@ module Kontena::Cli::Helpers
       end
 
       begin
-        query_params[:follow] = 1
         query_params[:from] = last_seen if last_seen
         result = client(token).get_stream(url, streamer, query_params)
       rescue => exc
@@ -42,6 +78,13 @@ module Kontena::Cli::Helpers
         @buffer << orig_chunk
         nil
       end
+    end
+
+    def show_log(log)
+      color = color_for_container(log['name'])
+      prefix = "#{log['created_at']} #{log['name']}:"
+
+      puts "#{prefix.colorize(color)} #{log['data']}"
     end
 
     # @param [String] container_id

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -9,70 +9,25 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
-    option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
-    option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
-    option "--since", "SINCE", "Show logs since given timestamp"
     option ["-i", "--instance"], "INSTANCE", "Show only given instance specific logs"
-
+    
     def execute
       require_api_url
-      token = require_token
-
 
       query_params = {}
-      query_params[:limit] = lines if lines
-      query_params[:since] = since if since
       query_params[:container] = "#{name}-#{instance}" if instance
 
-      if tail?
-        @buffer = ''
-        query_params[:follow] = 1
-        stream_logs(token, query_params)
-      else
-        list_logs(token, query_params)
+      show_logs("services/#{current_grid}/#{name}/container_logs", query_params) do |log|
+        show_log(log)
       end
-
     end
 
-    def render_log_line(log)
+    def show_log(log)
       color = color_for_container(log['name'])
       instance_number = log['name'].match(/^.+-(\d+)$/)[1]
       name = instance_number.nil? ? log['name'] : instance_number
       prefix = "#{log['created_at']} [#{name}]:".colorize(color)
       puts "#{prefix} #{log['data']}"
-    end
-
-    def list_logs(token, query_params)
-      result = client(token).get("services/#{current_grid}/#{name}/container_logs", query_params)
-      result['logs'].each do |log|
-        render_log_line(log)
-      end
-    end
-
-    # @param [String] token
-    # @param [Hash] query_params
-    def stream_logs(token, query_params)
-      last_seen = nil
-      streamer = lambda do |chunk, remaining_bytes, total_bytes|
-        log = buffered_log_json(chunk)
-        if log
-          last_seen = log['id']
-          render_log_line(log)
-        end
-      end
-
-      begin
-        query_params[:follow] = true
-        if last_seen
-          query_params[:from] = last_seen
-        end
-        result = client(token).get_stream(
-          "services/#{current_grid}/#{name}/container_logs", streamer, query_params
-        )
-      rescue => exc
-        retry if exc.cause.is_a?(EOFError) # Excon wraps the EOFerror into SocketError
-        raise
-      end
     end
   end
 end

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -18,8 +18,8 @@ describe Kontena::Cli::Apps::LogsCommand do
   end
 
   let(:current_grid) do
-  'test-grid'
-end
+    'test-grid'
+  end
 
   let(:service_prefix) do
     'test'
@@ -94,7 +94,7 @@ end
     it "shows all service logs" do
       expect(client).to receive(:get).with('grids/test-grid/container_logs', {
         services: 'test-wordpress,test-mysql',
-        limit: '100',
+        limit: 100,
       }) { { 'logs' => logs } }
 
       subject.run([])
@@ -107,7 +107,7 @@ end
 
       expect(client).to receive(:get).with('grids/test-grid/container_logs', {
         services: 'test-mysql',
-        limit: '100',
+        limit: 100,
       }) { { 'logs' => mysql_logs } }
 
       subject.run(["mysql"])
@@ -121,7 +121,7 @@ end
 
       expect(client).to receive(:get).with('grids/test-grid/container_logs', {
         services: 'test-wordpress,test-mysql',
-        limit: '100',
+        limit: 100,
         since: since,
       }) { { 'logs' => since_logs } }
 

--- a/cli/spec/kontena/cli/containers/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/logs_command_spec.rb
@@ -1,0 +1,50 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/grid_options'
+require "kontena/cli/containers/logs_command"
+
+describe Kontena::Cli::Containers::LogsCommand do
+  include ClientHelpers
+
+  context "for a single container with logs" do
+    let(:logs) do
+      [
+        {
+          'id' => '57cff2e8cfee65c8b6efc8bd',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:04.362690',
+          'data' => "mysql log message 1",
+        },
+        {
+          'id' => '57cff2e8cfee65c8b6efc8be',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:04.500000',
+          'data' => "mysql log message 2",
+        },
+        {
+          'id' => '57cff2e8cfee65c8b6efc8c1',
+          'name' => 'test-mysql-1',
+          'created_at' => '2016-09-07T15:19:06.100000',
+          'data' => "mysql log message 3",
+        },
+      ]
+    end
+
+    before do
+      # neuter String.colorize
+      String.disable_colorization = true
+    end
+
+    it "shows all logs" do
+      allow(client).to receive(:get).with('containers/test-grid/test-mysql/test-mysql-1/logs', {
+        limit: 100,
+      }) { { 'logs' => logs } }
+
+      expect { subject.run(['test-mysql-1']) }.to output(<<LOGS
+2016-09-07T15:19:04.362690 test-mysql-1: mysql log message 1
+2016-09-07T15:19:04.500000 test-mysql-1: mysql log message 2
+2016-09-07T15:19:06.100000 test-mysql-1: mysql log message 3
+LOGS
+      ).to_stdout
+    end
+  end
+end

--- a/cli/spec/kontena/cli/containers/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/logs_command_spec.rb
@@ -46,5 +46,9 @@ describe Kontena::Cli::Containers::LogsCommand do
 LOGS
       ).to_stdout
     end
+
+    it "errors for an invalid --lines" do
+      expect { subject.run(["--lines=invalid", "test-mysql-1"]) }.to raise_error(Clamp::UsageError, "option '--lines': invalid value for Integer(): \"invalid\"")
+    end
   end
 end


### PR DESCRIPTION
This PR continues the work from #995 to also refactor the cli to use a single `LogHelper` implementation, matching the server `LogsHelpers`.

* Moves as much of the implementation into the common `LogsHelpers` as possible for consistency, including the command-line option definitions.
* Changes the `--lines` option to use `{|s| Integer(s)}`, which provides syntax validation:

        $ kontena container logs -t --lines=100x test-1
        ERROR: option '--lines': invalid value for Integer(): "100x"

    Note that using `s.to_i` would silently return `0`.
* The output format used by the various logs commands should remain identical.
* Adds a `kontena container logs service-1` command, with "end to end" args-get-output specs.

AFAIK this refactoring should preserve the exact behavior of the existing commands...