### PR TITLE
Fix network startup ordering

### DIFF
--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -39,7 +39,7 @@ module Docker
 
     # @return [Boolean]
     def running?
-      self.state['Running']
+      self.state['Running'] && !self.state['Restarting']
     rescue
       false
     end

--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -33,6 +33,7 @@ require_relative 'kontena/workers/image_pull_worker'
 require_relative 'kontena/workers/health_check_worker'
 require_relative 'kontena/workers/container_starter_worker'
 require_relative 'kontena/workers/container_network_migrator'
+require_relative 'kontena/workers/network_create_worker'
 
 require_relative 'kontena/load_balancers/configurer'
 require_relative 'kontena/load_balancers/registrator'

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -144,6 +144,10 @@ module Kontena
         type: Kontena::Workers::ContainerNetworkMigratorWorker,
         as: :container_network_migrator
       )
+      @supervisor.supervise(
+        type: Kontena::Workers::NetworkCreateWorker,
+        as: :network_create_worker
+      )
     end
 
     def supervise_lb

--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -34,6 +34,8 @@ module Kontena::Launchers
 
     def start(info)
       create_container(@image_name, info)
+      sleep 1 until running?
+      Celluloid::Notifications.publish('ipam:start', nil)
     end
 
     def image_exists?
@@ -82,7 +84,6 @@ module Kontena::Launchers
       )
       container.start
       info 'started ipam-plugin service'
-      Celluloid::Notifications.publish('ipam:start', nil)
       @running = true
       container
     end

--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -40,6 +40,14 @@ module Kontena::Launchers
       @image_pulled
     end
 
+    def running?
+      container = Docker::Container.get(IPAM_SERVICE_NAME) rescue nil
+      if container
+        return container.running?
+      end
+      false
+    end
+
     def create_container(image, info)
       sleep 1 until image_exists?
 
@@ -49,11 +57,13 @@ module Kontena::Launchers
       elsif container && container.running?
         info 'ipam-plugin is already running'
         @running = true
+        Celluloid::Notifications.publish('ipam:start', nil)
         return container
       elsif container && !container.running?
         info 'ipam-plugin container exists but not running, starting it'
         container.start
         @running = true
+        Celluloid::Notifications.publish('ipam:start', nil)
         return container
       end
 
@@ -72,6 +82,7 @@ module Kontena::Launchers
       )
       container.start
       info 'started ipam-plugin service'
+      Celluloid::Notifications.publish('ipam:start', nil)
       @running = true
       container
     end

--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -28,7 +28,7 @@ module Kontena::Launchers
     end
 
     def on_network_start(topic, info)
-      info "node info received, launching ipam..."
+      info "network started, launching ipam..."
       async.start(info)
     end
 

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -195,8 +195,6 @@ module Kontena::NetworkAdapters
         sleep 0.5 until (plugin && plugin.running?) || (wait < Time.now.to_f)
 
       end
-      ensure_kontena_network
-
       Celluloid::Notifications.publish('network_adapter:start', info) unless already_started?
 
       @started = true
@@ -245,34 +243,6 @@ module Kontena::NetworkAdapters
     end
 
     private
-
-    def ensure_kontena_network
-      kontena_network = Docker::Network.get('kontena') rescue nil
-      unless kontena_network
-        info "creating default kontena network..."
-        opts = {
-          'Driver': 'weavemesh',
-          'IPAM': {
-            'Driver': 'kontena-ipam',
-            'Config': [
-              {
-                # Need to set the subnet for the default network so we can
-                # later migrate container to it with manually set IP's
-                'Subnet': '10.81.0.0/16',
-                # Allocate container addresses on the top part so that
-                # low part is reserved for node addresses
-                'IPRange': '10.81.128.0/17'
-              }
-            ],
-            'Options': {
-              'network': 'kontena'
-            }
-          }
-        }
-        network = Docker::Network.create('kontena', opts)
-        info "..done. network id: #{network.id}"
-      end
-    end
 
     def ensure_images
       images = [

--- a/agent/lib/kontena/workers/container_network_migrator.rb
+++ b/agent/lib/kontena/workers/container_network_migrator.rb
@@ -11,7 +11,7 @@ module Kontena::Workers
 
     def initialize(autostart = true)
       info 'initialized'
-      subscribe('network_adapter:start', :on_weave_start)
+      subscribe('network:ready', :on_weave_start)
       async.migrate_weavewait if autostart
     end
 

--- a/agent/lib/kontena/workers/container_network_migrator.rb
+++ b/agent/lib/kontena/workers/container_network_migrator.rb
@@ -16,7 +16,7 @@ module Kontena::Workers
     end
 
     def on_weave_start(topic, data)
-      info 'weave started, check if containers need to be migrated'
+      info 'network ready, check if containers need to be migrated'
       self.start
     end
 

--- a/agent/lib/kontena/workers/container_starter_worker.rb
+++ b/agent/lib/kontena/workers/container_starter_worker.rb
@@ -14,7 +14,7 @@ module Kontena::Workers
 
     def initialize
       info 'initialized'
-      subscribe('network_adapter:start', :on_overlay_start)
+      subscribe('network:ready', :on_overlay_start)
     end
 
     def on_overlay_start(topic, data)

--- a/agent/lib/kontena/workers/container_starter_worker.rb
+++ b/agent/lib/kontena/workers/container_starter_worker.rb
@@ -18,7 +18,7 @@ module Kontena::Workers
     end
 
     def on_overlay_start(topic, data)
-      info 'weave started, check if some containers need to be started'
+      info 'network ready, check if some containers need to be started'
       self.start
     end
 

--- a/agent/lib/kontena/workers/network_create_worker.rb
+++ b/agent/lib/kontena/workers/network_create_worker.rb
@@ -1,0 +1,64 @@
+
+module Kontena::Workers
+  class NetworkCreateWorker
+    include Celluloid
+    include Celluloid::Notifications
+    include Kontena::Logging
+
+
+    def initialize
+      @network_started = false
+      @ipam_started = false
+      subscribe('network_adapter:start', :network_started)
+      subscribe('ipam:start', :ipam_started)
+      info 'initialized'
+    end
+
+    def network_started(topic, data)
+      debug 'network_started'
+      @network_started = true
+      ensure_default_network
+    end
+
+    def ipam_started(topic, data)
+      debug 'ipam_started'
+      @ipam_started = true
+      ensure_default_network
+    end
+
+    
+    def create_network(name, driver, ipam_driver, subnet, ip_range = nil)
+      opts = {
+        'Driver': driver,
+        'IPAM': {
+          'Driver': ipam_driver,
+          'Config': [
+            {
+              'Subnet': subnet
+            }
+          ],
+          'Options': {
+            'network': name
+          }
+        }
+      }
+      opts[:IPAM][:Config][0][:IPRange] = ip_range if ip_range
+      Docker::Network.create(name, opts)
+    end
+
+    private
+
+    def ensure_default_network
+      if @network_started && @ipam_started
+        info 'network and ipam ready, ensuring default network existence'
+        kontena_network = Docker::Network.get('kontena') rescue nil
+        unless kontena_network
+          info "creating default kontena network..."
+          network = create_network('kontena', 'weavemesh', 'kontena-ipam', '10.81.0.0/16', '10.81.128.0/17')
+          info "..done. network id: #{network.id}"
+        end
+        Celluloid::Notifications.publish('network:ready', nil)
+      end
+    end
+  end
+end

--- a/agent/lib/kontena/workers/network_create_worker.rb
+++ b/agent/lib/kontena/workers/network_create_worker.rb
@@ -15,18 +15,15 @@ module Kontena::Workers
     end
 
     def network_started(topic, data)
-      debug 'network_started'
       @network_started = true
       ensure_default_network
     end
 
     def ipam_started(topic, data)
-      debug 'ipam_started'
       @ipam_started = true
       ensure_default_network
     end
 
-    
     def create_network(name, driver, ipam_driver, subnet, ip_range = nil)
       opts = {
         'Driver': driver,

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -69,7 +69,7 @@ module Kontena::Workers
           add_dns(container.id, ip, name)
         end
       else
-        warn "did not find ip for container: #{container.name}"
+        debug "did not find ip for container: #{container.name}"
       end
     rescue Docker::Error::NotFoundError
 

--- a/agent/spec/lib/kontena/launchers/ipam_launcer_spec.rb
+++ b/agent/spec/lib/kontena/launchers/ipam_launcer_spec.rb
@@ -8,6 +8,28 @@ describe Kontena::Launchers::IpamPlugin do
   before(:each) { Celluloid.boot }
   after(:each) { Celluloid.shutdown }
 
+  describe '#running?' do
+    it 'returns false when ipam container not existing' do
+      expect(Docker::Container).to receive(:get).and_return(nil)
+
+      expect(subject.running?).to be_falsey
+    end
+
+    it 'returns false when ipam container not running' do
+      expect(container).to receive(:running?).and_return(false)
+      expect(Docker::Container).to receive(:get).and_return(container)
+
+      expect(subject.running?).to be_falsey
+    end
+
+    it 'returns true when ipam container running' do
+      expect(container).to receive(:running?).and_return(true)
+      expect(Docker::Container).to receive(:get).and_return(container)
+
+      expect(subject.running?).to be_truthy
+    end
+  end
+
   describe '#create_container' do
 
     before do

--- a/agent/spec/lib/kontena/workers/container_starter_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_starter_worker_spec.rb
@@ -11,7 +11,7 @@ describe Kontena::Workers::ContainerStarterWorker do
   describe '#initialize' do
     it 'subscribes to network_adapter:start event' do
       expect(subject.wrapped_object).to receive(:on_overlay_start)
-      Celluloid::Notifications.publish('network_adapter:start', {})
+      Celluloid::Notifications.publish('network:ready', {})
       sleep 0.1
     end
   end

--- a/agent/spec/lib/kontena/workers/network_create_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/network_create_worker_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../../../spec_helper'
+
+describe Kontena::Workers::NetworkCreateWorker do
+
+  let(:network_adapter) { double(:network_adapter) }
+  let(:subject) { described_class.new }
+
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
+  describe '#ensure_default_network' do
+    it 'does not create network if ipam not started' do
+      expect(subject).not_to receive(:create_network)
+      subject.network_started(nil, nil)
+    end
+
+    it 'does not create network if network not started' do
+      expect(subject).not_to receive(:create_network)
+      subject.ipam_started(nil, nil)
+    end
+
+    it 'creates network when ipam and network started' do
+      expect(Docker::Network).to receive(:get).and_return(nil)
+      expect(subject.wrapped_object).to receive(:create_network).and_return(double(id: '123456789'))
+
+      subject.network_started(nil, nil)
+      subject.ipam_started(nil, nil)
+
+    end
+
+    it 'creates network when network and ipam started' do
+      expect(Docker::Network).to receive(:get).and_return(nil)
+      expect(subject.wrapped_object).to receive(:create_network).and_return(double(id: '123456789'))
+
+      subject.ipam_started(nil, nil)
+      subject.network_started(nil, nil)
+
+    end
+  end
+
+end


### PR DESCRIPTION
This PR fixes startup issues with new network components. The startup events are refactored into two separate events now, namely `ipam:start` and `network_adapter:start`. The latter is used as before to indicate that the network itself (weave) is started and etcd and others can continue to bootstrap. Combined these two now indicate that it is safe to ensure the existence of the default `kontena` network.

The `NetworkCreatorWorker` emits `network:ready` event when the default network is created to indicate that it is safe to start the network migrator and left-over container starter.

fixes #1270 