### PR TITLE
Fix ubuntu/bintray repo issues

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ Dotenv.load
 
 VERSION = File.read('./VERSION').strip
 UBUNTU_IMAGE = 'kontena-ubuntu-build'
-UBUNTU_REPO = ENV['UBUNTU_REPO'] || 'kontena'
+UBUNTU_REPO = ENV['UBUNTU_REPO'] || 'ubuntu'
 PKG_REV = ENV['PKG_REV'] || '1'
 
 namespace :release do

--- a/agent/lib/tasks/release.rake
+++ b/agent/lib/tasks/release.rake
@@ -72,7 +72,7 @@ namespace :release do
 
   desc 'Push ubuntu packages'
   task :push_ubuntu => :environment do
-    repo = ENV['REPO'] || 'kontena'
+    repo = ENV['REPO'] || 'ubuntu'
     bintray_user = ENV['BINTRAY_USER']
     bintray_key = ENV['BINTRAY_KEY']
     rev = ENV['REV']
@@ -81,9 +81,10 @@ namespace :release do
     raise ArgumentError.new('You must define REV') if rev.blank?
     sh('rm -rf release && mkdir release')
     sh('cp build/ubuntu/*.deb release/')
-    sh('rm -rf release_xenial && mkdir release_xenial')
-    sh('cp build/ubuntu_xenial/*.deb release_xenial/')
-    sh("curl -T ./release/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{bintray_user}:#{bintray_key} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/#{NAME}-#{VERSION}-#{rev}_all.deb;deb_distribution=trusty;deb_component=main;deb_architecture=amd64'")
-    sh("curl -T ./release_xenial/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{bintray_user}:#{bintray_key} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/#{NAME}-#{VERSION}-#{rev}_all.deb;deb_distribution=xenial;deb_component=main;deb_architecture=amd64'")
+    sh("curl -T ./release/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{bintray_user}:#{bintray_key} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/pool/main/k/#{NAME}-#{VERSION}-#{rev}~trusty_all.deb;deb_distribution=trusty;deb_component=main;deb_architecture=amd64'")
+
+    sh('rm -rf release && mkdir release')
+    sh('cp build/ubuntu/*.deb release/')
+    sh("curl -T ./release/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{bintray_user}:#{bintray_key} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/pool/main/k/#{NAME}-#{VERSION}-#{rev}~xenial_all.deb;deb_distribution=xenial;deb_component=main;deb_architecture=amd64'")
   end
 end

--- a/docs/getting-started/installing/ubuntu.md
+++ b/docs/getting-started/installing/ubuntu.md
@@ -36,9 +36,21 @@ $ sudo apt-get install docker-engine=1.12.2-0~trusty
 
 Kontena Master is an orchestrator component that manages Kontena Grids/Nodes. Installing Kontena Master to Ubuntu can be done by just installing kontena-server package:
 
+
+#### Ubuntu Xenial (16.04)
+
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/kontena /" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee -a /etc/apt/sources.list
+$ sudo apt-get update
+$ sudo apt-get install kontena-server
+```
+
+#### Ubuntu Trusty (14.04)
+
+```
+$ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
+$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-server
 ```
@@ -106,9 +118,20 @@ $ kontena grid show --token test-grid
 
 Now you can go ahead and install kontena-agent Ubuntu package:
 
+#### Ubuntu Xenial (16.04)
+
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/kontena /" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee -a /etc/apt/sources.list
+$ sudo apt-get update
+$ sudo apt-get install kontena-agent
+```
+
+#### Ubuntu Trusty (14.04)
+
+```
+$ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
+$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-agent
 ```

--- a/server/lib/tasks/release.rake
+++ b/server/lib/tasks/release.rake
@@ -58,14 +58,14 @@ namespace :release do
   desc 'Upload ubuntu packages'
   task :push_ubuntu do
     rev = ENV['REV'] || '1'
-    repo = ENV['REPO'] || 'kontena'
+    repo = ENV['REPO'] || 'ubuntu'
     sh('rm -rf release && mkdir release')
     sh('cp build/ubuntu/*.deb release/')
-    sh("curl -T ./release/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{BINTRAY_USER}:#{BINTRAY_KEY} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/#{NAME}-#{VERSION}-#{rev}_all.deb;deb_distribution=trusty;deb_component=main;deb_architecture=amd64'")
+    sh("curl -T ./release/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{BINTRAY_USER}:#{BINTRAY_KEY} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/pool/main/k/#{NAME}-#{VERSION}-#{rev}~trusty_all.deb;deb_distribution=trusty;deb_component=main;deb_architecture=amd64'")
 
-    sh('rm -rf release_xenial && mkdir release_xenial')
-    sh('cp build/ubuntu_xenial/*.deb release_xenial/')
-    sh("curl -T ./release_xenial/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{BINTRAY_USER}:#{BINTRAY_KEY} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/#{NAME}-#{VERSION}-#{rev}_all.deb;deb_distribution=xenial;deb_component=main;deb_architecture=amd64'")
+    sh('rm -rf release && mkdir release')
+    sh('cp build/ubuntu_xenial/*.deb release/')
+    sh("curl -T ./release/#{NAME}_#{VERSION}-#{rev}_all.deb -u#{BINTRAY_USER}:#{BINTRAY_KEY} 'https://api.bintray.com/content/kontena/#{repo}/#{NAME}/#{VERSION}/pool/main/k/#{NAME}-#{VERSION}-#{rev}~xenial_all.deb;deb_distribution=xenial;deb_component=main;deb_architecture=amd64'")
   end
 
   desc 'Upload docker image'


### PR DESCRIPTION
Changes ubuntu repo location because old one does not support multiple ubuntu versions properly.

**From bintray docs:**

There are two supported repository metadata layouts:

“Trivial”
This is the deprecated repository layout, however it is still used quite commonly. In this layout all the metadata files are stored in the root directory of the repository, so it can be useful when you are only hosting a bunch of files with no well defined structure in the repository.

“Automatic”
This is the default layout, and it contains information on the included distributions. Each distribution can include multiple components (e.g. “main”, “free”, …), each component can include multiple architectures (e.g. “amd64”, “i386”, …).


Old one is "trivial"....