### PR TITLE
Add validation for existing grid in grid create

### DIFF
--- a/server/app/mutations/grids/create.rb
+++ b/server/app/mutations/grids/create.rb
@@ -17,6 +17,8 @@ module Grids
 
     def validate
       add_error(:user, :invalid, 'Operation not allowed') unless user.can_create?(Grid)
+      existing = Grid.find_by(name: self.name)
+      add_error(:grid, :already_exists, "Grid with name #{self.name} already exists") if existing
     end
 
     def execute

--- a/server/spec/mutations/grids/create_spec.rb
+++ b/server/spec/mutations/grids/create_spec.rb
@@ -33,6 +33,17 @@ describe Grids::Create do
         }.to change{ Grid.count }.by(1)
       end
 
+      it 'fails to create grid with existing name' do
+        grid = Grid.create!(name: 'test-grid')
+        outcome = described_class.new(
+            user: user,
+            name: "test-grid"
+          ).run
+        expect(outcome.success?).to be_falsey
+        expect(outcome.errors.size).to eq(1)
+        expect(outcome.errors.message.keys).to include('grid')
+      end
+
       it 'initializes subnet' do
         outcome = described_class.new(
             user: user,


### PR DESCRIPTION
Grid create mutation now validates if grid already exists with given name

fixes #1079 