### PR TITLE
Better error messages when auth code exchange fails

### DIFF
--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -119,26 +119,24 @@ module Kontena::Cli::Master
         client = Kontena::Client.new(server.url, server.token)
         begin
           response = client.exchange_code(code)
-        rescue
-          ENV["DEBUG"] && puts("#{$!} : #{$!.message}\n#{$!.backtrace.join("  \n")}")
-          exit_with_error "Code exchange failed: #{$!.message}"
+        rescue StandardError => ex
+          ENV["DEBUG"] && puts("#{ex}\n#{ex.backtrace.join("  \n")}")
+          exit_with_error "Code exchange failed: #{ex}"
         end
 
-        if response && response.kind_of?(Hash) && !response.has_key?('error')
-          if response['server'] && response['server']['name']
-            server.name ||= response['server']['name']
-            server.username = response['user']['name'] || response['user']['email']
-            config.current_server = server.name
-          end
-
-          server.token = Kontena::Cli::Config::Token.new(
-            access_token: response['access_token'],
-            refresh_token: response['refresh_token'],
-            expires_at: response['expires_in'].to_i > 0 ? Time.now.utc.to_i + response['expires_in'].to_i : nil,
-          )
+        if response['server'] && response['server']['name']
+          server.name ||= response['server']['name']
+          server.username = response['user']['name'] || response['user']['email']
+          config.current_server = server.name
         else
-          raise Kontena::Errors::StandardError.new(500, 'Code exchange failed')
+          raise Kontena::Errors::StandardError.new(500, 'Code exchange invalid response')
         end
+
+        server.token = Kontena::Cli::Config::Token.new(
+          access_token: response['access_token'],
+          refresh_token: response['refresh_token'],
+          expires_at: response['expires_in'].to_i > 0 ? Time.now.utc.to_i + response['expires_in'].to_i : nil,
+        )
       end
       true
     end

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -117,7 +117,12 @@ module Kontena::Cli::Master
     def use_authorization_code(server, code)
       vspinner "Exchanging authorization code for an access token from Kontena Master" do
         client = Kontena::Client.new(server.url, server.token)
-        response = client.exchange_code(code) rescue nil
+        begin
+          response = client.exchange_code(code)
+        rescue
+          ENV["DEBUG"] && puts("#{$!} : #{$!.message}\n#{$!.backtrace.join("  \n")}")
+          exit_with_error "Code exchange failed: #{$!.message}"
+        end
 
         if response && response.kind_of?(Hash) && !response.has_key?('error')
           if response['server'] && response['server']['name']


### PR DESCRIPTION
```
$ kontena master login --code foo https://127.0.0.1:27017
 [error] Code exchange failed: SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A (OpenSSL::SSL::SSLError)state=SSLv2/v3 read server hello A  
$ kontena master login --code foofoo https://localhost:27010
 [error] Code exchange failed: Connection refused - connect(2) for 127.0.0.1:27010 (Errno::ECONNREFUSED)
```
