### PR TITLE
Interactive server deletion from config or cloud

### DIFF
--- a/cli/lib/kontena/cli/cloud/master/delete_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/delete_command.rb
@@ -7,13 +7,62 @@ module Kontena::Cli::Cloud::Master
 
     requires_current_account_token
 
-    parameter "MASTER_ID", "Master ID"
+    parameter "[MASTER_ID]", "Master ID"
 
     option ['-f', '--force'], :flag, "Don't ask for confirmation"
 
+    def delete_server(id)
+      spinner "Deleting server #{id} from Kontena Cloud" do |spin|
+        begin
+          cloud_client.delete("user/masters/#{id}")
+        rescue
+          spin.fail
+        end
+      end
+    end
+
+    def run_interactive
+      response = nil
+      spinner "Retrieving a list of registered masters on Kontena Cloud" do
+        response = cloud_client.get('user/masters')
+        unless response && response.kind_of?(Hash) && response['data'].kind_of?(Array)
+          abort 'Listing masters failed'.colorize(:red)
+        end
+      end
+
+      if response['data'].empty?
+        puts "No registered masters"
+        return
+      end
+
+      servers_to_delete = prompt.multi_select("Select registered master(s) to delete:") do |menu|
+        response['data'].each do |server|
+          menu.choice "#{server['attributes']['name']} (#{server['attributes']['url'] || "?"})", server['id']
+        end
+      end
+
+      if servers_to_delete.empty?
+        puts "No masters selected"
+      else
+        puts "About to delete servers from Kontena Cloud:"
+        servers_to_delete.each do |id|
+          puts " * #{id}"
+        end
+        confirm unless self.force?
+        servers_to_delete.each do |id|
+          delete_server(id)
+        end
+      end
+    end
+
     def execute
-      confirm unless self.force?
-      cloud_client.delete("user/masters/#{self.master_id}")
+      if self.master_id.nil?
+        run_interactive
+      else
+        confirm unless self.force?
+        delete_server(self.master_id)
+      end
+      exit 0
     end
   end
 end

--- a/cli/lib/kontena/cli/cloud/master/list_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/list_command.rb
@@ -12,8 +12,7 @@ module Kontena::Cli::Cloud::Master
     def execute
       response = cloud_client.get('user/masters')
       unless response && response.kind_of?(Hash) && response['data'].kind_of?(Array)
-        puts "Listing masters failed".colorize(:red)
-        exit 1
+        abort "Listing masters failed".colorize(:red)
       end
 
       if response['data'].empty?

--- a/cli/lib/kontena/cli/cloud/master/remove_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/remove_command.rb
@@ -1,5 +1,5 @@
 module Kontena::Cli::Cloud::Master
-  class DeleteCommand < Kontena::Command
+  class RemoveCommand < Kontena::Command
 
     include Kontena::Cli::Common
 

--- a/cli/lib/kontena/cli/cloud/master_command.rb
+++ b/cli/lib/kontena/cli/cloud/master_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::Cloud
     include Kontena::Cli::Common
 
     subcommand ['list', 'ls'], "List masters in Kontena Cloud", Kontena::Cli::Cloud::Master::ListCommand
-    subcommand ['remove', 'rm'], "Delete a master in Kontena Cloud", Kontena::Cli::Cloud::Master::DeleteCommand
+    subcommand ['remove', 'rm'], "Remove a master registration from Kontena Cloud", Kontena::Cli::Cloud::Master::RemoveCommand
     subcommand "add", "Register a master in Kontena Cloud", Kontena::Cli::Cloud::Master::AddCommand
     subcommand "show", "Show master settings in Kontena Cloud", Kontena::Cli::Cloud::Master::ShowCommand
     subcommand "update", "Update master settings in Kontena Cloud", Kontena::Cli::Cloud::Master::UpdateCommand

--- a/cli/lib/kontena/cli/cloud/master_command.rb
+++ b/cli/lib/kontena/cli/cloud/master_command.rb
@@ -1,6 +1,6 @@
 require_relative 'master/add_command'
 require_relative 'master/list_command'
-require_relative 'master/delete_command'
+require_relative 'master/remove_command'
 require_relative 'master/update_command'
 require_relative 'master/show_command'
 
@@ -9,8 +9,8 @@ module Kontena::Cli::Cloud
     include Kontena::Cli::Common
 
     subcommand ['list', 'ls'], "List masters in Kontena Cloud", Kontena::Cli::Cloud::Master::ListCommand
+    subcommand ['remove', 'rm'], "Delete a master in Kontena Cloud", Kontena::Cli::Cloud::Master::DeleteCommand
     subcommand "add", "Register a master in Kontena Cloud", Kontena::Cli::Cloud::Master::AddCommand
-    subcommand "delete", "Delete a master in Kontena Cloud", Kontena::Cli::Cloud::Master::DeleteCommand
     subcommand "show", "Show master settings in Kontena Cloud", Kontena::Cli::Cloud::Master::ShowCommand
     subcommand "update", "Update master settings in Kontena Cloud", Kontena::Cli::Cloud::Master::UpdateCommand
 

--- a/cli/lib/kontena/cli/master/remove_command.rb
+++ b/cli/lib/kontena/cli/master/remove_command.rb
@@ -1,0 +1,58 @@
+module Kontena::Cli::Master
+  class RemoveCommand < Kontena::Command
+    include Kontena::Cli::Common
+
+    parameter '[NAME]', "Master name"
+
+    banner "Note: This command only removes the master from your local configuration file"
+
+    option '--force', :flag, "Don't ask questions"
+
+    def run_interactive
+      selections = prompt.multi_select("Select masters to remove from configuration file:") do |menu|
+        config.servers.each do |server|
+          menu.choice " #{pastel.green("* ") if config.current_server == server.name}#{server.name} (#{server.username || 'unknown'} @ #{server.url})", server
+        end
+      end
+      if selections.empty?
+        puts "No masters selected"
+        exit 0
+      end
+      delete_servers(selections)
+    end
+
+    def delete_servers(servers)
+      case servers.size
+      when 0
+        abort "Master not found in configuration"
+      when 1
+        config.servers.delete(config.servers.delete(servers.first))
+        puts "Removed Master '#{servers.first.name}'"
+      else
+        unless self.force?
+          abort("Aborted") unless prompt.yes?("Remove #{servers.size} masters from configuration?")
+        end
+        config.servers.delete_if {|s| servers.include?(s) }
+        puts "Removed #{servers.size} masters from configuration"
+      end
+      unless config.find_server(config.current_server)
+        puts
+        puts "Current master was removed, to select a new current master use:"
+        puts "  " + pastel.green.on_black("  kontena master use <master_name>  ")
+        puts "Or log into another master by using:"
+        puts "  " + pastel.green.on_black("  kontena master login <master_url>  ")
+        config.current_server = nil
+      end
+      config.write
+    end
+
+    def execute
+      if self.name.nil?
+        run_interactive
+      else
+        delete_servers(config.servers.select {|s| s.name == self.name})
+      end
+    end
+  end
+end
+

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -1,5 +1,6 @@
 require_relative '../main_command'
 require_relative 'master/use_command'
+require_relative 'master/remove_command'
 require_relative 'master/list_command'
 require_relative 'master/users_command'
 require_relative 'master/current_command'
@@ -19,6 +20,7 @@ end
 
 class Kontena::Cli::MasterCommand < Kontena::Command
   subcommand ["list", "ls"], "List masters where client has logged in", Kontena::Cli::Master::ListCommand
+  subcommand ["remove", "rm"], "Remove a master from configuration file", Kontena::Cli::Master::RemoveCommand
   subcommand ["config", "cfg"], "Configure master settings", Kontena::Cli::Master::ConfigCommand
   subcommand "use", "Switch to use selected master", Kontena::Cli::Master::UseCommand
   subcommand "users", "Users specific commands", Kontena::Cli::Master::UsersCommand


### PR DESCRIPTION
Introduces:

```
$ kontena master rm [master_name]
```

If you don't supply a master name, you'll get a multi select menu where you can select multiple masters you want to remove from config.

Same goes with 
```
$ kontena cloud master rm
```

But Cloud API does not support DELETE yet so the command currently reports "Not found"
