### PR TITLE
 Fix Ubuntu xenial kontena-server HTTP/HTTPS ports

### DIFF
--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/templates
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/templates
@@ -1,6 +1,6 @@
 Template: kontena-agent/server_uri
 Type: string
-Default: ws://127.0.0.1:8080
+Default: ws://localhost:8080
 Description: Address of your Kontena server
 
 Template: kontena-agent/grid_token

--- a/agent/packaging/ubuntu_xenial/kontena-agent/etc/kontena-agent.env
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/etc/kontena-agent.env
@@ -1,5 +1,5 @@
 # Set URL of your kontena server
-#KONTENA_URI=wss://localhost:8443
+#KONTENA_URI=ws://127.0.0.1:8080
 
 # Set kontena token
 #KONTENA_TOKEN=

--- a/agent/packaging/ubuntu_xenial/kontena-agent/etc/kontena-agent.env
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/etc/kontena-agent.env
@@ -1,5 +1,5 @@
 # Set URL of your kontena server
-#KONTENA_URI=ws://127.0.0.1:8080
+#KONTENA_URI=ws://localhost:8080
 
 # Set kontena token
 #KONTENA_TOKEN=

--- a/server/packaging/ubuntu_xenial/kontena-server/etc/kontena-server.env
+++ b/server/packaging/ubuntu_xenial/kontena-server/etc/kontena-server.env
@@ -13,8 +13,8 @@
 
 # TCP ports used by clients and agents to connect to the kontena server on the master node
 # Configured as published ports on the Docker kontena-server-haproxy container
-HTTP_PORT=8080
-HTTPS_PORT=8443
+#HTTP_PORT=8080
+#HTTPS_PORT=8443
 
 # SSL Certificate
 #SSL_CERT=/etc/kontena-server.pem

--- a/server/packaging/ubuntu_xenial/kontena-server/etc/kontena-server.env
+++ b/server/packaging/ubuntu_xenial/kontena-server/etc/kontena-server.env
@@ -7,5 +7,14 @@
 # Kontena initial admin code
 #INITIAL_ADMIN_CODE=
 
+## These settings are used by the kontena-server-haproxy.service
+# To reload these settings, use:
+#   systemctl restart kontena-server-haproxy.service
+
+# TCP ports used by clients and agents to connect to the kontena server on the master node
+# Configured as published ports on the Docker kontena-server-haproxy container
+HTTP_PORT=8080
+HTTPS_PORT=8443
+
 # SSL Certificate
 #SSL_CERT=/etc/kontena-server.pem

--- a/server/packaging/ubuntu_xenial/kontena-server/opt/bin/kontena-haproxy.sh
+++ b/server/packaging/ubuntu_xenial/kontena-server/opt/bin/kontena-haproxy.sh
@@ -7,4 +7,4 @@ fi
 /usr/bin/docker run --name=kontena-server-haproxy \
   --link kontena-server-api:kontena-server-api \
   -e SSL_CERT="$SSL_CERT" \
-  -p 80:80 -p 443:443 kontena/haproxy:latest
+  -p ${HTTP_PORT:-8080}:80 -p ${HTTPS_PORT:-8443}:443 kontena/haproxy:latest


### PR DESCRIPTION
Fixes #1182

* Revert to the same default 8080/8443 default ports used in the existing Ubuntu packages

* Use environment variables to document and allow configuration of different ports via `/etc/kontena-server.env`

*  Fix Ubuntu xenial `/etc/kontena-agent.env` example `KONTENA_URI=ws://127.0.0.1:8080` to match the default value configured by debconf.

   The current `wss://localhost:8443` example does not work unless a `SSL_CERT=` is configured.