### PR TITLE
Replace dry-validation gem with hash_validator gem

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -26,10 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "tty-prompt", "~> 0.7.1"
   spec.add_runtime_dependency "clamp", "~> 1.0.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
-  spec.add_runtime_dependency "dry-validation", "0.8.0"
-  spec.add_runtime_dependency "dry-types", "0.8.0"
-  spec.add_runtime_dependency "dry-configurable", "0.1.6"
-  spec.add_runtime_dependency "dry-monads", "0.1.1"
-  spec.add_runtime_dependency "dry-logic", "0.3.0"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
+  spec.add_runtime_dependency "hash_validator", "~> 0.7.0"
 end

--- a/cli/lib/kontena/cli/apps/build_command.rb
+++ b/cli/lib/kontena/cli/apps/build_command.rb
@@ -10,13 +10,14 @@ module Kontena::Cli::Apps
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['--no-cache'], :flag, 'Do not use cache when building the image', default: false
+    option '--skip-validation', :flag, 'Skip YAML file validation', default: false
     parameter "[SERVICE] ...", "Services to build"
 
     attr_reader :services
 
     def execute
       require_config_file(filename)
-      @services = services_from_yaml(filename, service_list, service_prefix)
+      @services = services_from_yaml(filename, service_list, service_prefix, skip_validation?)
       if services.none?{ |name, service| service['build'] }
         error 'Not found any service with build option'
         abort

--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -16,9 +16,9 @@ module Kontena::Cli::Apps
     # @param [Array<String>] service_list
     # @param [String] prefix
     # @return [Hash]
-    def services_from_yaml(filename, service_list, prefix)
+    def services_from_yaml(filename, service_list, prefix, skip_validation=false)
       set_env_variables(prefix, current_grid)
-      reader = YAML::Reader.new(filename)
+      reader = YAML::Reader.new(filename, skip_validation)
       outcome = reader.execute
       hint_on_validation_notifications(outcome[:notifications]) if outcome[:notifications].size > 0
       abort_on_validation_errors(outcome[:errors]) if outcome[:errors].size > 0

--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -15,8 +15,9 @@ module Kontena::Cli::Apps
     # @param [String] filename
     # @param [Array<String>] service_list
     # @param [String] prefix
+    # @param [TrueClass|FalseClass] skip_validation
     # @return [Hash]
-    def services_from_yaml(filename, service_list, prefix, skip_validation=false)
+    def services_from_yaml(filename, service_list, prefix, skip_validation = false)
       set_env_variables(prefix, current_grid)
       reader = YAML::Reader.new(filename, skip_validation)
       outcome = reader.execute

--- a/cli/lib/kontena/cli/apps/config_command.rb
+++ b/cli/lib/kontena/cli/apps/config_command.rb
@@ -3,17 +3,17 @@ require 'pp'
 
 module Kontena::Cli::Apps
   class ConfigCommand < Kontena::Command
-    include Kontena::Cli::Common    
+    include Kontena::Cli::Common
     include Common
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
-
+    option '--skip-validation', :flag, 'Skip YAML file validation', default: false
     parameter "[SERVICE] ...", "Services to view"
 
     def execute
       require_config_file(filename)
-      services = services_from_yaml(filename, service_list, service_prefix)
+      services = services_from_yaml(filename, service_list, service_prefix, skip_validation?)
       services.each do |name, config|
         config['cmd'] = config['cmd'].join(" ") if config['cmd']
         config.delete_if {|key, value| value.nil? || (value.respond_to?(:empty?) && value.empty?) }

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -16,6 +16,7 @@ module Kontena::Cli::Apps
     option '--force', :flag, 'Force deploy even if service does not have any changes'
     option '--force-deploy', :flag, '[DEPRECATED: use --force]'
 
+    option '--skip-validation', :flag, 'Skip YAML file validation', default: false
     parameter "[SERVICE] ...", "Services to start"
 
     attr_reader :services, :deploy_queue

--- a/cli/lib/kontena/cli/apps/list_command.rb
+++ b/cli/lib/kontena/cli/apps/list_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Apps
     def execute
       require_config_file(filename)
 
-      @services = services_from_yaml(filename, service_list, service_prefix)
+      @services = services_from_yaml(filename, service_list, service_prefix, true)
       if services.size > 0
         show_services(services)
       elsif !service_list.empty?

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Apps
     def execute
       require_config_file(filename)
 
-      services = services_from_yaml(filename, service_list, service_prefix)
+      services = services_from_yaml(filename, service_list, service_prefix, true)
 
       if services.empty? && !service_list.empty?
         signal_error "No such service: #{service_list.join(', ')}"

--- a/cli/lib/kontena/cli/apps/monitor_command.rb
+++ b/cli/lib/kontena/cli/apps/monitor_command.rb
@@ -15,8 +15,8 @@ module Kontena::Cli::Apps
 
     def execute
       require_config_file(filename)
-            
-      @services = services_from_yaml(filename, service_list, service_prefix)
+
+      @services = services_from_yaml(filename, service_list, service_prefix, true)
       if services.size > 0
         show_monitor(services)
       elsif !service_list.empty?

--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -20,7 +20,7 @@ module Kontena::Cli::Apps
       require_config_file(filename)
       confirm unless forced?
 
-      @services = services_from_yaml(filename, service_list, service_prefix)
+      @services = services_from_yaml(filename, service_list, service_prefix, true)
       if services.size > 0
         remove_services(services)
       elsif !service_list.empty?

--- a/cli/lib/kontena/cli/apps/restart_command.rb
+++ b/cli/lib/kontena/cli/apps/restart_command.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Apps
     def execute
       require_config_file(filename)
 
-      @services = services_from_yaml(filename, service_list, service_prefix)
+      @services = services_from_yaml(filename, service_list, service_prefix, true)
       if services.size > 0
         restart_services(services)
       elsif !service_list.empty?

--- a/cli/lib/kontena/cli/apps/scale_command.rb
+++ b/cli/lib/kontena/cli/apps/scale_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Apps
 
     def execute
       require_config_file(filename)
-      yml_service = services_from_yaml(filename, [service], service_prefix)
+      yml_service = services_from_yaml(filename, [service], service_prefix, true)
       if yml_service[service]
         options = yml_service[service]
         exit_with_error("Service has already instances defined in #{filename}. Please update #{filename} and deploy service instead") if options['container_count']

--- a/cli/lib/kontena/cli/apps/start_command.rb
+++ b/cli/lib/kontena/cli/apps/start_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Apps
     def execute
       require_config_file(filename)
 
-      @services = services_from_yaml(filename, service_list, service_prefix)
+      @services = services_from_yaml(filename, service_list, service_prefix, true)
       if services.size > 0
         start_services(services)
       elsif !service_list.empty?

--- a/cli/lib/kontena/cli/apps/stop_command.rb
+++ b/cli/lib/kontena/cli/apps/stop_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Apps
     def execute
       require_config_file(filename)
 
-      @services = services_from_yaml(filename, service_list, service_prefix)
+      @services = services_from_yaml(filename, service_list, service_prefix, true)
       if services.size > 0
         stop_services(services)
       elsif !service_list.empty?

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/affinities_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/affinities_validator.rb
@@ -1,0 +1,19 @@
+module Kontena::Cli::Apps::YAML::CustomValidators
+  class AffinitiesValidator < HashValidator::Validator::Base
+    def initialize
+      super('valid_affinities')
+    end
+
+    def validate(key, value, validations, errors)
+      unless value.is_a?(Array)
+        errors[key] = 'affinity must be array'
+        return
+      end
+
+      invalid_formats = value.find_all { |a| !a.match(/(?<=\!|\=)=/) }
+      if invalid_formats.count > 0
+        errors[key] = "affinity contains invalid formats: #{invalid_formats.join(', ')}"
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/affinities_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/affinities_validator.rb
@@ -1,4 +1,4 @@
-module Kontena::Cli::Apps::YAML::CustomValidators
+module Kontena::Cli::Apps::YAML::Validations::CustomValidators
   class AffinitiesValidator < HashValidator::Validator::Base
     def initialize
       super('valid_affinities')

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/build_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/build_validator.rb
@@ -1,0 +1,22 @@
+module Kontena::Cli::Apps::YAML::CustomValidators
+  class BuildValidator < HashValidator::Validator::Base
+    def initialize
+      super('valid_build')
+    end
+
+    def validate(key, value, validations, errors)
+      unless value.is_a?(String) || value.is_a?(Hash)
+        errors[key] = 'build must be string or hash'
+        return
+      end
+      if value.is_a?(Hash)
+        build_validation = {
+          'context' => 'string',
+          'dockerfile' => HashValidator.optional('string'),
+          'args' => HashValidator.optional(-> (value) { value.is_a?(Array) || value.is_a?(Hash) })
+        }
+        HashValidator.validator_for(build_validation).validate(key, value, build_validation, errors)
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/build_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/build_validator.rb
@@ -1,4 +1,4 @@
-module Kontena::Cli::Apps::YAML::CustomValidators
+module Kontena::Cli::Apps::YAML::Validations::CustomValidators
   class BuildValidator < HashValidator::Validator::Base
     def initialize
       super('valid_build')

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/extends_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/extends_validator.rb
@@ -1,4 +1,4 @@
-module Kontena::Cli::Apps::YAML::CustomValidators
+module Kontena::Cli::Apps::YAML::Validations::CustomValidators
   class ExtendsValidator < HashValidator::Validator::Base
     def initialize
       super('valid_extends')

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/extends_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/extends_validator.rb
@@ -1,0 +1,21 @@
+module Kontena::Cli::Apps::YAML::CustomValidators
+  class ExtendsValidator < HashValidator::Validator::Base
+    def initialize
+      super('valid_extends')
+    end
+
+    def validate(key, value, validations, errors)
+      unless value.is_a?(String) || value.is_a?(Hash)
+        errors[key] = 'extends must be string or hash'
+        return
+      end
+      if value.is_a?(Hash)
+        extends_validation = {
+          'service' => 'string',
+          'file' => HashValidator.optional('string')
+        }
+        HashValidator.validator_for(extends_validation).validate(key, value, extends_validation, errors)
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/hooks_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/hooks_validator.rb
@@ -1,0 +1,45 @@
+module Kontena::Cli::Apps::YAML::CustomValidators
+  class HooksValidator < HashValidator::Validator::Base
+    def initialize
+      super('valid_hooks')
+    end
+
+    def validate(key, value, validations, errors)
+      unless value.is_a?(Hash)
+        errors[key] = 'hooks must be array'
+        return
+      end
+      hook_names = value.keys - ['pre_build', 'post_start']
+      if value['pre_build']
+        unless value['pre_build'].is_a?(Array)
+          errors[key] = 'pre_build must be array'
+          return
+        end
+        value['pre_build'].each do |pre_build|
+          pre_build_validation = {
+            'name' => 'string',
+            'cmd' => 'string'
+          }
+          HashValidator.validator_for(pre_build_validation).validate('hooks.pre_build', pre_build, pre_build_validation, errors)
+        end
+      end
+
+      if value['post_start']
+        unless value['post_start'].is_a?(Array)
+          errors["#{key}"] = 'post_start must be array'
+          return
+        end
+        value['post_start'].each do |post_start|
+
+          post_start_validation = {
+            'name' => 'string',
+            'instances' => (-> (value) { value.is_a?(Integer) || value == '*' }),
+            'cmd' => 'string',
+            'oneshot' => HashValidator.optional('boolean')
+          }
+          HashValidator.validator_for(post_start_validation).validate('hooks.post_start', post_start, post_start_validation, errors)
+        end
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/secrets_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/secrets_validator.rb
@@ -1,0 +1,22 @@
+module Kontena::Cli::Apps::YAML::CustomValidators
+  class SecretsValidator < HashValidator::Validator::Base
+    def initialize
+      super('valid_secrets')
+    end
+
+    def validate(key, value, validations, errors)
+      unless value.is_a?(Array)
+        errors[key] = 'secrets must be array'
+        return
+      end
+      secret_item_validation = {
+        'secret' => 'string',
+        'name' => 'string',
+        'type' => 'string'
+      }
+      value.each do |secret|
+        HashValidator.validator_for(secret_item_validation).validate(key, secret, secret_item_validation, errors)
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/apps/yaml/custom_validators/secrets_validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/custom_validators/secrets_validator.rb
@@ -1,4 +1,4 @@
-module Kontena::Cli::Apps::YAML::CustomValidators
+module Kontena::Cli::Apps::YAML::Validations::CustomValidators
   class SecretsValidator < HashValidator::Validator::Base
     def initialize
       super('valid_secrets')

--- a/cli/lib/kontena/cli/apps/yaml/validations.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validations.rb
@@ -1,20 +1,18 @@
-require_relative 'custom_validators/affinities_validator'
-require_relative 'custom_validators/build_validator'
-require_relative 'custom_validators/extends_validator'
-require_relative 'custom_validators/hooks_validator'
-require_relative 'custom_validators/secrets_validator'
-
 module Kontena::Cli::Apps::YAML
- module CustomValidators
-
- end
  module Validations
-
-   HashValidator.append_validator(CustomValidators::AffinitiesValidator.new)
-   HashValidator.append_validator(CustomValidators::BuildValidator.new)
-   HashValidator.append_validator(CustomValidators::ExtendsValidator.new)
-   HashValidator.append_validator(CustomValidators::SecretsValidator.new)
-   HashValidator.append_validator(CustomValidators::HooksValidator.new)
+   module CustomValidators
+     require_relative 'custom_validators/affinities_validator'
+     require_relative 'custom_validators/build_validator'
+     require_relative 'custom_validators/extends_validator'
+     require_relative 'custom_validators/hooks_validator'
+     require_relative 'custom_validators/secrets_validator'
+     
+     HashValidator.append_validator(AffinitiesValidator.new)
+     HashValidator.append_validator(BuildValidator.new)
+     HashValidator.append_validator(ExtendsValidator.new)
+     HashValidator.append_validator(SecretsValidator.new)
+     HashValidator.append_validator(HooksValidator.new)
+   end
 
    def common_validations
      {

--- a/cli/lib/kontena/cli/apps/yaml/validations.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validations.rb
@@ -1,97 +1,69 @@
+require_relative 'custom_validators/affinities_validator'
+require_relative 'custom_validators/build_validator'
+require_relative 'custom_validators/extends_validator'
+require_relative 'custom_validators/hooks_validator'
+require_relative 'custom_validators/secrets_validator'
+
 module Kontena::Cli::Apps::YAML
+ module CustomValidators
+
+ end
  module Validations
 
-   def append_common_validations(base)
-     base.optional('image').maybe(:str?)
+   HashValidator.append_validator(CustomValidators::AffinitiesValidator.new)
+   HashValidator.append_validator(CustomValidators::BuildValidator.new)
+   HashValidator.append_validator(CustomValidators::ExtendsValidator.new)
+   HashValidator.append_validator(CustomValidators::SecretsValidator.new)
+   HashValidator.append_validator(CustomValidators::HooksValidator.new)
 
-     base.optional('extends') { str? | type?(Hash) }
-     base.rule(when_extends_is_hash: ['extends']) do |extends|
-       extends.type?(Hash) > extends.schema do
-         required('service').filled(:str?)
-         optional('file').value(:str?)
-       end
-     end
+   def common_validations
+     {
+        'image' => optional('string'), # it's optional because some base yml file might contain image option
+        'extends' => optional('valid_extends'),
+        'stateful' => optional('boolean'),
+        'affinity' => optional('valid_affinities'),
+        'cap_add' => optional('array'),
+        'cap_drop' => optional('array'),
+        'command' => optional('string'),
+        'cpu_shares' => optional('integer'),
+        'external_links' => optional('array'),
+        'mem_limit' => optional('string'),
+        'mem_swaplimit' => optional('string'),
+        'environment' => optional(-> (value) { value.is_a?(Array) || value.is_a?(Hash) }),
+        'env_file' => optional(-> (value) { value.is_a?(String) || value.is_a?(Array) }),
+        'instances' => optional('integer'),
+        'links' => optional(-> (value) { value.is_a?(Array) || value.nil? }),
+        'ports' => optional('array'),
+        'pid' => optional('string'),
+        'privileged' => optional('boolean'),
+        'user' => optional('string'),
+        'volumes' => optional('array'),
+        'volumes_from' => optional('array'),
+        'secrets' => optional('valid_secrets'),
+        'hooks' => optional('valid_hooks'),
+        'deploy' => optional({
+          'strategy' => optional(%w(ha daemon random)),
+          'wait_for_port' => optional('integer'),
+          'min_health' => optional('float'),
+          'interval' => optional(/^\d+(min|h|d|)$/)
+        }),
+        'health_check' => optional({
+          'protocol' => /^(http|tcp)$/,
+          'port' => 'integer',
+          'uri' => optional(/\/[\S]*/),
+          'timeout' => optional('integer'),
+          'interval' => optional('integer'),
+          'initial_delay' => optional('integer')
+        })
+      }
+    end
 
-     base.optional('stateful') { bool? }
-     base.optional('affinity') { array? { each { format?(/(?<=\!|\=)=/) } } }
-     base.optional('cap_add').maybe(:array?)
-     base.optional('cap_drop').maybe(:array?)
-     base.optional('command').maybe(:str?)
-     base.optional('cpu_shares').maybe(:int?)
-     base.optional('external_links') { array? }
-     base.optional('mem_limit') { int? | str? }
-     base.optional('memswap_limit') { int? | str? }
-     base.optional('environment') { array? | type?(Hash) }
-     base.optional('env_file') { str? | array? }
-     base.optional('instances') { int? }
-     base.optional('links') { array? | empty? }
-     base.optional('ports').value(:array?)
-     base.optional('volumes').value(:array?)
-     base.optional('volumes_from').value(:array?)
+    def optional(type)
+      HashValidator.optional(type)
+    end
 
-     base.optional('deploy').schema do
-       optional('strategy').value(included_in?: %w(ha daemon random))
-       optional('wait_for_port').value(:int?)
-       optional('min_health').value(:float?)
-       optional('interval').value(format?: /^\d+(min|h|d|)$/)
-     end
-
-     base.optional('hooks').schema do
-       optional('post_start').each do
-         required('name').filled
-         required('cmd').filled
-         required('instances') { int? | eql?('*') }
-         optional('oneshot').value(:bool?)
-       end
-
-       optional('pre_build').each do
-         required('cmd').filled
-       end
-     end
-
-     base.optional('secrets').each do
-       required('secret').filled
-       required('name').filled
-       required('type').filled
-     end
-     base.optional('health_check').schema do
-      required('protocol').filled(format?: /^(http|tcp)$/)
-      required('port').filled(:int?)
-      optional('uri').value(format?: /\/[\S]*/)
-      optional('timeout').value(:int?)
-      optional('interval').value(:int?)
-      optional('initial_delay').value(:int?)
-     end
-   end
-
-   ##
-   # @param [Hash] service_config
-   def validate_options(service_config)
-     @yaml_schema.call(service_config)
-   end
-
-   ##
-   # @param [Hash] service_config
-   # @return [Array<String>] errors
-   def validate_keys(service_config)
-     errors = {}
-     service_config.keys.each do |key|
-       error = validate_required(key)
-       errors[key] = error if error
-     end
-     errors
-   end
-
-   ##
-   # @param [String] key
-   def validate_required(key)
-     if self.class::UNSUPPORTED_KEYS.include?(key)
-       ['unsupported option']
-     elsif !self.class::VALID_KEYS.include?(key)
-       ['invalid option']
-     else
-       nil
-     end
-   end
- end
+    def validate_options(service_config)
+      HashValidator.validate(service_config, @schema, true)
+    end
+  end
 end

--- a/cli/lib/kontena/cli/apps/yaml/validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator.rb
@@ -23,6 +23,10 @@ module Kontena::Cli::Apps
           notifications: []
         }
         yaml.each do |service, options|
+          unless options.is_a?(Hash)
+            result[:errors] << { service => { 'options' => 'must be a mapping not a string'}  }
+            next
+          end
           option_errors = validate_options(options)
           result[:errors] << { service => option_errors.errors } unless option_errors.valid?
         end

--- a/cli/lib/kontena/cli/apps/yaml/validator.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator.rb
@@ -1,36 +1,17 @@
-require 'dry-validation'
+require 'hash_validator'
 module Kontena::Cli::Apps
   module YAML
     class Validator
       require_relative 'validations'
       include Validations
 
-      VALID_KEYS = %w(
-      affinity build dockerfile cap_add cap_drop command deploy env_file environment extends external_links
-      image links log_driver log_opt net pid ports volumes volumes_from cpu_shares
-      mem_limit memswap_limit privileged stateful user instances hooks secrets health_check
-      ).freeze
-
-      UNSUPPORTED_KEYS = %w(
-      cgroup_parent container_name devices depends_on dns dns_search tmpfs entrypoint
-      expose extra_hosts labels logging network_mode networks security_opt stop_signal ulimits volume_driver
-      cpu_quota cpuset domainname hostname ipc mac_address
-      read_only restart shm_size stdin_open tty working_dir
-      ).freeze
-
-      ##
-      # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       def initialize(need_image=false)
-        base = self
-        @yaml_schema = Dry::Validation.Schema do
-          base.append_common_validations(self)
-
-          optional('build').value(:str?)
-          optional('dockerfile').value(:str?)
-          optional('net').value(included_in?: (%w(host bridge)))
-          optional('log_driver').value(:str?)
-          optional('log_opts').value(type?: Hash)
-        end
+        @schema = common_validations
+        @schema['build'] = optional('string')
+        @schema['dockerfile'] = optional('string')
+        @schema['net'] = optional(%w(host bridge))
+        @schema['log_driver'] = optional('string')
+        @schema['log_opts'] = optional({})
       end
 
       ##
@@ -41,16 +22,9 @@ module Kontena::Cli::Apps
           errors: [],
           notifications: []
         }
-
         yaml.each do |service, options|
-          unless options.is_a?(Hash)
-            result[:errors] << { service => { 'options' => 'must be a mapping not a string'}  }            
-            next
-          end
-          key_errors = validate_keys(options)
           option_errors = validate_options(options)
-          result[:errors] << { service => option_errors.messages } if option_errors.failure?
-          result[:notifications] << { service => key_errors } if key_errors.size > 0
+          result[:errors] << { service => option_errors.errors } unless option_errors.valid?
         end
         result
       end

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -1,4 +1,4 @@
-require 'dry-validation'
+require 'hash_validator'
 require_relative 'validator'
 
 module Kontena::Cli::Apps
@@ -7,45 +7,20 @@ module Kontena::Cli::Apps
       require_relative 'validations'
       include Validations
 
-      VALID_KEYS = %w(
-      affinity build cap_add cap_drop command deploy depends_on env_file environment extends external_links
-      image links logging network_mode pid ports volumes volumes_from cpu_shares
-      mem_limit memswap_limit privileged stateful user instances hooks secrets health_check
-      ).freeze
-
-      UNSUPPORTED_KEYS = %w(
-      cgroup_parent container_name devices dns dns_search tmpfs entrypoint
-      expose extra_hosts labels log_driver log_opt net networks security_opt stop_signal ulimits volume_driver
-      cpu_quota cpuset domainname hostname ipc mac_address
-      read_only restart shm_size stdin_open tty working_dir
-      ).freeze
-
-      ##
-      # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
       def initialize
-        base = self
-        @yaml_schema = Dry::Validation.Schema do
-          base.append_common_validations(self)
-          optional('build') { str? | type?(Hash) }
-
-          rule(build_hash: ['build']) do |build|
-            build.type?(Hash) > build.schema do
-              required('context').filled
-              optional('dockerfile').value(:str?)
-              optional('args') { array? | type?(Hash) }
-            end
-          end
-          optional('depends_on').value(:array?)
-          optional('network_mode').value(included_in?: (%w(host bridge)))
-          optional('logging').schema do
-            optional('driver').value(:str?)
-            optional('options') { type?(Hash) }
-          end
-        end
+        @schema = common_validations
+        @schema['build'] = optional('valid_build')
+        @schema['depends_on'] = optional('array')
+        @schema['network_mode'] = optional(%w(host bridge))
+        @schema['logging'] = optional({
+          'driver' => optional('string'),
+          'options' => optional(-> (value) { value.is_a?(Hash) })
+          })
       end
 
       ##
       # @param [Hash] yaml
+      # @param [TrueClass|FalseClass] strict
       # @return [Array] validation_errors
       def validate(yaml)
         result = {
@@ -53,15 +28,9 @@ module Kontena::Cli::Apps
           notifications: []
         }
         if yaml.key?('services')
-          yaml['services'].each do |service, options|            
-            unless options.is_a?(Hash)
-              result[:errors] << { service => { 'options' => 'must be a mapping not a string'} }
-              next
-            end
-            key_errors = validate_keys(options)
+          yaml['services'].each do |service, options|
             option_errors = validate_options(options)
-            result[:errors] << { service => option_errors.messages } if option_errors.failure?
-            result[:notifications] << { service => key_errors } if key_errors.size > 0
+            result[:errors] << { service => option_errors.errors } unless option_errors.valid?
           end
         else
           result[:errors] << { 'file' => 'services missing' }

--- a/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
+++ b/cli/lib/kontena/cli/apps/yaml/validator_v2.rb
@@ -29,6 +29,10 @@ module Kontena::Cli::Apps
         }
         if yaml.key?('services')
           yaml['services'].each do |service, options|
+            unless options.is_a?(Hash)
+              result[:errors] << { service => { 'options' => 'must be a mapping not a string'}  }
+              next
+            end
             option_errors = validate_options(options)
             result[:errors] << { service => option_errors.errors } unless option_errors.valid?
           end

--- a/cli/spec/kontena/cli/app/yaml/validator_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_spec.rb
@@ -2,134 +2,129 @@ require_relative '../../../../spec_helper'
 require 'kontena/cli/apps/yaml/validator'
 
 describe Kontena::Cli::Apps::YAML::Validator do
-  describe '#validate_keys' do
-    it 'returns error on invalid key' do
-      result = subject.validate_keys('name' => 'wordpress')
-      expect(result['name'].size).to eq(1)
-    end
-  end
 
   describe '#validate_options' do
     context 'build' do
       it 'is optional' do
         result = subject.validate_options({})
-        expect(result.success?).to be_truthy
-        expect(result.messages.key?('build')).to be_falsey
+        expect(result.valid?).to be_truthy
+
+        expect(result.errors.key?('build')).to be_falsey
       end
 
       it 'must be string' do
         result = subject.validate_options('build' => 12345)
-        expect(result.messages.key?('build')).to be_truthy
+        expect(result.errors.key?('build')).to be_truthy
 
         result = subject.validate_options('build' => '.')
-        expect(result.messages.key?('build')).to be_falsey
+        expect(result.errors.key?('build')).to be_falsey
       end
     end
 
     context 'image' do
       it 'is optional' do
         result = subject.validate_options('build' => '.')
-        expect(result.success?).to be_truthy
-        expect(result.messages.key?('image')).to be_falsey
+        expect(result.valid?).to be_truthy
+        expect(result.errors.key?('image')).to be_falsey
       end
 
       it 'must be string' do
         result = subject.validate_options('image' => 10)
-        expect(result.success?).to be_falsey
-        expect(result.messages.key?('image')).to be_truthy
+        expect(result.valid?).to be_falsey
+        expect(result.errors.key?('image')).to be_truthy
       end
     end
 
     it 'validates stateful is boolean' do
       result = subject.validate_options('stateful' => 'bool')
-      expect(result.messages.key?('stateful')).to be_truthy
+      expect(result.errors.key?('stateful')).to be_truthy
     end
 
     it 'validates net is host or bridge' do
       result = subject.validate_options('net' => 'invalid')
-      expect(result.messages.key?('net')).to be_truthy
+      expect(result.errors.key?('net')).to be_truthy
 
       result = subject.validate_options('net' => 'bridge')
-      expect(result.messages.key?('net')).to be_falsey
+      expect(result.errors.key?('net')).to be_falsey
 
       result = subject.validate_options('net' => 'host')
-      expect(result.messages.key?('net')).to be_falsey
+      expect(result.errors.key?('net')).to be_falsey
     end
 
     context 'affinity' do
       it 'is optional' do
         result = subject.validate_options({})
-        expect(result.messages.key?('affinity')).to be_falsey
+        expect(result.errors.key?('affinity')).to be_falsey
       end
 
       it 'must be array' do
         result = subject.validate_options('affinity' => 'node==node1')
-        expect(result.messages.key?('affinity')).to be_truthy
+        expect(result.errors.key?('affinity')).to be_truthy
         result = subject.validate_options('affinity' => ['node==node1'])
-        expect(result.messages.key?('affinity')).to be_falsey
+        expect(result.errors.key?('affinity')).to be_falsey
       end
 
       it 'validates format' do
         result = subject.validate_options('affinity' => ['node=node1'])
-        expect(result.messages.key?('affinity')).to be_truthy
+        expect(result.errors.key?('affinity')).to be_truthy
 
         result = subject.validate_options('affinity' => ['node==node1', 'service!=mariadb'])
-        expect(result.messages.key?('affinity')).to be_falsey
+        expect(result.errors.key?('affinity')).to be_falsey
       end
     end
 
     context 'deploy' do
       it 'is optional' do
         result = subject.validate_options({})
-        expect(result.messages.key?('deploy')).to be_falsey
+        expect(result.errors.key?('deploy')).to be_falsey
       end
 
       context 'strategy' do
         it 'accepts daemon' do
           result = subject.validate_options('deploy' => {'strategy' => 'daemon'})
-          expect(result.messages.key?('deploy')).to be_falsey
+          expect(result.errors.key?('deploy')).to be_falsey
         end
 
         it 'accepts random' do
           result = subject.validate_options('deploy' => {'strategy' => 'random'})
-          expect(result.messages.key?('deploy')).to be_falsey
+          expect(result.errors.key?('deploy')).to be_falsey
         end
 
         it 'accepts ha' do
           result = subject.validate_options('deploy' => {'strategy' => 'ha'})
-          expect(result.messages.key?('deploy')).to be_falsey
+          expect(result.errors.key?('deploy')).to be_falsey
         end
 
         it 'rejects invalid values' do
           result = subject.validate_options('deploy' => {'strategy' => 'global'})
-          expect(result.messages.key?('deploy')).to be_truthy
+          expect(result.errors.key?('deploy')).to be_truthy
         end
       end
 
       context 'interval' do
         it 'rejects wrong format' do
           result = subject.validate_options('deploy' => {'interval' => '1xyz'})
-          expect(result.messages.key?('deploy')).to be_truthy
+          expect(result.errors.key?('deploy')).to be_truthy
         end
 
         it 'accepts 1min as value' do
           result = subject.validate_options('deploy' => {'interval' => '1min'})
-          expect(result.messages.key?('deploy')).to be_falsey
+          expect(result.errors.key?('deploy')).to be_falsey
         end
 
         it 'accepts 1h as value' do
           result = subject.validate_options('deploy' => {'interval' => '1h'})
-          expect(result.messages.key?('deploy')).to be_falsey
+          expect(result.errors.key?('deploy')).to be_falsey
         end
 
         it 'accepts 1d as value' do
           result = subject.validate_options('deploy' => {'interval' => '1d'})
-          expect(result.messages.key?('deploy')).to be_falsey
+          expect(result.errors.key?('deploy')).to be_falsey
         end
 
         it 'accepts integer as value' do
           result = subject.validate_options('deploy' => {'interval' => '100'})
-          expect(result.messages.key?('deploy')).to be_falsey
+          expect(result.errors.key?('deploy')).to be_falsey
         end
       end
     end
@@ -137,59 +132,59 @@ describe Kontena::Cli::Apps::YAML::Validator do
     context 'command' do
       it 'is optional' do
         result = subject.validate_options({})
-        expect(result.messages.key?('command')).to be_falsey
+        expect(result.errors.key?('command')).to be_falsey
       end
 
       it 'must be string or empty' do
         result = subject.validate_options('command' => 1234)
-        expect(result.messages.key?('command')).to be_truthy
+        expect(result.errors.key?('command')).to be_truthy
 
         result = subject.validate_options('command' => nil)
-        expect(result.messages.key?('command')).to be_falsey
+        expect(result.errors.key?('command')).to be_falsey
 
         result = subject.validate_options('command' => 'bundle exec rails s')
-        expect(result.messages.key?('command')).to be_falsey
+        expect(result.errors.key?('command')).to be_falsey
       end
     end
 
     it 'validates cpu_shares is integer' do
       result = subject.validate_options('cpu_shares' => '1m')
-      expect(result.messages.key?('cpu_shares')).to be_truthy
+      expect(result.errors.key?('cpu_shares')).to be_truthy
       result = subject.validate_options('cpu_shares' => 1024)
-      expect(result.messages.key?('cpu_shares')).to be_falsey
+      expect(result.errors.key?('cpu_shares')).to be_falsey
       result = subject.validate_options({})
-      expect(result.messages.key?('cpu_shares')).to be_falsey
+      expect(result.errors.key?('cpu_shares')).to be_falsey
     end
 
     it 'validates environment is array or hash' do
       result = subject.validate_options('environment' => 'KEY=VALUE')
-      expect(result.messages.key?('environment')).to be_truthy
+      expect(result.errors.key?('environment')).to be_truthy
       result = subject.validate_options('environment' => ['KEY=VALUE'])
-      expect(result.messages.key?('environment')).to be_falsey
+      expect(result.errors.key?('environment')).to be_falsey
       result = subject.validate_options('environment' => { 'KEY' => 'VALUE' })
-      expect(result.messages.key?('environment')).to be_falsey
+      expect(result.errors.key?('environment')).to be_falsey
     end
 
     context 'validates secrets' do
       it 'must be array' do
         result = subject.validate_options('secrets' => {})
-        expect(result.messages.key?('secrets')).to be_truthy
+        expect(result.errors.key?('secrets')).to be_truthy
       end
 
       context 'item' do
         it 'must contain secret' do
           result = subject.validate_options('secrets' => [{ 'name' => 'test', 'type' => 'env' }])
-          expect(result.messages.key?('secrets')).to be_truthy
+          expect(result.errors.key?('secrets')).to be_truthy
         end
 
         it 'must contain name' do
           result = subject.validate_options('secrets' => [{ 'secret' => 'test', 'type' => 'env' }])
-          expect(result.messages.key?('secrets')).to be_truthy
+          expect(result.errors.key?('secrets')).to be_truthy
         end
 
         it 'must contain type' do
           result = subject.validate_options('secrets' => [{ 'secret' => 'test', 'name' => 'test' }])
-          expect(result.messages.key?('secrets')).to be_truthy
+          expect(result.errors.key?('secrets')).to be_truthy
         end
 
         it 'accepts valid input' do
@@ -201,7 +196,7 @@ describe Kontena::Cli::Apps::YAML::Validator do
                 'type' => 'env'
               }
             ])
-          expect(result.messages.key?('secrets')).to be_falsey
+          expect(result.errors.key?('secrets')).to be_falsey
         end
       end
     end
@@ -209,20 +204,20 @@ describe Kontena::Cli::Apps::YAML::Validator do
     context 'validates extends' do
       it 'accepts string value' do
         result = subject.validate_options('extends' => 'web')
-        expect(result.messages.key?('extends')).to be_falsey
+        expect(result.errors.key?('extends')).to be_falsey
       end
 
       context 'when value is hash' do
         it 'must contain service' do
           result = subject.validate_options('extends' => { 'file' => 'docker_compose.yml'})
-          expect(result.messages.key?('extends')).to be_truthy
+          expect(result.errors.key?('extends')).to be_truthy
         end
       end
 
       context 'when value is not string or hash' do
         it 'returns error' do
           result = subject.validate_options('extends' => ['array is invalid'])
-          expect(result.messages.key?('extends')).to be_truthy
+          expect(result.errors.key?('extends')).to be_truthy
         end
       end
     end
@@ -230,7 +225,7 @@ describe Kontena::Cli::Apps::YAML::Validator do
       context 'validates pre_build' do
         it 'must be array' do
           result = subject.validate_options('hooks' => { 'pre_build' => {} })
-          expect(result.messages.key?('hooks')).to be_truthy
+          expect(result.errors.key?('hooks')).to be_truthy
           data = {
             'hooks' => {
               'pre_build' => [
@@ -241,13 +236,13 @@ describe Kontena::Cli::Apps::YAML::Validator do
             }
           }
           result = subject.validate_options(data)
-          expect(result.messages.key?('hooks')).to be_falsey
+          expect(result.errors.key?('hooks')).to be_falsey
         end
       end
       context 'validates post_start' do
         it 'must be array' do
           result = subject.validate_options('hooks' => { 'post_start' => {} })
-          expect(result.messages.key?('hooks')).to be_truthy
+          expect(result.errors.key?('hooks')).to be_truthy
           data = {
             'hooks' => {
               'post_start' => [
@@ -260,7 +255,7 @@ describe Kontena::Cli::Apps::YAML::Validator do
             }
           }
           result = subject.validate_options(data)
-          expect(result.messages.key?('hooks')).to be_falsey
+          expect(result.errors.key?('hooks')).to be_falsey
         end
 
         context 'item' do
@@ -274,7 +269,7 @@ describe Kontena::Cli::Apps::YAML::Validator do
                 }
               ]
             })
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
 
           it 'must contain cmd' do
@@ -287,7 +282,7 @@ describe Kontena::Cli::Apps::YAML::Validator do
                 }
               ]
             })
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
 
           it 'must contain instance number or *' do
@@ -299,7 +294,7 @@ describe Kontena::Cli::Apps::YAML::Validator do
                 }
               ]
             })
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
             data = {
               'hooks' => {
                 'post_start' => [
@@ -313,7 +308,7 @@ describe Kontena::Cli::Apps::YAML::Validator do
               }
             }
             result = subject.validate_options(data)
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
 
           it 'may contain boolean oneshot' do
@@ -330,24 +325,24 @@ describe Kontena::Cli::Apps::YAML::Validator do
               }
             }
             result = subject.validate_options(data)
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
         end
 
         it 'validates volumes is array' do
           result = subject.validate_options('volumes' => '/app')
-          expect(result.messages.key?('volumes')).to be_truthy
+          expect(result.errors.key?('volumes')).to be_truthy
 
           result = subject.validate_options('volumes' => ['/app'])
-          expect(result.messages.key?('volumes')).to be_falsey
+          expect(result.errors.key?('volumes')).to be_falsey
         end
 
         it 'validates volumes_from is array' do
           result = subject.validate_options('volumes_from' => 'mysql_data')
-          expect(result.messages.key?('volumes_from')).to be_truthy
+          expect(result.errors.key?('volumes_from')).to be_truthy
 
           result = subject.validate_options('volumes_from' => ['mysql_data'])
-          expect(result.messages.key?('volumes_from')).to be_falsey
+          expect(result.errors.key?('volumes_from')).to be_falsey
         end
       end
     end
@@ -355,31 +350,31 @@ describe Kontena::Cli::Apps::YAML::Validator do
     context 'validates health_check' do
       it 'validates health_check' do
         result = subject.validate_options('health_check' => {})
-        expect(result.messages.key?('health_check')).to be_truthy
+        expect(result.errors.key?('health_check')).to be_truthy
       end
 
       it 'validates health_check port ' do
         result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 'abc'})
-        expect(result.messages.key?('health_check')).to be_truthy
+        expect(result.errors.key?('health_check')).to be_truthy
 
         result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 8080})
-        expect(result.messages.key?('health_check')).to be_falsey
+        expect(result.errors.key?('health_check')).to be_falsey
       end
 
       it 'validates health_check uri' do
         result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 8080, 'uri' => 'foobar'})
-        expect(result.messages.key?('health_check')).to be_truthy
+        expect(result.errors.key?('health_check')).to be_truthy
 
         result = subject.validate_options('health_check' => { 'protocol' => 'http', 'port' => 8080, 'uri' => '/health/foo/bar'})
-        expect(result.messages.key?('health_check')).to be_falsey
+        expect(result.errors.key?('health_check')).to be_falsey
       end
 
       it 'validates health_check protocol' do
         result = subject.validate_options('health_check' => { 'protocol' => 'foo', 'port' => 8080, 'uri' => 'foobar'})
-        expect(result.messages.key?('health_check')).to be_truthy
+        expect(result.errors.key?('health_check')).to be_truthy
 
         result = subject.validate_options('health_check' => { 'protocol' => 'tcp', 'port' => 3306 })
-        expect(result.messages.key?('health_check')).to be_falsey
+        expect(result.errors.key?('health_check')).to be_falsey
       end
     end
   end

--- a/cli/spec/kontena/cli/app/yaml/validator_v2_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_v2_spec.rb
@@ -2,31 +2,24 @@ require_relative '../../../../spec_helper'
 require 'kontena/cli/apps/yaml/validator_v2'
 
 describe Kontena::Cli::Apps::YAML::ValidatorV2 do
-  describe '#validate_keys' do
-    it 'returns error on invalid key' do
-      result = subject.validate_keys('name' => 'wordpress')
-      expect(result['name'].size).to eq(1)
-    end
-  end
-
   describe '#validate_options' do
     context 'build' do
       it 'can be string' do
         result = subject.validate_options('build' => '.')
-        expect(result.success?).to be_truthy
-        expect(result.messages.key?('build')).to be_falsey
+        expect(result.valid?).to be_truthy
+        expect(result.errors.key?('build')).to be_falsey
       end
 
       it 'can be hash' do
         result = subject.validate_options('build' => { 'context' => '.' })
-        expect(result.success?).to be_truthy
-        expect(result.messages.key?('build')).to be_falsey
+        expect(result.valid?).to be_truthy
+        expect(result.errors.key?('build')).to be_falsey
       end
 
       it 'returns error if build is hash and context is missing' do
         result = subject.validate_options('build' => {})
-        expect(result.success?).to be_falsey
-        expect(result.messages.key?('build')).to be_truthy
+        expect(result.valid?).to be_falsey
+        expect(result.errors.key?('build')).to be_truthy
       end
 
       it 'returns error if optional dockerfile is not string' do
@@ -34,110 +27,110 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
           'context' => '.',
           'dockerfile' => 123
         })
-        expect(result.success?).to be_falsey
-        expect(result.messages.key?('build')).to be_truthy
+        expect(result.valid?).to be_falsey
+        expect(result.errors.key?('build')).to be_truthy
       end
     end
     it 'validates image is string' do
       result = subject.validate_options('image' => true)
-      expect(result.success?).to be_falsey
-      expect(result.messages.key?('image')).to be_truthy
+      expect(result.valid?).to be_falsey
+      expect(result.errors.key?('image')).to be_truthy
     end
 
     it 'validates stateful is boolean' do
       result = subject.validate_options('stateful' => 'bool')
-      expect(result.messages.key?('stateful')).to be_truthy
+      expect(result.errors.key?('stateful')).to be_truthy
     end
 
     it 'validates network_mode is host or bridge' do
       result = subject.validate_options('network_mode' => 'invalid')
-      expect(result.messages.key?('network_mode')).to be_truthy
+      expect(result.errors.key?('network_mode')).to be_truthy
 
       result = subject.validate_options('network_mode' => 'bridge')
-      expect(result.messages.key?('network_mode')).to be_falsey
+      expect(result.errors.key?('network_mode')).to be_falsey
 
       result = subject.validate_options('network_mode' => 'host')
-      expect(result.messages.key?('network_mode')).to be_falsey
+      expect(result.errors.key?('network_mode')).to be_falsey
     end
 
     context 'affinity' do
       it 'is optional' do
         result = subject.validate_options({})
-        expect(result.messages.key?('affinity')).to be_falsey
+        expect(result.errors.key?('affinity')).to be_falsey
       end
 
       it 'must be array' do
         result = subject.validate_options('affinity' => 'node==node1')
-        expect(result.messages.key?('affinity')).to be_truthy
+        expect(result.errors.key?('affinity')).to be_truthy
         result = subject.validate_options('affinity' => ['node==node1'])
-        expect(result.messages.key?('affinity')).to be_falsey
+        expect(result.errors.key?('affinity')).to be_falsey
       end
 
       it 'validates format' do
         result = subject.validate_options('affinity' => ['node=node1'])
-        expect(result.messages.key?('affinity')).to be_truthy
+        expect(result.errors.key?('affinity')).to be_truthy
 
         result = subject.validate_options('affinity' => ['node==node1', 'service!=mariadb'])
-        expect(result.messages.key?('affinity')).to be_falsey
+        expect(result.errors.key?('affinity')).to be_falsey
       end
     end
 
     context 'command' do
       it 'is optional' do
         result = subject.validate_options({})
-        expect(result.messages.key?('command')).to be_falsey
+        expect(result.errors.key?('command')).to be_falsey
       end
 
       it 'must be string or empty' do
         result = subject.validate_options('command' => 1234)
-        expect(result.messages.key?('command')).to be_truthy
+        expect(result.errors.key?('command')).to be_truthy
 
         result = subject.validate_options('command' => nil)
-        expect(result.messages.key?('command')).to be_falsey
+        expect(result.errors.key?('command')).to be_falsey
 
         result = subject.validate_options('command' => 'bundle exec rails s')
-        expect(result.messages.key?('command')).to be_falsey
+        expect(result.errors.key?('command')).to be_falsey
       end
     end
 
     it 'validates cpu_shares is integer' do
       result = subject.validate_options('cpu_shares' => '1m')
-      expect(result.messages.key?('cpu_shares')).to be_truthy
+      expect(result.errors.key?('cpu_shares')).to be_truthy
       result = subject.validate_options('cpu_shares' => 1024)
-      expect(result.messages.key?('cpu_shares')).to be_falsey
+      expect(result.errors.key?('cpu_shares')).to be_falsey
       result = subject.validate_options({})
-      expect(result.messages.key?('cpu_shares')).to be_falsey
+      expect(result.errors.key?('cpu_shares')).to be_falsey
     end
 
     it 'validates environment is array or hash' do
       result = subject.validate_options('environment' => 'KEY=VALUE')
-      expect(result.messages.key?('environment')).to be_truthy
+      expect(result.errors.key?('environment')).to be_truthy
       result = subject.validate_options('environment' => ['KEY=VALUE'])
-      expect(result.messages.key?('environment')).to be_falsey
+      expect(result.errors.key?('environment')).to be_falsey
       result = subject.validate_options('environment' => { 'KEY' => 'VALUE' })
-      expect(result.messages.key?('environment')).to be_falsey
+      expect(result.errors.key?('environment')).to be_falsey
     end
 
     context 'validates secrets' do
       it 'must be array' do
         result = subject.validate_options('secrets' => {})
-        expect(result.messages.key?('secrets')).to be_truthy
+        expect(result.errors.key?('secrets')).to be_truthy
       end
 
       context 'item' do
         it 'must contain secret' do
           result = subject.validate_options('secrets' => [{ 'name' => 'test', 'type' => 'env' }])
-          expect(result.messages.key?('secrets')).to be_truthy
+          expect(result.errors.key?('secrets')).to be_truthy
         end
 
         it 'must contain name' do
           result = subject.validate_options('secrets' => [{ 'secret' => 'test', 'type' => 'env' }])
-          expect(result.messages.key?('secrets')).to be_truthy
+          expect(result.errors.key?('secrets')).to be_truthy
         end
 
         it 'must contain type' do
           result = subject.validate_options('secrets' => [{ 'secret' => 'test', 'name' => 'test' }])
-          expect(result.messages.key?('secrets')).to be_truthy
+          expect(result.errors.key?('secrets')).to be_truthy
         end
 
         it 'accepts valid input' do
@@ -149,7 +142,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
                 'type' => 'env'
               }
             ])
-          expect(result.messages.key?('secrets')).to be_falsey
+          expect(result.errors.key?('secrets')).to be_falsey
         end
       end
     end
@@ -158,7 +151,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
       context 'options' do
         it 'must be hash' do
           result = subject.validate_options('logging' => { 'options' => [] })
-          expect(result.messages.key?('logging')).to be_truthy
+          expect(result.errors.key?('logging')).to be_truthy
           data = {
             'logging' => {
               'options' => {
@@ -167,7 +160,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
             }
           }
           result = subject.validate_options(data)
-          expect(result.messages.key?('logging')).to be_falsey
+          expect(result.errors.key?('logging')).to be_falsey
         end
       end
     end
@@ -176,7 +169,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
       context 'validates pre_build' do
         it 'must be array' do
           result = subject.validate_options('hooks' => { 'pre_build' => {} })
-          expect(result.messages.key?('hooks')).to be_truthy
+          expect(result.errors.key?('hooks')).to be_truthy
           data = {
             'hooks' => {
               'pre_build' => [
@@ -187,13 +180,13 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
             }
           }
           result = subject.validate_options(data)
-          expect(result.messages.key?('hooks')).to be_falsey
+          expect(result.errors.key?('hooks')).to be_falsey
         end
       end
       context 'post_start' do
         it 'must be array' do
           result = subject.validate_options('hooks' => { 'post_start' => {} })
-          expect(result.messages.key?('hooks')).to be_truthy
+          expect(result.errors.key?('hooks')).to be_truthy
           data = {
             'hooks' => {
               'post_start' => [
@@ -206,7 +199,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
             }
           }
           result = subject.validate_options(data)
-          expect(result.messages.key?('hooks')).to be_falsey
+          expect(result.errors.key?('hooks')).to be_falsey
         end
 
         context 'item' do
@@ -220,7 +213,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
                 }
               ]
             })
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
 
           it 'must contain cmd' do
@@ -233,7 +226,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
                 }
               ]
             })
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
 
           it 'must contain instance number or *' do
@@ -245,7 +238,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
                 }
               ]
             })
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
             data = {
               'hooks' => {
                 'post_start' => [
@@ -259,7 +252,7 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
               }
             }
             result = subject.validate_options(data)
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
 
           it 'may contain boolean oneshot' do
@@ -276,32 +269,32 @@ describe Kontena::Cli::Apps::YAML::ValidatorV2 do
               }
             }
             result = subject.validate_options(data)
-            expect(result.messages.key?('hooks')).to be_truthy
+            expect(result.errors.key?('hooks.post_start')).to be_truthy
           end
         end
 
         it 'validates depends_on is array' do
           result = subject.validate_options('depends_on' => 'web')
-          expect(result.messages.key?('depends_on')).to be_truthy
+          expect(result.errors.key?('depends_on')).to be_truthy
 
           result = subject.validate_options('depends_on' => ['web'])
-          expect(result.messages.key?('depends_on')).to be_falsey
+          expect(result.errors.key?('depends_on')).to be_falsey
         end
 
         it 'validates volumes is array' do
           result = subject.validate_options('volumes' => '/app')
-          expect(result.messages.key?('volumes')).to be_truthy
+          expect(result.errors.key?('volumes')).to be_truthy
 
           result = subject.validate_options('volumes' => ['/app'])
-          expect(result.messages.key?('volumes')).to be_falsey
+          expect(result.errors.key?('volumes')).to be_falsey
         end
 
         it 'validates volumes_from is array' do
           result = subject.validate_options('volumes_from' => 'mysql_data')
-          expect(result.messages.key?('volumes_from')).to be_truthy
+          expect(result.errors.key?('volumes_from')).to be_truthy
 
           result = subject.validate_options('volumes_from' => ['mysql_data'])
-          expect(result.messages.key?('volumes_from')).to be_falsey
+          expect(result.errors.key?('volumes_from')).to be_falsey
         end
       end
     end


### PR DESCRIPTION
This PR replaces `dry-validation` (and its dependencies) with `hash_validator` gem. With hash_validator gem all service configs are also validated that they do not contain any extra options than those that are supported in `kontena.yml`. Because of this strict validation `--skip-validation` option is added to `app config`, `app build` and `app deploy` commands. This could be take in place when extending docker-compose.yml that contains some non-supported options, but they don't break Kontena deploys.

Rest of the `kontena app` commands skip the validation, because they are using only service names from the YAML file.