### PR TITLE
CLI: Improve request error handling

### DIFF
--- a/cli/Gemfile
+++ b/cli/Gemfile
@@ -8,4 +8,5 @@ group :development, :test do
   gem "kontena-plugin-hello", path: "./examples/kontena-plugin-hello"
   gem 'pry', require: false
   gem 'pry-byebug', require: false
+  gem 'webmock', require: false
 end

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -230,9 +230,7 @@ describe Kontena::Client do
       end
 
       it "returns the JSON object" do
-        response = subject.get('test')
-
-        expect(subject.get('test')['test'].join(" ")).to eq "This was a triumph. I’m making a note here: HUGE SUCCESS."
+        expect(subject.get('test')['test'].join(" / ")).to eq "This was a triumph. / I’m making a note here: HUGE SUCCESS."
       end
     end
 

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -273,7 +273,7 @@ describe Kontena::Client do
       end
 
       it "raises StandardError with the server error message" do
-        expect{subject.post('print', { 'code': "8A/HyA==" })}.to raise_error(Kontena::Errors::StandardError, "lp0 (printer) on fire")
+        expect{subject.post('print', { 'code' => "8A/HyA==" })}.to raise_error(Kontena::Errors::StandardError, "lp0 (printer) on fire")
       end
     end
 

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -216,6 +216,26 @@ describe Kontena::Client do
       Kontena::Client.new('http://localhost', master.token)
     end
 
+    context "for an expected response" do
+      before :each do
+        allow(subject).to receive(:http_client).and_call_original
+
+        WebMock.stub_request(:any, 'http://localhost/v1/test').to_return(
+        status: 200,
+        headers: {
+          'Content-Type' => 'application/json',
+        },
+        body: {'test' => [ "This was a triumph.", "I’m making a note here: HUGE SUCCESS." ]}.to_json,
+      )
+      end
+
+      it "returns the JSON object" do
+        response = subject.get('test')
+
+        expect(subject.get('test')['test'].join(" ")).to eq "This was a triumph. I’m making a note here: HUGE SUCCESS."
+      end
+    end
+
     context "with an empty error response" do
       before :each do
         # workaround https://github.com/bblimke/webmock/issues/653
@@ -258,7 +278,6 @@ describe Kontena::Client do
         expect{subject.post('print', { 'code': "8A/HyA==" })}.to raise_error(Kontena::Errors::StandardError, "lp0 (printer) on fire")
       end
     end
-
 
     context "with a 422 response with JSON error" do
       before :each do

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -38,7 +38,7 @@ describe Kontena::Client do
       client = Kontena::Client.new('https://localhost/v1/', token)
       expect(client.token).to eq token
     end
-    
+
     it 'uses the access token as a bearer token' do
       client = Kontena::Client.new('https://localhost/v1/', token)
       expect(client.http_client).to receive(:request) do |opts|
@@ -208,6 +208,74 @@ describe Kontena::Client do
         hash_including(headers: hash_including('Some-Header' => 'value'), method: :delete)
       ).and_return(spy(:response, status: 200))
       subject.delete('foo', nil, nil, {'Some-Header' => 'value'})
+    end
+  end
+
+  describe '#request' do
+    subject do
+      Kontena::Client.new('http://localhost', master.token)
+    end
+
+    context "with an empty error response" do
+      before :each do
+        # workaround https://github.com/bblimke/webmock/issues/653
+        expect(http_client).to receive(:request).with(
+          hash_including(path: '/v1/coffee', method: :brew)
+        ) {
+          raise Excon::Errors::HTTPStatusError.new("I'm a teapot",
+            {
+              method: 'brew',
+              path: '/v1/coffee',
+            },
+            double(:response,
+              status: 418,
+              reason_phrase: "I'm a teapot",
+              headers: {
+                'Content-Type' => 'short/stout',
+              },
+              body: "",
+            )
+          )
+        }
+      end
+
+      it "raises StandardError with the status phrase" do
+        expect{subject.request(http_method: :brew, path: 'coffee')}.to raise_error(Kontena::Errors::StandardError, "I'm a teapot")
+      end
+    end
+
+    context "with an 500 response with text error" do
+      before :each do
+        allow(subject).to receive(:http_client).and_call_original
+
+        WebMock.stub_request(:any, 'http://localhost/v1/print').to_return(
+          status: 500,
+          body: "lp0 (printer) on fire",
+        )
+      end
+
+      it "raises StandardError with the server error message" do
+        expect{subject.post('print', { 'code': "8A/HyA==" })}.to raise_error(Kontena::Errors::StandardError, "lp0 (printer) on fire")
+      end
+    end
+
+
+    context "with a 422 response with JSON error" do
+      before :each do
+        allow(subject).to receive(:http_client).and_call_original
+
+        WebMock.stub_request(:any, 'http://localhost/v1/test').to_return(
+          status: 422,
+          headers: {
+            'Content-Type' => 'application/json',
+          },
+          body: {'error' => "You are wrong"}.to_json,
+        )
+      end
+
+      it "raises StandardError with the server error message" do
+        expect{subject.get('test')}.to raise_error(Kontena::Errors::StandardError, "You are wrong")
+      end
     end
   end
 end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require 'stringio'
 require 'clamp'
 require 'ruby_dig'
 require 'kontena_cli'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true


### PR DESCRIPTION
Fix the client HTTP request error handling to give nicer error messages for all unexpected HTTP response codes.

Uses `Excon::Errors::HTTPStatusError` to raise a `Kontena::Errors::StandardError`, using either:

* response body string
* response body JSON `{"error": ...}` data
* response reason phrase

Adds rspec tests for the `Client#request` handling using WebMock.

## Preserves existing HTTP 404 errors

`bundle exec bin/kontena grid user add --grid asdfasdfasdf foobar@cloud.kontena.io`
```
 [error] Not found
```

vs existing:

```
 [error] Not found
```

## Nicer output for previously unhandled errors


`bundle exec bin/kontena grid create wat && echo yay`

```
 [warn] Option --initial-size=1 is only recommended for test/dev usage
 [fail] Creating wat grid      
 [error] Internal Server Error
```

vs existing:

```
 [warn] Option --initial-size=1 is only recommended for test/dev usage
 [fail] Creating wat grid      
 [error] Expected([200, 201]) <=> Actual(500 InternalServerError)
         Rerun the command with environment DEBUG=true set to get the full exception
```

## Nicer output for detailed errors returned by the server:

```ruby
  # POST /v1/grids/:name/users
  r.post do
    data = parse_json_body
    user = User.find_by(email: data['email'])
    halt_request(404, {error: 'User not found'}) unless user
```

`kontena grid user add foobar@cloud.kontena.io`

```
 [error] User not found
```

vs existing:

```
 [error] Not found
```