### PR TITLE
Use .to_s for URI.join in callback url, remove memoization

### DIFF
--- a/server/app/services/auth_provider.rb
+++ b/server/app/services/auth_provider.rb
@@ -112,7 +112,7 @@ class AuthProvider < OpenStruct
   end
 
   def callback_url
-    @callback_url ||= self.root_url.nil? ? nil : URI.join(self.root_url, 'cb')
+    self.root_url.nil? ? nil : URI.join(self.root_url, 'cb').to_s
   end
 
   # URL to the authentication provider authorization endpoint


### PR DESCRIPTION
URI.join returns an URI, not a string.
