### PR TITLE
Implement kontena master logout command

### DIFF
--- a/cli/lib/kontena/cli/logout_command.rb
+++ b/cli/lib/kontena/cli/logout_command.rb
@@ -1,38 +1,10 @@
 class Kontena::Cli::LogoutCommand < Kontena::Command
   include Kontena::Cli::Common
 
-  option ['-A', '--all'], :flag, 'Log out from all masters. By default only log out from current master.'
-  option ['--accounts'], :flag, 'Log out from cloud platform accounts', hidden: true
-
-  def use_refresh_token(server)
-    return unless server.token
-    return unless server.token.refresh_token
-    return if server.token.expired?
-    client = Kontena::Client.new(server.url, server.token)
-    ENV["DEBUG"] && puts("Trying to invalidate refresh token on #{server.name}")
-    client.refresh_token
-  rescue
-    ENV["DEBUG"] && puts("Refreshing failed: #{$!} : #{$!.message}")
-  end 
+  banner "Command removed, use 'kontena master logout' to log out of the Kontena Master"
+  banner "or 'kontena cloud logout' to log out of the Kontena Cloud", false
 
   def execute
-    if self.all?
-      config.servers.each do |server|
-        use_refresh_token(server)
-        server.token = nil
-      end
-    elsif self.accounts?
-      config.accounts.each do |account|
-        use_refresh_token(account)
-        account.token = nil
-      end
-    elsif config.current_master
-      use_refresh_token(config.current_master)
-      config.current_master.token = nil
-    else
-      puts "Current master has not been selected"
-      exit 0 # exiting with 0 not 1, it's not really an error situation (kontena logout && kontena master login...)
-    end
-    config.write
+    exit_with_error("Command removed. Use #{"kontena master logout".colorize(:yellow)} to log out of the Kontena Master")
   end
 end

--- a/cli/lib/kontena/cli/master/logout_command.rb
+++ b/cli/lib/kontena/cli/master/logout_command.rb
@@ -1,0 +1,23 @@
+class Kontena::Cli::Master::LogoutCommand < Kontena::Command
+  include Kontena::Cli::Common
+
+  option ['-A', '--all'], :flag, 'Log out from all masters. By default only log out from current master.'
+
+  def execute
+    if self.all?
+      config.servers.each do |server|
+        use_refresh_token(server)
+        server.token = nil
+        puts "Logged out of #{server.name.colorize(:green)}"
+      end
+    elsif config.current_master
+      use_refresh_token(config.current_master)
+      config.current_master.token = nil
+      puts "Logged out of #{config.current_master.name.colorize(:green)}"
+    else
+      warn "Current master has not been selected"
+      exit 0 # exiting with 0 not 1, it's not really an error situation (kontena logout && kontena master login...)
+    end
+    config.write
+  end
+end

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -5,6 +5,7 @@ require_relative 'master/users_command'
 require_relative 'master/current_command'
 require_relative 'master/config_command'
 require_relative 'master/login_command'
+require_relative 'master/logout_command'
 require_relative 'master/join_command'
 require_relative 'master/audit_log_command'
 require_relative 'master/token_command'
@@ -23,6 +24,7 @@ class Kontena::Cli::MasterCommand < Kontena::Command
   subcommand "users", "Users specific commands", Kontena::Cli::Master::UsersCommand
   subcommand "current", "Show current master details", Kontena::Cli::Master::CurrentCommand
   subcommand "login", "Authenticate to Kontena Master", Kontena::Cli::Master::LoginCommand
+  subcommand "logout", "Log out of Kontena Master", Kontena::Cli::Master::LogoutCommand
   subcommand "token", "Manage Kontena Master access tokens", Kontena::Cli::Master::TokenCommand
   subcommand "join", "Join Kontena Master using an invitation code", Kontena::Cli::Master::JoinCommand
   subcommand "audit-log", "Show master audit logs", Kontena::Cli::Master::AuditLogCommand

--- a/cli/spec/kontena/cli/master/logout_command_spec.rb
+++ b/cli/spec/kontena/cli/master/logout_command_spec.rb
@@ -1,0 +1,85 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/master/logout_command'
+
+describe Kontena::Cli::Master::LogoutCommand do
+
+  include ClientHelpers
+
+  let(:server) do
+    spy('server')
+  end
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  describe '#logout' do
+    context 'with all options' do
+      before(:each) do
+        allow(Kontena::Cli::Config.instance).to receive(:servers).and_return([server])
+        allow(Kontena::Cli::Config.instance).to receive(:write)
+        allow(server).to receive(:token=).with(nil)
+      end
+
+      it 'reads servers from config' do
+        expect(Kontena::Cli::Config.instance).to receive(:servers).and_return([server])
+        subject.run(['--all'])
+      end
+
+      it 'invalidates refresh_token for each server' do
+        expect(subject).to receive(:use_refresh_token).with(server)
+        subject.run(['--all'])
+      end
+
+      it 'clears token' do
+        expect(server).to receive(:token=).with(nil)
+        subject.run(['--all'])
+      end
+
+      it 'writes config file' do
+        allow(subject).to receive(:use_refresh_token).with(server)
+        expect(Kontena::Cli::Config.instance).to receive(:write)
+        subject.run(['--all'])
+      end
+    end
+
+    context 'without all options' do
+      before(:each) do
+        allow(Kontena::Cli::Config.instance).to receive(:current_master).and_return(server)
+        allow(Kontena::Cli::Config.instance).to receive(:write)
+        allow(server).to receive(:token=).with(nil)
+      end
+
+      it 'reads current master from config' do
+        expect(Kontena::Cli::Config.instance).to receive(:current_master).and_return(server)
+        subject.run([])
+      end
+
+      it 'invalidates refresh_token for current master' do
+        expect(subject).to receive(:use_refresh_token).with(server)
+        subject.run([])
+      end
+
+      it 'clears token' do
+        allow(subject).to receive(:use_refresh_token).with(server)
+        expect(server).to receive(:token=).with(nil)
+        subject.run([])
+      end
+
+      it 'writes config file' do
+        allow(subject).to receive(:use_refresh_token).with(server)
+        expect(Kontena::Cli::Config.instance).to receive(:write)
+        subject.run([])
+      end
+    end
+
+    context 'current master is not selected' do
+      it 'outputs warning' do
+        allow(Kontena::Cli::Config.instance).to receive(:current_master).and_return(nil)
+        expect {
+          subject.run([])
+        }.to output("Current master has not been selected\n").to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR implements `kontena master logout` command:

```
$ ./bin/kontena master logout --help
Usage:
    kontena master logout [OPTIONS]

Options:
    -A, --all                     Log out from all masters. By default only log out from current master.
    -h, --help                    print help
```

With this PR,  `kontena logout` command is deprecated:

```
$ kontena logout
 [error] Command removed. Use kontena master logout to log out of the Kontena Master
```
