### PR TITLE
Strip possible trailing arguments from remote code display

### DIFF
--- a/server/app/views/static/code.html
+++ b/server/app/views/static/code.html
@@ -7,7 +7,7 @@
     Enter this command to complete authentication:
     </p>
     <div style='background: black; color: white; font-family: "Lucida Console", Monaco, monospace; padding: 10px 10px 10px 10px;'>
-      kontena master login --code <script>document.write(window.location.hash.split('code=')[1]);</script> <script>document.write(window.location.origin);</script>
+      kontena master login --code <script>document.write(window.location.hash.split('code=')[1].split('&')[0]);</script> <script>document.write(window.location.origin);</script>
     </div>
   </body>
 </html>


### PR DESCRIPTION
`http://foo/code#code=abcd&server_name=foofoo` resulted in the code being shown as `abcd&server_name=foofoo` when performing login with --remote.


