### PR TITLE
Allow to set a grid token manually

### DIFF
--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -18,7 +18,7 @@ module Kontena::Cli::Grids
       payload = {
         name: name
       }
-      payload[:token] = grid_token if grid_token
+      payload[:token] = token if token
       payload[:initial_size] = initial_size if initial_size
       grid = nil
       if initial_size == 1

--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -9,6 +9,7 @@ module Kontena::Cli::Grids
 
     option "--initial-size", "INITIAL_SIZE", "Initial grid size (number of nodes)", default: 1
     option "--silent", :flag, "Reduce output verbosity"
+    option "--grid-token", "[TOKEN]", "Set grid token"
 
     def execute
       require_api_url
@@ -17,6 +18,7 @@ module Kontena::Cli::Grids
       payload = {
         name: name
       }
+      payload[:token] = grid_token if grid_token
       payload[:initial_size] = initial_size if initial_size
       grid = nil
       if initial_size == 1

--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::Grids
 
     option "--initial-size", "INITIAL_SIZE", "Initial grid size (number of nodes)", default: 1
     option "--silent", :flag, "Reduce output verbosity"
-    option "--grid-token", "[TOKEN]", "Set grid token"
+    option "--token", "[TOKEN]", "Set grid token"
 
     def execute
       require_api_url

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -87,6 +87,6 @@ class Grid
   private
 
   def set_token
-    self.token = SecureRandom.base64(64)
+    self.token ||= SecureRandom.base64(64)
   end
 end

--- a/server/app/mutations/grids/create.rb
+++ b/server/app/mutations/grids/create.rb
@@ -11,6 +11,10 @@ module Grids
       integer :initial_size, default: 1, min: 1, max: 7
     end
 
+    optional do
+      string :token
+    end
+
     def validate
       add_error(:user, :invalid, 'Operation not allowed') unless user.can_create?(Grid)
     end
@@ -19,7 +23,8 @@ module Grids
       self.name = generate_name if self.name.blank?
       grid = Grid.new(
         name: self.name,
-        initial_size: self.initial_size
+        initial_size: self.initial_size,
+        token: self.token
       )
       unless grid.save
         grid.errors.each do |key, message|

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -65,7 +65,8 @@ module V1
           outcome = Grids::Create.run(
               user: current_user,
               name: data['name'],
-              initial_size: data['initial_size'] || 1
+              initial_size: data['initial_size'] || 1,
+              token: data['token']
           )
 
           if outcome.success?

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -54,6 +54,22 @@ describe '/v1/grids' do
       }.to change{ david.reload.grids.count }.by(1)
     end
 
+    it 'a new grid has a generated token unless supplied' do
+      expect {
+        post '/v1/grids', {name: 'foo'}.to_json, request_headers
+        expect(response.status).to eq(201)
+      }.to change{ david.reload.grids.count }.by(1)
+      expect(Grid.where(name: 'foo').first.token).to match /\A[A-Za-z0-9+\/=]*\Z/
+    end
+
+    it 'creates a new grid with supplied token' do
+      expect {
+        post '/v1/grids', {name: 'foo', token: 'abcd1234'}.to_json, request_headers
+        expect(response.status).to eq(201)
+      }.to change{ david.reload.grids.count }.by(1)
+      expect(Grid.where(name: 'foo').first.token).to eq 'abcd1234'
+    end
+
     it 'requires authorization' do
       request_headers.delete('HTTP_AUTHORIZATION')
       post '/v1/grids', {}.to_json, request_headers

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -97,9 +97,9 @@ describe Grid do
   end
 
   describe '#token' do
-    let(:grid_with_automatic_token) { Grid.create!(name: 'test', initial_size: 3) }
-    let(:grid_with_manual_token) { Grid.create!(name: 'test', initial_size: 3, token: 'abcd123456') }
-    let(:grid_with_nil_token) { Grid.create!(name: 'test', initial_size: 3, token: nil) }
+    let(:grid_with_automatic_token) { Grid.create!(name: 'test1', initial_size: 3) }
+    let(:grid_with_manual_token) { Grid.create!(name: 'test2', initial_size: 3, token: 'abcd123456') }
+    let(:grid_with_nil_token) { Grid.create!(name: 'test3', initial_size: 3, token: nil) }
 
     it 'creates a token unless one is supplied' do
       expect(grid_with_automatic_token.token).to match /\A[A-Za-z0-9+\/=]*\Z/

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -95,4 +95,16 @@ describe Grid do
       expect(grid.initial_node?(node)).to be_falsey
     end
   end
+
+  describe '#token' do
+    let(:grid_with_automatic_token) { Grid.create!(name: 'test', initial_size: 3) }
+    let(:grid_with_manual_token) { Grid.create!(name: 'test', initial_size: 3, token: 'abcd123456') }
+    let(:grid_with_nil_token) { Grid.create!(name: 'test', initial_size: 3, token: nil) }
+
+    it 'creates a token unless one is supplied' do
+      expect(grid_with_automatic_token.token).to match /\A[A-Za-z0-9+\/=]*\Z/
+      expect(grid_with_nil_token.token).to match /\A[A-Za-z0-9+\/=]*\Z/
+      expect(grid_with_manual_token.token).to eq 'abcd123456'
+    end
+  end
 end


### PR DESCRIPTION
Implements #1045

```
$ kontena grid create --grid-token abcd1234 testing
```
