### PR TITLE
Fix example for docker-compose.yml file.

### DIFF
--- a/docs/getting-started/installing/docker-compose.md
+++ b/docs/getting-started/installing/docker-compose.md
@@ -27,7 +27,7 @@ services:
     container_name: kontena-master-haproxy
     environment:
       - SSL_CERT=**None**
-      - BACKEND_PORT=9292
+      - BACKENDS=kontena-master:9292
     ports:
       - 80:80
       - 443:443    


### PR DESCRIPTION
Was broken before:

~~~
I, [2016-10-13T18:30:48.589186 #1]  INFO -- : ~~ Starting Kontena HAProxy ~~
I, [2016-10-13T18:30:48.598676 #1]  INFO -- : Starting to resolve ip's for backends: ["kontena-server-api:9292"]
I, [2016-10-13T18:30:48.598797 #1]  INFO -- : with interval of 10 seconds
I, [2016-10-13T18:30:48.604761 #1]  INFO -- : global
  maxconn 4096
  pidfile /var/run/haproxy.pid
  user haproxy
  group haproxy
  daemon
  stats socket /var/run/haproxy.stats level admin
defaults
  mode http
  option redispatch
  option forwardfor
  timeout connect 5000
  timeout client 50000
  timeout server 50000
frontend default_frontend
  bind 0.0.0.0:80
  redirect scheme https code 301 if !{ ssl_fc } !{ url_beg /.well-known/acme-challenge/ }
  bind 0.0.0.0:443 ssl crt /etc/ssl/private/
  reqadd X-Forwarded-Proto:\ https
  acl acme url_beg /.well-known/acme-challenge/
  use_backend acme if acme
  default_backend default_backend
backend default_backend
  balance roundrobin
backend acme
  server acmetool 127.0.0.1:402
~~~