### PR TITLE
Add instance number to container env

### DIFF
--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -54,7 +54,7 @@ module Docker
         log_opts: grid_service.log_opts,
         pid: grid_service.pid
       }
-      spec[:env] = build_env
+      spec[:env] = build_env(instance_number)
       spec[:secrets] = build_secrets
       overlay_cidr = nil
       if grid_service.overlay_network?
@@ -95,12 +95,13 @@ module Docker
 
     ##
     # @return [Array<String>]
-    def build_env
+    def build_env(instance_number)
       env = grid_service.env.dup || []
       env << "KONTENA_SERVICE_ID=#{grid_service.id.to_s}"
       env << "KONTENA_SERVICE_NAME=#{grid_service.name}"
       env << "KONTENA_GRID_NAME=#{grid_service.grid.try(:name)}"
       env << "KONTENA_NODE_NAME=#{host_node.name}"
+      env << "KONTENA_SERVICE_INSTANCE=#{instance_number}"
       env
     end
 

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -101,7 +101,7 @@ module Docker
       env << "KONTENA_SERVICE_NAME=#{grid_service.name}"
       env << "KONTENA_GRID_NAME=#{grid_service.grid.try(:name)}"
       env << "KONTENA_NODE_NAME=#{host_node.name}"
-      env << "KONTENA_SERVICE_INSTANCE=#{instance_number}"
+      env << "KONTENA_SERVICE_INSTANCE_NUMBER=#{instance_number}"
       env
     end
 

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -131,6 +131,7 @@ describe Docker::ServiceCreator do
         expect(env).to include("KONTENA_SERVICE_NAME=#{service.name.to_s}")
         expect(env).to include("KONTENA_GRID_NAME=#{service.grid.name.to_s}")
         expect(env).to include("KONTENA_NODE_NAME=#{node.name.to_s}")
+        expect(env).to include("KONTENA_SERVICE_INSTANCE=2")
       end
     end
 

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -131,7 +131,7 @@ describe Docker::ServiceCreator do
         expect(env).to include("KONTENA_SERVICE_NAME=#{service.name.to_s}")
         expect(env).to include("KONTENA_GRID_NAME=#{service.grid.name.to_s}")
         expect(env).to include("KONTENA_NODE_NAME=#{node.name.to_s}")
-        expect(env).to include("KONTENA_SERVICE_INSTANCE=2")
+        expect(env).to include("KONTENA_SERVICE_INSTANCE_NUMBER=2")
       end
     end
 


### PR DESCRIPTION
As instance number is handy for some apps to know it should be populated in the container env.

fixes #1039