### PR TITLE
Option to check only cli version.

### DIFF
--- a/cli/lib/kontena/cli/version_command.rb
+++ b/cli/lib/kontena/cli/version_command.rb
@@ -3,9 +3,13 @@ require_relative 'version'
 class Kontena::Cli::VersionCommand < Kontena::Command
   include Kontena::Cli::Common
 
+  option "--cli", :flag, "Only CLI version"
+
   def execute
-    url = api_url rescue nil
     puts "cli: #{Kontena::Cli::VERSION}"
+    return if cli?
+
+    url = api_url rescue nil
     if url
       resp = JSON.parse(client.http_client.get(path: '/').body) rescue nil
       if resp


### PR DESCRIPTION
running `kontena version` pings the server every time, this PR introduces a `--cli` option to check only cli version faster.