### PR TITLE
cli: fix docker build helpers to not use shell syntax

### DIFF
--- a/cli/lib/kontena/cli/apps/docker_helper.rb
+++ b/cli/lib/kontena/cli/apps/docker_helper.rb
@@ -34,15 +34,15 @@ module Kontena::Cli::Apps
     def build_docker_image(service, no_cache = false)
       dockerfile = dockerfile = service['build']['dockerfile'] || 'Dockerfile'
       build_context = service['build']['context']
-      cmd = ["docker build -t #{service['image']}"]
-      cmd << "-f #{File.join(File.expand_path(build_context), dockerfile)}" if dockerfile != "Dockerfile"
-      cmd << "--no-cache" if no_cache
+      cmd = ['docker', 'build', '-t', service['image']]
+      cmd << ['-f', File.join(File.expand_path(build_context), dockerfile)] if dockerfile != "Dockerfile"
+      cmd << '--no-cache' if no_cache
       args = service['build']['args'] || {}
       args.each do |k, v|
-        cmd << "--build-arg #{k}=#{v}"
+        cmd << "--build-arg=#{k}=#{v}"
       end
       cmd << build_context
-      ret = system(cmd.join(' '))
+      ret = system(*cmd.flatten)
       raise ("Failed to build image #{service['image'].colorize(:cyan)}") unless ret
       ret
     end
@@ -50,7 +50,7 @@ module Kontena::Cli::Apps
     # @param [String] image
     # @return [Integer]
     def push_docker_image(image)
-      ret = system("docker push #{image}")
+      ret = system('docker', 'push', image)
       raise ("Failed to push image #{image.colorize(:cyan)}") unless ret
       ret
     end
@@ -58,7 +58,7 @@ module Kontena::Cli::Apps
     # @param [String] image
     # @return [Boolean]
     def image_exist?(image)
-      `docker history #{image} 2>&1` ; $?.success?
+      system("docker history '#{image}' >/dev/null 2>/dev/null")
     end
 
     # @param [String] path

--- a/cli/spec/kontena/cli/app/docker_helper_spec.rb
+++ b/cli/spec/kontena/cli/app/docker_helper_spec.rb
@@ -46,6 +46,11 @@ describe Kontena::Cli::Apps::DockerHelper do
     }
   end
 
+  before :each do
+    # image does not exist
+    allow(subject).to receive(:image_exist?).with('test_service').and_return(false)
+  end
+
   describe '#validate_image_name' do
     context 'when image name is valid' do
       it 'returns true' do
@@ -109,7 +114,7 @@ describe Kontena::Cli::Apps::DockerHelper do
         'build' => { 'context' => '.' },
         'image' => 'test_service'
       }
-      expect(subject).to receive(:system).with("docker build -t test_service ."). and_return(true)
+      expect(subject).to receive(:system).with('docker', 'build', '-t', 'test_service', '.'). and_return(true)
       subject.build_docker_image(service)
     end
 
@@ -118,7 +123,7 @@ describe Kontena::Cli::Apps::DockerHelper do
         'build' => { 'context' => '.' },
         'image' => 'test_service'
       }
-      expect(subject).to receive(:system).with("docker build -t test_service --no-cache ."). and_return(true)
+      expect(subject).to receive(:system).with('docker', 'build', '-t', 'test_service', '--no-cache', '.'). and_return(true)
       subject.build_docker_image(service, true)
     end
 
@@ -128,7 +133,7 @@ describe Kontena::Cli::Apps::DockerHelper do
         'image' => 'test_service'
       }
       expected_path = File.join(File.expand_path('.'), 'other_dockerfile')
-      expect(subject).to receive(:system).with("docker build -t test_service -f #{expected_path} ."). and_return(true)
+      expect(subject).to receive(:system).with('docker', 'build', '-t', 'test_service', '-f', expected_path, '.'). and_return(true)
       subject.build_docker_image(service)
     end
 
@@ -143,7 +148,7 @@ describe Kontena::Cli::Apps::DockerHelper do
         },
         'image' => 'test_service'
       }
-      expect(subject).to receive(:system).with("docker build -t test_service --build-arg FOO=bar --build-arg BAR=foo ."). and_return(true)
+      expect(subject).to receive(:system).with('docker', 'build', '-t', 'test_service', '--build-arg=FOO=bar', '--build-arg=BAR=foo', '.'). and_return(true)
       subject.build_docker_image(service)
     end
   end


### PR DESCRIPTION
Fixes #1123 with spaces in project dir paths.

With `kontena app build` force-build:

```
$ bundle exec bin/kontena app build -f "/home/kontena/kontena/examples test/kontena.yml" -p test 
Building image test-server:latest
Sending build context to Docker daemon 2.048 kB
Step 1 : FROM debian:jessie
 ---> 1b01529cc499
Step 2 : RUN apt-get update && apt-get install -y     python
```

With `kontena app deploy` build-if-needed:

```
$ bundle exec bin/kontena app deploy -f "/home/kontena/kontena/examples test/kontena.yml" -p test 
Building image test-server:latest
...
 [error] Failed to push image test-server:latest

$ bundle exec bin/kontena app deploy -f "/home/kontena/kontena/examples test/kontena.yml" -p test 
 [fail] Creating server      
Connection refused - connect(2) for 127.0.0.1:9292 (Errno::ECONNREFUSED)
```

(fail because I don't have the kontena server or registry running)