### PR TITLE
Require authenticated user on grid list command

### DIFF
--- a/cli/lib/kontena/cli/grids/list_command.rb
+++ b/cli/lib/kontena/cli/grids/list_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Grids
 
     def execute
       require_api_url
-
+      require_token
       vputs
 
       gridlist = []


### PR DESCRIPTION
With this PR a proper error message is shown if user is not logged in and he/she is trying to list grids.

Before:
```
$ kontena grid list
 [error] Expected([200, 201]) <=> Actual(400 Bad Request)
         Rerun the command with environment DEBUG=true set to get the full exception
```

After:
```
$ kontena grid list
 [error] You are not logged into a Kontena Master. Use: kontena master login
         Rerun the command with environment DEBUG=true set to get the full exception
```