### PR TITLE
Unified the way current master / grid is required

### DIFF
--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -86,7 +86,7 @@ module Kontena::Cli::Apps
     # @param [String] name
     # @return [Boolean]
     def service_exists?(name)
-      get_service(token, prefixed_name(name)) rescue false
+      get_service(prefixed_name(name)) rescue false
     end
 
     # @param [Hash] services

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -51,9 +51,9 @@ module Kontena::Cli::Apps
           warning " --force-deploy will deprecate in the future, use --force"
         end
         spinner "Deploying #{unprefixed_name(name).colorize(:cyan)} " do
-          deploy_service(token, name, options)
+          deploy_service(name, options)
           unless async?
-            wait_for_deploy_to_finish(token, service['id'])
+            wait_for_deploy_to_finish(service['id'])
           end
         end
       end
@@ -96,33 +96,22 @@ module Kontena::Cli::Apps
     def create(name, options)
       data = { 'name' => prefixed_name(name) }
       data.merge!(options)
-<<<<<<< c458ca1ce3d466c135abb32492859520942e5f4b
       result = nil
       spinner "Creating #{name.colorize(:cyan)} " do
-        result = create_service(token, current_grid, data)
+        result = create_service(current_grid, data)
       end
       result
-=======
-      create_service(current_grid, data)
->>>>>>> Unified the way current master / grid is required
     end
 
     # @param [String] name
     # @param [Hash] options
-<<<<<<< c458ca1ce3d466c135abb32492859520942e5f4b
     def update(name, options)
       prefixed_name = prefixed_name(name)
       result = nil
       spinner "Updating #{name.colorize(:cyan)} " do
-        result = update_service(token, prefixed_name, options)
+        result = update_service(prefixed_name, options)
       end
       result
-=======
-    def update(id, options)
-      puts "updating #{id.colorize(:cyan)}"
-      id = prefixed_name(id)
-      update_service(id, options)
->>>>>>> Unified the way current master / grid is required
     end
 
     # @param [String] name

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -21,9 +21,9 @@ module Kontena::Cli::Apps
 
     attr_reader :services, :deploy_queue
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_token
       require_config_file(filename)
       @deploy_queue = []
       @services = services_from_yaml(filename, service_list, service_prefix)
@@ -88,7 +88,7 @@ module Kontena::Cli::Apps
 
     # @param [String] name
     def find_service_by_name(name)
-      get_service(token, prefixed_name(name)) rescue nil
+      get_service(prefixed_name(name)) rescue nil
     end
 
     # @param [String] name
@@ -96,15 +96,20 @@ module Kontena::Cli::Apps
     def create(name, options)
       data = { 'name' => prefixed_name(name) }
       data.merge!(options)
+<<<<<<< c458ca1ce3d466c135abb32492859520942e5f4b
       result = nil
       spinner "Creating #{name.colorize(:cyan)} " do
         result = create_service(token, current_grid, data)
       end
       result
+=======
+      create_service(current_grid, data)
+>>>>>>> Unified the way current master / grid is required
     end
 
     # @param [String] name
     # @param [Hash] options
+<<<<<<< c458ca1ce3d466c135abb32492859520942e5f4b
     def update(name, options)
       prefixed_name = prefixed_name(name)
       result = nil
@@ -112,6 +117,12 @@ module Kontena::Cli::Apps
         result = update_service(token, prefixed_name, options)
       end
       result
+=======
+    def update(id, options)
+      puts "updating #{id.colorize(:cyan)}"
+      id = prefixed_name(id)
+      update_service(id, options)
+>>>>>>> Unified the way current master / grid is required
     end
 
     # @param [String] name

--- a/cli/lib/kontena/cli/apps/list_command.rb
+++ b/cli/lib/kontena/cli/apps/list_command.rb
@@ -13,6 +13,8 @@ module Kontena::Cli::Apps
 
     attr_reader :services
 
+    requires_current_master_token
+
     def execute
       require_config_file(filename)
 
@@ -30,7 +32,7 @@ module Kontena::Cli::Apps
       puts "%-30.30s %-50.50s %-15s %-10.10s %-15.20s %-50s" % titles
 
       services.each do |service_name, opts|
-        service = get_service(token, prefixed_name(service_name)) rescue false
+        service = get_service(prefixed_name(service_name)) rescue false
         if service
           name = service['name'].sub("#{@service_prefix}-", '')
           state = service['stateful'] ? 'yes' : 'no'

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -13,6 +13,8 @@ module Kontena::Cli::Apps
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
     parameter "[SERVICE] ...", "Show only specified service logs"
 
+    requires_current_master_token
+
     def execute
       require_config_file(filename)
 
@@ -32,6 +34,19 @@ module Kontena::Cli::Apps
       show_logs("grids/#{current_grid}/container_logs", query_params) do |log|
         show_log(log)
       end
+    end
+
+    def show_logs(services, query_params)
+      result = client.get("grids/#{current_grid}/container_logs", query_params)
+      result['logs'].each do |log|
+        show_log(log)
+      end
+    end
+
+    def show_log(log)
+      color = color_for_container(log['name'])
+      prefix = "#{log['created_at']} #{log['name']}:".colorize(color)
+      puts "#{prefix} #{log['data']}"
     end
   end
 end

--- a/cli/lib/kontena/cli/apps/monitor_command.rb
+++ b/cli/lib/kontena/cli/apps/monitor_command.rb
@@ -13,6 +13,8 @@ module Kontena::Cli::Apps
 
     attr_reader :services
 
+    requires_current_master_token
+
     def execute
       require_config_file(filename)
 
@@ -25,13 +27,11 @@ module Kontena::Cli::Apps
     end
 
     def show_monitor(services)
-      require_api_url
-      token = require_token
       loop do
         nodes = {}
         services.each do |name, data|
           service = prefixed_name(name)
-          result = client(token).get("services/#{current_grid}/#{service}/containers") rescue nil
+          result = client.get("services/#{current_grid}/#{service}/containers") rescue nil
           if result
             services[name]['instances'] = result['containers'].size
             result['containers'].each do |container|

--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -14,9 +14,9 @@ module Kontena::Cli::Apps
 
     attr_reader :services
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_token
       require_config_file(filename)
       confirm unless forced?
 
@@ -42,10 +42,10 @@ module Kontena::Cli::Apps
 
     def delete(name, options, async = true)
       unless deleted_services.include?(name)
-        service = get_service(token, prefixed_name(name)) rescue nil
+        service = get_service(prefixed_name(name)) rescue nil
         if(service)
           spinner "removing #{pastel.cyan(name)}" do
-            delete_service(token, prefixed_name(name))
+            delete_service(prefixed_name(name))
             unless async
               wait_for_delete_to_finish(service)
             end
@@ -59,7 +59,7 @@ module Kontena::Cli::Apps
 
     def wait_for_delete_to_finish(service)
       until service.nil?
-        service = get_service(token, service['name']) rescue nil
+        service = get_service(service['name']) rescue nil
         sleep 0.5
       end
     end

--- a/cli/lib/kontena/cli/apps/restart_command.rb
+++ b/cli/lib/kontena/cli/apps/restart_command.rb
@@ -12,6 +12,8 @@ module Kontena::Cli::Apps
 
     attr_reader :services
 
+    requires_current_master_token
+
     def execute
       require_config_file(filename)
 
@@ -28,7 +30,7 @@ module Kontena::Cli::Apps
       services.each do |service_name, opts|
         if service_exists?(service_name)
           spinner "Sending restart signal to #{service_name.colorize(:cyan)} " do
-            restart_service(token, prefixed_name(service_name))
+            restart_service(prefixed_name(service_name))
           end
         else
           warning "No such service: #{service_name}"

--- a/cli/lib/kontena/cli/apps/scale_command.rb
+++ b/cli/lib/kontena/cli/apps/scale_command.rb
@@ -14,6 +14,8 @@ module Kontena::Cli::Apps
 
     attr_reader :services
 
+    requires_current_master_token
+
     def execute
       require_config_file(filename)
       yml_service = services_from_yaml(filename, [service], service_prefix, true)
@@ -21,10 +23,9 @@ module Kontena::Cli::Apps
         options = yml_service[service]
         exit_with_error("Service has already instances defined in #{filename}. Please update #{filename} and deploy service instead") if options['container_count']
         spinner "Scaling #{service.colorize(:cyan)} " do
-          scale_service(require_token, prefixed_name(service), instances)
-          wait_for_deploy_to_finish(token, parse_service_id(prefixed_name(service)))
+          scale_service(prefixed_name(service), instances)
+          wait_for_deploy_to_finish(parse_service_id(prefixed_name(service)))
         end
-
       else
         exit_with_error("Service not found")
       end

--- a/cli/lib/kontena/cli/apps/show_command.rb
+++ b/cli/lib/kontena/cli/apps/show_command.rb
@@ -13,10 +13,12 @@ module Kontena::Cli::Apps
 
     attr_reader :services
 
+    requires_current_master_token
+
     def execute
       require_config_file(filename)
 
-      show_service(require_token, prefixed_name(service))
+      show_service(prefixed_name(service))
     end
   end
 end

--- a/cli/lib/kontena/cli/apps/start_command.rb
+++ b/cli/lib/kontena/cli/apps/start_command.rb
@@ -11,6 +11,8 @@ module Kontena::Cli::Apps
 
     parameter "[SERVICE] ...", "Services to start"
 
+    requires_current_master_token
+
     attr_reader :services
 
     def execute
@@ -29,7 +31,7 @@ module Kontena::Cli::Apps
       services.each do |service_name, opts|
         if service_exists?(service_name)
           spinner "Starting #{service_name.colorize(:cyan)} " do
-            start_service(token, prefixed_name(service_name))
+            start_service(prefixed_name(service_name))
           end
         else
           warning "No such service: #{service_name}"

--- a/cli/lib/kontena/cli/apps/stop_command.rb
+++ b/cli/lib/kontena/cli/apps/stop_command.rb
@@ -13,6 +13,8 @@ module Kontena::Cli::Apps
 
     attr_reader :services
 
+    requires_current_master_token
+
     def execute
       require_config_file(filename)
 
@@ -29,7 +31,7 @@ module Kontena::Cli::Apps
       services.each do |service_name, opts|
         if service_exists?(service_name)
           spinner "Sending stop signal to #{service_name.colorize(:cyan)} " do
-            stop_service(token, prefixed_name(service_name))
+            stop_service(prefixed_name(service_name))
           end
         else
           warning "No such service: #{service_name}"

--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -7,12 +7,12 @@ module Kontena::Cli::Certificate
 
     parameter "DOMAIN", "Domain to authorize"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
 
       data = {domain: domain}
-      response = client(token).post("certificates/#{current_grid}/authorize", data)
+      response = client.post("certificates/#{current_grid}/authorize", data)
       puts "Authorization successfully created. Use the following details to create necessary validations:"
       puts "Record name: #{response['record_name']}.#{domain}"
       puts "Record type: #{response['record_type']}"

--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -4,18 +4,17 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
+    parameter "DOMAIN ...", "Domain(s) to get certificate for"
 
     option '--secret-name', 'SECRET_NAME', 'The name for the secret to store the certificate in'
     option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain, chain or cert', default: 'fullchain'
-    parameter "DOMAIN ...", "Domain(s) to get certificate for"
 
+    requires_current_master_token
 
     def execute
-      require_api_url
-      token = require_token
       secret = secret_name || "LE_CERTIFICATE_#{domain_list[0].gsub('.', '_')}"
       data = {domains: domain_list, secret_name: secret}
-      response = client(token).post("certificates/#{current_grid}/certificate", data)
+      response = client.post("certificates/#{current_grid}/certificate", data)
       puts "Certificate successfully received and stored into vault with keys:"
       response.each do |secret|
         puts secret.colorize(:green)

--- a/cli/lib/kontena/cli/certificate/register_command.rb
+++ b/cli/lib/kontena/cli/certificate/register_command.rb
@@ -4,15 +4,13 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
     parameter "EMAIL", "Email to register"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
+    def execute
       data = {email: email}
-      response = client(token).post("certificates/#{current_grid}/register", data)
+      response = client.post("certificates/#{current_grid}/register", data)
       puts 'Email registered to LetsEncrypt'
     end
   end

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -85,7 +85,7 @@ module Kontena::Cli::Cloud
       server_thread  = Thread.new { Thread.main['response'] = web_server.serve_one }
       browser_thread = Thread.new { Launchy.open(uri.to_s) }
       
-      vspinner "Waiting for browser authorization response" do
+      spinner "Waiting for browser authorization response" do
         server_thread.join
       end
       browser_thread.join

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -208,7 +208,9 @@ module Kontena
       end
 
       def require_current_grid
-        config.require_current_grid
+        unless self.respond_to?(:grid) && self.grid
+          config.require_current_grid
+        end
       end
 
       def clear_current_grid

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -297,7 +297,7 @@ module Kontena
       def require_current_master_token
         require_current_master
         token = current_master.token
-        if token && token.access_token 
+        if token && token.access_token
           return token unless token.expired?
           raise TokenExpiredError, "The access token has expired and needs to be refreshed."
         end
@@ -355,7 +355,7 @@ module Kontena
       # @raise [ArgumentError] if no grid is selected
       def require_current_grid
         return current_grid if current_grid
-        raise ArgumentError, "You have not selected a grid. Use: kontena grid"
+        raise ArgumentError, "You have not selected a grid. Use: 'kontena grid use' or set KONTENA_GRID environment variable."
       end
 
       # Name of the currently selected grid. Can override using 
@@ -482,7 +482,7 @@ module Kontena
         include ConfigurationInstance
 
         def initialize(*args)
-          super
+          super(*args)
           @table[:account] ||= 'master'
         end
       end

--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -10,15 +10,14 @@ module Kontena::Cli::Containers
     parameter "CONTAINER_ID", "Container id"
     parameter "CMD ...", "Command"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
+    def execute
       cmd = build_command(cmd_list)
       payload = {cmd: ["sh", "-c", cmd]}
 
       service_name = container_id.match(/(.+)-(\d+)/)[1] rescue nil
-      result = client(token).post("containers/#{current_grid}/#{service_name}/#{container_id}/exec", payload)
+      result = client.post("containers/#{current_grid}/#{service_name}/#{container_id}/exec", payload)
 
       puts result[0].join(" ") unless result[0].size == 0
       STDERR.puts result[1].join(" ") unless result[1].size == 0

--- a/cli/lib/kontena/cli/containers/inspect_command.rb
+++ b/cli/lib/kontena/cli/containers/inspect_command.rb
@@ -5,14 +5,13 @@ module Kontena::Cli::Containers
 
     parameter "CONTAINER_ID", "Container id"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
+    def execute
       match = container_id.match(/(.+)-(\d+)/)
       if match
         service_name = match[1]
-        result = client(token).get("containers/#{current_grid}/#{service_name}/#{container_id}/inspect")
+        result = client.get("containers/#{current_grid}/#{service_name}/#{container_id}/inspect")
         puts JSON.pretty_generate(result)
       else
         exit_with_error("Cannot resolve container service")

--- a/cli/lib/kontena/cli/etcd/get_command.rb
+++ b/cli/lib/kontena/cli/etcd/get_command.rb
@@ -8,12 +8,12 @@ module Kontena::Cli::Etcd
 
     parameter "KEY", "Etcd key"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       validate_key
 
-      response = client(token).get("etcd/#{current_grid}/#{key}")
+      response = client.get("etcd/#{current_grid}/#{key}")
       if response['value']
         puts response['value']
       elsif response['children']

--- a/cli/lib/kontena/cli/etcd/list_command.rb
+++ b/cli/lib/kontena/cli/etcd/list_command.rb
@@ -10,14 +10,14 @@ module Kontena::Cli::Etcd
 
     option "--recursive", :flag, "List keys recursively", default: false
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       validate_key
 
       opts = []
       opts << 'recursive=true' if recursive?
-      response = client(token).get("etcd/#{current_grid}/#{key}?#{opts.join('&')}")
+      response = client.get("etcd/#{current_grid}/#{key}?#{opts.join('&')}")
       if response['children']
         children = response['children'].map{|c| c['key'] }
         puts children.join("\n")

--- a/cli/lib/kontena/cli/etcd/mkdir_command.rb
+++ b/cli/lib/kontena/cli/etcd/mkdir_command.rb
@@ -8,13 +8,13 @@ module Kontena::Cli::Etcd
 
     parameter "KEY", "Etcd key"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       validate_key
 
       data = {}
-      response = client(token).post("etcd/#{current_grid}/#{key}", data)
+      response = client.post("etcd/#{current_grid}/#{key}", data)
       if response['error']
         exit_with_error response['error']
       end

--- a/cli/lib/kontena/cli/etcd/remove_command.rb
+++ b/cli/lib/kontena/cli/etcd/remove_command.rb
@@ -11,15 +11,15 @@ module Kontena::Cli::Etcd
     option "--recursive", :flag, "Remove keys recursively"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       validate_key
       confirm unless forced?
 
       data = {}
       data[:recursive] = true if recursive?
-      response = client(token).delete("etcd/#{current_grid}/#{key}", data)
+      response = client.delete("etcd/#{current_grid}/#{key}", data)
 
       if response['error']
         exit_with_error response['error']

--- a/cli/lib/kontena/cli/etcd/set_command.rb
+++ b/cli/lib/kontena/cli/etcd/set_command.rb
@@ -9,13 +9,13 @@ module Kontena::Cli::Etcd
     parameter "KEY", "Etcd key"
     parameter "VALUE", "Etcd value"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       validate_key
 
       data = {value: value}
-      response = client(token).post("etcd/#{current_grid}/#{key}", data)
+      response = client.post("etcd/#{current_grid}/#{key}", data)
       if response['error']
         exit_with_error response['error']
       end

--- a/cli/lib/kontena/cli/external_registries/add_command.rb
+++ b/cli/lib/kontena/cli/external_registries/add_command.rb
@@ -9,14 +9,12 @@ module Kontena::Cli::ExternalRegistries
     option ['-e', '--email'], 'EMAIL', 'Email', required: true
     option ['-p', '--password'], 'PASSWORD', 'Password', required: true
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master_token
 
+    def execute
       data = { username: username, password: password, email: email, url: url }
       spinner "Adding #{url.colorize(:cyan)} to external registries " do
-        client(token).post("grids/#{current_grid}/external_registries", data)
+        client.post("grids/#{current_grid}/external_registries", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/external_registries/delete_command.rb
+++ b/cli/lib/kontena/cli/external_registries/delete_command.rb
@@ -5,11 +5,11 @@ module Kontena::Cli::ExternalRegistries
 
     parameter "NAME", "External registry name to delete"
 
+    requires_current_master_token
+
     def execute
       warning "Support for 'kontena external-registry delete' will be dropped. Use 'kontena external-registry remove' instead."
-      require_api_url
-      token = require_token
-      client(token).delete("external_registries/#{current_grid}/#{name}")
+      client.delete("external_registries/#{current_grid}/#{name}")
     end
   end
 end

--- a/cli/lib/kontena/cli/external_registries/list_command.rb
+++ b/cli/lib/kontena/cli/external_registries/list_command.rb
@@ -3,11 +3,10 @@ module Kontena::Cli::ExternalRegistries
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_current_grid
-      token = require_token
-      result = client(token).get("grids/#{current_grid}/external_registries")
+      result = client.get("grids/#{current_grid}/external_registries")
       puts "%-30s %-20s %-30s" % ['Name', 'Username', 'Email']
       result['external_registries'].each { |r|
         puts "%-30.30s %-20.20s %-30.30s" % [r['name'], r['username'], r['email']]

--- a/cli/lib/kontena/cli/external_registries/remove_command.rb
+++ b/cli/lib/kontena/cli/external_registries/remove_command.rb
@@ -1,16 +1,17 @@
 module Kontena::Cli::ExternalRegistries
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
     parameter "NAME", "External registry name to remove"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       confirm_command(name) unless forced?
       spinner "Removing #{name.colorize(:cyan)} external-registry from #{current_grid.colorize(:cyan)} grid " do
-        client(token).delete("external_registries/#{current_grid}/#{name}")
+        client.delete("external_registries/#{current_grid}/#{name}")
       end
     end
   end

--- a/cli/lib/kontena/cli/grid_options.rb
+++ b/cli/lib/kontena/cli/grid_options.rb
@@ -4,7 +4,8 @@ module Kontena
 
       def self.included(base)
         if base.respond_to?(:option)
-          base.option '--grid', 'GRID', 'Specify grid to use'
+          base.option '--grid', 'GRID', 'Specify grid to use', environment_variable: 'KONTENA_GRID'
+          base.requires_current_grid if base.respond_to?(:requires_current_grid)
         end
       end
     end

--- a/cli/lib/kontena/cli/grids/audit_log_command.rb
+++ b/cli/lib/kontena/cli/grids/audit_log_command.rb
@@ -3,13 +3,12 @@ require_relative 'common'
 module Kontena::Cli::Grids
   class AuditLogCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
     include Common
 
     option ["-l", "--lines"], "LINES", "Number of lines"
 
-    requires_current_master
     requires_current_master_token
-    requires_current_grid
 
     def execute
       audit_logs = client.get("grids/#{current_grid}/audit_log", {limit: lines})

--- a/cli/lib/kontena/cli/grids/cloud_config_command.rb
+++ b/cli/lib/kontena/cli/grids/cloud_config_command.rb
@@ -11,10 +11,9 @@ module Kontena::Cli::Grids
     option "--docker-bip", "BIP", "Docker bridge ip", default: "172.17.43.1/16"
     option "--version", "VERSION", "Agent version", default: "latest"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
+    def execute
       grid = find_grid_by_name(name)
       exit_with_error("Grid not found") unless grid
 

--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Grids
       puts "#{grid['name']}:"
       puts "  uri: #{host.sub('http', 'ws')}"
       root_dir = grid['engine_root_dir']
-      nodes = client(require_token).get("grids/#{grid['name']}/nodes")
+      nodes = client.get("grids/#{grid['name']}/nodes")
       nodes = nodes['nodes'].select{|n| n['connected'] == true }
       node_count = nodes.size
       puts "  stats:"

--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -18,6 +18,12 @@ module Kontena::Cli::Grids
         name: name
       }
       payload[:token] = self.token if self.token
+      begin
+        if client.get("grids/#{self.name}")
+          abort pastel.red("Grid '#{self.name}' already exists")
+        end
+      rescue Kontena::Errors::StandardError
+      end
       payload[:initial_size] = initial_size if initial_size
       grid = nil
       if initial_size == 1

--- a/cli/lib/kontena/cli/grids/current_command.rb
+++ b/cli/lib/kontena/cli/grids/current_command.rb
@@ -3,17 +3,24 @@ require_relative 'common'
 module Kontena::Cli::Grids
   class CurrentCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
     include Common
 
     option ["--name"], :flag, "Show name only", default: false
 
+    requires_current_master_token
+
     def execute
-      require_api_url
       if current_grid.nil?
         exit_with_error 'No grid selected. To select grid, please run: kontena grid use <grid name>'
       else
-
-        grid = client(require_token).get("grids/#{current_grid}")
+        begin
+          grid = client.get("grids/#{current_grid}")
+        rescue Kontena::Errors::StandardError
+          if $!.message =~ /Not found/
+            abort pastel.red('Grid not found')
+          end
+        end
         if name?
           puts "#{grid['name']}"
         else

--- a/cli/lib/kontena/cli/grids/env_command.rb
+++ b/cli/lib/kontena/cli/grids/env_command.rb
@@ -8,9 +8,9 @@ module Kontena::Cli::Grids
     parameter "[NAME]", "Grid name"
     option ["-e", "--export"], :flag, "Add export", default: false
 
-    def execute
-      require_api_url
+    requires_current_master_token
 
+    def execute
       name_or_current = name.nil? ? current_grid : name
 
       if name_or_current.nil?
@@ -21,10 +21,10 @@ module Kontena::Cli::Grids
 
         prefix = export? ? 'export ' : ''
 
-        server = settings['servers'].find{|s| s['name'] == settings['current_server']}
+        server = current_master
         if server
-          puts "#{prefix}KONTENA_URI=#{server['url'].sub('http', 'ws')}"
-          puts "#{prefix}KONTENA_TOKEN=#{server['token']}"
+          puts "#{prefix}KONTENA_URI=#{server.url.sub('http', 'ws')}"
+          puts "#{prefix}KONTENA_TOKEN=#{server.token.access_token}"
         end
       end
     end

--- a/cli/lib/kontena/cli/grids/list_command.rb
+++ b/cli/lib/kontena/cli/grids/list_command.rb
@@ -8,10 +8,10 @@ module Kontena::Cli::Grids
     option ['-u', '--use'], :flag, 'Automatically use first available grid sorted by user count', hidden: true
     option ['-v', '--verbose'], :flag, 'Use a more verbose output', hidden: true
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_token
-      vputs
+      vputs # output an empty line when verbose
 
       gridlist = []
 
@@ -20,9 +20,9 @@ module Kontena::Cli::Grids
       end
 
       if gridlist.size == 0
-        self.verbose? && puts
+        vputs
         puts "Kontena Master #{config.current_master.name} doesn't have any grids yet. Create one now using 'kontena grid create' command".colorize(:yellow)
-        self.verbose? && puts
+        vputs
       else
         vputs
         vputs "You have access to the following grids:"
@@ -40,7 +40,7 @@ module Kontena::Cli::Grids
 
         if self.use?
           vputs
-          vspinner "* Selecting '#{gridlist.first['name']}' as the current grid" do
+          vspinner "Selecting '#{gridlist.first['name']}' as the current grid" do
             config.current_master.grid = gridlist.first['name']
             config.write
           end

--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -4,13 +4,15 @@ module Kontena::Cli::Grids
   class LogsCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::Helpers::LogHelper
+    include Kontena::Cli::GridOptions
 
     option "--node", "NODE", "Filter by node name", multivalued: true
     option "--service", "SERVICE", "Filter by service name", multivalued: true
     option ["-c", "--container"], "CONTAINER", "Filter by container", multivalued: true
 
+    requires_current_master_token
+
     def execute
-      require_api_url
 
       query_params = {}
       query_params[:nodes] = node_list.join(",") unless node_list.empty?

--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -7,16 +7,16 @@ module Kontena::Cli::Grids
 
     parameter "NAME", "Grid name"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
+    
+    requires_current_master_token
 
     def execute
-      require_api_url
-      token = require_token
       confirm_command(name) unless forced?
       grid = find_grid_by_name(name)
 
       if !grid.nil?
         spinner "removing #{pastel.cyan(name)} grid " do
-          response = client(token).delete("grids/#{grid['id']}")
+          response = client.delete("grids/#{grid['id']}")
           if response
             clear_current_grid if grid['id'] == current_grid
           end

--- a/cli/lib/kontena/cli/grids/show_command.rb
+++ b/cli/lib/kontena/cli/grids/show_command.rb
@@ -9,9 +9,9 @@ module Kontena::Cli::Grids
 
     option '--token', :flag, 'Just output grid token'
 
-    def execute
-      require_api_url
+    requires_current_master_token
 
+    def execute
       grid = find_grid_by_name(name)
       exit_with_error("Grid not found") unless grid
 

--- a/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
@@ -5,13 +5,13 @@ module Kontena::Cli::Grids::TrustedSubnets
     parameter "NAME", "Grid name"
     parameter "SUBNET", "Trusted subnet"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      grid = client(token).get("grids/#{name}")
+      grid = client.get("grids/#{name}")
       data = {trusted_subnets: grid['trusted_subnets'] + [self.subnet]}
       spinner "Adding #{subnet.colorize(:cyan)} as a trusted subnet in #{name.colorize(:cyan)} grid " do
-        client(token).put("grids/#{name}", data)
+        client.put("grids/#{name}", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
@@ -4,10 +4,10 @@ module Kontena::Cli::Grids::TrustedSubnets
 
     parameter "NAME", "Grid name"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      grid = client(token).get("grids/#{current_grid}")
+      grid = client.get("grids/#{current_grid}")
       trusted_subnets = grid['trusted_subnets'] || []
       trusted_subnets.each do |subnet|
         puts subnet

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Grids::TrustedSubnets
     parameter "SUBNET", "Trusted subnet"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      grid = client(token).get("grids/#{name}")
+      grid = client.get("grids/#{name}")
       confirm_command(subnet) unless forced?
       trusted_subnets = grid['trusted_subnets'] || []
       unless trusted_subnets.delete(self.subnet)
@@ -17,7 +17,7 @@ module Kontena::Cli::Grids::TrustedSubnets
       end
       data = {trusted_subnets: trusted_subnets}
       spinner "Removing trusted subnet #{subnet.colorize(:cyan)} from #{name.colorize(:cyan)} grid " do
-        client(token).put("grids/#{name}", data)
+        client.put("grids/#{name}", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -8,9 +8,9 @@ module Kontena::Cli::Grids
     parameter "NAME", "Grid name"
     option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       payload = {}
       if statsd_server
         server, port = statsd_server.split(':')
@@ -21,7 +21,7 @@ module Kontena::Cli::Grids
           }
         }
       end
-      client(token).put("grids/#{name}", payload)
+      client.put("grids/#{name}", payload)
     end
   end
 end

--- a/cli/lib/kontena/cli/grids/users/add_command.rb
+++ b/cli/lib/kontena/cli/grids/users/add_command.rb
@@ -8,11 +8,11 @@ module Kontena::Cli::Grids::Users
 
     parameter "EMAIL", "Email address"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       data = { email: email }
-      client(token).post("grids/#{current_grid}/users", data)
+      client.post("grids/#{current_grid}/users", data)
     end
   end
 end

--- a/cli/lib/kontena/cli/grids/users/list_command.rb
+++ b/cli/lib/kontena/cli/grids/users/list_command.rb
@@ -5,10 +5,10 @@ module Kontena::Cli::Grids::Users
     include Kontena::Cli::Common
     include Kontena::Cli::Grids::Common
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      result = client(token).get("grids/#{current_grid}/users")
+      result = client.get("grids/#{current_grid}/users")
       puts "%-40s %-40s" % ['Email', 'Name']
       result['users'].each { |user|
         puts "%-40.40s %-40.40s" % [user['email'], user['name']]

--- a/cli/lib/kontena/cli/grids/users/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/users/remove_command.rb
@@ -9,12 +9,12 @@ module Kontena::Cli::Grids::Users
     parameter "EMAIL", "Email address"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       confirm_command(email) unless forced?
 
-      result = client(token).delete("grids/#{current_grid}/users/#{email}")
+      result = client.delete("grids/#{current_grid}/users/#{email}")
     end
   end
 end

--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -28,7 +28,7 @@ module Kontena::Cli::Helpers
       query_params[:limit] = lines if lines
       query_params[:since] = since if since
 
-      result = client(token).get(url, query_params)
+      result = client.get(url, query_params)
       result['logs'].each do |log|
         yield log
       end
@@ -52,7 +52,7 @@ module Kontena::Cli::Helpers
 
       begin
         query_params[:from] = last_seen if last_seen
-        result = client(token).get_stream(url, streamer, query_params)
+        result = client.get_stream(url, streamer, query_params)
       rescue => exc
         retry if exc.cause.is_a?(EOFError) # Excon wraps the EOFerror into SocketError
         raise

--- a/cli/lib/kontena/cli/master/config/get_command.rb
+++ b/cli/lib/kontena/cli/master/config/get_command.rb
@@ -13,11 +13,12 @@ module Kontena::Cli::Master::Config
     option ['-p', '--pair'], :flag, "Print key=value instead of only value"
 
     def execute
-      if self.pair?
-        puts client.get("config/#{self.key}").inspect
-      else
-        puts client.get("config/#{self.key}")[self.key]
+      begin
+        value = client.get("config/#{self.key}")[self.key]
+      rescue Kontena::Errors::StandardError
+        abort "Configuration key '#{self.key}' not found"
       end
+      puts self.pair? ? "#{self.key}=#{value}" : value
     end
   end
 end

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -18,6 +18,18 @@ module Kontena::Cli::Master
     option ['-s', '--silent'], :flag, 'Reduce output verbosity'
 
     option ['--no-login-info'], :flag, "Don't show login info", hidden: true
+    
+    def default_name
+      if config.find_server('kontena-master')
+        counter = 1
+        until config.find_server("kontena_master-#{counter}").nil?
+          counter += 1
+        end
+        "kontena-master-#{counter}"
+      else
+        "kontena-master"
+      end
+    end
 
     def execute
       # rewrites self.url

--- a/cli/lib/kontena/cli/master/users/list_command.rb
+++ b/cli/lib/kontena/cli/master/users/list_command.rb
@@ -4,10 +4,10 @@ module Kontena::Cli::Master::Users
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      response = client(token).get('users')
+      response = client.get('users')
 
       response['users'].each do |user|
         roles = user['roles'].map{|r| r['name']}

--- a/cli/lib/kontena/cli/master/users/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/remove_command.rb
@@ -7,14 +7,14 @@ module Kontena::Cli::Master::Users
     parameter "EMAIL ...", "List of emails"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       confirm unless forced?
 
       email_list.each do |email|
         begin
-          client(token).delete("users/#{email}")
+          client.delete("users/#{email}")
         rescue => exc
           STDERR.puts "Failed to remove user #{email}".colorize(:red)
           STDERR.puts exc.message

--- a/cli/lib/kontena/cli/master/users/roles/add_command.rb
+++ b/cli/lib/kontena/cli/master/users/roles/add_command.rb
@@ -9,16 +9,15 @@ module Kontena::Cli::Master::Users
       parameter "USER ...", "List of users"
 
       option '--silent', :flag, 'Reduce output verbosity'
+      requires_current_master_token
 
       def execute
-        require_api_url
-        token = require_token
         data = { role: role }
 
         user_list.each do |email|
           begin
-            response = client(token).post("users/#{email}/roles", data)
-            puts "Added role #{role} to #{email}" unless running_silent?
+            response = client.post("users/#{email}/roles", data)
+            puts "Added role #{role} to #{email}"
           rescue => exc
             abort "Failed to add role #{role} to #{email} : #{exc.message}".colorize(:red)
           end

--- a/cli/lib/kontena/cli/master/users/roles/remove_command.rb
+++ b/cli/lib/kontena/cli/master/users/roles/remove_command.rb
@@ -8,15 +8,14 @@ module Kontena::Cli::Master::Users::Roles
     parameter "USER ...", "List of users"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
 
     def execute
-      require_api_url
-      token = require_token
       confirm unless forced?
 
       user_list.each do |email|
         begin
-          response = client(token).delete("users/#{email}/roles/#{role}")
+          response = client.delete("users/#{email}/roles/#{role}")
           puts "Removed role #{role} from #{email}" if response
         rescue => exc
           puts "Failed to remove role #{role} from #{email}".colorize(:red)

--- a/cli/lib/kontena/cli/nodes/labels/add_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/add_command.rb
@@ -1,16 +1,15 @@
 module Kontena::Cli::Nodes::Labels
   class AddCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
     parameter "NODE_ID", "Node id"
     parameter "LABEL", "Label"
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master_token
 
-      node = client(token).get("grids/#{current_grid}/nodes/#{node_id}")
+    def execute
+      node = client.get("grids/#{current_grid}/nodes/#{node_id}")
       data = {}
       data[:labels] = node['labels'].to_a | [label]
       client.put("nodes/#{node['id']}", data, {}, {'Kontena-Grid-Token' => node['grid']['token']})

--- a/cli/lib/kontena/cli/nodes/labels/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/remove_command.rb
@@ -1,16 +1,15 @@
 module Kontena::Cli::Nodes::Labels
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
     parameter "NODE_ID", "Node id"
     parameter "LABEL", "Label"
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master_token
 
-      node = client(token).get("grids/#{current_grid}/nodes/#{node_id}")
+    def execute
+      node = client.get("grids/#{current_grid}/nodes/#{node_id}")
       unless node['labels'].include?(label)
         exit_with_error("Node #{node['name']} does not have label #{label}")
       end

--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -5,17 +5,15 @@ module Kontena::Cli::Nodes
 
     option ["--all"], :flag, "List nodes for all grids", default: false
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master_token
 
+    def execute
       if all?
-        grids = client(token).get("grids")
+        grids = client.get("grids")
         puts "%-70s %-10s %-40s" % [ 'Name', 'Status', 'Labels']
 
         grids['grids'].each do |grid|
-          nodes = client(token).get("grids/#{grid['name']}/nodes")
+          nodes = client.get("grids/#{grid['name']}/nodes")
           nodes['nodes'].each do |node|
             if node['connected']
               status = 'online'
@@ -30,7 +28,8 @@ module Kontena::Cli::Nodes
           end
         end
       else
-        nodes = client(token).get("grids/#{current_grid}/nodes")
+        require_current_grid
+        nodes = client.get("grids/#{current_grid}/nodes")
         puts "%-70s %-10s %-10s %-40s" % ['Name', 'Status', 'Initial', 'Labels']
         nodes = nodes['nodes'].sort_by{|n| n['node_number'] }
         nodes.each do |node|

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -6,14 +6,13 @@ module Kontena::Cli::Nodes
     parameter "NODE_ID", "Node id"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_current_grid
-      token = require_token
       confirm_command(node_id) unless forced?
 
       spinner "Removing #{node_id.colorize(:cyan)} node from #{current_grid.colorize(:cyan)} grid " do
-        client(token).delete("grids/#{current_grid}/nodes/#{node_id}")
+        client.delete("grids/#{current_grid}/nodes/#{node_id}")
       end
     end
   end

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -6,12 +6,10 @@ module Kontena::Cli::Nodes
 
     parameter "NODE_ID", "Node id"
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master_token
 
-      node = client(token).get("grids/#{current_grid}/nodes/#{node_id}")
+    def execute
+      node = client.get("grids/#{current_grid}/nodes/#{node_id}")
       puts "#{node['name']}:"
       puts "  id: #{node['id']}"
       puts "  agent version: #{node['agent_version']}"

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -9,12 +9,10 @@ module Kontena::Cli::Nodes
     option "--private-ip", :flag, "Connect to node's private IP address"
     option "--internal-ip", :flag, "Connect to node's internal IP address (requires VPN connection)"
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master_token
 
-      node = client(token).get("grids/#{current_grid}/nodes/#{node_id}")
+    def execute
+      node = client.get("grids/#{current_grid}/nodes/#{node_id}")
       cmd = ['ssh']
       cmd << "-i #{identity_file}" if identity_file
       if internal_ip?

--- a/cli/lib/kontena/cli/nodes/update_command.rb
+++ b/cli/lib/kontena/cli/nodes/update_command.rb
@@ -6,15 +6,13 @@ module Kontena::Cli::Nodes
     parameter "NODE_ID", "Node id"
     option ["-l", "--label"], "LABEL", "Node label", multivalued: true
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master_token
 
-      node = client(token).get("grids/#{current_grid}/nodes/#{node_id}")
+    def execute
+      node = client.get("grids/#{current_grid}/nodes/#{node_id}")
       data = {}
       data[:labels] = label_list if label_list
-      spinner "Updating #{node_id.colorize(:cyan)} node " do
+      spinner "Updating #{node_id.colorize(:cyan)} node" do
         client.put("nodes/#{node['id']}", data, {}, {'Kontena-Grid-Token' => node['grid']['token']})
       end
     end

--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -15,19 +15,19 @@ module Kontena::Cli::Registry
     option '--azure-account-name', 'AZURE_ACCOUNT_NAME', 'Azure account name'
     option '--azure-container-name', 'AZURE_CONTAINER_NAME', 'Azure container name'
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       preferred_node = node
       secrets = []
       affinity = []
       stateful = true
       instances = 1
 
-      registry = client(token).get("services/#{current_grid}/registry") rescue nil
+      registry = client.get("services/#{current_grid}/registry") rescue nil
       exit_with_error('Registry already exists') if registry
 
-      nodes = client(token).get("grids/#{current_grid}/nodes")
+      nodes = client.get("grids/#{current_grid}/nodes")
 
       if s3_bucket
         ['REGISTRY_STORAGE_S3_ACCESSKEY', 'REGISTRY_STORAGE_S3_SECRETKEY'].each do |secret|
@@ -95,10 +95,10 @@ module Kontena::Cli::Registry
           secrets: secrets,
           affinity: affinity
       }
-      client(token).post("grids/#{current_grid}/services", data)
-      client(token).post("services/#{current_grid}/registry/deploy", {})
+      client.post("grids/#{current_grid}/services", data)
+      client.post("services/#{current_grid}/registry/deploy", {})
       spinner "deploying #{data[:name].colorize(:cyan)} service " do
-        wait_for_deploy_to_finish(token, parse_service_id(data[:name]))
+        wait_for_deploy_to_finish(parse_service_id(data[:name]))
       end
       puts "\n"
       puts "Docker Registry #{REGISTRY_VERSION} is now running at registry.#{current_grid}.kontena.local."
@@ -110,7 +110,7 @@ module Kontena::Cli::Registry
     # @param [String] name
     # @return [Boolean]
     def vault_secret_exists?(name)
-      client(require_token).get("secrets/#{current_grid}/#{name}")
+      client.get("secrets/#{current_grid}/#{name}")
       true
     rescue
       false
@@ -119,7 +119,7 @@ module Kontena::Cli::Registry
     # @param [String] name
     # @return [String]
     def vault_secret(name)
-      secret = client(require_token).get("secrets/#{current_grid}/#{name}")
+      secret = client.get("secrets/#{current_grid}/#{name}")
       secret['value']
     end
 
@@ -131,7 +131,7 @@ module Kontena::Cli::Registry
         email: 'not@val.id',
         url: "http://registry.#{current_grid}.kontena.local/"
       }
-      client(require_token).post("grids/#{current_grid}/external_registries", data) rescue nil
+      client.post("grids/#{current_grid}/external_registries", data) rescue nil
     end
   end
 end

--- a/cli/lib/kontena/cli/registry/delete_command.rb
+++ b/cli/lib/kontena/cli/registry/delete_command.rb
@@ -3,16 +3,13 @@ module Kontena::Cli::Registry
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
+    requires_current_master_token
+
     def execute
       warning "Support for 'kontena registry delete' will be dropped. Use 'kontena registry remove' instead."
-
-      require_api_url
-      token = require_token
-
-      registry = client(token).get("services/#{current_grid}/registry") rescue nil
+      registry = client.get("services/#{current_grid}/registry") rescue nil
       exit_with_error("Docker Registry service does not exist") if registry.nil?
-
-      client(token).delete("services/#{current_grid}/registry")
+      client.delete("services/#{current_grid}/registry")
     end
   end
 end

--- a/cli/lib/kontena/cli/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/registry/remove_command.rb
@@ -1,20 +1,21 @@
 module Kontena::Cli::Registry
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       confirm unless forced?
       name = 'registry'
 
-      registry = client(token).get("services/#{current_grid}/#{name}") rescue nil
+      registry = client.get("services/#{current_grid}/#{name}") rescue nil
       exit_with_error("Service #{name.colorize(:cyan)} does not exist") if registry.nil?
 
       spinner "Removing #{name.colorize(:cyan)} service " do
-        client(token).delete("services/#{current_grid}/#{name}")
+        client.delete("services/#{current_grid}/#{name}")
       end
     end
   end

--- a/cli/lib/kontena/cli/services/containers_command.rb
+++ b/cli/lib/kontena/cli/services/containers_command.rb
@@ -8,11 +8,10 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
-      result = client(token).get("services/#{current_grid}/#{name}/containers")
+    def execute
+      result = client.get("services/#{current_grid}/#{name}/containers")
       result['containers'].each do |container|
         puts "#{container['id']}:"
         puts "  rev: #{container['deploy_rev']}"

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -41,9 +41,9 @@ module Kontena::Cli::Services
     option "--health-check-port", "HEALTH CHECK PORT", "Port for health check"
     option "--health-check-protocol", "HEALTH CHECK PROTOCOL", "Protocol of health check"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       data = {
         name: name,
         image: image,
@@ -51,7 +51,7 @@ module Kontena::Cli::Services
       }
       data.merge!(parse_service_data_from_options)
       spinner "Creating #{name.colorize(:cyan)} service " do
-        create_service(token, current_grid, data)
+        create_service(current_grid, data)
       end
     end
 

--- a/cli/lib/kontena/cli/services/delete_command.rb
+++ b/cli/lib/kontena/cli/services/delete_command.rb
@@ -8,12 +8,12 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
 
+    option ['--force'], :flag, 'Do not ask questions'
+
     def execute
       warning "Support for 'kontena service delete' will be dropped. Use 'kontena service remove' instead."
-      require_api_url
-      token = require_token
-
-      result = client(token).delete("services/#{parse_service_id(name)}")
+      confirm unless self.force?
+      client.delete("services/#{parse_service_id(name)}")
     end
   end
 end

--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -9,15 +9,15 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     option '--force-deploy', :flag, 'Force deploy even if service does not have any changes'
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       service_id = name
       data = {}
       data[:force] = true if force_deploy?
       spinner "Deploying service #{name.colorize(:cyan)} " do
-        deploy_service(token, name, data)
-        wait_for_deploy_to_finish(token, parse_service_id(name))
+        deploy_service(name, data)
+        wait_for_deploy_to_finish(parse_service_id(name))
       end
     end
   end

--- a/cli/lib/kontena/cli/services/envs/add_command.rb
+++ b/cli/lib/kontena/cli/services/envs/add_command.rb
@@ -9,12 +9,12 @@ module Kontena::Cli::Services::Envs
     parameter "NAME", "Service name"
     parameter "ENV", "Environment variable"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       data = {env: env}
       spinner "Adding env variable to #{name.colorize(:cyan)} service " do
-        client(token).post("services/#{parse_service_id(name)}/envs", data)
+        client.post("services/#{parse_service_id(name)}/envs", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/services/envs/list_command.rb
+++ b/cli/lib/kontena/cli/services/envs/list_command.rb
@@ -8,10 +8,10 @@ module Kontena::Cli::Services::Envs
 
     parameter "NAME", "Service name"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      service = client(token).get("services/#{parse_service_id(name)}")
+      service = client.get("services/#{parse_service_id(name)}")
       service["env"].sort.each do |env|
         puts env
       end

--- a/cli/lib/kontena/cli/services/envs/remove_command.rb
+++ b/cli/lib/kontena/cli/services/envs/remove_command.rb
@@ -9,11 +9,11 @@ module Kontena::Cli::Services::Envs
     parameter "NAME", "Service name"
     parameter "ENV", "Environment variable name"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      spinner "Removing env variable #{env.colorize(:cyan)} from #{name.colorize(:cyan)} service " do
-        client(token).delete("services/#{parse_service_id(name)}/envs/#{env}")
+      spinner "Removing env variable #{env.colorize(:cyan)} from #{name.colorize(:cyan)} service" do
+        client.delete("services/#{parse_service_id(name)}/envs/#{env}")
       end
     end
   end

--- a/cli/lib/kontena/cli/services/link_command.rb
+++ b/cli/lib/kontena/cli/services/link_command.rb
@@ -10,18 +10,17 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     parameter "TARGET", "Link target service name"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
-      service = client(token).get("services/#{parse_service_id(name)}")
+    def execute
+      service = client.get("services/#{parse_service_id(name)}")
       existing_targets = service['links'].map{|l| l['grid_service_id'].split('/')[1]}
       exit_with_error("Service is already linked to #{target.to_s}") if existing_targets.include?(target.to_s)
       links = service['links'].map{|l| {name: l['grid_service_id'].split('/')[1], alias: l['alias']} }
       links << {name: target.to_s, alias: target.to_s}
       data = {links: links}
-      spinner "Linking #{name.colorize(:cyan)} to #{target.colorize(:cyan)} " do
-        update_service(token, name, data)
+      spinner "Linking #{name.colorize(:cyan)} to #{target.colorize(:cyan)}" do
+        update_service(name, data)
       end
     end
   end

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -6,11 +6,10 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
-      grids = client(token).get("grids/#{current_grid}/services")
+    def execute
+      grids = client.get("grids/#{current_grid}/services")
       services = grids['services'].sort_by{|s| s['updated_at'] }.reverse
       titles = ['NAME', 'INSTANCES', 'STATEFUL', 'STATE', 'EXPOSED PORTS']
       puts "%-60s %-10s %-8s %-10s %-50s" % titles

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -10,10 +10,10 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
     option ["-i", "--instance"], "INSTANCE", "Show only given instance specific logs"
-    
-    def execute
-      require_api_url
 
+    requires_current_master_token
+
+    def execute
       query_params = {}
       query_params[:container] = "#{name}-#{instance}" if instance
 

--- a/cli/lib/kontena/cli/services/monitor_command.rb
+++ b/cli/lib/kontena/cli/services/monitor_command.rb
@@ -9,14 +9,13 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     option "--interval", "SECONDS", "How often view is refreshed", default: 2
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
+    def execute
       loop do
         nodes = {}
-        service = client(token).get("services/#{current_grid}/#{name}")
-        result = client(token).get("services/#{current_grid}/#{name}/containers")
+        service = client.get("services/#{current_grid}/#{name}")
+        result = client.get("services/#{current_grid}/#{name}/containers")
         result['containers'].each do |container|
           nodes[container['node']['name']] ||= []
           nodes[container['node']['name']] << container

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -8,17 +8,18 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       confirm_command(name) unless forced?
 
       spinner "Removing service #{name.colorize(:cyan)} " do
-        client(token).delete("services/#{parse_service_id(name)}")
+        client.delete("services/#{parse_service_id(name)}")
         removed = false
         until removed == true
           begin
-            client(token).get("services/#{parse_service_id(name)}")
+            client.get("services/#{parse_service_id(name)}")
+            sleep 0.1
           rescue Kontena::Errors::StandardError => exc
             if exc.status == 404
               removed = true

--- a/cli/lib/kontena/cli/services/restart_command.rb
+++ b/cli/lib/kontena/cli/services/restart_command.rb
@@ -8,11 +8,11 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       spinner "Sending restart signal to service #{name.colorize(:cyan)} " do
-        restart_service(token, name)
+        restart_service(name)
       end
     end
   end

--- a/cli/lib/kontena/cli/services/scale_command.rb
+++ b/cli/lib/kontena/cli/services/scale_command.rb
@@ -9,11 +9,12 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     parameter "INSTANCES", "Scales service to given number of instances"
 
+    requires_current_master_token
+
     def execute
-      token = require_token
       spinner "Scaling #{name} " do
-        scale_service(token, name, instances)
-        wait_for_deploy_to_finish(token, parse_service_id(name))
+        scale_service(name, instances)
+        wait_for_deploy_to_finish(parse_service_id(name))
       end
     end
   end

--- a/cli/lib/kontena/cli/services/secrets/link_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/link_command.rb
@@ -9,17 +9,17 @@ module Kontena::Cli::Services::Secrets
     parameter "NAME", "Service name"
     parameter "SECRET", "Secret to be added from Vault (format: secret:name:type)"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       spinner "Linking #{secret.colorize(:cyan)} from Vault to #{name.colorize(:cyan)} " do
-        result = client(token).get("services/#{parse_service_id(name)}")
+        result = client.get("services/#{parse_service_id(name)}")
         secrets = result['secrets']
         secrets << parse_secrets([secret])[0]
         data = {
           secrets: secrets
         }
-        client(token).put("services/#{parse_service_id(name)}", data)
+        client.put("services/#{parse_service_id(name)}", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/services/secrets/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/unlink_command.rb
@@ -9,17 +9,17 @@ module Kontena::Cli::Services::Secrets
     parameter "NAME", "Service name"
     parameter "SECRET", "Secret to be removed (format: secret:name:type)"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      result = client(token).get("services/#{parse_service_id(name)}")
+      result = client.get("services/#{parse_service_id(name)}")
       secrets = result['secrets']
       remove_secret = parse_secrets([secret])[0]
       if secrets.delete_if{|s| s['name'] == remove_secret[:name] && s['secret'] == remove_secret[:secret]}
         data = {
           secrets: secrets
         }
-        client(token).put("services/#{parse_service_id(name)}", data)
+        client.put("services/#{parse_service_id(name)}", data)
       else
         exit_with_error("Secret not found")
       end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -7,40 +7,35 @@ module Kontena
       module ServicesHelper
         include Kontena::Cli::Common
 
-        # @param [String] token
         # @param [String] grid_id
         # @param [Hash] data
-        def create_service(token, grid_id, data)
-          client(token).post("grids/#{grid_id}/services", data)
+        def create_service(grid_id, data)
+          client.post("grids/#{grid_id}/services", data)
         end
 
-        # @param [String] token
         # @param [String] service_id
         # @param [Hash] data
-        def update_service(token, service_id, data)
+        def update_service(service_id, data)
           param = parse_service_id(service_id)
-          client(token).put("services/#{param}", data)
+          client.put("services/#{param}", data)
         end
 
-        # @param [String] token
         # @param [String] service_id
         # @param [Integer] instances
-        def scale_service(token, service_id, instances)
+        def scale_service(service_id, instances)
           param = parse_service_id(service_id)
-          client(token).post("services/#{param}/scale", {instances: instances})
+          client.post("services/#{param}/scale", {instances: instances})
         end
 
-        # @param [String] token
         # @param [String] service_id
-        def get_service(token, service_id)
+        def get_service(service_id)
           param = parse_service_id(service_id)
-          client(token).get("services/#{param}")
+          client.get("services/#{param}")
         end
 
-        # @param [String] token
         # @param [String] service_id
-        def show_service(token, service_id)
-          service = get_service(token, service_id)
+        def show_service(service_id)
+          service = get_service(service_id)
           grid = service['id'].split('/')[0]
           puts "#{service['id']}:"
           puts "  status: #{service['state'] }"
@@ -183,7 +178,7 @@ module Kontena
           end
 
           puts "  instances:"
-          result = client(token).get("services/#{parse_service_id(service_id)}/containers")
+          result = client.get("services/#{parse_service_id(service_id)}/containers")
           result['containers'].each do |container|
             puts "    #{container['name']}:"
             puts "      rev: #{container['deploy_rev']}"
@@ -206,29 +201,27 @@ module Kontena
           end
         end
 
-        # @param [String] token
         # @param [String] service_id
         # @param [Hash] data
-        def deploy_service(token, service_id, data)
+        def deploy_service(service_id, data)
           param = parse_service_id(service_id)
-          client(token).post("services/#{param}/deploy", data)
+          client.post("services/#{param}/deploy", data)
         end
 
-        # @param [String] token
         # @param [String] name
         # @return [Boolean]
-        def wait_for_deploy_to_finish(token, name, timeout = 600)
-          service = client(token).get("services/#{name}")
+        def wait_for_deploy_to_finish(name, timeout = 600)
+          service = client.get("services/#{name}")
           desired_count = service['container_count']
           updated_at = DateTime.parse(service['updated_at']) rescue DateTime.now
           deployed = false
           Timeout::timeout(timeout) do
             until deployed
-              containers = client(token).get("services/#{name}/containers")['containers']
+              containers = client.get("services/#{name}/containers")['containers']
               deployed = containers.size == desired_count && containers.all?{ |c|
                 DateTime.parse(c['created_at']) >= updated_at rescue false
               }
-              sleep 1
+              sleep 0.5
             end
           end
 
@@ -237,32 +230,28 @@ module Kontena
           raise Kontena::Errors::StandardError.new(500, 'deploy timed out')
         end
 
-        # @param [String] token
         # @param [String] service_id
-        def start_service(token, service_id)
+        def start_service(service_id)
           param = parse_service_id(service_id)
-          client(token).post("services/#{param}/start", {})
+          client.post("services/#{param}/start", {})
         end
 
-        # @param [String] token
         # @param [String] service_id
-        def stop_service(token, service_id)
+        def stop_service(service_id)
           param = parse_service_id(service_id)
-          client(token).post("services/#{param}/stop", {})
+          client.post("services/#{param}/stop", {})
         end
 
-        # @param [String] token
         # @param [String] service_id
-        def restart_service(token, service_id)
+        def restart_service(service_id)
           param = parse_service_id(service_id)
-          client(token).post("services/#{param}/restart", {})
+          client.post("services/#{param}/restart", {})
         end
 
-        # @param [String] token
         # @param [String] service_id
-        def delete_service(token, service_id)
+        def delete_service(service_id)
           param = parse_service_id(service_id)
-          client(token).delete("services/#{param}")
+          client.delete("services/#{param}")
         end
 
         # @param [String] service_id

--- a/cli/lib/kontena/cli/services/show_command.rb
+++ b/cli/lib/kontena/cli/services/show_command.rb
@@ -8,11 +8,10 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
-      show_service(token, name)
+    def execute
+      show_service(name)
     end
   end
 end

--- a/cli/lib/kontena/cli/services/start_command.rb
+++ b/cli/lib/kontena/cli/services/start_command.rb
@@ -8,11 +8,11 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       spinner "Sending start signal to #{name.colorize(:cyan)} service " do
-        start_service(token, name)
+        start_service(name)
       end
     end
   end

--- a/cli/lib/kontena/cli/services/stats_command.rb
+++ b/cli/lib/kontena/cli/services/stats_command.rb
@@ -13,15 +13,15 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     option ["-t", "--tail"], :flag, "Tail (follow) stats in real time", default: false
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       if tail?
         system('clear')
         render_header
       end
       loop do
-        fetch_stats(token, name, tail?)
+        fetch_stats(name, tail?)
         break unless tail?
         sleep(2)
       end
@@ -29,8 +29,8 @@ module Kontena::Cli::Services
 
     private
 
-    def fetch_stats(token, service_id, follow)
-      result = client(token).get("services/#{current_grid}/#{service_id}/stats")
+    def fetch_stats(service_id, follow)
+      result = client.get("services/#{current_grid}/#{service_id}/stats")
       system('clear') if follow
       render_header
       result['stats'].each do |stat|

--- a/cli/lib/kontena/cli/services/stop_command.rb
+++ b/cli/lib/kontena/cli/services/stop_command.rb
@@ -8,11 +8,11 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       spinner "Sending stop signal to #{name.colorize(:cyan)} service " do
-        stop_service(token, name)
+        stop_service(name)
       end
     end
   end

--- a/cli/lib/kontena/cli/services/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/unlink_command.rb
@@ -10,16 +10,15 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     parameter "TARGET", "Link target service name"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
-      service = client(token).get("services/#{parse_service_id(name)}")
+    def execute
+      service = client.get("services/#{parse_service_id(name)}")
       links = service['links'].map{|l| {name: l['grid_service_id'].split('/')[1], alias: l['alias']} }
       exit_with_error("Service is not linked to #{target.to_s}") unless links.find{|l| l[:name] == target.to_s}
       links.delete_if{|l| l[:name] == target.to_s}
       data = {links: links}
-      update_service(token, name, data)
+      update_service(name, data)
     end
   end
 end

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -38,13 +38,12 @@ module Kontena::Cli::Services
     option "--health-check-port", "HEALTH CHECK PORT", "Port for HTTP health check"
     option "--health-check-protocol", "HEALTH CHECK PROTOCOL", "Protocol of health check"
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master_token
 
+    def execute
       data = parse_service_data_from_options
       spinner "Updating #{name.colorize(:cyan)} service " do
-        update_service(token, name, data)
+        update_service(name, data)
       end
     end
 

--- a/cli/lib/kontena/cli/stacks/create_command.rb
+++ b/cli/lib/kontena/cli/stacks/create_command.rb
@@ -8,9 +8,9 @@ module Kontena::Cli::Stacks
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena stack file', attribute_name: :filename, default: 'kontena.yml'
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_token
       require_config_file(filename)
       @stack = stack_from_yaml(filename)
 
@@ -20,7 +20,7 @@ module Kontena::Cli::Stacks
     private
 
     def create_stack
-      client(token).post("stacks/#{current_grid}", @stack)
+      client.post("stacks/#{current_grid}", @stack)
     end
 
   end

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -8,10 +8,9 @@ module Kontena::Cli::Stacks
 
     parameter "NAME", "Stack name"
 
-    def execute
-      require_api_url
-      require_token
+    requires_current_master_token
 
+    def execute
       deploy_stack(name)
     end
 
@@ -19,7 +18,7 @@ module Kontena::Cli::Stacks
 
 
     def deploy_stack
-      client(token).post("stacks/#{current_grid}/#{name}/deploy", {})
+      client.post("stacks/#{current_grid}/#{name}/deploy", {})
     end
 
   end

--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -8,17 +8,16 @@ module Kontena::Cli::Stacks
 
     COLUMNS = "%-30s %-10s %-10s".freeze
 
-    def execute
-      require_api_url
-      require_token
+    requires_current_master_token
 
+    def execute
       list_stacks
     end
 
     private
 
     def list_stacks
-      response = client(token).get("stacks/#{current_grid}")
+      response = client.get("stacks/#{current_grid}")
       
       titles = ['NAME', 'SERVICES', 'STATE']
       puts COLUMNS % titles

--- a/cli/lib/kontena/cli/stacks/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/remove_command.rb
@@ -8,10 +8,9 @@ module Kontena::Cli::Stacks
 
     parameter "NAME", "Service name"
 
-    def execute
-      require_api_url
-      require_token
+    requires_current_master_token
 
+    def execute
       remove_stack(name)
     end
 
@@ -19,7 +18,7 @@ module Kontena::Cli::Stacks
 
 
     def remove_stack(name)
-      client(token).delete("stacks/#{current_grid}/#{name}")
+      client.delete("stacks/#{current_grid}/#{name}")
     end
 
   end

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -8,10 +8,9 @@ module Kontena::Cli::Stacks
 
     parameter "NAME", "Service name"
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_token
-      
       show_stack(name)
       
     end
@@ -19,7 +18,7 @@ module Kontena::Cli::Stacks
     private
 
     def show_stack(name)
-      stack = client(token).get("stacks/#{current_grid}/#{name}")
+      stack = client.get("stacks/#{current_grid}/#{name}")
 
       puts stack
 

--- a/cli/lib/kontena/cli/stacks/update_command.rb
+++ b/cli/lib/kontena/cli/stacks/update_command.rb
@@ -8,9 +8,9 @@ module Kontena::Cli::Stacks
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena stack file', attribute_name: :filename, default: 'kontena.yml'
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      require_token
       require_config_file(filename)
       @stack = stack_from_yaml(filename)
 
@@ -20,7 +20,7 @@ module Kontena::Cli::Stacks
     private
 
     def update_stack
-      client(token).put("stacks/#{current_grid}/#{@stack['name']}", @stack)
+      client.put("stacks/#{current_grid}/#{@stack['name']}", @stack)
     end
 
   end

--- a/cli/lib/kontena/cli/vault/list_command.rb
+++ b/cli/lib/kontena/cli/vault/list_command.rb
@@ -3,12 +3,10 @@ module Kontena::Cli::Vault
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    def execute
-      require_api_url
-      require_current_grid
+    requires_current_master_token
 
-      token = require_token
-      result = client(token).get("grids/#{current_grid}/secrets")
+    def execute
+      result = client.get("grids/#{current_grid}/secrets")
 
       column_width_paddings = '%-54s %-25.25s %-25.25s'
       puts column_width_paddings % ['NAME', 'CREATED AT', 'UPDATED AT']

--- a/cli/lib/kontena/cli/vault/read_command.rb
+++ b/cli/lib/kontena/cli/vault/read_command.rb
@@ -5,12 +5,10 @@ module Kontena::Cli::Vault
 
     parameter "NAME", "Secret name"
 
-    def execute
-      require_api_url
-      require_current_grid
+    requires_current_master_token
 
-      token = require_token
-      result = client(token).get("secrets/#{current_grid}/#{name}")
+    def execute
+      result = client.get("secrets/#{current_grid}/#{name}")
       puts "#{result['name']}:"
       puts "  created_at: #{result['created_at']}"
       puts "  value: #{result['value']}"

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -6,14 +6,12 @@ module Kontena::Cli::Vault
     parameter "NAME", "Secret name"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
-    def execute
-      require_api_url
-      require_current_grid
-      confirm_command(name) unless forced?
+    requires_current_master_token
 
-      token = require_token
+    def execute
+      confirm_command(name) unless forced?
       spinner "Removing #{name.colorize(:cyan)} from the vault " do
-        client(token).delete("secrets/#{current_grid}/#{name}")
+        client.delete("secrets/#{current_grid}/#{name}")
       end
     end
   end

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -6,11 +6,9 @@ module Kontena::Cli::Vault
     parameter '[VALUE]', 'Secret value'
     option ['-u', '--upsert'], :flag, 'Create secret unless already exists', default: false
 
-    def execute
-      require_api_url
-      require_current_grid
+    requires_current_master_token
 
-      token = require_token
+    def execute
       secret = value
       if secret.to_s == ''
         secret = STDIN.read
@@ -22,7 +20,7 @@ module Kontena::Cli::Vault
         upsert: upsert?
       }
       spinner "Updating #{name.colorize(:cyan)} value in the vault " do
-        client(token).put("grids/#{current_grid}/secrets/#{name}", data)
+        client.put("grids/#{current_grid}/secrets/#{name}", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -6,11 +6,9 @@ module Kontena::Cli::Vault
     parameter 'NAME', 'Secret name'
     parameter '[VALUE]', 'Secret value'
 
-    def execute
-      require_api_url
-      require_current_grid
+    requires_current_master_token
 
-      token = require_token
+    def execute
       secret = value
       if secret.to_s == ''
         secret = STDIN.read
@@ -21,7 +19,7 @@ module Kontena::Cli::Vault
           value: secret
       }
       spinner "Writing #{name.colorize(:cyan)} to the vault " do
-        client(token).post("grids/#{current_grid}/secrets", data)
+        client.post("grids/#{current_grid}/secrets", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/vpn/config_command.rb
+++ b/cli/lib/kontena/cli/vpn/config_command.rb
@@ -3,11 +3,12 @@ module Kontena::Cli::Vpn
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
+    requires_current_master_token
+
     def execute
       require 'rbconfig'
-      require_api_url
       payload = {cmd: ['/usr/local/bin/ovpn_getclient', 'KONTENA_VPN_CLIENT']}
-      stdout, stderr = client(require_token).post("containers/#{current_grid}/vpn/vpn-1/exec", payload)
+      stdout, stderr = client.post("containers/#{current_grid}/vpn/vpn-1/exec", payload)
       if linux?
         stdout << "\n"
         stdout << "up /etc/openvpn/update-resolv-conf\n"

--- a/cli/lib/kontena/cli/vpn/delete_command.rb
+++ b/cli/lib/kontena/cli/vpn/delete_command.rb
@@ -3,15 +3,13 @@ module Kontena::Cli::Vpn
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
+    requires_current_master_token
+
     def execute
       warning "Support for 'kontena vpn delete' will be dropped. Use 'kontena vpn remove' instead."
-      require_api_url
-      token = require_token
-
-      vpn = client(token).get("services/#{current_grid}/vpn") rescue nil
+      vpn = client.get("services/#{current_grid}/vpn") rescue nil
       abort("VPN service does not exist") if vpn.nil?
-
-      client(token).delete("services/#{current_grid}/vpn")
+      client.delete("services/#{current_grid}/vpn")
     end
   end
 end

--- a/cli/lib/kontena/cli/vpn/remove_command.rb
+++ b/cli/lib/kontena/cli/vpn/remove_command.rb
@@ -4,16 +4,16 @@ module Kontena::Cli::Vpn
 
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
       confirm unless forced?
       name = 'vpn'
-      vpn = client(token).get("services/#{current_grid}/#{name}") rescue nil
+      vpn = client.get("services/#{current_grid}/#{name}") rescue nil
       exit_with_error("#{name} service does not exist") if vpn.nil?
 
       spinner "Removing #{vpn.colorize(:cyan)} service " do
-        client(token).delete("services/#{current_grid}/vpn")
+        client.delete("services/#{current_grid}/vpn")
       end
     end
   end

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -360,8 +360,8 @@ module Kontena
         token.account
       elsif token.kind_of?(Hash) && token['account'].kind_of?(String)
         config.find_account(token['account'])
-      else
-        {}
+      elsif token.respond_to(:parent_type) && token.parent_type == :master
+        config.find_account('master')
       end
     rescue
       logger.debug "Access token refresh exception: #{$!} - #{$!.message} #{$!.backtrace}"

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -96,7 +96,7 @@ class Kontena::Command < Clamp::Command
   end
 
   def self.requires_current_grid
-    banner "#{Kontena.pastel.green("Requires current grid")}: This command requires that you have selected a grid as the current grid using 'kontena grid use' or by setting KONTENA_GRID environment variable."
+    banner "#{Kontena.pastel.green("Requires current grid")}: This command requires that you have selected a grid as the current grid using 'kontena grid use', by setting KONTENA_GRID environment variable or using the --grid option."
     @requires_current_grid = true
   end
 
@@ -119,7 +119,11 @@ class Kontena::Command < Clamp::Command
   end
 
   def verify_current_grid
-    Kontena::Cli::Config.instance.require_current_grid if self.class.requires_current_grid?
+    if self.class.requires_current_grid?
+      unless self.respond_to?(:grid) && self.grid
+        Kontena::Cli::Config.instance.require_current_grid if self.class.requires_current_grid?
+      end
+    end
   end
 
   def self.requires_current_account_token?
@@ -132,6 +136,7 @@ class Kontena::Command < Clamp::Command
   end
 
   def self.requires_current_master_token
+    requires_current_master unless requires_current_master?
     @requires_current_master_token = true
   end
 

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -117,7 +117,7 @@ describe Kontena::Cli::Apps::DeployCommand do
               'env' => ['MYSQL_ADMIN_PASSWORD=password', 'TEST_ENV_VAR=test', 'TEST_ENV_VAR2=test3'],
           }
 
-          expect(subject).to receive(:create_service).with(duck_type(:access_token), '1', hash_including(data))
+          expect(subject).to receive(:create_service).with('1', hash_including(data))
           subject.run([])
         end
       end
@@ -137,7 +137,7 @@ describe Kontena::Cli::Apps::DeployCommand do
               'env' => ['MYSQL_ADMIN_PASSWORD=password', 'TEST_ENV_VAR=test']
           }
 
-          expect(subject).to receive(:create_service).with(duck_type(:access_token), '1', hash_including(data))
+          expect(subject).to receive(:create_service).with('1', hash_including(data))
           subject.run([])
         end
       end
@@ -161,7 +161,7 @@ describe Kontena::Cli::Apps::DeployCommand do
           ]
         }
 
-        expect(subject).to receive(:create_service).with(duck_type(:access_token), '1', hash_including(data))
+        expect(subject).to receive(:create_service).with('1', hash_including(data))
         subject.run([])
       end
 
@@ -174,7 +174,7 @@ describe Kontena::Cli::Apps::DeployCommand do
             'container_count' => nil,
             'stateful' => true,
         }
-        expect(subject).to receive(:create_service).with(duck_type(:access_token), '1', hash_including(data))
+        expect(subject).to receive(:create_service).with('1', hash_including(data))
 
         subject.run([])
       end
@@ -192,15 +192,15 @@ describe Kontena::Cli::Apps::DeployCommand do
           'links' => [{ 'name' => 'kontena-test-mysql', 'alias' => 'mysql' }],
           'ports' => [{ 'ip' => '0.0.0.0','container_port' => '80', 'node_port' => '80', 'protocol' => 'tcp' }]
         }
-        expect(subject).to receive(:create_service).with(duck_type(:access_token), '1', hash_including(data))
+        expect(subject).to receive(:create_service).with('1', hash_including(data))
 
         subject.run([])
       end
 
       it 'deploys services' do
         allow(subject).to receive(:current_dir).and_return('kontena-test')
-        expect(subject).to receive(:deploy_service).with(duck_type(:access_token), 'kontena-test-mysql', {})
-        expect(subject).to receive(:deploy_service).with(duck_type(:access_token), 'kontena-test-wordpress', {})
+        expect(subject).to receive(:deploy_service).with('kontena-test-mysql', {})
+        expect(subject).to receive(:deploy_service).with('kontena-test-wordpress', {})
         subject.run([])
       end
 

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -97,7 +97,7 @@ describe Kontena::Cli::Apps::LogsCommand do
         limit: 100,
       }) { { 'logs' => logs } }
 
-      subject.run([])
+      subject.run(['--grid', 'test-grid'])
 
       expect(@logs).to eq logs
     end
@@ -110,7 +110,7 @@ describe Kontena::Cli::Apps::LogsCommand do
         limit: 100,
       }) { { 'logs' => mysql_logs } }
 
-      subject.run(["mysql"])
+      subject.run(["--grid", "test-grid", "mysql"])
 
       expect(@logs).to eq mysql_logs
     end
@@ -125,7 +125,7 @@ describe Kontena::Cli::Apps::LogsCommand do
         since: since,
       }) { { 'logs' => since_logs } }
 
-      subject.run(["--since=#{since}"])
+      subject.run(["--grid=test-grid", "--since=#{since}"])
 
       expect(@logs).to eq since_logs
     end

--- a/cli/spec/kontena/cli/app/scale_spec.rb
+++ b/cli/spec/kontena/cli/app/scale_spec.rb
@@ -42,7 +42,7 @@ describe Kontena::Cli::Apps::ScaleCommand do
 
     it 'scales given service' do
       allow(File).to receive(:read).with("#{Dir.getwd}/kontena.yml").and_return(kontena_yml_no_instances)
-      expect(subject).to receive(:scale_service).with(duck_type(:access_token),'kontena-test-wordpress',3)
+      expect(subject).to receive(:scale_service).with('kontena-test-wordpress',3)
       subject.run(['wordpress', 3])
     end
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
@@ -8,12 +8,12 @@ describe Kontena::Cli::Grids::TrustedSubnets::AddCommand do
 
   describe '#execute' do
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['grid', 'subnet'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['grid', 'subnet'])
     end
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
@@ -8,12 +8,12 @@ describe Kontena::Cli::Grids::TrustedSubnets::ListCommand do
 
   describe '#execute' do
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['grid'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['grid'])
     end
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
@@ -8,13 +8,13 @@ describe Kontena::Cli::Grids::TrustedSubnets::RemoveCommand do
 
   describe '#execute' do
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
-      subject.run(['--force', 'grid', 'subnet'])
+      expect(subject.class.requires_current_master).to be_truthy
+      subject.run(['grid', 'subnet'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
-      subject.run(['--force', 'grid', 'subnet'])
+      expect(subject.class.requires_current_master_token).to be_truthy
+      subject.run(['grid', 'subnet'])
     end
 
     it 'requires grid as param' do

--- a/cli/spec/kontena/cli/grids/use_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/use_command_spec.rb
@@ -6,26 +6,27 @@ describe Kontena::Cli::Grids::UseCommand do
 
   include RequirementsHelper
 
-  let(:client) do 
-    Kontena::Client.new('https://foo', {access_token: 'abcd1234'})
-  end
-
   let(:subject) do
     described_class.new(File.basename($0))
   end
 
   let(:server) do
-    Kontena::Cli::Config::Server.new(url: 'https://localhost', token: 'abcd1234')
+    Kontena::Cli::Config::Server.new(name: 'server', url: 'https://localhost', token: Kontena::Cli::Config::Token.new(access_token: 'abcd1234', parent_type: :master, parent_name: 'server'))
+  end
+
+  let(:client) do
+    double
   end
 
   expect_to_require_current_master
 
   describe "#use" do
     before(:each) do
+      allow(Kontena::Cli::Config.instance).to receive(:servers).and_return([server])
       expect(subject).to receive(:client).and_return(client)
+      expect(subject.class.requires_current_master_token).to be_truthy
       expect(Kontena::Cli::Config.instance).to receive(:write).and_return(true)
-      expect(Kontena::Cli::Config.instance).to receive(:require_current_master).and_return(server)
-      expect(Kontena::Cli::Config.instance).to receive(:current_master).and_return(server)
+      expect(Kontena::Cli::Config.instance).to receive(:current_master).at_least(:once).and_return(server)
     end
 
     it "should set the current grid in config" do

--- a/cli/spec/kontena/cli/master/users/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/remove_command_spec.rb
@@ -13,7 +13,7 @@ describe Kontena::Cli::Master::Users::RemoveCommand do
     end
 
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['john@domain.com'])
     end
 
@@ -23,7 +23,7 @@ describe Kontena::Cli::Master::Users::RemoveCommand do
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['john@domain.com'])
     end
 

--- a/cli/spec/kontena/cli/services/containers_command_spec.rb
+++ b/cli/spec/kontena/cli/services/containers_command_spec.rb
@@ -14,12 +14,12 @@ describe Kontena::Cli::Services::ContainersCommand do
     end
 
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['service-a'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['service-a'])
     end
 

--- a/cli/spec/kontena/cli/services/link_command_spec.rb
+++ b/cli/spec/kontena/cli/services/link_command_spec.rb
@@ -13,12 +13,12 @@ describe Kontena::Cli::Services::LinkCommand do
     end
 
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['service-a', 'service-b'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['service-a', 'service-b'])
     end
 

--- a/cli/spec/kontena/cli/services/restart_command_spec.rb
+++ b/cli/spec/kontena/cli/services/restart_command_spec.rb
@@ -12,12 +12,12 @@ describe Kontena::Cli::Services::RestartCommand do
     end
 
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['service'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).once
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['service'])
     end
 

--- a/cli/spec/kontena/cli/services/secrets/link_command_spec.rb
+++ b/cli/spec/kontena/cli/services/secrets/link_command_spec.rb
@@ -8,12 +8,12 @@ describe Kontena::Cli::Services::Secrets::LinkCommand do
 
   describe '#execute' do
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['service', 'secret:name:env'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['service', 'secret:name:env'])
     end
 

--- a/cli/spec/kontena/cli/services/secrets/unlink_command_spec.rb
+++ b/cli/spec/kontena/cli/services/secrets/unlink_command_spec.rb
@@ -8,12 +8,12 @@ describe Kontena::Cli::Services::Secrets::UnlinkCommand do
 
   describe '#execute' do
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['service', 'secret:name:env'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['service', 'secret:name:env'])
     end
 

--- a/cli/spec/kontena/cli/services/services_helper_spec.rb
+++ b/cli/spec/kontena/cli/services/services_helper_spec.rb
@@ -11,54 +11,50 @@ module Kontena::Cli::Services
       double
     end
 
-    let(:token) do
-      'token'
-    end
-
     before(:each) do
-      allow(subject).to receive(:client).with(token).and_return(client)
+      allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:current_grid).and_return('test-grid')
     end
 
     describe '#create_service' do
       it 'creates POST grids/:grid/:name/services request to Kontena Server' do
         expect(client).to receive(:post).with('grids/test-grid/services', {'name' => 'test-service'})
-        subject.create_service(token, 'test-grid', {'name' => 'test-service'})
+        subject.create_service('test-grid', {'name' => 'test-service'})
       end
     end
 
     describe '#update_service' do
       it 'creates PUT services/:id request to Kontena Server' do
         expect(client).to receive(:put).with('services/test-grid/1', {'name' => 'test-service'})
-        subject.update_service(token, '1', {'name' => 'test-service'})
+        subject.update_service('1', {'name' => 'test-service'})
       end
     end
 
     describe '#get_service' do
       it 'creates GET services/:id request to Kontena Server' do
         expect(client).to receive(:get).with('services/test-grid/test-service')
-        subject.get_service(token, 'test-service')
+        subject.get_service('test-service')
       end
     end
 
     describe '#stop_service' do
       it 'creates POST services/:id/stop request to Kontena Server' do
         expect(client).to receive(:post).with('services/test-grid/test-service/stop', {})
-        subject.stop_service(token, 'test-service')
+        subject.stop_service('test-service')
       end
     end
 
     describe '#start_service' do
       it 'creates POST services/:id/start request to Kontena Server' do
         expect(client).to receive(:post).with('services/test-grid/test-service/start', {})
-        subject.start_service(token, 'test-service')
+        subject.start_service('test-service')
       end
     end
 
     describe '#restart_service' do
       it 'creates POST services/:id/restart request to Kontena Server' do
         expect(client).to receive(:post).with('services/test-grid/test-service/restart', {})
-        subject.restart_service(token, 'test-service')
+        subject.restart_service('test-service')
       end
     end
 
@@ -66,7 +62,7 @@ module Kontena::Cli::Services
       it 'creates POST services/:id/deploy request to Kontena Server' do
         allow(client).to receive(:get).with('services/test-grid/1').and_return({'state' => 'running'})
         expect(client).to receive(:post).with('services/test-grid/1/deploy', {'strategy' => 'ha'})
-        subject.deploy_service(token, '1', {'strategy' => 'ha'})
+        subject.deploy_service('1', {'strategy' => 'ha'})
       end
     end
 

--- a/cli/spec/kontena/cli/services/unlink_command_spec.rb
+++ b/cli/spec/kontena/cli/services/unlink_command_spec.rb
@@ -15,12 +15,12 @@ describe Kontena::Cli::Services::UnlinkCommand do
     end
 
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['service-a', 'service-b'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).and_return(token)
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['service-a', 'service-b'])
     end
 

--- a/cli/spec/kontena/cli/services/update_command_spec.rb
+++ b/cli/spec/kontena/cli/services/update_command_spec.rb
@@ -13,38 +13,38 @@ describe Kontena::Cli::Services::UpdateCommand do
     end
 
     it 'requires api url' do
-      expect(subject).to receive(:require_api_url).once
+      expect(subject.class.requires_current_master).to be_truthy
       subject.run(['service'])
     end
 
     it 'requires token' do
-      expect(subject).to receive(:require_token).once
+      expect(subject.class.requires_current_master_token).to be_truthy
       subject.run(['service'])
     end
 
     it 'sends update command' do
-      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', {privileged: false})
+      expect(subject).to receive(:update_service).with('service', {privileged: false})
       subject.run(['service'])
     end
 
     it 'sends --cap-add' do
-      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', hash_including(cap_add: ['NET_ADMIN']))
+      expect(subject).to receive(:update_service).with('service', hash_including(cap_add: ['NET_ADMIN']))
       subject.run(['--cap-add', 'NET_ADMIN', 'service'])
     end
 
     it 'sends --cap-drop' do
-      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', hash_including(cap_drop: ['MKNOD']))
+      expect(subject).to receive(:update_service).with('service', hash_including(cap_drop: ['MKNOD']))
       subject.run(['--cap-drop', 'MKNOD', 'service'])
     end
 
     it 'sends --log-driver' do
-      expect(subject).to receive(:update_service).with(duck_type(:access_token), 'service', hash_including(log_driver: 'syslog'))
+      expect(subject).to receive(:update_service).with('service', hash_including(log_driver: 'syslog'))
       subject.run(['--log-driver', 'syslog', 'service'])
     end
 
     it 'sends --log-opt' do
       expect(subject).to receive(:update_service).with(
-        duck_type(:access_token), 'service', hash_including(log_opts: {
+        'service', hash_including(log_opts: {
           'gelf-address'  => 'udp://log_forwarder-logstash_internal:12201'
         })
       )

--- a/cli/spec/kontena/cli/vpn/create_command_spec.rb
+++ b/cli/spec/kontena/cli/vpn/create_command_spec.rb
@@ -31,7 +31,7 @@ describe Kontena::Cli::Vpn::CreateCommand do
         })
 
       expect {
-        subject.find_node(token, nil)
+        subject.find_node(nil)
       }.to raise_error SystemExit
     end
 
@@ -44,7 +44,7 @@ describe Kontena::Cli::Vpn::CreateCommand do
           ]
         })
 
-      node = subject.find_node(token, nil)
+      node = subject.find_node(nil)
       expect(node['public_ip']).to eq('1.2.3.4')
     end
 
@@ -57,7 +57,7 @@ describe Kontena::Cli::Vpn::CreateCommand do
           ]
         })
 
-      node = subject.find_node(token, 'preferred')
+      node = subject.find_node('preferred')
       expect(node['name']).to eq('preferred')
     end
 
@@ -71,7 +71,7 @@ describe Kontena::Cli::Vpn::CreateCommand do
         })
 
       expect {
-        subject.find_node(token, 'foobar')
+        subject.find_node('foobar')
       }.to raise_error SystemExit
     end
 

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -43,6 +43,7 @@ RSpec.configure do |config|
       example.run
     rescue SystemExit
       puts "Got SystemExit: #{$!.message} - Exit code: #{$!.status}"
+      puts $!.backtrace.join("\n  ") if ENV["DEBUG"]
     end
   end
 

--- a/cli/spec/support/client_helpers.rb
+++ b/cli/spec/support/client_helpers.rb
@@ -17,8 +17,8 @@ module ClientHelpers
       {'current_server' => 'alias',
        'current_account' => 'kontena',
        'servers' => [
-           {'name' => 'some_master', 'url' => 'some_master'},
-           {'name' => 'alias', 'url' => 'someurl', 'token' => token, 'account' => 'master'}
+           {'name' => 'some_master', 'url' => 'some_master', 'grid' => 'some_grid'},
+           {'name' => 'alias', 'url' => 'someurl', 'token' => token, 'grid' => 'alias_grid'}
        ]
       }
     end


### PR DESCRIPTION
Instead of:

``` ruby
def execute
  require_api_url
  token = require_token
  client(token).get(foofoo)
end
```

There now is:

``` ruby
class FooCommand < Kontena::Command
  requires_current_master

  def execute
    client.get(foofoo)
  end
end
```

Which will also add this to the help:

```
Usage:
    kontena service list [OPTIONS]

  Requires current grid: This command requires that you have selected a grid as the current grid using 'kontena grid use', by setting KONTENA_GRID environment variable or using the --grid option.

  Requires current master: This command requires that you have selected a current master using 'kontena master login' or 'kontena master use'. You can also use the environment variable KONTENA_URL to specify the master address or KONTENA_MASTER=master_name to override the current_master setting.
```

The help text may be a bit much, perhaps it should only show "Requires current master" and no further explanation.

Also modified GridOptions to use env KONTENA_GRID as an alternative way of passing '--grid'.

Also changed a bunch of `client(token).post...` lines to `client.post...` (client defaults to current master + current_master.token)
