### PR TITLE
Basic auth support for http services

### DIFF
--- a/agent/lib/kontena/load_balancers/configurer.rb
+++ b/agent/lib/kontena/load_balancers/configurer.rb
@@ -54,7 +54,11 @@ module Kontena::LoadBalancers
         set("#{etcd_path}/services/#{service_name}/virtual_path", virtual_path)
         set("#{etcd_path}/services/#{service_name}/keep_virtual_path", keep_virtual_path)
         set("#{etcd_path}/services/#{service_name}/cookie", cookie)
-        set("#{etcd_path}/services/#{service_name}/basic_auth_secrets", basic_auth_secrets) unless basic_auth_secrets.empty?
+        if !basic_auth_secrets.empty?
+          set("#{etcd_path}/services/#{service_name}/basic_auth_secrets", basic_auth_secrets) unless basic_auth_secrets.empty?
+        else
+          unset("#{etcd_path}/services/#{service_name}/basic_auth_secrets")
+        end
         rmdir("#{etcd_path}/tcp-services/#{service_name}") rescue nil
       else
         external_port = env_hash['KONTENA_LB_EXTERNAL_PORT'] || '5000'

--- a/agent/lib/kontena/load_balancers/configurer.rb
+++ b/agent/lib/kontena/load_balancers/configurer.rb
@@ -46,6 +46,7 @@ module Kontena::LoadBalancers
         end
         keep_virtual_path = env_hash['KONTENA_LB_KEEP_VIRTUAL_PATH']
         cookie = env_hash['KONTENA_LB_COOKIE']
+        basic_auth_secrets = env_hash['KONTENA_LB_BASIC_AUTH_SECRETS'].to_s
         set("#{etcd_path}/services/#{service_name}/balance", balance)
         set("#{etcd_path}/services/#{service_name}/health_check_uri", check_uri)
         set("#{etcd_path}/services/#{service_name}/custom_settings", custom_settings)
@@ -53,6 +54,7 @@ module Kontena::LoadBalancers
         set("#{etcd_path}/services/#{service_name}/virtual_path", virtual_path)
         set("#{etcd_path}/services/#{service_name}/keep_virtual_path", keep_virtual_path)
         set("#{etcd_path}/services/#{service_name}/cookie", cookie)
+        set("#{etcd_path}/services/#{service_name}/basic_auth_secrets", basic_auth_secrets) unless basic_auth_secrets.empty?
         rmdir("#{etcd_path}/tcp-services/#{service_name}") rescue nil
       else
         external_port = env_hash['KONTENA_LB_EXTERNAL_PORT'] || '5000'

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -102,6 +102,13 @@ describe Kontena::LoadBalancers::Configurer do
       subject.ensure_config(container)
     end
 
+    it 'sets basic auth' do
+      container.env_hash['KONTENA_LB_BASIC_AUTH_SECRETS'] = 'user admin insecure-password passwd'
+      expect(etcd).to receive(:set).
+        with("#{etcd_prefix}/lb/services/test-api/basic_auth_secrets", {value: 'user admin insecure-password passwd'})
+      subject.ensure_config(container)
+    end
+
     it 'sets http check uri' do
       container.labels['io.kontena.health_check.uri'] = '/health'
       expect(etcd).to receive(:set).

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -109,6 +109,12 @@ describe Kontena::LoadBalancers::Configurer do
       subject.ensure_config(container)
     end
 
+    it 'removes basic auth' do
+      expect(etcd).to receive(:delete).
+        with("#{etcd_prefix}/lb/services/test-api/basic_auth_secrets")
+      subject.ensure_config(container)
+    end
+
     it 'sets http check uri' do
       container.labels['io.kontena.health_check.uri'] = '/health'
       expect(etcd).to receive(:set).

--- a/docs/using-kontena/loadbalancer.md
+++ b/docs/using-kontena/loadbalancer.md
@@ -81,6 +81,50 @@ These environment variables configure the loadbalancer itself.
 
 Kontena loadbalancer exposes statistics web UI only on private overlay network. To access the statistics you must use [VPN](vpn-access) to access the overlay network. The statistics are exposed on port 1000 on the loadbalancer instances.
 
+## Basic authentication for services
+
+Kontena loadbalancer supports automatic [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) for balanced services. To enable basic authentication on a given service, use following configuration:
+```
+version: 2
+services:
+  internet_lb:
+    image: kontena/lb:latest
+    ports:
+      - 80:80
+
+  web:
+    image: nginx:latest
+    environment:
+      - KONTENA_LB_MODE=http
+      - KONTENA_LB_BALANCE=roundrobin
+      - KONTENA_LB_INTERNAL_PORT=80
+      - KONTENA_LB_VIRTUAL_HOSTS=www.kontena.io,kontena.io
+    links:
+      - internet_lb
+    secrets:
+      - secret: BASIC_AUTH_FOR_XYZ
+        name: KONTENA_LB_BASIC_AUTH_SECRETS
+        type: env
+
+```
+
+To write the configuration in the vault, use following:
+```
+$ kontena vault write BASIC_AUTH_FOR_XYZ << EOF
+→ user user1 password <bcrypt_password>
+→ user user2 insecure-password pass1234
+→ EOF
+```
+
+If you want to use encrypted password note that encrypted passwords are evaluated using the crypt(3) function so different algorithms are supported. For example MD5, SHA-256, SHA-512 are supported. To generate an encrypted password you can use following examples:
+```
+mkpasswd -m sha-512 passwd
+```
+Or if your system does not have `mkpasswd` available but you have Docker available, use following:
+```
+docker run -ti --rm alpine mkpasswd -m sha-512 passwd
+```
+
 ## SSL Termination
 
 Kontena Load Balancer supports ssl termination on multiple certificates. These certificates can be configured to load balancer by setting `SSL_CERTS` environment variable. Recommended way to do this is by using Kontena Vault.
@@ -153,4 +197,3 @@ These options are defined on the services that are balanced through lb.
 * `KONTENA_LB_KEEP_VIRTUAL_PATH`: if set to true, virtual path will be kept in request path (only for http mode)
 * `KONTENA_LB_CUSTOM_SETTINGS`: extra settings, each line will be appended to either related backend section or listen session in the HAProxy configuration file
 * `KONTENA_LB_COOKIE`: Enables cookie based session stickyness. With empty value defaults to LB set cookie. Can be customized to utilize application cookies. See details at [HAProxy docs](https://cbonte.github.io/haproxy-dconv/configuration-1.5.html#4.2-cookie)
-


### PR DESCRIPTION
This PR add support for basic auth.

Basic auth is automatically configured if following secret is configured for a service:
```
secrets:
  - secret: BASIC_AUTH_FOR_XYZ
    name: KONTENA_LB_BASIC_AUTH_SECRETS
    type: env
```

```
$ kontena vault write BASIC_AUTH_FOR_XYZ << EOF
→ user user1 password <bcrypt_password>
→ user user2 insecure-password pass1234
→ EOF
```

Password can be encrypted eg. with:
`docker run -ti --rm alpine mkpasswd -m sha-512 passwd`

This needs the LB support: https://github.com/kontena/kontena-loadbalancer/pull/21

fixes #1053 