### PR TITLE
Agent: log weaveexec errors

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -138,6 +138,13 @@ module Kontena::NetworkAdapters
           error exc.message
           return false
         end
+
+        if (status_code = response["StatusCode"]) == 0
+          debug "weaveexec ok: #{cmd}"
+        else
+          logs = container.streaming_logs(stdout: true, stderr: true)
+          error "weaveexec exit #{status_code}: #{cmd}\n#{logs}"
+        end
         response
       ensure
         container.delete(force: true, v: true) if container

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -110,7 +110,8 @@ module Kontena::NetworkAdapters
           },
           'Env' => [
             'HOST_ROOT=/host',
-            "VERSION=#{WEAVE_VERSION}"
+            "VERSION=#{WEAVE_VERSION}",
+            "WEAVE_DEBUG=#{ENV['WEAVE_DEBUG']}",
           ],
           'HostConfig' => {
             'Privileged' => true,


### PR DESCRIPTION
Minimal version of #1241 that should be cherry-pickable for 0.16.

Does not change the behavior of the kontena-agent, but allows logging weaveexec errors, which would otherwise be lost.

```
kontena-agent | D, [2016-11-04T12:04:09.227689 #1] DEBUG -- RpcServer: rpc notification: Kontena::Rpc::AgentApi#node_info ...
kontena-agent | E, [2016-11-04T12:04:09.573170 #1] ERROR -- Kontena::NetworkAdapters::Weave: weaveexec exit 1: ["--local", "launch-router", "--ipalloc-range", "", "--dns-domain", "kontena.local", "--password", "...", "--trusted-subnets", ""]
kontena-agent | weave is already running; you can stop it with 'weave stop-router'.
kontena-agent | 
kontena-agent | D, [2016-11-04T12:04:09.762029 #1] DEBUG -- NetworkAdapters::Weave: weaveexec ok: ["--local", "connect", "--replace", "192.168.66.101"]
kontena-agent | I, [2016-11-04T12:04:09.770270 #1]  INFO -- Kontena::NetworkAdapters::Weave: router connected to peers 192.168.66.101
kontena-agent | I, [2016-11-04T12:04:09.770334 #1]  INFO -- Kontena::NetworkAdapters::Weave: using trusted subnets: 
kontena-agent | D, [2016-11-04T12:04:09.966332 #1] DEBUG -- NetworkAdapters::Weave: weaveexec ok: ["--local", "expose", "ip:10.81.0.2/16"]
kontena-agent | I, [2016-11-04T12:04:09.971366 #1]  INFO -- Kontena::NetworkAdapters::Weave: bridge exposed: 10.81.0.2/16
kontena-agent | D, [2016-11-04T12:04:10.159157 #1] DEBUG -- NetworkAdapters::Weave: weaveexec ok: ["--local", "launch-plugin"]
```

Minor issue is that it will always log an error for the initial "launch-router" at startup.

Run the kontena-agent with `WEAVE_DEBUG=` for excessively verbose output:

```
kontena-agent | E, [2016-11-04T12:12:31.298612 #1] ERROR -- Kontena::NetworkAdapters::Weave: weaveexec exit 1: ["--local", "launch-router", "--ipalloc-range", "", "--dns-domain", "kontena.local", "--password", "tBsoco4sBClMtIOD/bHeIqS1KYM0kZMG7B960jNWWQXMOxqhOf8W1QgiNJlW9u6B/qS+rfS2ZLpC/ZJsyPNj0A==", "--trusted-subnets", ""]
kontena-agent | + SCRIPT_VERSION=1.7.2
...
kontena-agent | + check_not_running router weave weaveworks/weave
kontena-agent | + docker inspect --format={{.State.Running}} {{.State.Status}} {{.Config.Image}} weave
kontena-agent | + RUN_STATUS=true running weaveworks/weave:1.7.2
kontena-agent | + echo weave is already running; you can stop it with 'weave stop-router'.
kontena-agent | weave is already running; you can stop it with 'weave stop-router'.
kontena-agent | + return 1
kontena-agent | 
```