### PR TITLE
Fix Ubuntu xenial server/agent Docker image version pinning

### DIFF
--- a/agent/lib/tasks/release.rake
+++ b/agent/lib/tasks/release.rake
@@ -51,7 +51,7 @@ namespace :release do
     sh('rm -rf build/ubuntu_xenial/')
     sh('cp -ar packaging/ubuntu_xenial build/')
     sh("sed -i \"s/VERSION/#{VERSION}-#{rev}/g\" build/ubuntu_xenial/#{NAME}/DEBIAN/control")
-    sh("sed -i \"s/VERSION$/#{VERSION}/g\" build/ubuntu_xenial/#{NAME}/etc/kontena-agent.env")
+    sh("sed -i \"s/{{VERSION}}/#{VERSION}/g\" build/ubuntu_xenial/#{NAME}/lib/systemd/system/kontena-agent.service.d/kontena-version.conf")
 
     Dir.chdir("build/ubuntu_xenial") do
       sh("dpkg-deb -b #{NAME} .")

--- a/agent/packaging/ubuntu_xenial/kontena-agent/etc/kontena-agent.env
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/etc/kontena-agent.env
@@ -6,6 +6,3 @@
 
 # kontena peer interface (overlay network interface)
 KONTENA_PEER_INTERFACE=eth1
-
-# kontena version
-KONTENA_VERSION=VERSION

--- a/agent/packaging/ubuntu_xenial/kontena-agent/lib/systemd/system/kontena-agent.service
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/lib/systemd/system/kontena-agent.service
@@ -13,11 +13,9 @@ RestartSec=5
 EnvironmentFile=/etc/kontena-agent.env
 ExecStartPre=-/usr/bin/docker stop kontena-agent
 ExecStartPre=-/usr/bin/docker rm kontena-agent
-ExecStartPre=-/usr/bin/docker pull kontena/agent:${KONTENA_VERSION}
 ExecStart=/usr/bin/docker run --name kontena-agent \
     --env-file /etc/kontena-agent.env \
     -v=/var/run/docker.sock:/var/run/docker.sock \
-    -v=/etc/kontena-agent.env:/etc/kontena.env \
     --net=host \
     kontena/agent:${KONTENA_VERSION}
 ExecStop=/usr/bin/docker stop kontena-agent

--- a/agent/packaging/ubuntu_xenial/kontena-agent/lib/systemd/system/kontena-agent.service.d/kontena-version.conf
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/lib/systemd/system/kontena-agent.service.d/kontena-version.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=KONTENA_VERSION={{VERSION}}

--- a/server/lib/tasks/release.rake
+++ b/server/lib/tasks/release.rake
@@ -37,7 +37,7 @@ namespace :release do
     sh('rm -rf build/ubuntu_xenial/')
     sh('cp -ar packaging/ubuntu_xenial build/')
     sh("sed -i \"s/VERSION/#{VERSION}-#{rev}/g\" build/ubuntu_xenial/#{NAME}/DEBIAN/control")
-    sh("sed -i \"s/VERSION$/#{VERSION}/g\" build/ubuntu_xenial/#{NAME}/etc/kontena-server.env")
+    sh("sed -i \"s/{{VERSION}}/#{VERSION}/g\" build/ubuntu_xenial/#{NAME}/lib/systemd/system/kontena-server.service.d/kontena-version.conf")
     sh("cd build/ubuntu_xenial && dpkg-deb -b #{NAME} .")
   end
 

--- a/server/packaging/ubuntu_xenial/kontena-server/etc/kontena-server.env
+++ b/server/packaging/ubuntu_xenial/kontena-server/etc/kontena-server.env
@@ -9,5 +9,3 @@
 
 # SSL Certificate
 #SSL_CERT=/etc/kontena-server.pem
-
-KONTENA_VERSION=VERSION

--- a/server/packaging/ubuntu_xenial/kontena-server/lib/systemd/system/kontena-server.service
+++ b/server/packaging/ubuntu_xenial/kontena-server/lib/systemd/system/kontena-server.service
@@ -16,7 +16,6 @@ RestartSec=5
 EnvironmentFile=/etc/kontena-server.env
 ExecStartPre=-/usr/bin/docker stop kontena-server-api
 ExecStartPre=-/usr/bin/docker rm kontena-server-api
-ExecStartPre=-/usr/bin/docker pull kontena/server:${KONTENA_VERSION}
 ExecStart=/usr/bin/docker run --name kontena-server-api \
     --link kontena-server-mongo:mongodb \
     -e MONGODB_URI=mongodb://mongodb:27017/kontena_server \

--- a/server/packaging/ubuntu_xenial/kontena-server/lib/systemd/system/kontena-server.service.d/kontena-version.conf
+++ b/server/packaging/ubuntu_xenial/kontena-server/lib/systemd/system/kontena-server.service.d/kontena-version.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=KONTENA_VERSION={{VERSION}}


### PR DESCRIPTION
* Move the version out of the `/etc/kontena-*.env` conffile

  Upgrading the `KONTENA_VERSION=` within the conffile while preserving the
  initial `KONTENA_TOKEN=` etc configuration would have required manual editing
  on every upgrade.

* Use a systemd service drop-in to provide the `KONTENA_VERSION=`

  Using a `/lib/systemd/system/kontena-*.service.d/kontena-version.conf` unit allows
  using the same customized `/etc/systemd/system/kontena-*.service` unit file across version
  upgrades.

* Disable automatic agent version upgrades

  Removes the `-v etc/kontena-agent.env:/etc/kontena.env` bind mount, disabling
  the automatic `KONTENA_VERSION=` upgrades on server_info version conflicts.

* Drop the extraneous `docker pull` step

  Assuming that the tagged images never change, the `docker run kontena/*:${KONTENA_VERSION}`
  should be sufficient to pull the image on the initial run, or use any existing local image.