### PR TITLE
Reintroduce kontena register with a link to signup page

### DIFF
--- a/cli/lib/kontena/cli/register_command.rb
+++ b/cli/lib/kontena/cli/register_command.rb
@@ -1,0 +1,9 @@
+module Kontena::Cli
+  class RegisterCommand < Kontena::Command
+    include Kontena::Cli::Common
+
+    def execute
+      exit_with_error "The register command has been removed in this version. Visit https://cloud.kontena.io/sign-up to create a Kontena Cloud account or use: kontena cloud login"
+    end
+  end
+end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -25,6 +25,7 @@ require_relative 'cli/version_command'
 require_relative 'cli/stack_command'
 require_relative 'cli/certificate_command'
 require_relative 'cli/cloud_command'
+require_relative 'cli/register_command'
 
 class Kontena::MainCommand < Kontena::Command
   include Kontena::Util
@@ -47,7 +48,8 @@ class Kontena::MainCommand < Kontena::Command
   subcommand "whoami", "Shows current logged in user", Kontena::Cli::WhoamiCommand
   subcommand "plugin", "Plugin related commands", Kontena::Cli::PluginCommand
   subcommand "version", "Show version", Kontena::Cli::VersionCommand
-  subcommand "login", "Login to Kontena Master (removed, use kontena master login)", Kontena::Cli::LoginCommand
+  subcommand "login", "[DEPRECATED] Login to Kontena Master", Kontena::Cli::LoginCommand
+  subcommand "register", "[DEPRECATED] Register a Kontena Cloud account", Kontena::Cli::RegisterCommand
 
   def execute
   end


### PR DESCRIPTION
Some tutorials may have "kontena register" as one of the first steps, it may scare some people away if the first command in the tutorial just reports "unknown subcommand".

