### PR TITLE
Add global --version and --debug

### DIFF
--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -2,6 +2,15 @@ require 'clamp'
 
 class Kontena::Command < Clamp::Command
 
+  option '--version', :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
+    puts Kontena::Cli::VERSION
+    exit 0
+  end
+
+  option ['-D', '--debug'], :flag, "Enable debug", environment_variable: 'DEBUG' do
+    ENV['DEBUG'] = 'true'
+  end
+
   attr_accessor :arguments
   attr_reader :result
   attr_reader :exit_code
@@ -188,6 +197,7 @@ class Kontena::Command < Clamp::Command
     exit(@exit_code) if @exit_code.to_i > 0
     @result
   end
+
 end
 
 require_relative 'callback'

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -2,11 +2,6 @@ require 'clamp'
 
 class Kontena::Command < Clamp::Command
 
-  option '--version', :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
-    puts Kontena::Cli::VERSION
-    exit 0
-  end
-
   option ['-D', '--debug'], :flag, "Enable debug", environment_variable: 'DEBUG' do
     ENV['DEBUG'] = 'true'
   end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -31,8 +31,8 @@ class Kontena::MainCommand < Kontena::Command
   include Kontena::Util
   include Kontena::Cli::Common
 
-  option '--version', :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
-    puts Kontena::Cli::VERSION
+  option ['-v', '--version'], :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
+    puts ['kontena-cli', Kontena::Cli::VERSION, '[ruby' + RUBY_VERSION + '+' + RUBY_PLATFORM + ']'].join(' ')
     exit 0
   end
 

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -31,6 +31,11 @@ class Kontena::MainCommand < Kontena::Command
   include Kontena::Util
   include Kontena::Cli::Common
 
+  option '--version', :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
+    puts Kontena::Cli::VERSION
+    exit 0
+  end
+
   subcommand "cloud", "Kontena Cloud specific commands", Kontena::Cli::CloudCommand
   subcommand "logout", "Logout from Kontena Masters or Kontena Cloud accounts", Kontena::Cli::LogoutCommand
   subcommand "grid", "Grid specific commands", Kontena::Cli::GridCommand


### PR DESCRIPTION
Alternative to #1269

```
$ kontena master list --version
0.16.2
```

```
$ kontena master list --debug
D, [2016-11-07T09:23:10.260333 #68766] DEBUG -- CONFIG: Loading configuration from /Users/kimmo/.kontena_client.json
D, [2016-11-07T09:23:10.261007 #68766] DEBUG -- CONFIG: Configuration loaded with 8 servers.
D, [2016-11-07T09:23:10.261057 #68766] DEBUG -- CONFIG: Current master: (not selected)
D, [2016-11-07T09:23:10.261071 #68766] DEBUG -- CONFIG: Current grid: (not selected)
weathered-river-41-admin http://192.168.66.100:8080
purple-dream-52-admin    http://192.168.66.100:8080
```

The problem is that the provision plugins use --version to define which version to install.

