### PR TITLE
[WIP] Agent weaveexec error handling

### DIFF
--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -30,7 +30,7 @@ module Kontena
       # @return [Boolean]
       def wait_running?(timeout = 10.0, &block)
         wait = Time.now.to_f + timeout
-        until running = running? || (wait < Time.now.to_f)
+        until (running = running?) || (wait < Time.now.to_f)
           yield if block # debugging
           sleep 0.5
         end

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -5,11 +5,43 @@ module Kontena
   module Helpers
     module WeaveHelper
 
+      # @param [String] image
       # @return [Boolean]
-      def weave_running?
+      def adapter_image?(image)
+        image.to_s.include?(WEAVEEXEC_IMAGE)
+      rescue
+        false
+      end
+
+      def router_image?(image)
+        image.to_s == "#{WEAVE_IMAGE}:#{WEAVE_VERSION}"
+      rescue
+        false
+      end
+
+      # @return [Boolean]
+      def running?
         weave = Docker::Container.get('weave') rescue nil
-        return false if weave.nil?
-        weave.info['State']['Running'] == true
+        !weave.nil? && weave.running?
+      end
+
+      # @yield before sleeping
+      # @param timeout [Float] seconds
+      # @return [Boolean]
+      def wait_running?(timeout = 10.0, &block)
+        wait = Time.now.to_f + timeout
+        until running = running? || (wait < Time.now.to_f)
+          yield if block # debugging
+          sleep 0.5
+        end
+        return running
+      end
+
+      # @raise [Kontena::NetworkAdapters::WeaveError] not running
+      def wait_running!(timeout = 30.0, &block)
+        if !wait_running?(timeout, &block)
+          raise Kontena::NetworkAdapters::WeaveError, "timeout waiting for weave to be running"
+        end
       end
 
       # @param [String] container_id

--- a/agent/lib/kontena/logging.rb
+++ b/agent/lib/kontena/logging.rb
@@ -49,8 +49,7 @@ module Kontena
     # Send an error message for an exception
     # @param [Exception] exception
     def error_exception(exception, string)
-      logger.error(self.class.name) { string }
-      logger.error(self.class.name) { exception.backtrace.join("\n") }
+      logger.error(self.class.name) { "#{string}\n#{exception.backtrace.join("\n")}" }
     end
   end
 end

--- a/agent/lib/kontena/logging.rb
+++ b/agent/lib/kontena/logging.rb
@@ -45,5 +45,12 @@ module Kontena
     def error(string)
       logger.error(self.class.name) { string }
     end
+
+    # Send an error message for an exception
+    # @param [Exception] exception
+    def error_exception(exception, string)
+      logger.error(self.class.name) { string }
+      logger.error(self.class.name) { exception.backtrace.join("\n") }
+    end
   end
 end

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -195,11 +195,12 @@ module Kontena::NetworkAdapters
         exec_params += ['--trusted-subnets', trusted_subnets.join(',')] if trusted_subnets
         self.exec(exec_params)
 
-        if wait_running! { debug "start: waiting for weave to be running..." }
-
-          warn "reset weave router"
+        if !wait_running? { debug "start: waiting for weave to be running..." }
+          warn "reset weave router on unsuccesfull start: #{error}"
 
           self.exec(['--local', 'reset'])
+
+          raise WeaveError, "weave did not start running"
         end
       end
 

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -166,7 +166,7 @@ module Kontena::NetworkAdapters
     # @param [String] topic
     # @param [Hash] info
     def on_node_info(topic, info)
-      # Let the actor crash on errors
+      # Let the actor crash on start errors
       async.start(info)
     end
 
@@ -185,7 +185,7 @@ module Kontena::NetworkAdapters
 
       peer_ips = info['peer_ips'] || []
       trusted_subnets = info.dig('grid', 'trusted_subnets')
-      until running? do
+      if !running?
         info "starting weave router..."
 
         exec_params = [

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -188,7 +188,7 @@ module Kontena::NetworkAdapters
           raise "weaveexec exit #{status_code}: #{cmd}\n#{logs}"
         end
       ensure
-        container.delete(v: true)
+        container.delete(force: true, v: true)
       end
     end
 

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -24,7 +24,7 @@ module Kontena
         end
         service_container = get_container(service_pod.name)
 
-        sleep 1 until Celluloid::Actor[:network_adapter].running?
+        Celluloid::Actor[:network_adapter].wait_running! { debug "waiting for weave to be running..." }
 
         if service_container
           if service_uptodate?(service_container)

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -24,7 +24,9 @@ module Kontena
         end
         service_container = get_container(service_pod.name)
 
-        Celluloid::Actor[:network_adapter].wait_running! { debug "waiting for weave to be running..." }
+        if !Celluloid::Actor[:network_adapter].wait_running? { debug "waiting for weave to be running..." }
+          raise "Timeout waiting for weave to be running"
+        end
 
         if service_container
           if service_uptodate?(service_container)

--- a/agent/lib/kontena/workers/event_worker.rb
+++ b/agent/lib/kontena/workers/event_worker.rb
@@ -3,6 +3,7 @@ module Kontena::Workers
     include Celluloid
     include Celluloid::Notifications
     include Kontena::Logging
+    include Kontena::Helpers::WeaveHelper
 
     EVENT_NAME = 'container:event'
 
@@ -72,7 +73,7 @@ module Kontena::Workers
 
     # @param [Docker::Event] event
     def publish_event(event)
-      return if Actor[:network_adapter].adapter_image?(event.from)
+      return if adapter_image?(event.from)
 
       data = {
         event: EVENT_NAME,

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -52,6 +52,8 @@ module Kontena::Workers
 
     # @param [Docker::Container] container
     def weave_attach(container)
+      container.name # preload for rescue case
+
       wait_running! { debug "weave_attach: waiting for weave to be running..." }
 
       config = container.info['Config'] || container.json['Config']

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -21,7 +21,7 @@ module Kontena::Workers
     end
 
     def start
-      sleep 1 until weave_running?
+      wait_running! { debug "start: waiting for weave to be running..." }
       info 'attaching network to existing containers'
       Docker::Container.all(all: false).each do |container|
         self.weave_attach(container)
@@ -29,7 +29,7 @@ module Kontena::Workers
     end
 
     def on_dns_add(topic, event)
-      sleep 1 until weave_running?
+      wait_running! { debug "on_dns_add: waiting for weave to be running..." }
       add_dns(event[:id], event[:ip], event[:name])
     end
 
@@ -37,17 +37,14 @@ module Kontena::Workers
     # @param [Docker::Event] event
     def on_container_event(topic, event)
       if event.status == 'start'
-        sleep 1 until weave_running?
         container = Docker::Container.get(event.id) rescue nil
         if container
           self.weave_attach(container)
         end
       elsif event.status == 'destroy'
-        sleep 1 until weave_running?
         self.weave_detach(event)
       elsif event.status == 'restart'
-        sleep 1 until weave_running?
-        if Actor[:network_adapter].router_image?(event.from)
+        if router_image?(event.from)
           self.start
         end
       end
@@ -55,6 +52,8 @@ module Kontena::Workers
 
     # @param [Docker::Container] container
     def weave_attach(container)
+      wait_running! { debug "weave_attach: waiting for weave to be running..." }
+
       config = container.info['Config'] || container.json['Config']
       labels = config['Labels'] || {}
       overlay_cidr = labels['io.kontena.container.overlay_cidr']
@@ -63,6 +62,10 @@ module Kontena::Workers
         service_name = labels['io.kontena.service.name']
         grid_name = labels['io.kontena.grid.name']
         ip = overlay_cidr.split('/')[0]
+
+        Actor[:network_adapter].attach_container(container, overlay_cidr)
+
+        # register DNS names once attached
         dns_names = [
           "#{container_name}.kontena.local",
           "#{service_name}.kontena.local",
@@ -72,18 +75,22 @@ module Kontena::Workers
         dns_names.each do |name|
           add_dns(container.id, ip, name)
         end
-
-        Actor[:network_adapter].exec(['--local', 'attach', overlay_cidr, '--rewrite-hosts', container.id])
       end
     rescue Docker::Error::NotFoundError => error
       warn "ignoring weave attach for missing container: #{error}"
+    rescue => error
+      error_exception error, "weave attach for container #{container.name}: #{error}"
     end
 
     # @param [Docker::Event] event
     def weave_detach(event)
+      wait_running! { debug "weave_detach: waiting for weave to be running..." }
+
       remove_dns(event.id)
     rescue Docker::Error::NotFoundError => error
       warn "ignoring weave detach for missing container: #{error}"
+    rescue => error
+      error_exception error, "weave detach for container #{event.id}: #{error}"
     end
   end
 end

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -75,21 +75,15 @@ module Kontena::Workers
 
         Actor[:network_adapter].exec(['--local', 'attach', overlay_cidr, '--rewrite-hosts', container.id])
       end
-    rescue Docker::Error::NotFoundError
-
-    rescue => exc
-      error "#{exc.class.name}: #{exc.message}"
-      error exc.backtrace.join("\n")
+    rescue Docker::Error::NotFoundError => error
+      warn "ignoring weave attach for missing container: #{error}"
     end
 
     # @param [Docker::Event] event
     def weave_detach(event)
       remove_dns(event.id)
-    rescue Docker::Error::NotFoundError
-
-    rescue => exc
-      error exc.message
-      error exc.backtrace.join("\n")
+    rescue Docker::Error::NotFoundError => error
+      warn "ignoring weave detach for missing container: #{error}"
     end
   end
 end


### PR DESCRIPTION
TODO on things like testing all the error cases. It would probably be a good idea to split out the harmless logging stuff from the actual error handling changes...

Fixes #1178
- Raise on weaveexec errors (including output logs in the message)
- Only launch weave router if not already running
- Remove error handling/retry logic, and let the weave actor crash if start fails
  
  Rely on the celluloid supervisor restarting the actor instead. 
- Trap exec errors on `container_attach` (don't want the weave actor to crash)
- Minimize dependencies on the weave actor, using helper methods instead
- Limit wait-for-weave-to-be-running to a 10/30s timeout, and log debug messages showing which class is spinning in wait.
- Log weave actions and errors
  - Each `weavexec` error is logged at **_warn**_ on retry, and **_error**_ when raising.
  - Trapped errors are logged at **_error**_ (using `error_exception` with backtrace).
  - Ignored errors are logged at `warn`.
  - Weave actions like start, attach are logged at `info`
  - Each weaveexec and `wait_running` sleep is logged at `debug`
  - Use `WEAVE_DEBUG=1` for extreme `weaveexec` details.
## Fixes
- The current [Weave#start sleep loop](https://github.com/kontena/kontena/blob/v0.16.0/agent/lib/kontena/network_adapters/weave.rb#L195) is broken if `Docker::Container.get('weave')` raises any exception after the `weaveexec launch-router`:

``` ruby
        weave = Docker::Container.get('weave') rescue nil
        wait = Time.now.to_f + 10.0
        sleep 0.5 until (weave && weave.running?) || (wait < Time.now.to_f)
```

If the `weave = ... rescue nil` is nil then it will remain nil regardless if how long you sleep.
## TODO
- Fix `Kontena::NetworkAdapters::Weave` to retry `start()` with the existing `node_info` after crashing...
