### PR TITLE
Server: Fix all requires to use deterministic ordering across different systems

### DIFF
--- a/server/app/boot.rb
+++ b/server/app/boot.rb
@@ -17,17 +17,16 @@ require 'msgpack'
 require 'tilt/jbuilder.rb'
 require 'mongoid/enum'
 
-Dir[__dir__ + '/initializers/*.rb'].sort.each {|file| require file }
+def require_glob(glob)
+  Dir.glob(glob).sort.each do |path|
+    require path
+  end
+end
 
-Dir[__dir__ + '/authorizers/*.rb'].each {|file| require file }
-
-Dir[__dir__ + '/models/*.rb'].each {|file| require file }
-
-Dir[__dir__ + '/helpers/*.rb'].each {|file| require file }
-
-Dir[__dir__ + '/mutations/**/*.rb'].each {|file| require file }
-
-Dir[__dir__ + '/jobs/**/*.rb'].each {|file| require file }
-
-Dir[__dir__ + '/services/**/*.rb'].each {|file| require file }
-
+require_glob __dir__ + '/initializers/*.rb'
+require_glob __dir__ + '/authorizers/*.rb'
+require_glob __dir__ + '/models/*.rb'
+require_glob __dir__ + '/helpers/*.rb'
+require_glob __dir__ + '/mutations/**/*.rb'
+require_glob __dir__ + '/jobs/**/*.rb'
+require_glob __dir__ + '/services/**/*.rb'

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -12,7 +12,7 @@ module V1
     plugin :multi_route
     plugin :streaming
 
-    Dir[File.join(__dir__, '/grids/*.rb')].each{|f| require f}
+    require_glob File.join(__dir__, '/grids/*.rb')
 
     route do |r|
 

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -9,7 +9,7 @@ module V1
     plugin :multi_route
     plugin :streaming
 
-    Dir[File.join(__dir__, '/services/*.rb')].each{|f| require f}
+    require_glob File.join(__dir__, '/services/*.rb')
 
     route do |r|
 

--- a/server/app/routes/v1/user_api.rb
+++ b/server/app/routes/v1/user_api.rb
@@ -1,4 +1,3 @@
-
 module V1
   class UserApi < Roda
     include TokenAuthenticationHelper
@@ -7,7 +6,7 @@ module V1
 
     plugin :multi_route
 
-    Dir[File.join(__dir__, '/user/*.rb')].each{|f| require f}
+    require_glob File.join(__dir__, '/user/*.rb')
 
     # Route: /v1/user
     route do |r|

--- a/server/app/routes/v1/users_api.rb
+++ b/server/app/routes/v1/users_api.rb
@@ -8,7 +8,7 @@ module V1
 
     plugin :multi_route
 
-    Dir[File.join(__dir__, '/users/*.rb')].each{|f| require f}
+    require_glob File.join(__dir__, '/users/*.rb')
 
     route do |r|
       r.on ':username' do |username|

--- a/server/app/routes/v1_api.rb
+++ b/server/app/routes/v1_api.rb
@@ -1,6 +1,6 @@
 module V1
 
-  Dir[File.expand_path('../v1/*.rb', __FILE__)].each { |f| require f }
+  require_glob File.expand_path('../v1/*.rb', __FILE__)
 
   class Api < Roda
     route do |r|

--- a/server/app/services/grid_service_scheduler.rb
+++ b/server/app/services/grid_service_scheduler.rb
@@ -1,5 +1,5 @@
-Dir[__dir__ + '/scheduler/**/*.rb'].each {|file| require file }
-Dir[__dir__ + '/docker/*.rb'].each {|file| require file }
+require_glob __dir__ + '/scheduler/**/*.rb'
+require_glob __dir__ + '/docker/*.rb'
 
 class GridServiceScheduler
 

--- a/server/server.rb
+++ b/server/server.rb
@@ -6,8 +6,8 @@ require_relative 'app/boot_jobs'
 require_relative 'app/middlewares/token_authentication'
 require_relative 'app/helpers/config_helper'
 
-Dir[__dir__ + '/app/routes/*.rb'].each {|file| require file }
-Dir[__dir__ + '/app/routes/**/*.rb'].each {|file| require file }
+require_glob __dir__ + '/app/routes/*.rb'
+require_glob __dir__ + '/app/routes/**/*.rb'
 
 Logger.class_eval { alias :write :'<<' }
 

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -86,4 +86,4 @@ RSpec.configure do |config|
   end
 end
 
-Dir[__dir__ + '/support/*.rb'].each {|file| require file }
+require_glob __dir__ + '/support/*.rb'


### PR DESCRIPTION
Many of the server components use a similar `Dir['.../*.rb'].each {|file| require file }` pattern to load the ruby code files. As shown in #1277, the non-deterministic ruby `Dir.glob` ordering can lead to issues where different systems load those files in a different order.

This PR fixes the server code to use a new `require_glob` helper that sorts the files into a deterministic order to guarantee the same execution across different systems.

This should avoid any potential issues with some required file implicitly relying on some symbol required by some earlier file, where a change in the require ordering could lead to errors.

## TODO
Fix the server rake task environment to use the real `app/boot.rb` file, instead of an outdated copy-pasted list of partial requirements + the models. First attempt here: https://github.com/kontena/kontena/commit/c9aad101c7069af95db450203b3a9037e031c957

However, this needs some variation of `boot.rb` that does not load e.g. the initializers.

## Example
Consider the following example diff that introduces an implicit ordering dependency on the `server/app/mutations/grid_certificates/*.rb` files:

```diff
diff --git a/server/app/mutations/grid_certificates/common.rb b/server/app/mutations/grid_certificates/common.rb
index f017e2a..1d69d7e 100644
--- a/server/app/mutations/grid_certificates/common.rb
+++ b/server/app/mutations/grid_certificates/common.rb
@@ -1,5 +1,3 @@
-require 'openssl'
-require 'acme-client'
 
 require_relative '../../services/logging'
 
diff --git a/server/app/mutations/grid_certificates/register.rb b/server/app/mutations/grid_certificates/register.rb
index 854d925..5796480 100644
--- a/server/app/mutations/grid_certificates/register.rb
+++ b/server/app/mutations/grid_certificates/register.rb
@@ -1,6 +1,3 @@
-require 'acme-client'
-require 'openssl'
-
 require_relative 'common'
 require_relative '../../services/logging'
 
@@ -9,6 +6,10 @@ module GridCertificates
     include Common
     include Logging
 
+    class MyError < Acme::Client::Error
+
+    end
+
     required do
       model :grid, class: Grid
       string :email
```

With the following instrumentation:

```diff
diff --git a/server/app/boot.rb b/server/app/boot.rb
index 3043891..e9b3516 100644
--- a/server/app/boot.rb
+++ b/server/app/boot.rb
@@ -17,13 +17,16 @@ require 'msgpack'
 require 'tilt/jbuilder.rb'
 require 'mongoid/enum'
 
-def require_glob(glob)
-  Dir.glob(glob).sort.each do |path|
+def require_glob(glob, reversed: ENV["REQUIRE_REVERSED"])
+  files = Dir.glob(glob).sort
+  files = files.reverse if reversed
+  files.each do |path|
+    STDERR.puts "require #{path}"
     require path
   end
 end
 
-require_glob __dir__ + '/initializers/*.rb'
+require_glob __dir__ + '/initializers/*.rb', reversed: false
 require_glob __dir__ + '/authorizers/*.rb'
 require_glob __dir__ + '/models/*.rb'
 require_glob __dir__ + '/helpers/*.rb'
```

The server may crash at boot depending on the require ordering used:

#### `DEBUG=1 RACK_ENV=development bundle exec puma -p 9292 -e development > /dev/null && echo yay`

```
...
require /home/kontena/kontena/kontena/server/app/mutations/grid_certificates/authorize_domain.rb
require /home/kontena/kontena/kontena/server/app/mutations/grid_certificates/common.rb
require /home/kontena/kontena/kontena/server/app/mutations/grid_certificates/get_certificate.rb
require /home/kontena/kontena/kontena/server/app/mutations/grid_certificates/register.rb
...
yay
```

#### `DEBUG=1 RACK_ENV=development REQUIRE_REVERSED=yes bundle exec puma -p 9292 -e development > /dev/null`

```
...
require /home/kontena/kontena/kontena/server/app/mutations/grid_certificates/register.rb
/home/kontena/kontena/kontena/server/app/mutations/grid_certificates/register.rb:9:in `<class:Register>': uninitialized constant GridCertificates::Register::Acme (NameError)
	from /home/kontena/kontena/kontena/server/app/mutations/grid_certificates/register.rb:5:in `<module:GridCertificates>'
	from /home/kontena/kontena/kontena/server/app/mutations/grid_certificates/register.rb:4:in `<top (required)>'
	from /home/kontena/kontena/kontena/server/app/boot.rb:25:in `require'
	from /home/kontena/kontena/kontena/server/app/boot.rb:25:in `block in require_glob'
	from /home/kontena/kontena/kontena/server/app/boot.rb:23:in `each'
	from /home/kontena/kontena/kontena/server/app/boot.rb:23:in `require_glob'
	from /home/kontena/kontena/kontena/server/app/boot.rb:33:in `<top (required)>'
	from config/puma.rb:5:in `require_relative'
	from config/puma.rb:5:in `block in _load_from'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/configuration.rb:271:in `block in run_hooks'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/configuration.rb:271:in `each'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/configuration.rb:271:in `run_hooks'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:237:in `worker'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:120:in `block (2 levels) in spawn_workers'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:120:in `fork'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:120:in `block in spawn_workers'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:116:in `times'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:116:in `spawn_workers'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:426:in `run'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/launcher.rb:172:in `run'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cli.rb:74:in `run'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/bin/puma:10:in `<top (required)>'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/bin/puma:23:in `load'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/bin/puma:23:in `<main>'
```