### PR TITLE
Speed up CLI launching by lazy-loading subcommands

### DIFF
--- a/cli/lib/kontena/cli/app_command.rb
+++ b/cli/lib/kontena/cli/app_command.rb
@@ -1,32 +1,19 @@
-require_relative 'apps/init_command'
-require_relative 'apps/build_command'
-require_relative 'apps/config_command'
-require_relative 'apps/deploy_command'
-require_relative 'apps/start_command'
-require_relative 'apps/stop_command'
-require_relative 'apps/restart_command'
-require_relative 'apps/remove_command'
-require_relative 'apps/list_command'
-require_relative 'apps/logs_command'
-require_relative 'apps/monitor_command'
-require_relative 'apps/show_command'
-require_relative 'apps/scale_command'
 
 class Kontena::Cli::AppCommand < Kontena::Command
 
-  subcommand "init", "Init Kontena application", Kontena::Cli::Apps::InitCommand
-  subcommand "build", "Build Kontena services", Kontena::Cli::Apps::BuildCommand
-  subcommand "config", "View service configurations", Kontena::Cli::Apps::ConfigCommand
-  subcommand "deploy", "Deploy Kontena services", Kontena::Cli::Apps::DeployCommand
-  subcommand "scale", "Scale services", Kontena::Cli::Apps::ScaleCommand
-  subcommand "start", "Start services", Kontena::Cli::Apps::StartCommand
-  subcommand "stop", "Stop services", Kontena::Cli::Apps::StopCommand
-  subcommand "restart", "Restart services", Kontena::Cli::Apps::RestartCommand
-  subcommand "show", "Show service details", Kontena::Cli::Apps::ShowCommand
-  subcommand ["ps", "list", "ls"], "List services", Kontena::Cli::Apps::ListCommand
-  subcommand ["logs"], "Show service logs", Kontena::Cli::Apps::LogsCommand
-  subcommand "monitor", "Monitor services", Kontena::Cli::Apps::MonitorCommand
-  subcommand ["remove","rm"], "Remove services", Kontena::Cli::Apps::RemoveCommand
+  subcommand "init", "Init Kontena application", load_subcommand('apps/init_command')
+  subcommand "build", "Build Kontena services", load_subcommand('apps/build_command')
+  subcommand "config", "View service configurations", load_subcommand('apps/config_command')
+  subcommand "deploy", "Deploy Kontena services", load_subcommand('apps/deploy_command')
+  subcommand "scale", "Scale services", load_subcommand('apps/scale_command')
+  subcommand "start", "Start services", load_subcommand('apps/start_command')
+  subcommand "stop", "Stop services", load_subcommand('apps/stop_command')
+  subcommand "restart", "Restart services", load_subcommand('apps/restart_command')
+  subcommand "show", "Show service details", load_subcommand('apps/show_command')
+  subcommand ["ps", "list", "ls"], "List services", load_subcommand('apps/list_command')
+  subcommand ["logs"], "Show service logs", load_subcommand('apps/logs_command')
+  subcommand "monitor", "Monitor services", load_subcommand('apps/monitor_command')
+  subcommand ["remove","rm"], "Remove services", load_subcommand('apps/remove_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/certificate_command.rb
+++ b/cli/lib/kontena/cli/certificate_command.rb
@@ -1,13 +1,10 @@
-require_relative 'certificate/register_command'
-require_relative 'certificate/authorize_command'
-require_relative 'certificate/get_command'
 
 class Kontena::Cli::CertificateCommand < Kontena::Command
 
 
-  subcommand "register", "Register to LetsEncrypt", Kontena::Cli::Certificate::RegisterCommand
-  subcommand "authorize", "Create DNS authorization for domain", Kontena::Cli::Certificate::AuthorizeCommand
-  subcommand "get", "Get certificate for domain", Kontena::Cli::Certificate::GetCommand
+  subcommand "register", "Register to LetsEncrypt", load_subcommand('certificate/register_command')
+  subcommand "authorize", "Create DNS authorization for domain", load_subcommand('certificate/authorize_command')
+  subcommand "get", "Get certificate for domain", load_subcommand('certificate/get_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/cloud/master_command.rb
+++ b/cli/lib/kontena/cli/cloud/master_command.rb
@@ -1,21 +1,14 @@
-require_relative 'master/add_command'
-require_relative 'master/list_command'
-require_relative 'master/remove_command'
-require_relative 'master/update_command'
-require_relative 'master/show_command'
-
 module Kontena::Cli::Cloud
   class MasterCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    subcommand ['list', 'ls'], "List masters in Kontena Cloud", Kontena::Cli::Cloud::Master::ListCommand
-    subcommand ['remove', 'rm'], "Remove a master registration from Kontena Cloud", Kontena::Cli::Cloud::Master::RemoveCommand
-    subcommand "add", "Register a master in Kontena Cloud", Kontena::Cli::Cloud::Master::AddCommand
-    subcommand "show", "Show master settings in Kontena Cloud", Kontena::Cli::Cloud::Master::ShowCommand
-    subcommand "update", "Update master settings in Kontena Cloud", Kontena::Cli::Cloud::Master::UpdateCommand
+    subcommand ['list', 'ls'], "List masters in Kontena Cloud", load_subcommand('cloud/master/list_command')
+    subcommand "add", "Register a master in Kontena Cloud", load_subcommand('cloud/master/add_command')
+    subcommand ['remove', 'rm'], "Remove a master registration from Kontena Cloud", load_subcommand('cloud/master/remove_command')
+    subcommand "show", "Show master settings in Kontena Cloud", load_subcommand('cloud/master/show_command')
+    subcommand "update", "Update master settings in Kontena Cloud", load_subcommand('cloud/master/update_command')
 
     def execute
     end
   end
 end
-

--- a/cli/lib/kontena/cli/cloud_command.rb
+++ b/cli/lib/kontena/cli/cloud_command.rb
@@ -1,11 +1,8 @@
-require_relative 'cloud/login_command'
-require_relative 'cloud/logout_command'
-require_relative 'cloud/master_command'
 
 class Kontena::Cli::CloudCommand < Kontena::Command
-  subcommand "login", "Authenticate to Kontena Cloud", Kontena::Cli::Cloud::LoginCommand
-  subcommand "logout", "Logout from Kontena Cloud", Kontena::Cli::Cloud::LogoutCommand
-  subcommand "master", "Master specific commands", Kontena::Cli::Cloud::MasterCommand
+  subcommand "login", "Authenticate to Kontena Cloud", load_subcommand('cloud/login_command')
+  subcommand "logout", "Logout from Kontena Cloud", load_subcommand('cloud/logout_command')
+  subcommand "master", "Master specific commands", load_subcommand('cloud/master_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/container_command.rb
+++ b/cli/lib/kontena/cli/container_command.rb
@@ -1,14 +1,9 @@
-require_relative 'containers/list_command'
-require_relative 'containers/exec_command'
-require_relative 'containers/inspect_command'
-require_relative 'containers/logs_command'
-
 class Kontena::Cli::ContainerCommand < Kontena::Command
 
-  subcommand ["list", "ls"], "List grid containers", Kontena::Cli::Containers::ListCommand
-  subcommand "exec", "Execute command inside a container", Kontena::Cli::Containers::ExecCommand
-  subcommand "inspect", "Inspect the container", Kontena::Cli::Containers::InspectCommand
-  subcommand "logs", "Show container logs", Kontena::Cli::Containers::LogsCommand
+  subcommand ["list", "ls"], "List grid containers", load_subcommand('containers/list_command')
+  subcommand "exec", "Execute command inside a container", load_subcommand('containers/exec_command')
+  subcommand "inspect", "Inspect the container", load_subcommand('containers/inspect_command')
+  subcommand "logs", "Show container logs", load_subcommand('containers/logs_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/etcd/health_command.rb
+++ b/cli/lib/kontena/cli/etcd/health_command.rb
@@ -1,4 +1,5 @@
 require_relative 'common'
+require 'kontena/cli/helpers/health_helper'
 
 module Kontena::Cli::Etcd
   class HealthCommand < Kontena::Command

--- a/cli/lib/kontena/cli/etcd_command.rb
+++ b/cli/lib/kontena/cli/etcd_command.rb
@@ -1,18 +1,11 @@
-require_relative 'etcd/get_command'
-require_relative 'etcd/set_command'
-require_relative 'etcd/mkdir_command'
-require_relative 'etcd/list_command'
-require_relative 'etcd/remove_command'
-require_relative 'etcd/health_command'
-
 class Kontena::Cli::EtcdCommand < Kontena::Command
 
-  subcommand "get", "Get the current value for a single key", Kontena::Cli::Etcd::GetCommand
-  subcommand "set", "Set a value on the specified key", Kontena::Cli::Etcd::SetCommand
-  subcommand ["mkdir", "mk"], "Create a directory", Kontena::Cli::Etcd::MkdirCommand
-  subcommand ["list", "ls"], "List a directory", Kontena::Cli::Etcd::ListCommand
-  subcommand "rm", "Remove a key or a directory", Kontena::Cli::Etcd::RemoveCommand
-  subcommand "health", "Check etcd health", Kontena::Cli::Etcd::HealthCommand
+  subcommand "get", "Get the current value for a single key", load_subcommand('etcd/get_command')
+  subcommand "set", "Set a value on the specified key", load_subcommand('etcd/set_command')
+  subcommand ["mkdir", "mk"], "Create a directory", load_subcommand('etcd/mkdir_command')
+  subcommand ["list", "ls"], "List a directory", load_subcommand('etcd/list_command')
+  subcommand "rm", "Remove a key or a directory", load_subcommand('etcd/remove_command')
+  subcommand "health", "Check etcd health", load_subcommand('etcd/health_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/external_registry_command.rb
+++ b/cli/lib/kontena/cli/external_registry_command.rb
@@ -1,12 +1,8 @@
-require_relative 'external_registries/add_command'
-require_relative 'external_registries/list_command'
-require_relative 'external_registries/remove_command'
-
 class Kontena::Cli::ExternalRegistryCommand < Kontena::Command
 
-  subcommand "add", "Add external Docker image registry", Kontena::Cli::ExternalRegistries::AddCommand
-  subcommand ["list", "ls"], "List external Docker image registries", Kontena::Cli::ExternalRegistries::ListCommand
-  subcommand ["remove", "rm"], "Remove external Docker image registry", Kontena::Cli::ExternalRegistries::RemoveCommand
+  subcommand "add", "Add external Docker image registry", load_subcommand('external_registries/add_command')
+  subcommand ["list", "ls"], "List external Docker image registries", load_subcommand('external_registries/list_command')
+  subcommand ["remove", "rm"], "Remove external Docker image registry", load_subcommand('external_registries/remove_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/grid_command.rb
+++ b/cli/lib/kontena/cli/grid_command.rb
@@ -1,34 +1,19 @@
-require_relative 'grids/list_command'
-require_relative 'grids/create_command'
-require_relative 'grids/update_command'
-require_relative 'grids/use_command'
-require_relative 'grids/show_command'
-require_relative 'grids/logs_command'
-require_relative 'grids/remove_command'
-require_relative 'grids/current_command'
-require_relative 'grids/env_command'
-require_relative 'grids/audit_log_command'
-require_relative 'grids/user_command'
-require_relative 'grids/cloud_config_command'
-require_relative 'grids/trusted_subnet_command'
-require_relative 'grids/health_command'
-
 class Kontena::Cli::GridCommand < Kontena::Command
 
-  subcommand ["list","ls"], "List all grids", Kontena::Cli::Grids::ListCommand
-  subcommand "create", "Create a new grid", Kontena::Cli::Grids::CreateCommand
-  subcommand "update", "Update grid", Kontena::Cli::Grids::UpdateCommand
-  subcommand "use", "Switch to use specific grid", Kontena::Cli::Grids::UseCommand
-  subcommand "show", "Show grid details", Kontena::Cli::Grids::ShowCommand
-  subcommand "logs", "Show logs from grid containers", Kontena::Cli::Grids::LogsCommand
-  subcommand ["remove","rm"], "Remove a grid", Kontena::Cli::Grids::RemoveCommand
-  subcommand "current", "Show current grid details", Kontena::Cli::Grids::CurrentCommand
-  subcommand "env", "Show the current grid environment details", Kontena::Cli::Grids::EnvCommand
-  subcommand "audit-log", "Show audit log of the current grid", Kontena::Cli::Grids::AuditLogCommand
-  subcommand "user", "User specific commands", Kontena::Cli::Grids::UserCommand
-  subcommand "cloud-config", "Generate cloud-config", Kontena::Cli::Grids::CloudConfigCommand
-  subcommand "trusted-subnet", "Trusted subnet related commands", Kontena::Cli::Grids::TrustedSubnetCommand
-  subcommand "health", "Check grid health", Kontena::Cli::Grids::HealthCommand
+  subcommand ["list","ls"], "List all grids", load_subcommand('grids/list_command')
+  subcommand "create", "Create a new grid", load_subcommand('grids/create_command')
+  subcommand "update", "Update grid", load_subcommand('grids/update_command')
+  subcommand "use", "Switch to use specific grid", load_subcommand('grids/use_command')
+  subcommand "show", "Show grid details", load_subcommand('grids/show_command')
+  subcommand "logs", "Show logs from grid containers", load_subcommand('grids/logs_command')
+  subcommand ["remove","rm"], "Remove a grid", load_subcommand('grids/remove_command')
+  subcommand "current", "Show current grid details", load_subcommand('grids/current_command')
+  subcommand "env", "Show the current grid environment details", load_subcommand('grids/env_command')
+  subcommand "audit-log", "Show audit log of the current grid", load_subcommand('grids/audit_log_command')
+  subcommand "user", "User specific commands", load_subcommand('grids/user_command')
+  subcommand "cloud-config", "Generate cloud-config", load_subcommand('grids/cloud_config_command')
+  subcommand "trusted-subnet", "Trusted subnet related commands", load_subcommand('grids/trusted_subnet_command')
+  subcommand "health", "Check grid health", load_subcommand('grids/health_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
@@ -1,9 +1,10 @@
 module Kontena::Cli::Grids
-
-
   class TrustedSubnetCommand < Kontena::Command
-    subcommand ["list", "ls"], "List trusted subnets", Trustedload_subcommand('subnets/list_command')
-    subcommand "add", "Add trusted subnet", Trustedload_subcommand('subnets/add_command')
-    subcommand ["remove", "rm"], "Remove trusted subnet", Trustedload_subcommand('subnets/remove_command')
+    subcommand ["list", "ls"], "List trusted subnets", load_subcommand('grids/trusted_subnets/list_command')
+    subcommand "add", "Add trusted subnet", load_subcommand('grids/trusted_subnets/add_command')
+    subcommand ["remove", "rm"], "Remove trusted subnet", load_subcommand('grids/trusted_subnets/remove_command')
+
+    def execute
+    end
   end
 end

--- a/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnet_command.rb
@@ -1,12 +1,9 @@
 module Kontena::Cli::Grids
 
-  require_relative 'trusted_subnets/list_command'
-  require_relative 'trusted_subnets/add_command'
-  require_relative 'trusted_subnets/remove_command'
 
   class TrustedSubnetCommand < Kontena::Command
-    subcommand ["list", "ls"], "List trusted subnets", TrustedSubnets::ListCommand
-    subcommand "add", "Add trusted subnet", TrustedSubnets::AddCommand
-    subcommand ["remove", "rm"], "Remove trusted subnet", TrustedSubnets::RemoveCommand
+    subcommand ["list", "ls"], "List trusted subnets", Trustedload_subcommand('subnets/list_command')
+    subcommand "add", "Add trusted subnet", Trustedload_subcommand('subnets/add_command')
+    subcommand ["remove", "rm"], "Remove trusted subnet", Trustedload_subcommand('subnets/remove_command')
   end
 end

--- a/cli/lib/kontena/cli/grids/user_command.rb
+++ b/cli/lib/kontena/cli/grids/user_command.rb
@@ -1,12 +1,9 @@
 module Kontena::Cli::Grids
 
-  require_relative 'users/list_command'
-  require_relative 'users/add_command'
-  require_relative 'users/remove_command'
 
   class UserCommand < Kontena::Command
-    subcommand ["list", "ls"], "List grid users", Users::ListCommand
-    subcommand "add", "Add user to grid", Users::AddCommand
-    subcommand ["remove", "rm"], "Remove user from grid", Users::RemoveCommand
+    subcommand ["list", "ls"], "List grid users", load_subcommand('users/list_command')
+    subcommand "add", "Add user to grid", load_subcommand('users/add_command')
+    subcommand ["remove", "rm"], "Remove user from grid", load_subcommand('users/remove_command')
   end
 end

--- a/cli/lib/kontena/cli/master/config_command.rb
+++ b/cli/lib/kontena/cli/master/config_command.rb
@@ -1,18 +1,13 @@
-require_relative 'config/set_command'
-require_relative 'config/get_command'
-require_relative 'config/unset_command'
-require_relative 'config/export_command'
-require_relative 'config/import_command'
 
 module Kontena
   module Cli
     module Master
       class ConfigCommand < Kontena::Command
-        subcommand "set", "Set a config value", Kontena::Cli::Master::Config::SetCommand
-        subcommand "get", "Get a config value", Kontena::Cli::Master::Config::GetCommand
-        subcommand "unset", "Clear a config value", Kontena::Cli::Master::Config::UnsetCommand
-        subcommand ["load", "import"], "Upload config to Master", Kontena::Cli::Master::Config::ImportCommand
-        subcommand ["dump", "export"], "Download config from Master", Kontena::Cli::Master::Config::ExportCommand
+        subcommand "set", "Set a config value", load_subcommand('master/config/set_command')
+        subcommand "get", "Get a config value", load_subcommand('master/config/get_command')
+        subcommand "unset", "Clear a config value", load_subcommand('master/config/unset_command')
+        subcommand ["load", "import"], "Upload config to Master", load_subcommand('master/config/import_command')
+        subcommand ["dump", "export"], "Download config from Master", load_subcommand('master/config/export_command')
 
         def execute
         end
@@ -20,4 +15,3 @@ module Kontena
     end
   end
 end
-

--- a/cli/lib/kontena/cli/master/token_command.rb
+++ b/cli/lib/kontena/cli/master/token_command.rb
@@ -1,16 +1,11 @@
-require_relative 'token/list_command'
-require_relative 'token/remove_command'
-require_relative 'token/create_command'
-require_relative 'token/current_command'
-require_relative 'token/show_command'
 
 module Kontena::Cli::Master
   class TokenCommand < Kontena::Command
-    subcommand ["list", "ls"], "List access tokens", Kontena::Cli::Master::Token::ListCommand
-    subcommand ["rm", "remove"], "Remove / revoke an access token", Kontena::Cli::Master::Token::RemoveCommand
-    subcommand "show", "Display access token", Kontena::Cli::Master::Token::ShowCommand
-    subcommand "current", "Display current access token", Kontena::Cli::Master::Token::CurrentCommand
-    subcommand "create", "Generate an access token", Kontena::Cli::Master::Token::CreateCommand
+    subcommand ["list", "ls"], "List access tokens", load_subcommand('master/token/list_command')
+    subcommand ["rm", "remove"], "Remove / revoke an access token", load_subcommand('master/token/remove_command')
+    subcommand "show", "Display access token", load_subcommand('master/token/show_command')
+    subcommand "current", "Display current access token", load_subcommand('master/token/current_command')
+    subcommand "create", "Generate an access token", load_subcommand('master/token/create_command')
 
     def execute
     end

--- a/cli/lib/kontena/cli/master/users/role_command.rb
+++ b/cli/lib/kontena/cli/master/users/role_command.rb
@@ -1,10 +1,8 @@
 module Kontena::Cli::Master::Users
 
-  require_relative 'roles/add_command'
-  require_relative 'roles/remove_command'
 
   class RoleCommand < Kontena::Command
-    subcommand "add", "Add role to user", Roles::AddCommand
-    subcommand ["remove", "rm"], "Remove role from user", Roles::RemoveCommand
+    subcommand "add", "Add role to user", load_subcommand('roles/add_command')
+    subcommand ["remove", "rm"], "Remove role from user", load_subcommand('roles/remove_command')
   end
 end

--- a/cli/lib/kontena/cli/master/users_command.rb
+++ b/cli/lib/kontena/cli/master/users_command.rb
@@ -1,14 +1,10 @@
 module Kontena::Cli::Master
 
-  require_relative 'users/invite_command'
-  require_relative 'users/remove_command'
-  require_relative 'users/list_command'
-  require_relative 'users/role_command'
 
   class UsersCommand < Kontena::Command
-    subcommand "invite", "Invite user to Kontena Master", Users::InviteCommand
-    subcommand ["remove", "rm"], "Remove user from Kontena Master", Users::RemoveCommand
-    subcommand ["list", "ls"], "List users", Users::ListCommand
-    subcommand "role", "User role specific commands", Users::RoleCommand
+    subcommand "invite", "Invite user to Kontena Master", load_subcommand('users/invite_command')
+    subcommand ["remove", "rm"], "Remove user from Kontena Master", load_subcommand('users/remove_command')
+    subcommand ["list", "ls"], "List users", load_subcommand('users/list_command')
+    subcommand "role", "User role specific commands", load_subcommand('users/role_command')
   end
 end

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -1,39 +1,19 @@
-require_relative '../main_command'
-require_relative 'master/use_command'
-require_relative 'master/remove_command'
-require_relative 'master/list_command'
-require_relative 'master/users_command'
-require_relative 'master/current_command'
-require_relative 'master/config_command'
-require_relative 'master/login_command'
-require_relative 'master/logout_command'
-require_relative 'master/join_command'
-require_relative 'master/audit_log_command'
-require_relative 'master/token_command'
-require_relative 'master/init_cloud_command'
-require_relative 'master/ssh_command'
-
 class Kontena::Cli::MasterCommand < Kontena::Command
   include Kontena::Util
 
-  subcommand ["list", "ls"], "List masters where client has logged in", Kontena::Cli::Master::ListCommand
-  subcommand ["remove", "rm"], "Remove a master from configuration file", Kontena::Cli::Master::RemoveCommand
-  subcommand ["config", "cfg"], "Configure master settings", Kontena::Cli::Master::ConfigCommand
-  subcommand "use", "Switch to use selected master", Kontena::Cli::Master::UseCommand
-  subcommand "users", "Users specific commands", Kontena::Cli::Master::UsersCommand
-  subcommand "current", "Show current master details", Kontena::Cli::Master::CurrentCommand
-  subcommand "login", "Authenticate to Kontena Master", Kontena::Cli::Master::LoginCommand
-  subcommand "logout", "Log out of Kontena Master", Kontena::Cli::Master::LogoutCommand
-  subcommand "token", "Manage Kontena Master access tokens", Kontena::Cli::Master::TokenCommand
-  subcommand "join", "Join Kontena Master using an invitation code", Kontena::Cli::Master::JoinCommand
-  subcommand "audit-log", "Show master audit logs", Kontena::Cli::Master::AuditLogCommand
-  subcommand "init-cloud", "Configure current master to use Kontena Cloud services", Kontena::Cli::Master::InitCloudCommand
-  subcommand "ssh", "Connect to the master via SSH", Kontena::Cli::Master::SshCommand
-
-  if experimental?
-    require_relative 'master/create_command'
-    subcommand "create", "Install a new Kontena Master", Kontena::Cli::Master::CreateCommand
-  end
+  subcommand ["list", "ls"], "List masters where client has logged in", load_subcommand('master/list_command')
+  subcommand ["config", "cfg"], "Configure master settings", load_subcommand('master/config_command')
+  subcommand "use", "Switch to use selected master", load_subcommand('master/use_command')
+  subcommand "users", "Users specific commands", load_subcommand('master/users_command')
+  subcommand "current", "Show current master details", load_subcommand('master/current_command')
+  subcommand "login", "Authenticate to Kontena Master", load_subcommand('master/login_command')
+  subcommand "logout", "Log out of Kontena Master", load_subcommand('master/logout_command')
+  subcommand "token", "Manage Kontena Master access tokens", load_subcommand('master/token_command')
+  subcommand "join", "Join Kontena Master using an invitation code", load_subcommand('master/join_command')
+  subcommand "audit-log", "Show master audit logs", load_subcommand('master/audit_log_command')
+  subcommand "create", "Install a new Kontena Master", load_subcommand('master/create_command') if experimental?
+  subcommand "init-cloud", "Configure current master to use Kontena Cloud services", load_subcommand('master/init_cloud_command')
+  subcommand "ssh", "Connect to the master via SSH", load_subcommand('master/ssh_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -2,6 +2,7 @@ class Kontena::Cli::MasterCommand < Kontena::Command
   include Kontena::Util
 
   subcommand ["list", "ls"], "List masters where client has logged in", load_subcommand('master/list_command')
+  subcommand ["remove", "rm"], "Remove a master from configuration", load_subcommand('master/remove_command')
   subcommand ["config", "cfg"], "Configure master settings", load_subcommand('master/config_command')
   subcommand "use", "Switch to use selected master", load_subcommand('master/use_command')
   subcommand "users", "Users specific commands", load_subcommand('master/users_command')

--- a/cli/lib/kontena/cli/node_command.rb
+++ b/cli/lib/kontena/cli/node_command.rb
@@ -1,20 +1,12 @@
-require_relative 'nodes/list_command'
-require_relative 'nodes/remove_command'
-require_relative 'nodes/show_command'
-require_relative 'nodes/update_command'
-require_relative 'nodes/ssh_command'
-require_relative 'nodes/label_command'
-require_relative 'nodes/health_command'
-
 class Kontena::Cli::NodeCommand < Kontena::Command
 
-  subcommand ["list","ls"], "List grid nodes", Kontena::Cli::Nodes::ListCommand
-  subcommand "show", "Show node", Kontena::Cli::Nodes::ShowCommand
-  subcommand "ssh", "Ssh into node", Kontena::Cli::Nodes::SshCommand
-  subcommand "update", "Update node", Kontena::Cli::Nodes::UpdateCommand
-  subcommand ["remove","rm"], "Remove node", Kontena::Cli::Nodes::RemoveCommand
-  subcommand "label", "Node label specific commands", Kontena::Cli::Nodes::LabelCommand
-  subcommand "health", "Check node health", Kontena::Cli::Nodes::HealthCommand
+  subcommand ["list","ls"], "List grid nodes", load_subcommand('nodes/list_command')
+  subcommand "show", "Show node", load_subcommand('nodes/show_command')
+  subcommand "ssh", "Ssh into node", load_subcommand('nodes/ssh_command')
+  subcommand "update", "Update node", load_subcommand('nodes/update_command')
+  subcommand ["remove","rm"], "Remove node", load_subcommand('nodes/remove_command')
+  subcommand "label", "Node label specific commands", load_subcommand('nodes/label_command')
+  subcommand "health", "Check node health", load_subcommand('nodes/health_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/nodes/health_command.rb
+++ b/cli/lib/kontena/cli/nodes/health_command.rb
@@ -1,4 +1,4 @@
-require_relative '../helpers/health_helper'
+require 'kontena/cli/helpers/health_helper'
 
 module Kontena::Cli::Nodes
   class HealthCommand < Kontena::Command

--- a/cli/lib/kontena/cli/nodes/label_command.rb
+++ b/cli/lib/kontena/cli/nodes/label_command.rb
@@ -1,14 +1,8 @@
 module Kontena::Cli::Nodes
-
-  require_relative 'labels/add_command'
-  require_relative 'labels/remove_command'
-  require_relative 'labels/list_command'
-
   class LabelCommand < Kontena::Command
-
-    subcommand ["list", "ls"], "List node labels", Labels::ListCommand
-    subcommand "add", "Add label to node", Labels::AddCommand
-    subcommand ["remove", "rm"], "Remove label from node", Labels::RemoveCommand
+    subcommand ["list", "ls"], "List node labels", load_subcommand('labels/list_command')
+    subcommand "add", "Add label to node", load_subcommand('labels/add_command')
+    subcommand ["remove", "rm"], "Remove label from node", load_subcommand('labels/remove_command')
 
     def execute
     end

--- a/cli/lib/kontena/cli/plugin_command.rb
+++ b/cli/lib/kontena/cli/plugin_command.rb
@@ -1,14 +1,10 @@
-require_relative 'plugins/list_command'
-require_relative 'plugins/search_command'
-require_relative 'plugins/install_command'
-require_relative 'plugins/uninstall_command'
 
 class Kontena::Cli::PluginCommand < Kontena::Command
 
-  subcommand ["list","ls"], "List plugins", Kontena::Cli::Plugins::ListCommand
-  subcommand "search", "Search plugins", Kontena::Cli::Plugins::SearchCommand
-  subcommand "install", "Install a plugin", Kontena::Cli::Plugins::InstallCommand
-  subcommand "uninstall", "Uninstall a plugin", Kontena::Cli::Plugins::UninstallCommand
+  subcommand ["list","ls"], "List plugins", load_subcommand('plugins/list_command')
+  subcommand "search", "Search plugins", load_subcommand('plugins/search_command')
+  subcommand "install", "Install a plugin", load_subcommand('plugins/install_command')
+  subcommand "uninstall", "Uninstall a plugin", load_subcommand('plugins/uninstall_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/registry_command.rb
+++ b/cli/lib/kontena/cli/registry_command.rb
@@ -1,10 +1,7 @@
-require_relative 'registry/create_command'
-require_relative 'registry/remove_command'
-
 class Kontena::Cli::RegistryCommand < Kontena::Command
 
-  subcommand "create", "Create Docker image registry service", Kontena::Cli::Registry::CreateCommand
-  subcommand ["remove","rm"], "Remove Docker image registry service", Kontena::Cli::Registry::RemoveCommand
+  subcommand "create", "Create Docker image registry service", load_subcommand('registry/create_command')
+  subcommand ["remove","rm"], "Remove Docker image registry service", load_subcommand('registry/remove_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -1,49 +1,27 @@
-require_relative 'services/list_command'
-require_relative 'services/show_command'
-require_relative 'services/update_command'
-require_relative 'services/deploy_command'
-require_relative 'services/stop_command'
-require_relative 'services/start_command'
-require_relative 'services/restart_command'
-require_relative 'services/create_command'
-require_relative 'services/scale_command'
-require_relative 'services/remove_command'
-require_relative 'services/containers_command'
-require_relative 'services/logs_command'
-require_relative 'services/stats_command'
-require_relative 'services/monitor_command'
-
-require_relative 'services/env_command'
-require_relative 'services/secret_command'
-
-require_relative 'services/link_command'
-require_relative 'services/unlink_command'
-require_relative 'services/exec_command'
-
 class Kontena::Cli::ServiceCommand < Kontena::Command
+  subcommand ["list","ls"], "List services", load_subcommand('services/list_command')
+  subcommand "create", "Create a new service", load_subcommand('services/create_command')
+  subcommand "show", "Show service details", load_subcommand('services/show_command')
+  subcommand "update", "Update service configuration", load_subcommand('services/update_command')
+  subcommand "deploy", "Deploy service", load_subcommand('services/deploy_command')
+  subcommand "stop", "Stop service", load_subcommand('services/stop_command')
+  subcommand "start", "Start service", load_subcommand('services/start_command')
+  subcommand "restart", "Restart service", load_subcommand('services/restart_command')
+  subcommand "scale", "Scale service", load_subcommand('services/scale_command')
+  subcommand ["remove", "rm"], "Remove service", load_subcommand('services/remove_command')
+  subcommand "delete", "[DEPRECATED] Delete service", load_subcommand('services/delete_command')
+  subcommand "containers", "List service containers", load_subcommand('services/containers_command')
+  subcommand "logs", "Show service logs", load_subcommand('services/logs_command')
+  subcommand "stats", "Show service statistics", load_subcommand('services/stats_command')
+  subcommand "monitor", "Monitor", load_subcommand('services/monitor_command')
 
-  subcommand ["list","ls"], "List services", Kontena::Cli::Services::ListCommand
-  subcommand "create", "Create a new service", Kontena::Cli::Services::CreateCommand
-  subcommand "show", "Show service details", Kontena::Cli::Services::ShowCommand
-  subcommand "update", "Update service configuration", Kontena::Cli::Services::UpdateCommand
-  subcommand "deploy", "Deploy service", Kontena::Cli::Services::DeployCommand
-  subcommand "stop", "Stop service", Kontena::Cli::Services::StopCommand
-  subcommand "start", "Start service", Kontena::Cli::Services::StartCommand
-  subcommand "restart", "Restart service", Kontena::Cli::Services::RestartCommand
-  subcommand "scale", "Scale service", Kontena::Cli::Services::ScaleCommand
-  subcommand ["remove", "rm"], "Remove service", Kontena::Cli::Services::RemoveCommand
-  subcommand "containers", "List service containers", Kontena::Cli::Services::ContainersCommand
-  subcommand "logs", "Show service logs", Kontena::Cli::Services::LogsCommand
-  subcommand "stats", "Show service statistics", Kontena::Cli::Services::StatsCommand
-  subcommand "monitor", "Monitor", Kontena::Cli::Services::MonitorCommand
+  subcommand "env", "Environment variable specific commands", load_subcommand('services/env_command')
 
-  subcommand "env", "Environment variable specific commands", Kontena::Cli::Services::EnvCommand
+  subcommand "secret", "Secret specific commands", load_subcommand('services/secret_command')
 
-  subcommand "secret", "Secret specific commands", Kontena::Cli::Services::SecretCommand
-
-  subcommand "link", "Link service to another service", Kontena::Cli::Services::LinkCommand
-  subcommand "unlink", "Unlink service from another service", Kontena::Cli::Services::UnlinkCommand
-  subcommand "exec", "Execute commands in service containers", Kontena::Cli::Services::ExecCommand
+  subcommand "link", "Link service to another service", load_subcommand('services/link_command')
+  subcommand "unlink", "Unlink service from another service", load_subcommand('services/unlink_command')
+  subcommand "exec", "Execute commands in service containers", load_subcommand('services/exec_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -9,7 +9,6 @@ class Kontena::Cli::ServiceCommand < Kontena::Command
   subcommand "restart", "Restart service", load_subcommand('services/restart_command')
   subcommand "scale", "Scale service", load_subcommand('services/scale_command')
   subcommand ["remove", "rm"], "Remove service", load_subcommand('services/remove_command')
-  subcommand "delete", "[DEPRECATED] Delete service", load_subcommand('services/delete_command')
   subcommand "containers", "List service containers", load_subcommand('services/containers_command')
   subcommand "logs", "Show service logs", load_subcommand('services/logs_command')
   subcommand "stats", "Show service statistics", load_subcommand('services/stats_command')

--- a/cli/lib/kontena/cli/services/container_command.rb
+++ b/cli/lib/kontena/cli/services/container_command.rb
@@ -1,8 +1,7 @@
-require_relative 'containers/exec_command'
 
 class Kontena::Cli::ContainerCommand < Kontena::Command
 
-  subcommand "exec", "Execute command inside a container", Kontena::Cli::Containers::ExecCommand
+  subcommand "exec", "Execute command inside a container", load_subcommand('containers/exec_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/services/env_command.rb
+++ b/cli/lib/kontena/cli/services/env_command.rb
@@ -1,12 +1,9 @@
 module Kontena::Cli::Services
 
-  require_relative 'envs/add_command'
-  require_relative 'envs/list_command'
-  require_relative 'envs/remove_command'
 
   class EnvCommand < Kontena::Command
-    subcommand ["list", "ls"], "List service environment variables", Envs::ListCommand
-    subcommand "add", "Add environment variable", Envs::AddCommand
-    subcommand ["remove", "rm"], "Remove environment variable", Envs::RemoveCommand
+    subcommand ["list", "ls"], "List service environment variables", load_subcommand('envs/list_command')
+    subcommand "add", "Add environment variable", load_subcommand('envs/add_command')
+    subcommand ["remove", "rm"], "Remove environment variable", load_subcommand('envs/remove_command')
   end
 end

--- a/cli/lib/kontena/cli/services/secret_command.rb
+++ b/cli/lib/kontena/cli/services/secret_command.rb
@@ -1,10 +1,8 @@
 module Kontena::Cli::Services
 
-  require_relative 'secrets/link_command'
-  require_relative 'secrets/unlink_command'
 
   class SecretCommand < Kontena::Command
-    subcommand "link", "Link secret from Vault", Secrets::LinkCommand
-    subcommand "unlink", "Unlink secret from Vault", Secrets::UnlinkCommand
+    subcommand "link", "Link secret from Vault", load_subcommand('secrets/link_command')
+    subcommand "unlink", "Unlink secret from Vault", load_subcommand('secrets/unlink_command')
   end
 end

--- a/cli/lib/kontena/cli/stack_command.rb
+++ b/cli/lib/kontena/cli/stack_command.rb
@@ -1,28 +1,15 @@
-require_relative 'stacks/install_command'
-require_relative 'stacks/remove_command'
-require_relative 'stacks/deploy_command'
-require_relative 'stacks/upgrade_command'
-require_relative 'stacks/list_command'
-require_relative 'stacks/show_command'
-require_relative 'stacks/build_command'
-require_relative 'stacks/monitor_command'
-require_relative 'stacks/logs_command'
-require_relative 'stacks/registry_command'
-require_relative 'stacks/validate_command'
-
 class Kontena::Cli::StackCommand < Kontena::Command
-
-  subcommand "install", "Install a stack to a grid", Kontena::Cli::Stacks::InstallCommand
-  subcommand ["ls", "list"], "List installed stacks in a grid", Kontena::Cli::Stacks::ListCommand
-  subcommand ["remove","rm"], "Remove a deployed stack from a grid", Kontena::Cli::Stacks::RemoveCommand
-  subcommand "show", "Show details about a stack in a grid", Kontena::Cli::Stacks::ShowCommand
-  subcommand "upgrade", "Upgrade a stack in a grid", Kontena::Cli::Stacks::UpgradeCommand
-  subcommand ["start", "deploy"], "Deploy an installed stack in a grid", Kontena::Cli::Stacks::DeployCommand
-  subcommand "logs", "Show logs from services in a stack", Kontena::Cli::Stacks::LogsCommand
-  subcommand "monitor", "Monitor services in a stack", Kontena::Cli::Stacks::MonitorCommand
-  subcommand "build", "Build images listed in a stack file and push them to an image registry", Kontena::Cli::Stacks::BuildCommand
-  subcommand ["reg", "registry"], "Stack registry related commands", Kontena::Cli::Stacks::RegistryCommand
-  subcommand "validate", "Process and validate a stack file", Kontena::Cli::Stacks::ValidateCommand
+  subcommand "install", "Install a stack to a grid", load_subcommand('stacks/install_command')
+  subcommand ["ls", "list"], "List installed stacks in a grid", load_subcommand('stacks/list_command')
+  subcommand ["remove","rm"], "Remove a deployed stack from a grid", load_subcommand('stacks/remove_command')
+  subcommand "show", "Show details about a stack in a grid", load_subcommand('stacks/show_command')
+  subcommand "upgrade", "Upgrade a stack in a grid", load_subcommand('stacks/upgrade_command')
+  subcommand ["start", "deploy"], "Deploy an installed stack in a grid", load_subcommand('stacks/deploy_command')
+  subcommand "logs", "Show logs from services in a stack", load_subcommand('stacks/logs_command')
+  subcommand "monitor", "Monitor services in a stack", load_subcommand('stacks/monitor_command')
+  subcommand "build", "Build images listed in a stack file and push them to an image registry", load_subcommand('stacks/build_command')
+  subcommand ["reg", "registry"], "Stack registry related commands", load_subcommand('stacks/registry_command')
+  subcommand "validate", "Process and validate a stack file", load_subcommand('stacks/validate_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/subcommand_loader.rb
+++ b/cli/lib/kontena/cli/subcommand_loader.rb
@@ -13,22 +13,22 @@ module Kontena::Cli
     #
     # @param path [String]
     # @return [Array<Symbol>]
-    def constantize(path)
+    def symbolize_path(path)
       path.gsub(/.*\/cli\//, '').split('/').map do |path_part|
         path_part.split('_').map{ |e| e.capitalize }.join
       end.map(&:to_sym)
     end
 
     # Takes an array such as [:Foo] or [:Cli, :Foo] and returns [:Kontena, :Cli, :Foo]
-    def kontenaize(tree)
+    def prepend_kontena_cli(tree)
       [:Kontena, :Cli] + (tree - [:Cli])
     end
 
-    # Takes an array such as [:Master, :FooCommand] and returns Master::FooCommand or if not defined, Kontena::Cli::Master::FooCommand
+    # Takes an array such as [:Master, :FooCommand] and returns Master::FooCommand
     #
     # @param tree [Array<Symbol]
     # @return [Class]
-    def get_class(tree)
+    def const_get_tree(tree)
       if tree.size == 1
         Object.const_get(tree.first)
       else
@@ -48,7 +48,7 @@ module Kontena::Cli
       else
         raise ArgumentError, "Can not load #{real_path} or #{Kontena.cli_root(real_path)}"
       end
-      @subcommand_class = get_class(kontenaize(constantize(path)))
+      @subcommand_class = const_get_tree(prepend_kontena_cli(symbolize_path(path)))
     end
 
     def new(*args)

--- a/cli/lib/kontena/cli/subcommand_loader.rb
+++ b/cli/lib/kontena/cli/subcommand_loader.rb
@@ -2,7 +2,7 @@ module Kontena::Cli
   class SubcommandLoader
     attr_reader :path, :class_definition
 
-    # Create a subcommand loader instnace
+    # Create a subcommand loader instance
     #
     # @param [String] path path to command definition
     # @param [Symbol|String|Array] class_definition example: :Kontena, :Cli, :Master, :UseCommand.

--- a/cli/lib/kontena/cli/subcommand_loader.rb
+++ b/cli/lib/kontena/cli/subcommand_loader.rb
@@ -1,0 +1,81 @@
+module Kontena::Cli
+  class SubcommandLoader
+    attr_reader :path, :class_definition
+
+    # Create a subcommand loader instnace
+    #
+    # @param [String] path path to command definition
+    # @param [Symbol|String|Array] class_definition example: :Kontena, :Cli, :Master, :UseCommand.
+    #   if left empty, tries to guess from path: 'master/use_command' will become :Master, :UseCommand
+    def initialize(path, *class_definition)
+      @path = path
+      if class_definition.empty?
+        @class_definition = path.gsub(/.*\/cli\//, '').split('/').map do |path_part|
+          path_part.split('_').map{ |e| e.capitalize }.join
+        end.map(&:to_sym)
+      elsif class_definition.first.kind_of?(String) && class_definition.size == 1
+        @class_definition = class_definition.split('::').map(&:to_sym)
+      else
+        @class_definition = class_definition.map(&:to_sym)
+      end
+    end
+
+    def get_class
+      retried = false
+      begin
+        definition = class_definition.dup
+        base = Object.const_get(definition.shift)
+        if definition.empty?
+          subcommand_class = base
+        else
+          subcommand_class = class_definition.inject(base) { |new_base, part| new_base.const_get(part) }
+        end
+      rescue
+        unless retried
+          @class_definition.delete_if {|v| v == :Kontena || v == :Cli}
+          @class_definition = [:Kontena, :Cli] + @class_definition
+          retried = true
+          retry
+        end
+        raise ArgumentError, "Can not figure out command class name: #{@class_definition.inspect} (#{@path.inspect})"
+      end
+
+      subcommand_class
+    end
+
+    def klass
+      return @subcommand_class if @subcommand_class
+      path = @path + '.rb' unless @path.end_with?('.rb')
+      if File.exist?(path)
+        require(path)
+      elsif File.exist?(Kontena.cli_root(path))
+        require(Kontena.cli_root(path))
+      else
+        raise ArgumentError, "Can not load #{path} or #{Kontena.cli_root(path)}"
+      end
+      @subcommand_class = get_class
+    end
+
+    def new(*args)
+      klass.new(*args)
+    end
+
+    def method_missing(meth, *args)
+      klass.send(meth, *args)
+    end
+
+    def respond_to_missing?(meth)
+      klass.respond_to?(meth)
+    end
+
+    def const_get(const)
+      klass.const_get(const)
+    end
+
+    def const_defined?(const)
+      klass.const_defined?(const)
+    end
+
+    alias_method :class, :klass
+  end
+end

--- a/cli/lib/kontena/cli/vault_command.rb
+++ b/cli/lib/kontena/cli/vault_command.rb
@@ -1,20 +1,12 @@
-require_relative 'vault/export_command'
-require_relative 'vault/import_command'
-require_relative 'vault/list_command'
-require_relative 'vault/read_command'
-require_relative 'vault/remove_command'
-require_relative 'vault/update_command'
-require_relative 'vault/write_command'
-
 class Kontena::Cli::VaultCommand < Kontena::Command
 
-  subcommand ["list", "ls"], "List secrets", Kontena::Cli::Vault::ListCommand
-  subcommand "write", "Write a secret", Kontena::Cli::Vault::WriteCommand
-  subcommand "read", "Read secret", Kontena::Cli::Vault::ReadCommand
-  subcommand "update", "Update secret", Kontena::Cli::Vault::UpdateCommand
-  subcommand ["remove", "rm"], "Remove secret", Kontena::Cli::Vault::RemoveCommand
-  subcommand "export", "Export secrets to STDOUT", Kontena::Cli::Vault::ExportCommand
-  subcommand "import", "Import secrets from a file or STDIN", Kontena::Cli::Vault::ImportCommand
+  subcommand ["list", "ls"], "List secrets", load_subcommand('vault/list_command')
+  subcommand "write", "Write a secret", load_subcommand('vault/write_command')
+  subcommand "read", "Read secret", load_subcommand('vault/read_command')
+  subcommand "update", "Update secret", load_subcommand('vault/update_command')
+  subcommand ["remove", "rm"], "Remove secret", load_subcommand('vault/remove_command')
+  subcommand "export", "Export secrets to STDOUT", load_subcommand('vault/export_command')
+  subcommand "import", "Import secrets from a file or STDIN", load_subcommand('vault/import_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/vpn_command.rb
+++ b/cli/lib/kontena/cli/vpn_command.rb
@@ -1,12 +1,8 @@
-require_relative 'vpn/create_command'
-require_relative 'vpn/config_command'
-require_relative 'vpn/remove_command'
-
 class Kontena::Cli::VpnCommand < Kontena::Command
 
-  subcommand "create", "Create VPN service", Kontena::Cli::Vpn::CreateCommand
-  subcommand "config", "Show/Export VPN config", Kontena::Cli::Vpn::ConfigCommand
-  subcommand ["remove", "rm"], "Remove VPN service", Kontena::Cli::Vpn::RemoveCommand
+  subcommand "create", "Create VPN service", load_subcommand('vpn/create_command')
+  subcommand "config", "Show/Export VPN config", load_subcommand('vpn/config_command')
+  subcommand ["remove", "rm"], "Remove VPN service", load_subcommand('vpn/remove_command')
 
   def execute
   end

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -1,4 +1,5 @@
 require 'clamp'
+require_relative 'cli/subcommand_loader'
 
 class Kontena::Command < Clamp::Command
 
@@ -62,7 +63,14 @@ class Kontena::Command < Clamp::Command
     end
   end
 
+  def self.load_subcommand(path, *class_definition)
+    Kontena::Cli::SubcommandLoader.new(path, *class_definition)
+  end
+
   def self.inherited(where)
+    if ENV["DEBUG"].to_s == "super"
+      puts "Class #{where} inherited from Kontena::Command"
+    end
     where.extend Finalizer
   end
 

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -63,8 +63,8 @@ class Kontena::Command < Clamp::Command
     end
   end
 
-  def self.load_subcommand(path, *class_definition)
-    Kontena::Cli::SubcommandLoader.new(path, *class_definition)
+  def self.load_subcommand(path)
+    Kontena::Cli::SubcommandLoader.new(path)
   end
 
   def self.inherited(where)

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -68,9 +68,6 @@ class Kontena::Command < Clamp::Command
   end
 
   def self.inherited(where)
-    if ENV["DEBUG"].to_s == "super"
-      puts "Class #{where} inherited from Kontena::Command"
-    end
     where.extend Finalizer
   end
 

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -5,25 +5,6 @@ require_relative 'command'
 require_relative 'callback'
 require_relative 'cli/bytes_helper'
 require_relative 'cli/grid_options'
-require_relative 'cli/app_command'
-require_relative 'cli/logout_command'
-require_relative 'cli/whoami_command'
-require_relative 'cli/container_command'
-require_relative 'cli/grid_command'
-require_relative 'cli/master_command'
-require_relative 'cli/node_command'
-require_relative 'cli/service_command'
-require_relative 'cli/vpn_command'
-require_relative 'cli/registry_command'
-require_relative 'cli/external_registry_command'
-require_relative 'cli/app_command'
-require_relative 'cli/etcd_command'
-require_relative 'cli/vault_command'
-require_relative 'cli/plugin_command'
-require_relative 'cli/version_command'
-require_relative 'cli/stack_command'
-require_relative 'cli/certificate_command'
-require_relative 'cli/cloud_command'
 
 class Kontena::MainCommand < Kontena::Command
   include Kontena::Util
@@ -37,24 +18,24 @@ class Kontena::MainCommand < Kontena::Command
     exit 0
   end
 
-  subcommand "cloud", "Kontena Cloud specific commands", Kontena::Cli::CloudCommand
-  subcommand "logout", "Logout from Kontena Masters or Kontena Cloud accounts", Kontena::Cli::LogoutCommand
-  subcommand "grid", "Grid specific commands", Kontena::Cli::GridCommand
-  subcommand "app", "App specific commands", Kontena::Cli::AppCommand
-  subcommand "stack", "Stack specific commands", Kontena::Cli::StackCommand
-  subcommand "service", "Service specific commands", Kontena::Cli::ServiceCommand
-  subcommand "vault", "Vault specific commands", Kontena::Cli::VaultCommand
-  subcommand "certificate", "LE Certificate specific commands", Kontena::Cli::CertificateCommand
-  subcommand "node", "Node specific commands", Kontena::Cli::NodeCommand
-  subcommand "master", "Master specific commands", Kontena::Cli::MasterCommand
-  subcommand "vpn", "VPN specific commands", Kontena::Cli::VpnCommand
-  subcommand "registry", "Registry specific commands", Kontena::Cli::RegistryCommand
-  subcommand "container", "Container specific commands", Kontena::Cli::ContainerCommand
-  subcommand "etcd", "Etcd specific commands", Kontena::Cli::EtcdCommand
-  subcommand "external-registry", "External registry specific commands", Kontena::Cli::ExternalRegistryCommand
-  subcommand "whoami", "Shows current logged in user", Kontena::Cli::WhoamiCommand
-  subcommand "plugin", "Plugin related commands", Kontena::Cli::PluginCommand
-  subcommand "version", "Show version", Kontena::Cli::VersionCommand
+  subcommand "cloud", "Kontena Cloud specific commands", load_subcommand('cloud_command')
+  subcommand "logout", "Logout from Kontena Masters or Kontena Cloud accounts", load_subcommand('logout_command')
+  subcommand "grid", "Grid specific commands", load_subcommand('grid_command')
+  subcommand "app", "App specific commands", load_subcommand('app_command')
+  subcommand "stack", "Stack specific commands", load_subcommand('stack_command')
+  subcommand "service", "Service specific commands", load_subcommand('service_command')
+  subcommand "vault", "Vault specific commands", load_subcommand('vault_command')
+  subcommand "certificate", "LE Certificate specific commands", load_subcommand('certificate_command')
+  subcommand "node", "Node specific commands", load_subcommand('node_command')
+  subcommand "master", "Master specific commands", load_subcommand('master_command')
+  subcommand "vpn", "VPN specific commands", load_subcommand('vpn_command')
+  subcommand "registry", "Registry specific commands", load_subcommand('registry_command')
+  subcommand "container", "Container specific commands", load_subcommand('container_command')
+  subcommand "etcd", "Etcd specific commands", load_subcommand('etcd_command')
+  subcommand "external-registry", "External registry specific commands", load_subcommand('external_registry_command')
+  subcommand "whoami", "Shows current logged in user", load_subcommand('whoami_command')
+  subcommand "plugin", "Plugin related commands", load_subcommand('plugin_command')
+  subcommand "version", "Show version #{Kontena::Cli::VERSION}", load_subcommand('version_command')
 
   def execute
   end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -35,7 +35,7 @@ class Kontena::MainCommand < Kontena::Command
   subcommand "external-registry", "External registry specific commands", load_subcommand('external_registry_command')
   subcommand "whoami", "Shows current logged in user", load_subcommand('whoami_command')
   subcommand "plugin", "Plugin related commands", load_subcommand('plugin_command')
-  subcommand "version", "Show version #{Kontena::Cli::VERSION}", load_subcommand('version_command')
+  subcommand "version", "Show CLI and current master version", load_subcommand('version_command')
 
   def execute
   end

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -74,6 +74,14 @@ module Kontena
   def self.root
     File.dirname(__dir__)
   end
+
+  def self.cli_root(*joinables)
+    if joinables.empty?
+      File.join(Kontena.root, 'lib/kontena/cli')
+    else
+      File.join(Kontena.root, 'lib/kontena/cli', *joinables)
+    end
+  end
 end
 
 # Monkeypatching string to mimick 'colorize' gem

--- a/cli/spec/kontena/cli/etcd/health_command_spec.rb
+++ b/cli/spec/kontena/cli/etcd/health_command_spec.rb
@@ -1,3 +1,5 @@
+require 'kontena/cli/etcd/health_command'
+
 describe Kontena::Cli::Etcd::HealthCommand do
   include ClientHelpers
   include OutputHelpers

--- a/cli/spec/kontena/cli/nodes/list_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/list_command_spec.rb
@@ -1,3 +1,5 @@
+require 'kontena/cli/nodes/list_command'
+
 describe Kontena::Cli::Nodes::ListCommand do
   include ClientHelpers
   include OutputHelpers

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -1,6 +1,7 @@
 require_relative '../spec_helper'
 require 'kontena_cli'
 require 'kontena/light_prompt'
+require 'kontena/cli/whoami_command'
 
 describe Kontena do
   context 'prompt' do


### PR DESCRIPTION
Current implementation loads all commands when running any command.

This implementation loads only the command that is being run.

Spin up time improvement on an SSD disk is about 2x.
