### PR TITLE
Reload config after cloud login

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
@@ -1,17 +1,17 @@
-module Kontena
-  module Callbacks
-    class BeforeDeployConfigurationWizard < Kontena::Callback
+module kontena
+  module callbacks
+    class beforedeployconfigurationwizard < kontena::callback
 
-      include Kontena::Cli::Common
+      include kontena::cli::common
 
       matches_commands 'master create'
 
       def after_load
         command.class_eval do
-          option ['--no-prompt'], :flag, "Don't ask questions"
-          option ['--skip-auth-provider'], :flag, "Skip auth provider configuration (single user mode)"
-          option ['--use-kontena-cloud'], :flag, "Use Kontena Cloud as authentication provider"
-          option ['--cloud-master-id'], '[ID]', "Use Kontena Cloud Master ID for auth provider configuration"
+          option ['--no-prompt'], :flag, "don't ask questions"
+          option ['--skip-auth-provider'], :flag, "skip auth provider configuration (single user mode)"
+          option ['--use-kontena-cloud'], :flag, "use kontena cloud as authentication provider"
+          option ['--cloud-master-id'], '[id]', "use kontena cloud master id for auth provider configuration"
         end
       end
 
@@ -21,7 +21,7 @@ module Kontena
         yield
       end
 
-      # Scans config server names and returns default-2 if default exists,
+      # scans config server names and returns default-2 if default exists,
       # default-3 if default-2 exists, etc.
       def next_default_name
         last_default = config.servers.map(&:name).select{ |n| n =~ /kontena\-master(?:\-\d+)?$/ }.sort.last
@@ -37,10 +37,12 @@ module Kontena
           return true if cloud_client.authentication_ok?(kontena_account.userinfo_endpoint)
         end
         puts
-        puts "You don't seem to be logged in to Kontena Cloud"
+        puts "you don't seem to be logged in to kontena cloud"
         puts
-        Kontena.run("cloud login --verbose")
+        kontena.run("cloud login --verbose")
         result = false
+        config.reset_instance
+        reset_cloud_client
         Retriable.retriable do
           result = cloud_client.authentication_ok?(kontena_account.userinfo_endpoint)
         end

--- a/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
@@ -1,17 +1,17 @@
-module kontena
-  module callbacks
-    class beforedeployconfigurationwizard < kontena::callback
+module Kontena
+  module Callbacks
+    class BeforeDeployConfigurationWizard < Kontena::Callback
 
-      include kontena::cli::common
+      include Kontena::Cli::Common
 
       matches_commands 'master create'
 
       def after_load
         command.class_eval do
-          option ['--no-prompt'], :flag, "don't ask questions"
-          option ['--skip-auth-provider'], :flag, "skip auth provider configuration (single user mode)"
-          option ['--use-kontena-cloud'], :flag, "use kontena cloud as authentication provider"
-          option ['--cloud-master-id'], '[id]', "use kontena cloud master id for auth provider configuration"
+          option ['--no-prompt'], :flag, "Don't ask questions"
+          option ['--skip-auth-provider'], :flag, "Skip auth provider configuration (single user mode)"
+          option ['--use-kontena-cloud'], :flag, "Use Kontena Cloud as authentication provider"
+          option ['--cloud-master-id'], '[ID]', "Use Kontena Cloud Master ID for auth provider configuration"
         end
       end
 
@@ -21,7 +21,7 @@ module kontena
         yield
       end
 
-      # scans config server names and returns default-2 if default exists,
+      # Scans config server names and returns default-2 if default exists,
       # default-3 if default-2 exists, etc.
       def next_default_name
         last_default = config.servers.map(&:name).select{ |n| n =~ /kontena\-master(?:\-\d+)?$/ }.sort.last
@@ -37,12 +37,12 @@ module kontena
           return true if cloud_client.authentication_ok?(kontena_account.userinfo_endpoint)
         end
         puts
-        puts "you don't seem to be logged in to kontena cloud"
+        puts "You don't seem to be logged in to Kontena Cloud"
         puts
-        kontena.run("cloud login --verbose")
-        result = false
+        Kontena.run("cloud login --verbose")
         config.reset_instance
         reset_cloud_client
+        result = false
         Retriable.retriable do
           result = cloud_client.authentication_ok?(kontena_account.userinfo_endpoint)
         end

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -120,6 +120,8 @@ module Kontena::Cli::Cloud
         config.write
         display_logo
         display_login_info(only: :account)
+        config.reset_instance
+        reset_cloud_client
         exit 0
       else
         puts "Authentication failed".colorize(:red)

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -112,6 +112,8 @@ module Kontena::Cli::Cloud::Master
     def execute
       unless cloud_client.authentication_ok?(kontena_account.userinfo_endpoint)
         Kontena.run('cloud login')
+        config.reset_instance
+        reset_cloud_client
       end
 
       return register_current if self.current?

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -166,6 +166,10 @@ module Kontena
         @cloud_client ||= Kontena::Client.new(kontena_account.url, kontena_account.token, prefix: '/')
       end
 
+      def reset_cloud_client
+        @cloud_client = nil
+      end
+
       def client(token = nil, api_url = nil)
         if token.kind_of?(String)
           token = Kontena::Cli::Config::Token.new(access_token: token)


### PR DESCRIPTION
Config needs to be reloaded by the caller when doing Kontena.run('cloud login')
