### PR TITLE
Remove Content-Type request header when sending empty request body

### DIFF
--- a/cli/lib/kontena/cli/cloud/master/remove_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/remove_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Cloud::Master
     def delete_server(id)
       spinner "Deleting server #{id} from Kontena Cloud" do |spin|
         begin
-          cloud_client.delete("user/masters/#{id}", nil, {}, { 'Content-Type' => 'text/plain' })          
+          cloud_client.delete("user/masters/#{id}")
         rescue
           spin.fail
         end

--- a/cli/lib/kontena/cli/cloud/master/remove_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/remove_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Cloud::Master
     def delete_server(id)
       spinner "Deleting server #{id} from Kontena Cloud" do |spin|
         begin
-          cloud_client.delete("user/masters/#{id}")
+          cloud_client.delete("user/masters/#{id}", nil, {}, { 'Content-Type' => 'text/plain' })          
         rescue
           spin.fail
         end
@@ -66,4 +66,3 @@ module Kontena::Cli::Cloud::Master
     end
   end
 end
-

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -276,7 +276,7 @@ module Kontena
     # @param expects [Array] raises unless response status code matches this list.
     # @param auth [Boolean] use token authentication default = true
     # @return [Hash, String] response parsed response object
-    def request(http_method: :get, path:'/', body: nil, query: {}, headers: {}, response_block: nil, expects: [200, 201], host: nil, port: nil, auth: true)
+    def request(http_method: :get, path:'/', body: nil, query: {}, headers: {}, response_block: nil, expects: [200, 201, 204], host: nil, port: nil, auth: true)
 
       retried ||= false
 
@@ -286,9 +286,11 @@ module Kontena
 
       request_headers = request_headers(headers, auth)
 
-      body_content = body.nil? ? '' : encode_body(body, request_headers[CONTENT_TYPE])
-      if http_method == :get
-        request_headers.delete('Content-Type')
+      if body.nil?
+        body_content = ''
+        request_headers.delete(CONTENT_TYPE)
+      else
+        body_content =  encode_body(body, request_headers[CONTENT_TYPE])
       end
       request_headers.merge!('Content-Length' => body_content.bytesize)
 

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -291,8 +291,8 @@ module Kontena
         request_headers.delete(CONTENT_TYPE)
       else
         body_content =  encode_body(body, request_headers[CONTENT_TYPE])
+        request_headers.merge!('Content-Length' => body_content.bytesize)
       end
-      request_headers.merge!('Content-Length' => body_content.bytesize)
 
       uri = URI.parse(path)
       host_options = {}


### PR DESCRIPTION
This PR removes Content-Type request header when sending empty request body. By default `application/json` content type is sent and that is causing problems.

Also 204 response status is added to accepted response status codes.