### PR TITLE
Add health status actions on agent and master

### DIFF
--- a/agent/lib/kontena/workers/container_health_check_worker.rb
+++ b/agent/lib/kontena/workers/container_health_check_worker.rb
@@ -47,6 +47,24 @@ module Kontena::Workers
         msg = check_tcp_status(ip, port, timeout)
       end
       @queue << msg
+
+      if msg.dig(:data, 'status') == 'unhealthy'
+        name = @container.labels['io.kontena.container.name']
+        # Restart the container, master will handle re-scheduling logic
+        info "About to restart container #{name} as it's reported to be unhealthy"
+        log = {
+            event: 'container:log',
+            data: {
+                id: @container.id,
+                time: Time.now.utc.xmlschema,
+                type: 'stderr',
+                data: "*** [Kontena/Agent] Restarting service as it's reported to be unhealthy."
+            }
+        }
+        @queue << log
+        Kontena::ServicePods::Restarter.perform_async(name)
+      end
+
     end
 
     def check_http_status(ip, port, uri, timeout)

--- a/agent/lib/kontena/workers/container_health_check_worker.rb
+++ b/agent/lib/kontena/workers/container_health_check_worker.rb
@@ -48,6 +48,11 @@ module Kontena::Workers
       end
       @queue << msg
 
+      handle_action(msg)
+
+    end
+
+    def handle_action(msg)
       if msg.dig(:data, 'status') == 'unhealthy'
         name = @container.labels['io.kontena.container.name']
         # Restart the container, master will handle re-scheduling logic
@@ -64,7 +69,6 @@ module Kontena::Workers
         @queue << log
         Kontena::ServicePods::Restarter.perform_async(name)
       end
-
     end
 
     def check_http_status(ip, port, uri, timeout)

--- a/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
@@ -71,7 +71,8 @@ describe Kontena::Workers::ContainerHealthCheckWorker do
     end
 
     it 'restarts container when unhealthy' do
-      expect(Kontena::ServicePods::Restarter).to receive(:perform_async)
+      expect(Kontena::ServicePods::Restarter).to receive(:perform_async).with('foo')
+      expect(container).to receive(:labels).and_return({'io.kontena.container.name' => 'foo'})
       expect {
         subject.handle_action({data: {'status' => 'unhealthy'}})
       }.to change {queue.size}.by (1)

--- a/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
@@ -30,6 +30,7 @@ describe Kontena::Workers::ContainerHealthCheckWorker do
         expect(subject.wrapped_object).to receive(:every).with(30).and_yield
         expect(subject.wrapped_object).to receive(:sleep).with(20)
         expect(subject.wrapped_object).to receive(:check_http_status).with('1.2.3.4', 8080, '/', 10).twice.and_return({})
+      expect(subject.wrapped_object).to receive(:handle_action).twice
         expect {
           subject.start
         }.to change {queue.size}.by (2) # runs check after initial delay and once within the every block
@@ -55,10 +56,25 @@ describe Kontena::Workers::ContainerHealthCheckWorker do
         expect(subject.wrapped_object).to receive(:every).with(30).and_yield
         expect(subject.wrapped_object).to receive(:sleep).with(20)
         expect(subject.wrapped_object).to receive(:check_tcp_status).with('1.2.3.4', 1234, 10).twice.and_return({})
+      expect(subject.wrapped_object).to receive(:handle_action).twice
         expect {
           subject.start
         }.to change {queue.size}.by (2) # runs check after initial delay and once within the every block
       end
+    end
+  end
+
+  describe '#handle_action' do
+    it 'does nothing when healthy' do
+      expect(Kontena::ServicePods::Restarter).not_to receive(:perform_async)
+      subject.handle_action({data: {'status' => 'healthy'}})
+    end
+
+    it 'restarts container when unhealthy' do
+      expect(Kontena::ServicePods::Restarter).to receive(:perform_async)
+      expect {
+        subject.handle_action({data: {'status' => 'unhealthy'}})
+      }.to change {queue.size}.by (1)
     end
   end
 

--- a/docs/using-kontena/health-check.md
+++ b/docs/using-kontena/health-check.md
@@ -54,8 +54,10 @@ Options:
 
 ## Loadbalancer
 
-Configuring a custom healthcheck on a service also ensures that same health check is used by the loadbalancer, if the service is attached to one. When Kontena loadbalancer detects unhealthy instances, it will remove them from the routing. In practice this means, that unhealthy instances will not get any traffic through the loadbalancer untill they report being healthy again.
+Configuring a custom healthcheck on a service also ensures that same health check is used by the loadbalancer, if the service is attached to one. When Kontena loadbalancer detects unhealthy instances, it will remove them from the routing. In practice this means, that unhealthy instances will not get any traffic through the loadbalancer until they report being healthy again.
 
 ## Using the health status
 
-Currently the health check status is used only to indicate a service health for the user. We are planning to use this information also when re-scheduling services so that any unhealthy instance will be re-scheduled/re-created. As explained above, the same configuration is used also by Kontena loadbalancer to decide whether or not an instance should be given traffic.
+Kontena collects the service health status and displays it in the service details as well in service / app listing using symbols.
+
+Kontena agent will do a restart of a container which health status is reported to be `unhealthy`. Master will trigger full service deployment if the healthiness of a service goes below a given threshold. The threshold is determined using the `min_health` deployment option (see [deploy](deploy.md)) using formula `1 - min_health`. So if you specify `0.8` as the min health during deployment, Kontena will re-deploy your service if its overall health goes under 20%.

--- a/server/app/jobs/grid_service_health_monitor_job.rb
+++ b/server/app/jobs/grid_service_health_monitor_job.rb
@@ -1,0 +1,37 @@
+class GridServiceHealthMonitorJob
+  include Celluloid
+  include Logging
+
+  PUBSUB_KEY = 'service:health_status_events'
+
+  def initialize
+    async.subscribe_health_events
+  end
+
+  def subscribe_health_events
+    MongoPubsub.subscribe(PUBSUB_KEY) do |message|
+      self.handle_event(message)
+    end
+  end
+
+  def handle_event(event)
+    service = GridService.find_by(id: event['id'])
+    if deploy_needed?(service)
+      info "service health too low, triggering full deploy for #{service.to_path}"
+      GridServiceDeploy.create(grid_service: service)
+    end
+  end
+
+  def deploy_needed?(service)
+    health_status = service.health_status
+    health_percent = health_status[:healthy].to_f / health_status[:total].to_f
+    min_health = service.deploy_opts.min_health || 0.8
+    expected_health = 1 - min_health
+    if health_percent < expected_health
+      service.running? && !service.deploy_pending?
+    else
+      false
+    end
+  end
+
+end

--- a/server/app/jobs/grid_service_health_monitor_job.rb
+++ b/server/app/jobs/grid_service_health_monitor_job.rb
@@ -1,6 +1,7 @@
 class GridServiceHealthMonitorJob
   include Celluloid
   include Logging
+  include CurrentLeader
 
   PUBSUB_KEY = 'service:health_status_events'
 
@@ -15,6 +16,7 @@ class GridServiceHealthMonitorJob
   end
 
   def handle_event(event)
+    return unless leader?
     service = GridService.find_by(id: event['id'])
     if deploy_needed?(service)
       info "service health too low, triggering full deploy for #{service.to_path}"

--- a/server/app/services/agent/message_handler.rb
+++ b/server/app/services/agent/message_handler.rb
@@ -175,6 +175,8 @@ module Agent
           health_status: data['status'],
           health_status_at: Time.now
         )
+        MongoPubsub.publish(GridServiceHealthMonitorJob::PUBSUB_KEY, id: container.grid_service.id)
+
       else
         warn "health status update failed, could not find container for id: #{data['id']}"
       end

--- a/server/app/services/job_supervisor.rb
+++ b/server/app/services/job_supervisor.rb
@@ -5,4 +5,5 @@ class JobSupervisor < Celluloid::SupervisionGroup
   supervise ServiceBalancerJob, as: :service_balancer_job
   supervise LeaderElectorJob, as: :leader_elector_job
   supervise TelemetryJob, as: :telemetry_job
+  supervise GridServiceHealthMonitorJob, as: :service_health_monitor_job
 end

--- a/server/spec/jobs/grid_service_health_monitor_job_spec.rb
+++ b/server/spec/jobs/grid_service_health_monitor_job_spec.rb
@@ -1,0 +1,72 @@
+require_relative '../spec_helper'
+
+describe GridServiceHealthMonitorJob do
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
+  let(:grid) { Grid.create(name: 'test')}
+  let(:service) { GridService.create(name: 'test', image_name: 'foo/bar:latest', grid: grid)}
+
+  let(:subject) do
+    described_class.new
+  end
+
+  describe '#handle_event' do
+    it 'create deployment' do
+      expect(subject.wrapped_object).to receive(:deploy_needed?).and_return(true)
+      subject.handle_event({'id' => service.id})
+      expect(GridServiceDeploy.count).to eq(1)
+    end
+
+    it 'create deployment' do
+      expect(subject.wrapped_object).to receive(:deploy_needed?).and_return(false)
+      subject.handle_event({'id' => service.id})
+      expect(GridServiceDeploy.count).to eq(0)
+    end
+
+  end
+
+  describe '#deploy_needed?' do
+    it 'return false when service healthy enough' do
+      service = double(
+        {
+          health_status: {healthy: 4, total: 5},
+          deploy_opts: double({min_health: 0.8}),
+          running?: true
+        })
+      expect(subject.deploy_needed?(service)).to be_falsey
+    end
+
+    it 'return true when service not healthy enough' do
+      service = double(
+        {
+          health_status: {healthy: 1, total: 6},
+          deploy_opts: double({min_health: 0.8}),
+          running?: true,
+          deploy_pending?: false
+        })
+      expect(subject.deploy_needed?(service)).to be_truthy
+    end
+
+    it 'return false when service not healthy enough but deploy pending' do
+      service = double(
+        {
+          health_status: {healthy: 1, total: 6},
+          deploy_opts: double({min_health: 0.8}),
+          running?: true,
+          deploy_pending?: true
+        })
+      expect(subject.deploy_needed?(service)).to be_falsey
+    end
+
+    it 'returns false when service not healthy enough but not running' do
+      service = double(
+        {
+          health_status: {healthy: 1, total: 5},
+          deploy_opts: double({min_health: 0.8}),
+          running?: false
+        })
+      expect(subject.deploy_needed?(service)).to be_falsey
+    end
+  end
+end

--- a/server/spec/jobs/grid_service_health_monitor_job_spec.rb
+++ b/server/spec/jobs/grid_service_health_monitor_job_spec.rb
@@ -12,13 +12,22 @@ describe GridServiceHealthMonitorJob do
   end
 
   describe '#handle_event' do
-    it 'create deployment' do
+    it 'create deployment if leader' do
+      expect(subject.wrapped_object).to receive(:leader?).and_return(true)
       expect(subject.wrapped_object).to receive(:deploy_needed?).and_return(true)
       subject.handle_event({'id' => service.id})
       expect(GridServiceDeploy.count).to eq(1)
     end
 
-    it 'create deployment' do
+    it 'does nothing if not leader' do
+      expect(subject.wrapped_object).to receive(:leader?).and_return(false)
+      expect(subject.wrapped_object).not_to receive(:deploy_needed?)
+      subject.handle_event({'id' => service.id})
+      expect(GridServiceDeploy.count).to eq(0)
+    end
+
+    it 'does not create deployment' do
+      expect(subject.wrapped_object).to receive(:leader?).and_return(true)
       expect(subject.wrapped_object).to receive(:deploy_needed?).and_return(false)
       subject.handle_event({'id' => service.id})
       expect(GridServiceDeploy.count).to eq(0)

--- a/server/spec/services/agent/message_handler_spec.rb
+++ b/server/spec/services/agent/message_handler_spec.rb
@@ -6,6 +6,7 @@ describe Agent::MessageHandler do
   let(:queue) { Queue.new }
   let(:node) { HostNode.create!(grid: grid, name: 'test-node') }
   let(:subject) { described_class.new(queue) }
+  let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
 
   describe '#run' do
     it 'performs', :performance => true do
@@ -168,7 +169,7 @@ describe Agent::MessageHandler do
   describe '#on_container_health' do
     it 'updates health status' do
       container_id = SecureRandom.hex(16)
-      container = grid.containers.new(name: 'foo-1')
+      container = grid.containers.new(name: 'foo-1', grid_service: grid_service)
       container.update_attribute(:container_id, container_id)
 
       expect {


### PR DESCRIPTION
This PR adds health status actions. Agent restart unhealthy containers and master will schedule full re-deploy if overall health goes under threshold.

fixes #911 
