### PR TITLE
CLI: fix #1006 grid logs --tail breakage

### DIFF
--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -12,9 +12,13 @@ module Kontena::Cli::Grids
     option "--service", "SERVICE", "Filter by service name", multivalued: true
     option ["-c", "--container"], "CONTAINER", "Filter by container", multivalued: true
 
+    # @return [String]
+    def token
+      @token ||= require_token
+    end
+
     def execute
       require_api_url
-      token = require_token
 
       query_params = {}
       query_params[:nodes] = node_list.join(",") unless node_list.empty?
@@ -24,13 +28,13 @@ module Kontena::Cli::Grids
       query_params[:since] = since if since
 
       if tail?
-        tail_logs(token, query_params)
+        tail_logs(query_params)
       else
-        list_logs(token, query_params)
+        list_logs(query_params)
       end
     end
 
-    def list_logs(token, query_params)
+    def list_logs(query_params)
       result = client(token).get("grids/#{current_grid}/container_logs", query_params)
       result['logs'].each do |log|
         color = color_for_container(log['name'])
@@ -44,7 +48,7 @@ module Kontena::Cli::Grids
 
     # @param [String] token
     # @param [Hash] query_params
-    def tail_logs(token, query_params)
+    def tail_logs(query_params)
       stream_logs("grids/#{current_grid}/container_logs", query_params) do |log|
         color = color_for_container(log['name'])
         puts "#{log['name'].colorize(color)} | #{log['data']}"


### PR DESCRIPTION
Quick fix for #1006 where #987 broke `grid logs --tail`. I ended up fixing this in #1001 without noticing it was broken. Let's discuss any more complete fix there, including the lack of any test specs covering this functionality :(

    kontena grid logs --lines 10

```
2016-09-12T18:05:16.000Z test-client-1: Mon Sep 12 18:05:16 UTC 2016
2016-09-12T18:05:17.000Z test-client-1: Mon Sep 12 18:05:17 UTC 2016
2016-09-12T18:05:18.000Z test-client-1: Mon Sep 12 18:05:18 UTC 2016
2016-09-12T18:05:19.000Z test-client-1: Mon Sep 12 18:05:19 UTC 2016
2016-09-12T18:05:20.000Z test-client-1: Mon Sep 12 18:05:20 UTC 2016
2016-09-12T18:05:21.000Z test-client-1: Mon Sep 12 18:05:21 UTC 2016
2016-09-12T18:05:22.000Z test-client-1: Mon Sep 12 18:05:22 UTC 2016
2016-09-12T18:05:23.000Z test-client-1: Mon Sep 12 18:05:23 UTC 2016
2016-09-12T18:05:24.000Z test-client-1: Mon Sep 12 18:05:24 UTC 2016
2016-09-12T18:05:25.000Z test-client-1: Mon Sep 12 18:05:25 UTC 2016
```

    kontena grid logs --lines 10 --tail

```
test-client-1 | Mon Sep 12 18:05:31 UTC 2016
test-client-1 | Mon Sep 12 18:05:32 UTC 2016
test-client-1 | Mon Sep 12 18:05:33 UTC 2016
test-client-1 | Mon Sep 12 18:05:34 UTC 2016
test-client-1 | Mon Sep 12 18:05:35 UTC 2016
test-client-1 | Mon Sep 12 18:05:36 UTC 2016
test-client-1 | Mon Sep 12 18:05:37 UTC 2016
test-client-1 | Mon Sep 12 18:05:38 UTC 2016
test-client-1 | Mon Sep 12 18:05:39 UTC 2016
test-client-1 | Mon Sep 12 18:05:41 UTC 2016
test-client-1 | Mon Sep 12 18:05:42 UTC 2016
test-client-1 | Mon Sep 12 18:05:43 UTC 2016
test-client-1 | Mon Sep 12 18:05:44 UTC 2016
test-client-1 | Mon Sep 12 18:05:45 UTC 2016
test-client-1 | Mon Sep 12 18:05:46 UTC 2016
```