### PR TITLE
Ssh command improvements

### DIFF
--- a/cli/lib/kontena/cli/master/config/get_command.rb
+++ b/cli/lib/kontena/cli/master/config/get_command.rb
@@ -12,9 +12,13 @@ module Kontena::Cli::Master::Config
 
     option ['-p', '--pair'], :flag, "Print key=value instead of only value"
 
+    option '--return', :flag, "Return the value", hidden: true
+
     def execute
       if self.pair?
         puts client.get("config/#{self.key}").inspect
+      elsif self.return?
+        return client.get("config/#{self.key}")[self.key]
       else
         puts client.get("config/#{self.key}")[self.key]
       end

--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -1,0 +1,40 @@
+module Kontena::Cli::Master
+  class SshCommand < Kontena::Command
+
+    include Kontena::Cli::Common
+
+    parameter "[COMMANDS] ...", "Run command on host"
+
+    option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
+    option ["-u", "--user"], "USER", "Login as a user", default: "core"
+
+    requires_current_master
+
+    def master_host
+      require 'uri'
+      URI.parse(current_master.url).host
+    end
+
+    def master_provider
+      Kontena.run('master config get --return server.provider', returning: :result)
+    end
+
+    def execute
+      if master_provider == 'vagrant'
+        cmd = "ssh"
+        cmd << " #{self.commands_list.join(' ')}" unless self.commands_list.empty?
+        Kontena.run("vagrant master #{cmd}")
+      else
+        cmd = ['ssh']
+        cmd << "#{user}@#{master_host}"
+        cmd << "-i #{identity_file}" if identity_file
+        if self.commands_list && !self.commands_list.empty?
+          cmd << '--'
+          cmd += self.commands_list
+        end
+        exec(cmd.join(' '))
+      end
+    end
+  end
+end
+

--- a/cli/lib/kontena/cli/master_command.rb
+++ b/cli/lib/kontena/cli/master_command.rb
@@ -11,6 +11,7 @@ require_relative 'master/join_command'
 require_relative 'master/audit_log_command'
 require_relative 'master/token_command'
 require_relative 'master/init_cloud_command'
+require_relative 'master/ssh_command'
 
 class Kontena::Cli::MasterCommand < Kontena::Command
   include Kontena::Util
@@ -27,6 +28,8 @@ class Kontena::Cli::MasterCommand < Kontena::Command
   subcommand "join", "Join Kontena Master using an invitation code", Kontena::Cli::Master::JoinCommand
   subcommand "audit-log", "Show master audit logs", Kontena::Cli::Master::AuditLogCommand
   subcommand "init-cloud", "Configure current master to use Kontena Cloud services", Kontena::Cli::Master::InitCloudCommand
+  subcommand "ssh", "Connect to the master via SSH", Kontena::Cli::Master::SshCommand
+
   if experimental?
     require_relative 'master/create_command'
     subcommand "create", "Install a new Kontena Master", Kontena::Cli::Master::CreateCommand

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -4,28 +4,47 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::GridOptions
 
     parameter "NODE_ID", "Node id"
+    parameter "[COMMANDS] ...", "Run command on host"
+
     option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
     option ["-u", "--user"], "USER", "Login as a user", default: "core"
     option "--private-ip", :flag, "Connect to node's private IP address"
     option "--internal-ip", :flag, "Connect to node's internal IP address (requires VPN connection)"
 
-    def execute
-      require_api_url
-      require_current_grid
-      token = require_token
+    requires_current_master
+    requires_current_grid
 
-      node = client(token).get("nodes/#{current_grid}/#{node_id}")
-      cmd = ['ssh']
-      cmd << "-i #{identity_file}" if identity_file
-      if internal_ip?
-        ip = "10.81.0.#{node['node_number']}"
-      elsif private_ip?
-        ip = node['private_ip']
+    def execute
+      node = client.get("nodes/#{current_grid}/#{node_id}")
+
+      provider = node["labels"].find{ |l| l.start_with?('provider=')}.to_s.split('=').last
+
+      if provider == 'vagrant'
+        unless Kontena::PluginManager.instance.plugins.find { |plugin| plugin.name == 'kontena-plugin-vagrant' }
+          exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'
+        end
+        cmd = "ssh #{node['name']}"
+        if self.commands_list && !self.commands_list.empty?
+          cmd << " " << self.commands_list.join(' ')
+        end
+        Kontena.run("vagrant node #{cmd}")
       else
-        ip = node['public_ip']
+        cmd = ['ssh']
+        cmd << "-i #{identity_file}" if identity_file
+        if internal_ip?
+          ip = "10.81.0.#{node['node_number']}"
+        elsif private_ip?
+          ip = node['private_ip']
+        else
+          ip = node['public_ip']
+        end
+        cmd << "#{user}@#{ip}"
+        if self.commands_list && !self.commands_list.empty?
+          cmd << '--'
+          cmd += self.commands_list
+        end
+        exec(cmd.join(' '))
       end
-      cmd << "#{user}@#{ip}"
-      exec(cmd.join(" "))
     end
   end
 end

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::Nodes
     def execute
       node = client.get("nodes/#{current_grid}/#{node_id}")
 
-      provider = node["labels"].find{ |l| l.start_with?('provider=')}.to_s.split('=').last
+      provider = Array(node["labels"]).find{ |l| l.start_with?('provider=')}.to_s.split('=').last
 
       commands_list.insert('--') unless commands_list.empty?
 

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -4,12 +4,19 @@ module Kontena
   # @example
   #   Kontena.run("grid list --help")
   #
-  # @param [String] command_line
+  # @param [String,Array<String>] command_line
   # @return [Fixnum] exit_code
-  def self.run(cmdline = "", returning: :status)
-    ENV["DEBUG"] && STDERR.puts("Running Kontena.run(#{cmdline.inspect}, returning: #{returning}")
-    result = Kontena::MainCommand.new(File.basename(__FILE__)).run(cmdline.shellsplit)
-    ENV["DEBUG"] && STDERR.puts("Command completed, result: #{result.inspect} status: 0")
+  def self.run(*cmdline, returning: :status)
+    if cmdline.first.kind_of?(Array)
+      command = cmdline.first
+    elsif cmdline.size == 1 && cmdline.first.include?(' ')
+      command = cmdline.first.shellsplit
+    else
+      command = cmdline
+    end
+    ENV["DEBUG"] && puts("Running Kontena.run(#{command.inspect}, returning: #{returning}")
+    result = Kontena::MainCommand.new(File.basename(__FILE__)).run(command)
+    ENV["DEBUG"] && puts("Command completed, result: #{result.inspect} status: 0")
     return 0 if returning == :status
     return result if returning == :result
   rescue SystemExit

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../spec_helper'
+require 'kontena_cli'
+
+describe Kontena do
+  let(:subject) { described_class }
+
+  describe '#run' do
+    let(:whoami) { double(:whoami_command) }
+
+    before(:each) do
+      expect(Kontena::MainCommand).to receive(:new).and_call_original
+      expect(Kontena::Cli::WhoamiCommand).to receive(:new).and_return(whoami)
+      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
+    end
+
+    it 'accepts a command line as string' do
+      subject.run('whoami --bash-completion-path')
+    end
+
+    it 'accepts a command line as a list of parameters' do
+      subject.run('whoami', '--bash-completion-path')
+    end
+
+    it 'accepts a command line as an array' do
+      subject.run(['whoami', '--bash-completion-path'])
+    end
+  end
+end


### PR DESCRIPTION
```
$ kontena master ssh docker logs kontena-server-api
192.168.66.1 - - [25/Oct/2016:12:29:17 +0000] "GET /v1/config/server.provider HTTP/1.1" 200 29 0.0678
192.168.66.1 - - [25/Oct/2016:12:32:19 +0000] "GET /v1/config/server.provider HTTP/1.1" 200 29 0.0754
...
Connection to 127.0.0.1 closed.
```

```
$ kontena node ssh echo foo
foo
Connection to 127.0.0.1 closed.
```

Node ssh uses vagrant plugin if labels include `provider=vagrant`.
Master ssh uses vagrant plugin if master config has `server.provider=vagrant`. (which it doesn't unless you put it there manually)

Gets master host from `URI.parse(current_master.url).host` <-- maybe there is a more correct way?
