### PR TITLE
Implement 'kontena master init-cloud' command

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -7,11 +7,11 @@ module Kontena
       matches_commands 'master create'
 
       def configure_auth_provider_using_id(cloud_id)
-        Kontena.run("master init-cloud --current --force --cloud-master-id #{cloud_id.shellescape}")
+        Kontena.run("master init-cloud --force --cloud-master-id #{cloud_id.shellescape}")
       end
 
       def configure_auth_provider
-        Kontena.run("master init-cloud --current --force")
+        Kontena.run("master init-cloud --force")
       end
 
       def after

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -6,27 +6,12 @@ module Kontena
 
       matches_commands 'master create'
 
-      def get_oauth_app_config(master_id)
-        attrs = nil
-        spinner "Retrieving master OAuth2 application settings from Kontena Cloud" do
-          attrs = cloud_client.get("user/masters/#{master_id}")["data"]["attributes"]
-        end
-        attrs
-      rescue
-        nil
+      def configure_auth_provider_using_id(cloud_id)
+        Kontena.run("cloud master add --current --force --cloud-master-id #{cloud_id.shellescape}")
       end
 
-      def configure_auth_provider(oauth_config)
-        require 'shellwords'
-        spinner "Setting Kontena Cloud authentication provider settings to Master config" do
-          Retriable.retriable do
-            Kontena.run("master config import --force --preset kontena_auth_provider")
-          end
-
-          Retriable.retriable do
-            Kontena.run("master config set oauth2.client_id=#{oauth_config['client-id'].shellescape} oauth2.client_secret=#{oauth_config['client-secret'].shellescape} server.root_url=#{config.current_master.url.shellescape}")
-          end
-        end
+      def configure_auth_provider
+        Kontena.run("cloud master add --current --force")
       end
 
       def after
@@ -40,10 +25,9 @@ module Kontena
         end
 
         if command.respond_to?(:cloud_master_id) && command.cloud_master_id
-          oauth_config = get_oauth_app_config(command.cloud_master_id)
-          if oauth_config
-            configure_auth_provider(oauth_config)
-          end
+          configure_auth_provider_using_id(command.cloud_master_id)
+        else
+          configure_auth_provider
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -7,11 +7,11 @@ module Kontena
       matches_commands 'master create'
 
       def configure_auth_provider_using_id(cloud_id)
-        Kontena.run("cloud master add --current --force --cloud-master-id #{cloud_id.shellescape}")
+        Kontena.run("master init-cloud --current --force --cloud-master-id #{cloud_id.shellescape}")
       end
 
       def configure_auth_provider
-        Kontena.run("cloud master add --current --force")
+        Kontena.run("master init-cloud --current --force")
       end
 
       def after

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -116,7 +116,7 @@ module Kontena::Cli::Cloud
 
       response = client.get(path) rescue nil
       if response && response.kind_of?(Hash)
-        kontena_account.username = response['username']
+        kontena_account.username = response['data']['attributes']['username']
         config.write
         display_logo
         display_login_info(only: :account)

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -7,47 +7,82 @@ module Kontena::Cli::Cloud::Master
 
     requires_current_account_token
 
-    parameter "NAME", "Master name"
+    parameter "[NAME]", "Master name"
 
-    option ['--redirect-uri'], '[URL]',      'Se master redirect URL'
-    option ['--url'],          '[URL]',      'Se master URL'
-    option ['--provider'],     '[NAME]',     'Se master provider'
-    option ['--name'],         '[NAME]',     'Se master name',        hidden: true
-    option ['--version'],      '[VERSION]',  'Se master version',     hidden: true
-    option ['--owner'],        '[NAME]',     'Se master owner',       hidden: true
+    option ['--redirect-uri'], '[URL]',      'Set master redirect URL'
+    option ['--url'],          '[URL]',      'Set master URL'
+    option ['--provider'],     '[NAME]',     'Set master provider'
+    option ['--name'],         '[NAME]',     'Set master name',        hidden: true
+    option ['--version'],      '[VERSION]',  'Set master version',     hidden: true
+    option ['--owner'],        '[NAME]',     'Set master owner',       hidden: true
 
-    option ['--id'], :flag, 'Just output the ID'
-    option ['--arg'], :flag, 'Output as command line arguments'
+    option ['--id'],      :flag, 'Just output the ID'
+    option ['--current'], :flag, 'Register and configure current master'
+    option ['--return'],  :flag, 'Return the ID', hidden: true
+    option ['--force'],   :flag, "Don't ask questions"
 
-    option ['--return'], :flag, 'Return the ID', hidden: true
-
-    def execute
-      attributes = { 'name' => self.name }
-      attributes['url'] = self.url if self.url
-      attributes['provider'] = self.provider if self.provider
-      attributes['redirect-uri'] = self.redirect_uri if self.redirect_uri
-      attributes['version'] = self.version if self.version
-      attributes['owner'] = self.owner if self.owner
+    def register(name, url = nil, provider = nil, redirect_uri = nil, version = nil, owner = nil)
+      attributes = {}
+      attributes['name']         = name 
+      attributes['url']          = url if url
+      attributes['provider']     = provider if provider
+      attributes['redirect-uri'] = redirect_uri if redirect_uri
+      attributes['version']      = version if version
+      attributes['owner']        = owner if owner
 
       response = cloud_client.post('user/masters', { data: { attributes: attributes } })
-      if response.kind_of?(Hash)
-        if response['error']
-          puts "Failed: #{response['error']}"
-          exit 1
-        else
-          if self.return?
-            return response['data']['id']
-          elsif self.id?
-            puts response['data']['id']
-          elsif self.arg?
-            puts "--client-id #{response['data']['attributes']['client-id']} --client-secret #{response['data']['attributes']['client-secret']}"
-          else
-            puts "Created master.".colorize(:green)
-            puts "ID: #{response['data']['id']}"
-            puts "Client ID: #{response['data']['attributes']['client-id']}"
-            puts "Client Secret: #{response['data']['attributes']['client-secret']}"
-          end
-        end
+      exit_with_error "Failed (invalid response)" unless response.kind_of?(Hash)
+      exit_with_error "Failed (no data)" unless response['data']
+      exit_with_error "Failed: #{response['error']}" if response['error']
+      response
+    end
+
+    def register_current
+      require_api_url
+      require_token
+
+      unless self.force?
+        puts "Proceeding will:"
+        puts " * Register the Kontena Master #{current_master.name} to Kontena Cloud"
+        puts " * Configure the Kontena Master to use Kontena Cloud as the"
+        puts "   authentication provider"
+        puts
+        puts "After this:"
+        puts " * Users will not be able to reauthenticate without authorizing the"
+        puts "   Master to access their Kontena Cloud user information"
+        puts " * Users that have registered a different email address to Kontena"
+        puts "   Cloud than the one they currently have as their username in the"
+        puts "   master will not be able to authenticate before an administrator"
+        puts "   of the Kontena Master creates an invitation code for them"
+        puts "   (kontena master users invite old@email.example.com)"
+        exit_with_error "Aborted" unless prompt.yes?("Proceed?")
+      end
+
+      response = spinner "Registering current Kontena Master '#{current_master.name}' to Kontena Cloud" do
+        register(current_master.name, current_master.url)
+      end
+
+      spinner "Loading Kontena Cloud auth provider base configuration to Kontena Master" do
+        Kontena.run('master config import --force --preset kontena_auth_provider')
+      end
+
+      spinner "Updating OAuth2 client-id and client-secret to Kontena Master" do
+        Kontena.run("master config set oauth2.client_id=#{response['data']['attributes']['client-id'].shellescape} oauth2.client_secret=#{response['data']['attributes']['client-secret'].shellescape} server.root_url=#{current_master.url.shellescape} server.name=#{current_master.name.shellescape} cloud.provider_is_kontena=true")
+      end
+    end
+
+    def execute
+      return register_current if self.current?
+      response = register(self.name, self.url, self.provider, self.redirect_uri, self.version, self.owner)
+      if self.return?
+        return response['data']['id']
+      elsif self.id?
+        puts response['data']['id']
+      else
+        puts "Registered master.".colorize(:green)
+        puts "ID: #{response['data']['id']}"
+        puts "Client ID: #{response['data']['attributes']['client-id']}"
+        puts "Client Secret: #{response['data']['attributes']['client-secret']}"
       end
     end
   end

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -73,6 +73,9 @@ module Kontena::Cli::Cloud::Master
 
     def execute
       return register_current if self.current?
+
+      exit_with_error 'Master name is required' unless self.name
+
       response = register(self.name, self.url, self.provider, self.redirect_uri, self.version, self.owner)
       if self.return?
         return response['data']['id']

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -117,8 +117,8 @@ module Kontena
         {
           name: 'kontena',
           url: 'https://cloud-api.kontena.io',
-          token_endpoint: 'https://auth2.kontena.io/v1/oauth2/token',
-          authorization_endpoint: 'https://cloud-beta.kontena.io/login/oauth/authorize',
+          token_endpoint: 'https://cloud-api.kontena.io/oauth2/token',
+          authorization_endpoint: 'https://cloud.kontena.io/login/oauth/authorize',
           userinfo_endpoint: 'https://cloud-api.kontena.io/user',
           token_post_content_type: 'application/x-www-form-urlencoded',
           code_requires_basic_auth: false,

--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -1,0 +1,21 @@
+module Kontena::Cli::Master
+  class InitCloudCommand < Kontena::Command
+
+    include Kontena::Cli::Common
+
+    banner "Configures the current Kontena Master to use Kontena Cloud services and authentication"
+
+    option '--force',           :flag,  "Don't ask questions"
+    option '--cloud-master-id', '[ID]', "Use existing cloud master ID"
+
+    requires_current_master
+    requires_current_account_token
+
+    def execute
+      args = ["--current"]
+      args << "--force" if self.force?
+      args << "--cloud-master-id #{self.cloud_master_id}" if self.cloud_master_id
+      Kontena.run("cloud master add #{args.map(&:shellescape).join(' ')}")
+    end
+  end
+end

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -10,15 +10,11 @@ require_relative 'master/logout_command'
 require_relative 'master/join_command'
 require_relative 'master/audit_log_command'
 require_relative 'master/token_command'
-
-if ENV["DEV"]
-  begin
-    require_relative 'master/create_command'
-  rescue LoadError
-  end
-end
+require_relative 'master/init_cloud_command'
 
 class Kontena::Cli::MasterCommand < Kontena::Command
+  include Kontena::Util
+
   subcommand ["list", "ls"], "List masters where client has logged in", Kontena::Cli::Master::ListCommand
   subcommand ["remove", "rm"], "Remove a master from configuration file", Kontena::Cli::Master::RemoveCommand
   subcommand ["config", "cfg"], "Configure master settings", Kontena::Cli::Master::ConfigCommand
@@ -30,8 +26,9 @@ class Kontena::Cli::MasterCommand < Kontena::Command
   subcommand "token", "Manage Kontena Master access tokens", Kontena::Cli::Master::TokenCommand
   subcommand "join", "Join Kontena Master using an invitation code", Kontena::Cli::Master::JoinCommand
   subcommand "audit-log", "Show master audit logs", Kontena::Cli::Master::AuditLogCommand
-
-  if ENV["DEV"]
+  subcommand "init-cloud", "Configure current master to use Kontena Cloud services", Kontena::Cli::Master::InitCloudCommand
+  if experimental?
+    require_relative 'master/create_command'
     subcommand "create", "Install a new Kontena Master", Kontena::Cli::Master::CreateCommand
   end
 

--- a/cli/lib/kontena/presets/kontena_auth_provider.yml
+++ b/cli/lib/kontena/presets/kontena_auth_provider.yml
@@ -1,7 +1,7 @@
 ---
-oauth2.authorize_endpoint: https://cloud-beta.kontena.io/login/oauth/authorize
+oauth2.authorize_endpoint: https://cloud.kontena.io/login/oauth/authorize
 oauth2.code_requires_basic_auth: false
-oauth2.token_endpoint: https://auth2.kontena.io/v1/oauth2/token
+oauth2.token_endpoint: https://cloud-api.kontena.io/oauth2/token
 oauth2.token_method: post
 oauth2.token_post_content_type: application/x-www-form-urlencoded
 oauth2.userinfo_endpoint: https://cloud-api.kontena.io/user

--- a/docs/using-kontena/authentication.md
+++ b/docs/using-kontena/authentication.md
@@ -45,16 +45,7 @@ $ kontena cloud login
 If you have upgraded from a previous version you can configure your Master to use Kontena Cloud by registering the Master to the Kontena Cloud service and configuring the authentication provider settings on the master:
 
 ```
-$ kontena master config import --preset kontena_auth_provider
-$ kontena cloud master add my-master-name
-Created master.
-ID: 000010000
-Client ID: abcd123456
-Client Secret: defg23456
-
-$ kontena master config set server.url=`kontena master current --url`
-$ kontena master config set oauth2.client_id=abcd123456 
-$ kontena master config set oauth2.client_secret=defg23456
+$ kontena cloud master add --current
 ```
 
 

--- a/docs/using-kontena/authentication.md
+++ b/docs/using-kontena/authentication.md
@@ -45,7 +45,7 @@ $ kontena cloud login
 If you have upgraded from a previous version you can configure your Master to use Kontena Cloud by registering the Master to the Kontena Cloud service and configuring the authentication provider settings on the master:
 
 ```
-$ kontena cloud master add --current
+$ kontena master init-cloud
 ```
 
 


### PR DESCRIPTION
```
$ kontena master init-cloud
Proceeding will:
 * Register the Kontena Master kontena-master-5 to Kontena Cloud
 * Configure the Kontena Master to use Kontena Cloud as the
   authentication provider

After this:
 * Users will not be able to reauthenticate without authorizing the
   Master to access their Kontena Cloud user information
 * Users that have registered a different email address to Kontena
   Cloud than the one they currently have as their username in the
   master will not be able to authenticate before an administrator
   of the Kontena Master creates an invitation code for them
   (kontena master users invite old@email.example.com)
> Proceed? Yes
 [done] Registering current Kontena Master 'kontena-master-5' to Kontena Cloud
 [done] Loading Kontena Cloud auth provider base configuration to Kontena Master
 [done] Updating OAuth2 client-id and client-secret to Kontena Master
```

Also the URL's to production cloud have been updated.
