### PR TITLE
Add script security to openVPN config output

### DIFF
--- a/cli/lib/kontena/cli/vpn/config_command.rb
+++ b/cli/lib/kontena/cli/vpn/config_command.rb
@@ -10,6 +10,7 @@ module Kontena::Cli::Vpn
       stdout, stderr = client(require_token).post("containers/#{current_grid}/vpn/vpn-1/exec", payload)
       if linux?
         stdout << "\n"
+        stdout << "script-security 2 system\n"
         stdout << "up /etc/openvpn/update-resolv-conf\n"
         stdout << "down /etc/openvpn/update-resolv-conf\n"
       end


### PR DESCRIPTION
Added `script-security 2 system` to config output. Fixes #1230.

See https://openvpn.net/index.php/open-source/documentation/manuals/69-openvpn-21.html (--script-security) for details.