### PR TITLE
Fix Agent IfaceHelper#interface_ip Errno::EADDRNOTAVAIL case

### DIFF
--- a/agent/lib/kontena/helpers/iface_helper.rb
+++ b/agent/lib/kontena/helpers/iface_helper.rb
@@ -21,6 +21,9 @@ module Kontena
           sock.ioctl(SIOCGIFADDR, buf);
           sock.close
           buf[20..24].unpack("CCCC").join(".")
+        rescue Errno::EADDRNOTAVAIL
+          # interface is up, but does not have any address configured
+          nil
         rescue Errno::ENODEV
           nil
         end


### PR DESCRIPTION
Fixes #1165

The agent `NodeInfoWorker#private_ip` will fall back to `eth0` if the `KONTENA_PEER_INTERFACE` does not have any address configured.