### PR TITLE
Set cloud master provider and version if provision plugin returns them

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -6,12 +6,17 @@ module Kontena
 
       matches_commands 'master create'
 
-      def configure_auth_provider_using_id(cloud_id)
-        Kontena.run("master init-cloud --force --cloud-master-id #{cloud_id.shellescape}")
+      def init_cloud_args
+        args = []
+        args << '--force' 
+        args << "--cloud-master-id #{command.cloud_master_id}" if command.cloud_master_id
+        args << "--provider #{command.result[:provider]}" if command.result[:provider]
+        args << "--version #{command.result[:version]}" if command.result[:version]
+        args.join(' ')
       end
 
       def configure_auth_provider
-        Kontena.run("master init-cloud --force")
+        Kontena.run("master init-cloud #{init_cloud_args}")
       end
 
       def after
@@ -24,11 +29,7 @@ module Kontena
           return
         end
 
-        if command.respond_to?(:cloud_master_id) && command.cloud_master_id
-          configure_auth_provider_using_id(command.cloud_master_id)
-        else
-          configure_auth_provider
-        end
+        configure_auth_provider
       end
     end
   end

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -94,6 +94,16 @@ module Kontena::Cli::Cloud::Master
         response = spinner "Retrieving Master information from Kontena Cloud using id" do
           get_existing(self.cloud_master_id)
         end
+        if response && response.kind_of?(Hash) && response.has_key?('data') && response['data']['attributes']
+          if (self.provider && response['data']['attributes']['provider'] != self.provider) || (self.version && response['data']['attributes']['version'] != self.version)
+            spinner "Updating provider and version attributes to Kontena Cloud master" do
+              args = []
+              args << "--provider #{self.provider.shellescape}" if self.provider
+              args << "--version #{self.version.shellescape}" if self.version
+              Kontena.run("cloud master update #{args.join(' ')}")
+            end
+          end
+        end
       else
         response = spinner "Registering current Kontena Master '#{current_master.name}' #{" as '#{new_name}' " unless new_name == current_master.name}to Kontena Cloud" do
           register(new_name, current_master.url)

--- a/cli/lib/kontena/cli/cloud/master/update_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/update_command.rb
@@ -38,13 +38,7 @@ module Kontena::Cli::Cloud::Master
 
       response = cloud_client.put(
         "master",
-        { data: { attributes: attrs.reject{ |k, _| ['client-id', 'client-secret'].include?(k) } } },
-        {},
-        cloud_client.basic_auth_header(
-          attrs["client-id"],
-          attrs["client-secret"]
-        ),
-        false
+        { data: { attributes: attrs.reject{ |k, _| ['client-id', 'client-secret'].include?(k) } } }
       )
 
       if response

--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -5,17 +5,22 @@ module Kontena::Cli::Master
 
     banner "Configures the current Kontena Master to use Kontena Cloud services and authentication"
 
-    option '--force',           :flag,  "Don't ask questions"
-    option '--cloud-master-id', '[ID]', "Use existing cloud master ID"
+    option '--force',           :flag,       "Don't ask questions"
+    option '--cloud-master-id', '[ID]',      "Use existing cloud master ID"
+    option '--provider',        '[NAME]',    "Set master provider name"
+    option '--version',         '[VERSION]', "Set master version"
 
     requires_current_master
+    requires_current_master_token
     requires_current_account_token
 
     def execute
       args = ["--current"]
       args << "--force" if self.force?
-      args << "--cloud-master-id #{self.cloud_master_id}" if self.cloud_master_id
-      Kontena.run("cloud master add #{args.map(&:shellescape).join(' ')}")
+      args += ["--cloud-master-id", self.cloud_master_id.shellescape] if self.cloud_master_id
+      args += ["--provider", self.provider.shellescape] if self.provider
+      args += ["--version", self.version.shellescape] if self.version
+      Kontena.run("cloud master add #{args.join(' ')}")
     end
   end
 end


### PR DESCRIPTION
Provision plugin return hash now has `:name`, `:public_ip` and `:code`. Now you can also return `:provider` and `:version` to set them to cloud master attributes during deploy.

