### PR TITLE
Adjust node ls name column width automatically

### DIFF
--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::GridOptions
 
     option ['-a', '--all'], :flag, "List nodes for all grids", default: false
-    option ['-w', '--wide'], :flag, "Don't truncate lines"
+    option ['-l', '--long'], :flag, "Don't truncate lines"
 
     def term_width
       return @width if @width
@@ -49,7 +49,7 @@ module Kontena::Cli::Nodes
           node['name'], node['connected'] ? 'online' : 'offline',
           node['initial_member'] ? 'yes' : 'no',
           node['labels'].join(',')
-        if !wide? && line.length > term_width - 1
+        if !long? && line.length > term_width - 1
           puts line[0..term_width-3] + ".."
         else
           puts line

--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -3,7 +3,20 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    option ["--all"], :flag, "List nodes for all grids", default: false
+    option ['-a', '--all'], :flag, "List nodes for all grids", default: false
+    option ['-w', '--wide'], :flag, "Don't truncate lines"
+
+    def max_node_name_length(nodes)
+      if nodes.nil? || nodes.empty?
+        10
+      else
+        nodes.map {|n| n['name'].length}.max
+      end
+    end
+
+    def grid_nodes(grid_name)
+      client.get("grids/#{grid_name}/nodes")['nodes']
+    end
 
     def execute
       require_api_url
@@ -11,36 +24,29 @@ module Kontena::Cli::Nodes
       token = require_token
 
       if all?
-        grids = client(token).get("grids")
-        puts "%-70s %-10s %-40s" % [ 'Name', 'Status', 'Labels']
-
-        grids['grids'].each do |grid|
-          nodes = client(token).get("grids/#{grid['name']}/nodes")
-          nodes['nodes'].each do |node|
-            if node['connected']
-              status = 'online'
-            else
-              status = 'offline'
-            end
-            puts "%-70.70s %-10s %-40s" % [
-              "#{grid['name']}/#{node['name']}",
-              status,
-              (node['labels'] || ['-']).join(",")
-            ]
-          end
+        grids = client.get('grids')['grids']
+        nodes = grids.flat_map do |grid|
+          items = grid_nodes(grid['name'])
+          items.each {|i| i['name'] = "#{grid['name']}/#{i['name']}"}
+          items
         end
       else
-        nodes = client(token).get("grids/#{current_grid}/nodes")
-        puts "%-70s %-10s %-10s %-40s" % ['Name', 'Status', 'Initial', 'Labels']
-        nodes = nodes['nodes'].sort_by{|n| n['node_number'] }
-        nodes.each do |node|
-          puts "%-70.70s %-10s %-10s %-40s" % [
-            node['name'],
-            node['connected'] ? 'online' : 'offline',
-            node['initial_member'] ? 'yes' : 'no',
-            (node['labels'] || ['-']).join(",")
-          ]
+        nodes = grid_nodes(current_grid)
+      end
+
+      max_length = max_node_name_length(nodes)
+      puts "%-#{max_length}s %-7s %-7s %-40s" % [ all? ? 'Grid/Name' : 'Name', 'Status', 'Initial', 'Labels']
+      nodes.each do |node|
+        labels = node['labels'].join(',')
+        if !wide? && labels.length > 40
+          labels = labels[0..37] + ".."
         end
+        puts "%-#{max_length}.#{max_length}s %-7.7s %-7.7s %-40s" % [
+          node['name'],
+          node['connected'] ? 'online' : 'offline',
+          node['initial_member'] ? 'yes' : 'no',
+          labels
+        ]
       end
     end
   end


### PR DESCRIPTION
Field width for node name now automatically set to the longest node name.

Lines now truncated to terminal width unless `-l|--long` given.

Fixes #1110 
