### PR TITLE
Add auth references in installation guides

### DIFF
--- a/docs/getting-started/installing/coreos.md
+++ b/docs/getting-started/installing/coreos.md
@@ -136,7 +136,8 @@ $ cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1
 
 The SSL certificate specified is a pem file, containing a public certificate followed by a private key (the public certificate must be put before the private key, order matters).
 
-After Kontena Master has provisioned you will be automatically authenticated as the Kontena Master internal administrator and the default grid 'test' is set as the current grid.
+
+After Kontena Master has started you can authenticate as the Kontena Master internal administrator using the `INITIAL_ADMIN_CODE` you provided. Refer to [authetication](../../using-kontena/authentication.md) how to login with the admin code and how to configure [Kontena Cloud](https://cloud.kontena.io) as the authentication provider.
 
 ## Installing Kontena Nodes
 

--- a/docs/getting-started/installing/docker-compose.md
+++ b/docs/getting-started/installing/docker-compose.md
@@ -71,7 +71,7 @@ cat certificate.crt privateKey.key > cert.pem
 
 **Step 2:** Run the command `docker-compose up -d`
 
-After Kontena Master has provisioned you will be automatically authenticated as the Kontena Master internal administrator and the default grid 'test' is set as the current grid.
+After Kontena Master has started you can authenticate as the Kontena Master internal administrator using the `INITIAL_ADMIN_CODE` you provided. Refer to [authetication](../../using-kontena/authentication.md) how to login with the admin code and how to configure [Kontena Cloud](https://cloud.kontena.io) as the authentication provider.
 
 ## Installing Kontena Nodes
 

--- a/docs/getting-started/installing/ubuntu.md
+++ b/docs/getting-started/installing/ubuntu.md
@@ -88,7 +88,8 @@ $ sudo start kontena-server-haproxy
 
 ### Login to Kontena Master
 
-After Kontena Master has provisioned you will be automatically authenticated as the Kontena Master internal administrator and the default grid 'test' is set as the current grid. Login with the same initial admin code when you setup the master.
+
+After Kontena Master has started you can authenticate as the Kontena Master internal administrator using the `INITIAL_ADMIN_CODE` you provided. Refer to [authetication](../../using-kontena/authentication.md) how to configure [Kontena Cloud](https://cloud.kontena.io) as the authentication provider.
 
 ```
 kontena master login --name some-name --code <admin code> https://master_ip:8443

--- a/docs/using-kontena/authentication.md
+++ b/docs/using-kontena/authentication.md
@@ -22,7 +22,7 @@ If you are installing a fresh Kontena Master v0.16.0 or newer this happens autom
 $ kontena cloud login
 ```
 
-If you have upgraded your Kontena Master from a previous version you can configure it to use Kontena Cloud by using the command:
+If you have upgraded your Kontena Master from a previous version or installed Kontena without Kontena CLI plugins you can configure it to use Kontena Cloud by using the command:
 
 ```
 $ kontena master init-cloud


### PR DESCRIPTION
Installation guides didn't have references to auth guides so users missed the `kontena master init-cloud` step when setting up master with e.g. compose.