### PR TITLE
Dont use existing token when --force login to master

### DIFF
--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -108,7 +108,7 @@ module Kontena::Cli::Master
       if self.token
         # Use supplied token
         server.token = Kontena::Cli::Config::Token.new(access_token: self.token, parent_type: :master, parent_name: server.name)
-      elsif server.token.nil?
+      elsif server.token.nil? || self.force?
         # Create new empty token if the server does not have one yet
         server.token = Kontena::Cli::Config::Token.new(parent_type: :master, parent_name: server.name)
       end

--- a/server/app/routes/oauth2/authenticate_api.rb
+++ b/server/app/routes/oauth2/authenticate_api.rb
@@ -52,7 +52,7 @@ module OAuth2Api
           unless user
             mime_halt(403, 'access_denied', 'Invalid invite code') and return
           end
-        elsif current_user
+        elsif current_user && !current_user.is_local_admin?
           user = current_user
         end
 

--- a/server/app/routes/oauth2/callback_api.rb
+++ b/server/app/routes/oauth2/callback_api.rb
@@ -88,8 +88,8 @@ module OAuth2Api
         end
 
         user = state.user || find_user_by_userdata(user_data)
-        unless user
-          halt_request(403, 'Access denid') and return
+        if user.nil? || user.is_local_admin?
+          halt_request(403, 'Access denied') and return
         end
 
         unless update_user_from_userdata(user, user_data)


### PR DESCRIPTION
This PR should make master login not pick up the existing token from config when doing `kontena master login --force`

