### PR TITLE
Change Ubuntu xenial packages to allow either docker-engine or docker.io

### DIFF
--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>> 1.8), docker-engine (<< 1.13), resolvconf
+Depends: docker-engine (>= 1.9) | docker.io (>= 1.9), resolvconf
 Description: Kontena Agent

--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.9) | docker.io (>= 1.9), resolvconf
+Depends: docker-engine (>= 1.9) | docker.io (>= 1.11), resolvconf
 Description: Kontena Agent

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>> 1.9), docker-engine (<< 1.13)
+Depends: docker-engine (>= 1.9) | docker.io (>= 1.9), resolvconf
 Description: Kontena Server

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.9) | docker.io (>= 1.9), resolvconf
+Depends: docker-engine (>= 1.9) | docker.io (>= 1.11), resolvconf
 Description: Kontena Server


### PR DESCRIPTION

* Depends on Docker >= 1.9

* Avoids the Ubuntu Docker 1.10 packages built with Go 1.6 that break Weave
    
* Drops the future-proofing against future Docker releases

