### PR TITLE
Improve travis automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 language: ruby
+sudo: required
 rvm:
   - 2.0.0-p648
   - 2.1.8
   - 2.2.3
   - 2.3.1
 cache: bundler
-addons:
-  apt:
-    sources:
-      - mongodb-3.0-precise
-    packages:
-      - mongodb-org-server
+cache:
+  directories:
+  - $TEST_DIR/vendor/bundle
+services:
+  - docker
+before_install:
+  - ./build/travis/before_install.sh
 env:
-  - TEST_DIR=server
-  - TEST_DIR=agent
-  - TEST_DIR=cli
+  global:
+    - secure: "mM0iv3ooqyqYsbBBNw73/88EURi5PO529E2Sm2ovy5xzL0SadOyCz4uLYmTMiIoP+pXDvmH1/XjoPxVLR2MH4shXe0VtrKFYiTEjan3X05VUyVMnfnm0Z+uMgHsBFZxl941o27N0jFY+0dcAstofprP/PF5SxKvKwcb0rCfdUYs="
+    - secure: "YKHqxWKFfrhJoQ5ptfgnByGNdcRLcQVpI22EGjU5WWzQrUw3Frq8+zsRmSNjzF6qEi5oXfxzxUaOItzY8W8bkWUVHCaVGalfyK+C4ad55n8ZpP2cZkOJtenocPhhUTRFwOuAZsUYCI+hXroMyoBUsnu4AJqpkYVimlNblOdcWoA="
+  matrix:
+    - TEST_DIR=agent
+    - TEST_DIR=cli
+    - TEST_DIR=server
 matrix:
   exclude:
     - rvm: 2.0.0-p648
@@ -29,4 +35,12 @@ matrix:
       env: TEST_DIR=agent
     - rvm: 2.2.3
       env: TEST_DIR=agent
-script: CI=true cd $TEST_DIR && bundle install && bundle exec rspec spec/
+script: ./build/travis/test.sh
+deploy:
+  - provider: script
+    script: "rvm $TRAVIS_RUBY_VERSION do $TRAVIS_BUILD_DIR/build/travis/deploy.sh"
+    on:
+      tags: true
+      condition: $TEST_DIR = server
+      rvm: 2.3.1
+      repo: kontena/kontena

--- a/agent/lib/tasks/release.rake
+++ b/agent/lib/tasks/release.rake
@@ -1,10 +1,14 @@
 
 
 namespace :release do
-  VERSION = File.read('VERSION').strip
+  VERSION = Gem::Version.new(File.read('VERSION').strip)
   NAME = 'kontena-agent'
   DOCKER_NAME = 'kontena/agent'
-  DOCKER_VERSIONS = ['latest', VERSION.match(/(\d+\.\d+)/)[1]]
+  if VERSION.prerelease?
+    DOCKER_VERSIONS = ['edge']
+  else
+    DOCKER_VERSIONS = ['latest', VERSION.to_s.match(/(\d+\.\d+)/)[1]]
+  end
 
   desc 'Build all'
   task :build => [:build_docker, :build_ubuntu] do
@@ -23,9 +27,7 @@ namespace :release do
 
   desc 'Build ubuntu packages'
   task :build_ubuntu => :environment do
-    rev = ENV['REV']
-    raise ArgumentError.new('You must define REV') if rev.blank?
-
+    rev = ENV['REV'] || '1'
     sh('mkdir -p build')
     sh('rm -rf build/ubuntu/')
     sh('cp -ar packaging/ubuntu build/')

--- a/build/travis/before_install.sh
+++ b/build/travis/before_install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$TEST_DIR" = "server" ]; then
+  sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+  echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+  sudo apt-get update
+  sudo apt-get remove -y -q --purge mongodb-org*
+  sudo rm -rf /var/lib/mongodb
+  sudo apt-get install -y -q -f mongodb-org-server=3.0.12
+fi

--- a/build/travis/deploy.sh
+++ b/build/travis/deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# login
+curl -u $RUBYGEMS_USER https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials
+docker login -u kontenabot -p $DOCKER_HUB_PASSWORD
+
+# install dependencies
+gem install --no-ri --no-doc bundler rake colorize dotenv
+
+cd $TRAVIS_BUILD_DIR
+rake release:setup
+rake release:push_gem
+rake release:push
+
+# cleanup
+rm ~/.gem/credentials

--- a/build/travis/test.sh
+++ b/build/travis/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+cd $TEST_DIR && \
+  bundle install --path vendor/bundle && \
+  bundle exec rspec spec/

--- a/cli/tasks/release.rake
+++ b/cli/tasks/release.rake
@@ -1,7 +1,11 @@
 namespace :release do
-  VERSION = File.read('VERSION').strip
+  VERSION = Gem::Version.new(File.read('VERSION').strip)
   DOCKER_NAME = 'kontena/cli'
-  DOCKER_VERSIONS = ['latest', VERSION.match(/(\d+\.\d+)/)[1]]
+  if VERSION.prerelease?
+    DOCKER_VERSIONS = ['edge']
+  else
+    DOCKER_VERSIONS = ['latest', VERSION.to_s.match(/(\d+\.\d+)/)[1]]
+  end
 
   desc 'Build all'
   task :build => [:build_docker] do

--- a/server/lib/tasks/release.rake
+++ b/server/lib/tasks/release.rake
@@ -1,10 +1,12 @@
-
-
 namespace :release do
-  VERSION = File.read('VERSION').strip
+  VERSION = Gem::Version.new(File.read('VERSION').strip)
   NAME = 'kontena-server'
   DOCKER_NAME = 'kontena/server'
-  DOCKER_VERSIONS = ['latest', VERSION.match(/(\d+\.\d+)/)[1]]
+  if VERSION.prerelease?
+    DOCKER_VERSIONS = ['edge']
+  else
+    DOCKER_VERSIONS = ['latest', VERSION.to_s.match(/(\d+\.\d+)/)[1]]
+  end
   BINTRAY_USER = ENV['BINTRAY_USER']
   BINTRAY_KEY = ENV['BINTRAY_KEY']
 
@@ -38,8 +40,7 @@ namespace :release do
 
   desc 'Upload ubuntu package'
   task :push_ubuntu => :environment do
-    rev = ENV['REV']
-    raise ArgumentError.new('You must define REV') if rev.blank?
+    rev = ENV['REV'] || '1'
     repo = ENV['REPO'] || 'kontena'
     sh('rm -rf release && mkdir release')
     sh('cp build/ubuntu/*.deb release/')


### PR DESCRIPTION
- use bundler cache
- install mongodb stuff only when `$TEST_DIR=server`
- deploy gem & docker images on tags
  - if a pre-release, tag image also as `:edge`
 - if not a pre-release, tag with semver and `:latest`


![travis](http://blog.biicode.com/wp-content/uploads/sites/2/2014/11/logotravis.png)