### PR TITLE
Link CHANGELOG version heading to the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.5 (2016-10-02)
+## [0.15.5](https://github.com/kontena/kontena/releases/tag/v0.15.5) (2016-10-02)
 
 **CLI:**
 
@@ -9,13 +9,13 @@
 - do not clip service env output (#1036)
 - handle invalid master name gracefully and improve formatting (#997)
 
-## 0.15.4 (2016-09-22)
+## [0.15.4](https://github.com/kontena/kontena/releases/tag/v0.15.4) (2016-09-22)
 
 **CLI:**
 
 - lock dry-gems to exact versions (#1031)
 
-## 0.15.3 (2016-09-20)
+## [0.15.3](https://github.com/kontena/kontena/releases/tag/v0.15.3) (2016-09-20)
 
 **Master & Agents:**
 
@@ -26,7 +26,7 @@
 
 - lock cli dry-monads version (#1023)
 
-## 0.15.2 (2016-09-10)
+## [0.15.2](https://github.com/kontena/kontena/releases/tag/v0.15.2) (2016-09-10)
 
 **Master & Agents:**
 
@@ -48,7 +48,7 @@
 - lock all cli runtime dependencies (#966)
 - allow to use strings as value of extends option in kontena.yml (#965)
 
-## 0.15.1 (2016-09-01)
+## [0.15.1](https://github.com/kontena/kontena/releases/tag/v0.15.1) (2016-09-01)
 
 **Master & Agent:**
 
@@ -65,7 +65,7 @@
 - freeze dry-configurable version (#949)
 - fix build arguments normalizing (#921)
 
-## 0.15.0 (2016-08-11)
+## [0.15.0](https://github.com/kontena/kontena/releases/tag/v0.15.0) (2016-08-11)
 
 **Master & Agent:**
 - use correct cadvisor tag in cadvisor launcher (#908)
@@ -99,13 +99,13 @@
 - show "not found any build options" only in app build command (#801)
 - cli plugins (#794, #917)
 
-## 0.14.7 (2016-08-08)
+## [0.14.7](https://github.com/kontena/kontena/releases/tag/v0.14.7) (2016-08-08)
 
 **Master & Agent:**
 - update cadvisor to 0.23.2 (#883)
 - fix possible event stream lockups (#878)
 
-## 0.14.6 (2016-07-21)
+## [0.14.6](https://github.com/kontena/kontena/releases/tag/v0.14.6) (2016-07-21)
 
 **Master & Agent:**
 - fix agent not reconnecting to master (#859)
@@ -115,7 +115,7 @@
 **CLI:**
 - fix deploy interval handling in app yaml parsing (#821)
 
-## 0.14.5 (2016-07-09)
+## [0.14.5](https://github.com/kontena/kontena/releases/tag/v0.14.5) (2016-07-09)
 
 **Master & Agent:**
 
@@ -128,7 +128,7 @@
 
 - do not require Master connection on user verification (#839)
 
-## 0.14.4 (2016-07-01)
+## [0.14.4](https://github.com/kontena/kontena/releases/tag/v0.14.4) (2016-07-01)
 
 **CLI:**
 
@@ -138,7 +138,7 @@
 
 - remove image before tagging, because --force is deprecated (#833)
 
-## 0.14.3 (2016-06-16)
+## [0.14.3](https://github.com/kontena/kontena/releases/tag/v0.14.3) (2016-06-16)
 
 **Master & Agent:**
 - update excon to 0.49.0 (#806)
@@ -147,7 +147,7 @@
 **CLI:**
 - fix aws public ip assign (#808)
 
-## 0.14.2 (2016-06-06)
+## [0.14.2](https://github.com/kontena/kontena/releases/tag/v0.14.2) (2016-06-06)
 
 **Master & Agent:**
 - do not allow ImageCleanupWorker to remove agent images (#791)
@@ -157,7 +157,7 @@
 - improve vpn creation for non-public environments (#787)
 - generate yaml v2 formatted files on app init command (#785)
 
-## 0.14.1 (2016-06-03)
+## [0.14.1](https://github.com/kontena/kontena/releases/tag/v0.14.1) (2016-06-03)
 
 **Master & Agent:**
 - fix automatic scale down on too many service instances (#772)
@@ -172,7 +172,7 @@
 - add option in AWS to associate public ip for VPC (#771)
 - fix log_opts disappearing after service update (#770)
 
-## 0.14.0 (2016-05-31)
+## [0.14.0](https://github.com/kontena/kontena/releases/tag/v0.14.0) (2016-05-31)
 
 **Master & Agent:**
 - dynamic etcd cluster member replacement functionality (#719)
@@ -195,7 +195,7 @@
 - option for upserting secrets (#711)
 - improved kontena.yml parsing (#696)
 
-## 0.13.4 (2016-05-29)
+## [0.13.4](https://github.com/kontena/kontena/releases/tag/v0.13.4) (2016-05-29)
 
 **Master & Agent:**
 - allow to deploy service that is already in deploying state (#743)
@@ -203,7 +203,7 @@
 **Packaging:**
 - add resolvconf as dependency in ubuntu kontena-agent (#744)
 
-## 0.13.3 (2016-05-27)
+## [0.13.3](https://github.com/kontena/kontena/releases/tag/v0.13.3) (2016-05-27)
 
 **Master & Agent:**
 - fix possible agent websocket ping_timer race condition (#731)
@@ -211,7 +211,7 @@
 - fix service balancer not picking up instances without any deploys (#725)
 - fix stopped services with open deploys blocking deploy queue (#724)
 
-## 0.13.2 (2016-05-24)
+## [0.13.2](https://github.com/kontena/kontena/releases/tag/v0.13.2) (2016-05-24)
 
 **Master & Agent**
 - fix how daemon service state is calculated (#716)
@@ -226,11 +226,11 @@
 - show debug help only for non Kontena StandardErrors (#710)
 
 
-## 0.13.1 (2016-05-19)
+## [0.13.1](https://github.com/kontena/kontena/releases/tag/v0.13.1) (2016-05-19)
 
 - fix agent websocket hang on close when connection is unstable (#698)
 
-## 0.13.0 (2016-05-18)
+## [0.13.0](https://github.com/kontena/kontena/releases/tag/v0.13.0) (2016-05-18)
 
 **Master & Agent**
 - grid trusted subnets (weave fast data path) (#644)
@@ -270,18 +270,18 @@
 - show node stats on node details (#607)
 - save login email to local config (#589)
 
-## 0.12.3 (2016-05-06)
+## [0.12.3](https://github.com/kontena/kontena/releases/tag/v0.12.3) (2016-05-06)
 
 - fix node unplugger unclean shutdown (#662)
 
-## 0.12.2 (2016-04-26)
+## [0.12.2](https://github.com/kontena/kontena/releases/tag/v0.12.2) (2016-04-26)
 
 - fix too aggressive overlay cidr cleanup (#626)
 - fix image puller cache invalidation on new deploy using same image tag (#627)
 - do not ignore containers with name containing weave (#631)
 - return nil for current_grid if master settings not present in cli (#632)
 
-## 0.12.1 (2016-04-19)
+## [0.12.1](https://github.com/kontena/kontena/releases/tag/v0.12.1) (2016-04-19)
 
 - use overlay ip when checking port status on deploy
 - allow to use docker 1.10.x on ubuntu
@@ -294,7 +294,7 @@
 - fix typo in `grid list` command when no grids exist
 - fix `service containers` exception on nil overlay_cidr
 
-## 0.12.0 (2016-04-04)
+## [0.12.0](https://github.com/kontena/kontena/releases/tag/v0.12.0) (2016-04-04)
 
 - improve user roles implementation
 - automatic image gc for nodes
@@ -330,13 +330,13 @@
 - fix: AWS node termination not using correct tag
 - remove: deprecated top-level deploy command
 
-## 0.11.7 (2016-03-07)
+## [0.11.7](https://github.com/kontena/kontena/releases/tag/v0.11.7) (2016-03-07)
 
 - increase deploy timeout to 5 minutes
 - update docker-api
 - make default logs/stats collections smaller
 
-## 0.11.6 (2016-02-13)
+## [0.11.6](https://github.com/kontena/kontena/releases/tag/v0.11.6) (2016-02-13)
 
 - do not update container.deleted_at timestamp if it's already set
 - fix error in docker 1.9 when net=host
@@ -345,30 +345,30 @@
 - show missing memory & memory_swap in service details
 - fix error in service restart command
 
-## 0.11.5 (2016-02-08)
+## [0.11.5](https://github.com/kontena/kontena/releases/tag/v0.11.5) (2016-02-08)
 
 - handle force_deploy flag correctly on app deploy command
 
-## 0.11.4 (2016-02-08)
+## [0.11.4](https://github.com/kontena/kontena/releases/tag/v0.11.4) (2016-02-08)
 
 - add missing vault update command
 - add missing app restart command
 - add missing --force-deploy option to deploy commands
 - fix broken pid option in kontena.yml
 
-## 0.11.3 (2016-02-01)
+## [0.11.3](https://github.com/kontena/kontena/releases/tag/v0.11.3) (2016-02-01)
 
 - fix error on grid destroy
 - fix agent stats collect interval
 
-## 0.11.2 (2016-01-25)
+## [0.11.2](https://github.com/kontena/kontena/releases/tag/v0.11.2) (2016-01-25)
 
 - better error handling on lb changes
 - update node information when agent reconnects
 - aws provisioner update
 - grid env subcommand fix
 
-## 0.11.1 (2016-01-16)
+## [0.11.1](https://github.com/kontena/kontena/releases/tag/v0.11.1) (2016-01-16)
 
 - cleanup etcd correctly when load balanced service is removed
 - fix MessageHandler internal caching
@@ -380,7 +380,7 @@
 - send container information to master asap (don't wait for weave to start)
 - fix "bring your own load balancer" functionality
 
-## 0.11.0 (2016-01-10)
+## [0.11.0](https://github.com/kontena/kontena/releases/tag/v0.11.0) (2016-01-10)
 
 - secrets management (vault)
 - multi master management in cli
@@ -417,24 +417,24 @@
 - update activesupport to latest patch version
 - update kontena master tagline
 
-## 0.10.3 (2016-01-05)
+## [0.10.3](https://github.com/kontena/kontena/releases/tag/v0.10.3) (2016-01-05)
 
 - fix `app scale` command
 - cleanup weaveexec volumes
 
-## 0.10.2 (2015-12-14)
+## [0.10.2](https://github.com/kontena/kontena/releases/tag/v0.10.2) (2015-12-14)
 
 - fix shell spinner error on vpn & registry commands
 - revert state to running if deploy is cancelled
 
-## 0.10.1 (2015-12-03)
+## [0.10.1](https://github.com/kontena/kontena/releases/tag/v0.10.1) (2015-12-03)
 
 - update container node mapping always when updating container info
 - fix agent version update message sending
 - use docker hub registry v2 as a default when adding external registry
 - use debug log level for rpc notifications in agent
 
-## 0.10.0 (2015-12-01)
+## [0.10.0](https://github.com/kontena/kontena/releases/tag/v0.10.0) (2015-12-01)
 
 - improved scheduler with auto-failover/rebalance
 - new deploy strategy: daemon
@@ -459,14 +459,14 @@
 - show reason for service instance error (from docker) in service details
 - handle partial log streams better in cli
 
-## 0.9.3 (2015-11-03)
+## [0.9.3](https://github.com/kontena/kontena/releases/tag/v0.9.3) (2015-11-03)
 
 - do not overwrite existing node labels on update
 - fix node label affinity when labels do not exist
 - append node number to node name if name is not unique within grid
 - fix user provided ip on vpn create
 
-## 0.9.2 (2015-10-31)
+## [0.9.2](https://github.com/kontena/kontena/releases/tag/v0.9.2) (2015-10-31)
 
 - export port for web process on app init command
 - increase timeout on container create
@@ -479,7 +479,7 @@
 - fix vpn/dns config in linux workstations
 - use nodes internal ip for vpn in vagrant
 
-## 0.9.1 (2015-10-25)
+## [0.9.1](https://github.com/kontena/kontena/releases/tag/v0.9.1) (2015-10-25)
 
 - app init: fix addon services persistence
 - update weave to 1.1.2
@@ -488,7 +488,7 @@
 - fix linked services environment variable build order
 - add missing --ssl-cert option to AWS master provisioner
 
-## 0.9.0 (2015-10-12)
+## [0.9.0](https://github.com/kontena/kontena/releases/tag/v0.9.0) (2015-10-12)
 
 - Heroku style deployment model (optional)
 - integrated loadbalancing based on haproxy/confd
@@ -512,19 +512,19 @@
 - allow to update service links
 - improved db indexing/migration logic
 
-## 0.8.4 (2015-09-21)
+## [0.8.4](https://github.com/kontena/kontena/releases/tag/v0.8.4) (2015-09-21)
 
 - handle agent connection errors on boot
 - allow to define weave image names through env variables
 - fix reset-password subcommand
 - fix duplication on app deploy command
 
-## 0.8.3 (2015-09-18)
+## [0.8.3](https://github.com/kontena/kontena/releases/tag/v0.8.3) (2015-09-18)
 
 - fix db automatic indexing
 - add "latest" image tag if it's not specified
 
-## 0.8.2 (2015-09-09)
+## [0.8.2](https://github.com/kontena/kontena/releases/tag/v0.8.2) (2015-09-09)
 
 - update weave to 1.1.0
 - add dns entry for etcd
@@ -533,7 +533,7 @@
 - service network stats fix
 - fix multivalue handling in `kontena service deploy` command
 
-## 0.8.1 (2015-09-01)
+## [0.8.1](https://github.com/kontena/kontena/releases/tag/v0.8.1) (2015-09-01)
 
 - fix digitalocean node provision dns issue
 - fix failed nodes not detected under some circumstances
@@ -542,7 +542,7 @@
 - fix error in setting node labels
 - fix service name validation (do not allow dash as a first char)
 
-## 0.8.0 (2015-08-30)
+## [0.8.0](https://github.com/kontena/kontena/releases/tag/v0.8.0) (2015-08-30)
 
 - initial multi-master support
 - simpler setup: can be installed with plain docker commands
@@ -559,27 +559,27 @@
 - registry 2.1 with optional authentication
 - minor bug fixes
 
-## 0.7.4 (2015-08-15)
+## [0.7.4](https://github.com/kontena/kontena/releases/tag/v0.7.4) (2015-08-15)
 
 - Fix etcd boot errors on flaky networks
 
-## 0.7.3 (2015-07-26)
+## [0.7.3](https://github.com/kontena/kontena/releases/tag/v0.7.3) (2015-07-26)
 
 - Fix `kontena deploy` regression
 - Fix cli service id handling
 
-## 0.7.2 (2015-07-25)
+## [0.7.2](https://github.com/kontena/kontena/releases/tag/v0.7.2) (2015-07-25)
 
 - Fix installation error when eth1 is not present on agent node
 - Change default initial grid size to 1
 
-## 0.7.1 (2015-07-24)
+## [0.7.1](https://github.com/kontena/kontena/releases/tag/v0.7.1) (2015-07-24)
 
 - Ubuntu packages docker dependency fix
 - Database indexing fix
 - Containers api fix
 
-## 0.7.0 (2015-07-22)
+## [0.7.0](https://github.com/kontena/kontena/releases/tag/v0.7.0) (2015-07-22)
 
 - Private Docker registry inside grid
 - Improved node join/discovery procedure
@@ -596,13 +596,13 @@
 - Hide internal kontena services from `kontena services list`
 - Auto-expire container stats/logs in master
 
-## 0.6.1 (2015-06-01)
+## [0.6.1](https://github.com/kontena/kontena/releases/tag/v0.6.1) (2015-06-01)
 
 - Improve `kontena container exec`
 - Fix unexpected behaviour in agent container exec calls
 - Fix weave-helper to catch already running containers
 
-## 0.6.0 (2015-05-25)
+## [0.6.0](https://github.com/kontena/kontena/releases/tag/v0.6.0) (2015-05-25)
 
 - New cli command: `kontena deploy`
 - New cli commands for managing OpenVPN server
@@ -614,7 +614,7 @@
 - Automatic lost node cleanup routine
 - Show container id (with color) in service logs
 
-## 0.5.0 (2015-05-02)
+## [0.5.0](https://github.com/kontena/kontena/releases/tag/v0.5.0) (2015-05-02)
 
 - Fix memory leak problems with Docker streaming API's
 - Improve kontena-agent dns performance


### PR DESCRIPTION
For faster access [and as a reminder] that the github releases page exists