### PR TITLE
Watch & notify when dead containers are gone

### DIFF
--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -52,6 +52,20 @@ module Docker
     end
 
     # @return [Boolean]
+    def dead?
+      self.state['Dead']
+    rescue
+      false
+    end
+
+    # @return [Boolean]
+    def suspiously_dead?
+      self.state['Dead'] && self.state['ExitCode'].to_i == 137
+    rescue
+      false
+    end
+
+    # @return [Boolean]
     def service_container?
       self.labels['io.kontena.container.type'] == 'container'
     rescue

--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -3,6 +3,8 @@ require 'docker'
 module Docker
   class Container
 
+    SUSPICIOUS_EXIT_CODES = [137]
+
     def name
       cached_json['Name']
     end
@@ -59,8 +61,8 @@ module Docker
     end
 
     # @return [Boolean]
-    def suspiously_dead?
-      self.state['Dead'] && self.state['ExitCode'].to_i == 137
+    def suspiciously_dead?
+      self.state['Dead'] && SUSPICIOUS_EXIT_CODES.include?(self.state['ExitCode'].to_i)
     rescue
       false
     end

--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -35,6 +35,8 @@ require_relative 'kontena/workers/container_starter_worker'
 require_relative 'kontena/workers/container_network_migrator'
 require_relative 'kontena/workers/network_create_worker'
 
+require_relative 'kontena/actors/container_coroner'
+
 require_relative 'kontena/load_balancers/configurer'
 require_relative 'kontena/load_balancers/registrator'
 

--- a/agent/lib/kontena/actors/container_coroner.rb
+++ b/agent/lib/kontena/actors/container_coroner.rb
@@ -1,0 +1,41 @@
+module Kontena::Actors
+  class ContainerCoroner
+    include Celluloid
+    include Kontena::Logging
+
+    # @param [Docker::Container]
+    # @param [Boolean] autostart
+    def initialize(container, autostart = true)
+      @container = container
+      async.start if autostart
+    end
+
+    def start
+      info "starting to investigate #{@container.name}"
+      every(5) {
+        investigate
+      }
+    end
+
+    def investigate
+      exists = Docker::Container.get(@container.id) rescue nil
+      unless exists
+        confirm
+      end
+    end
+
+    def confirm
+      info "container #{@container.name} has gone"
+      event = Docker::Event.new(
+        'destroy'.freeze, @container.id, '', Time.now.utc
+      )
+      event_worker.publish_event(event)
+      self.terminate
+    end
+
+    # @return [Kontena::Workers::EventWorker]
+    def event_worker
+      Actor[:event_worker]
+    end
+  end
+end

--- a/agent/lib/kontena/actors/container_coroner.rb
+++ b/agent/lib/kontena/actors/container_coroner.rb
@@ -3,6 +3,9 @@ module Kontena::Actors
     include Celluloid
     include Kontena::Logging
 
+    INVESTIGATION_TIME = (5 * 60)
+    INVESTIGATION_PERIOD = 5
+
     # @param [Docker::Container]
     # @param [Boolean] autostart
     def initialize(container, autostart = true)
@@ -13,8 +16,8 @@ module Kontena::Actors
     def start
       @started = Time.now.to_i
       info "starting to investigate #{@container.name}"
-      every(5) {
-        if @started >= (Time.now.to_i - 300) # 5 minutes
+      every(INVESTIGATION_PERIOD) {
+        if @started >= (Time.now.to_i - INVESTIGATION_TIME)
           investigate
         else
           self.terminate

--- a/agent/lib/kontena/workers/container_info_worker.rb
+++ b/agent/lib/kontena/workers/container_info_worker.rb
@@ -30,7 +30,7 @@ module Kontena::Workers
       end
     end
 
-    ##
+    # @param [String] topic
     # @param [Docker::Event] event
     def on_container_event(topic, event)
       return if event.status == 'destroy'.freeze
@@ -39,6 +39,7 @@ module Kontena::Workers
       container = Docker::Container.get(event.id)
       if container
         self.publish_info(container)
+        self.notify_coroner(container) if container.dead?
       end
     rescue Docker::Error::NotFoundError
       self.publish_destroy_event(event)
@@ -93,6 +94,12 @@ module Kontena::Workers
     # @return [Hash]
     def node_info
       @node_info ||= Docker.info
+    end
+
+    # @param [Docker::Container]
+    # @return [Kontena::Actors::ContainerCoroner]
+    def notify_coroner(container)
+      Kontena::Actors::ContainerCoroner.new(container)
     end
   end
 end

--- a/agent/lib/kontena/workers/container_info_worker.rb
+++ b/agent/lib/kontena/workers/container_info_worker.rb
@@ -39,7 +39,7 @@ module Kontena::Workers
       container = Docker::Container.get(event.id)
       if container
         self.publish_info(container)
-        self.notify_coroner(container) if container.dead?
+        self.notify_coroner(container) if container.suspiously_dead?
       end
     rescue Docker::Error::NotFoundError
       self.publish_destroy_event(event)

--- a/agent/lib/kontena/workers/container_info_worker.rb
+++ b/agent/lib/kontena/workers/container_info_worker.rb
@@ -39,7 +39,7 @@ module Kontena::Workers
       container = Docker::Container.get(event.id)
       if container
         self.publish_info(container)
-        self.notify_coroner(container) if container.suspiously_dead?
+        self.notify_coroner(container) if container.suspiciously_dead?
       end
     rescue Docker::Error::NotFoundError
       self.publish_destroy_event(event)

--- a/agent/spec/lib/docker/container_spec.rb
+++ b/agent/spec/lib/docker/container_spec.rb
@@ -65,4 +65,25 @@ describe Docker::Container do
       expect(subject.load_balanced?).to be_falsey
     end
   end
+
+  describe '#suspiciously_dead?' do
+    it 'returns false if not dead' do
+      allow(subject).to receive(:state).and_return({'Dead' => false})
+      expect(subject.suspiciously_dead?).to be_falsey
+    end
+
+    it 'returns false if dead but non-suspicious exit code' do
+      allow(subject).to receive(:state).and_return({
+        'Dead' => true, 'ExitCode' => -1
+      })
+      expect(subject.suspiciously_dead?).to be_falsey
+    end
+
+    it 'returns true if suspiciously dead' do
+      allow(subject).to receive(:state).and_return({
+        'Dead' => true, 'ExitCode' => Docker::Container::SUSPICIOUS_EXIT_CODES[0]
+      })
+      expect(subject.suspiciously_dead?).to be_truthy
+    end
+  end
 end

--- a/agent/spec/lib/kontena/actors/container_coroner_spec.rb
+++ b/agent/spec/lib/kontena/actors/container_coroner_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../../../spec_helper'
+
+describe Kontena::Actors::ContainerCoroner do
+
+  let(:container) do
+    double(:container, id: 'dead-id', name: '/dead')
+  end
+  let(:subject) { described_class.new(container, false) }
+
+  before(:each) { Celluloid.boot }
+  after(:each) { Celluloid.shutdown }
+
+  describe '#investigate' do
+    it 'confirms if container has gone' do
+      allow(Docker::Container).to receive(:get).with(container.id).and_return(nil)
+      expect(subject.wrapped_object).to receive(:confirm)
+      subject.investigate
+    end
+
+    it 'does not config if container still exists' do
+      allow(Docker::Container).to receive(:get).with(container.id).and_return(container)
+      expect(subject.wrapped_object).not_to receive(:confirm)
+      subject.investigate
+    end
+  end
+
+  describe '#confirm' do
+    let(:event_worker) do
+      double(:event_worker)
+    end
+
+    before(:each) do
+      allow(subject.wrapped_object).to receive(:event_worker).and_return(event_worker)
+    end
+
+    it 'publishes event' do
+      expect(event_worker).to receive(:publish_event)
+      subject.confirm
+    end
+
+    it 'terminates actor' do
+      allow(event_worker).to receive(:publish_event)
+      subject.confirm
+      expect(subject.alive?).to be_falsey
+    end
+  end
+end

--- a/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
@@ -56,7 +56,7 @@ describe Kontena::Workers::ContainerInfoWorker do
 
     it 'notifies coroner if container is dead' do
       event = double(:event, status: 'die', id: 'foo')
-      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :dead? => true)
+      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :suspiously_dead? => true)
       allow(Docker::Container).to receive(:get).once.and_return(container)
       expect(subject.wrapped_object).to receive(:notify_coroner).with(container)
       subject.on_container_event('topic', event)
@@ -64,7 +64,7 @@ describe Kontena::Workers::ContainerInfoWorker do
 
     it 'does not notify coroner if container is alive' do
       event = double(:event, status: 'start', id: 'foo')
-      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :dead? => false)
+      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :suspiously_dead? => false)
       allow(Docker::Container).to receive(:get).once.and_return(container)
       expect(subject.wrapped_object).not_to receive(:notify_coroner).with(container)
       subject.on_container_event('topic', event)

--- a/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
@@ -56,7 +56,7 @@ describe Kontena::Workers::ContainerInfoWorker do
 
     it 'notifies coroner if container is dead' do
       event = double(:event, status: 'die', id: 'foo')
-      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :suspiously_dead? => true)
+      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :suspiciously_dead? => true)
       allow(Docker::Container).to receive(:get).once.and_return(container)
       expect(subject.wrapped_object).to receive(:notify_coroner).with(container)
       subject.on_container_event('topic', event)
@@ -64,7 +64,7 @@ describe Kontena::Workers::ContainerInfoWorker do
 
     it 'does not notify coroner if container is alive' do
       event = double(:event, status: 'start', id: 'foo')
-      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :suspiously_dead? => false)
+      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :suspiciously_dead? => false)
       allow(Docker::Container).to receive(:get).once.and_return(container)
       expect(subject.wrapped_object).not_to receive(:notify_coroner).with(container)
       subject.on_container_event('topic', event)

--- a/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
@@ -53,6 +53,22 @@ describe Kontena::Workers::ContainerInfoWorker do
       expect(subject.wrapped_object.logger).to receive(:error).twice
       subject.on_container_event('topic', event)
     end
+
+    it 'notifies coroner if container is dead' do
+      event = double(:event, status: 'die', id: 'foo')
+      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :dead? => true)
+      allow(Docker::Container).to receive(:get).once.and_return(container)
+      expect(subject.wrapped_object).to receive(:notify_coroner).with(container)
+      subject.on_container_event('topic', event)
+    end
+
+    it 'does not notify coroner if container is alive' do
+      event = double(:event, status: 'start', id: 'foo')
+      container = double(:container, :json => {'Image' => 'foo/bar:latest'}, :dead? => false)
+      allow(Docker::Container).to receive(:get).once.and_return(container)
+      expect(subject.wrapped_object).not_to receive(:notify_coroner).with(container)
+      subject.on_container_event('topic', event)
+    end
   end
 
   describe '#publish_info' do
@@ -77,6 +93,17 @@ describe Kontena::Workers::ContainerInfoWorker do
       expect(queue.length).to eq(1)
       item = queue.pop
       expect(item).to eq(valid_event)
+    end
+  end
+
+  describe '#notify_coroner' do
+    let(:container) do
+      double(:container, id: 'dead-id', name: '/dead')
+    end
+
+    it 'creates a coroner actor' do
+      coroner = subject.notify_coroner(container)
+      expect(coroner).to be_an_instance_of(Kontena::Actors::ContainerCoroner)
     end
   end
 end


### PR DESCRIPTION
This PR implements `ContainerCoroner` actor that is created when `ContainerInfoWorker` gets event from a container that is marked as dead. `ContainerCoroner` investigates dead container and sends `destroy` event when container has gone from the docker engine. After an event is sent, coroner terminates itself.

Should fix #828

![coroner](http://images.buddytv.com/btv_2_700034224_1_590_-1_0_/coroner-coronation--.jpg)