### PR TITLE
Skip init-cloud when not using KC

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -20,7 +20,7 @@ module Kontena
         return unless command.result.has_key?(:name)
         return unless config.current_master
         return unless config.current_master.name == command.result[:name]
-        if command.respond_to?(:skip_auth_provider) && command.skip_auth_provider?
+        if command.respond_to?(:skip_auth_provider?) && command.skip_auth_provider?
           return
         end
 


### PR DESCRIPTION
Auth provider config was not skipped properly because a question mark was missing from the method name in `respond_to?`