### PR TITLE
Add quiet option to service list command

### DIFF
--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -6,33 +6,45 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
+    option ["-q", "--quiet"], :flag, "Show only service names"
+
     def execute
       require_api_url
       token = require_token
 
       grids = client(token).get("grids/#{current_grid}/services")
       services = grids['services'].sort_by{|s| s['updated_at'] }.reverse
-      titles = ['NAME', 'INSTANCES', 'STATEFUL', 'STATE', 'EXPOSED PORTS']
-      puts "%-60s %-10s %-8s %-10s %-50s" % titles
-      services.each do |service|
-        stateful = service['stateful'] ? 'yes' : 'no'
-        running = service['instances']['running']
-        desired = service['container_count']
-        instances = "#{running} / #{desired}"
-        ports = service['ports'].map{|p|
-          "#{p['ip']}:#{p['node_port']}->#{p['container_port']}/#{p['protocol']}"
-        }.join(", ")
-        health = health_status(service)
-        vars = [
-          health_status_icon(health),
-          "#{service['name']}",
-          instances,
-          stateful,
-          service['state'],
-          ports
-        ]
-        puts "%s %-58s %-10.10s %-8s %-10s %-50s" % vars
+      if quiet?
+        services.each do |service|
+          puts service['name']
+        end
+      else
+        titles = ['NAME', 'INSTANCES', 'STATEFUL', 'STATE', 'EXPOSED PORTS']
+        puts "%-60s %-10s %-8s %-10s %-50s" % titles
+        services.each do |service|
+          print_service_row(service)
+        end
       end
+    end
+
+    def print_service_row(service)
+      stateful = service['stateful'] ? 'yes' : 'no'
+      running = service['instances']['running']
+      desired = service['container_count']
+      instances = "#{running} / #{desired}"
+      ports = service['ports'].map{|p|
+        "#{p['ip']}:#{p['node_port']}->#{p['container_port']}/#{p['protocol']}"
+      }.join(", ")
+      health = health_status(service)
+      vars = [
+        health_status_icon(health),
+        "#{service['name']}",
+        instances,
+        stateful,
+        service['state'],
+        ports
+      ]
+      puts "%s %-58s %-10.10s %-8s %-10s %-50s" % vars
     end
   end
 end


### PR DESCRIPTION
This PR adds `-q , --quiet` option to `kontena service ls` command. With that option only service names are shown in the output.

Fixes #1306 