### PR TITLE
Removing ruby versions between 2.0 and 2.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 sudo: required
 rvm:
   - 2.0.0-p648
-  - 2.1.8
-  - 2.2.3
   - 2.3.1
 cache: bundler
 cache:
@@ -25,15 +23,7 @@ matrix:
   exclude:
     - rvm: 2.0.0-p648
       env: TEST_DIR=server
-    - rvm: 2.1.8
-      env: TEST_DIR=server
-    - rvm: 2.2.3
-      env: TEST_DIR=server
     - rvm: 2.0.0-p648
-      env: TEST_DIR=agent
-    - rvm: 2.1.8
-      env: TEST_DIR=agent
-    - rvm: 2.2.3
       env: TEST_DIR=agent
 script: ./build/travis/test.sh
 deploy:


### PR DESCRIPTION
If something works on 2.0.0 and 2.3.1 it's hard to think of something that could break in 2.1 or 2.2.
