### PR TITLE
Retry when unknown exception occurs while streaming docker events

### DIFF
--- a/agent/lib/kontena/workers/event_worker.rb
+++ b/agent/lib/kontena/workers/event_worker.rb
@@ -49,6 +49,11 @@ module Kontena::Workers
             sleep 0.01
             retry
           end
+        rescue => exc
+          if processing?
+            error "unknown error occurred: #{exc.message}"
+            retry
+          end
         end
       }
     end


### PR DESCRIPTION
This PR fixes a possible bug that might cause event stream to stop by adding catch-all exception handler that will retry event streaming if processing flag is still enabled.