### PR TITLE
Remove previous version of a plugin on install

### DIFF
--- a/cli/lib/kontena/cli/plugins/common.rb
+++ b/cli/lib/kontena/cli/plugins/common.rb
@@ -1,0 +1,8 @@
+module Kontena::Cli::Plugins
+  module Common
+
+    def short_name(name)
+      name.sub('kontena-plugin-', '')
+    end
+  end
+end

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -16,13 +16,13 @@ module Kontena::Cli::Plugins
 
     def install_plugin(name)
       plugin = "kontena-plugin-#{name}"
-      gem_bin = which('gem')
+      uninstall_previous(plugin) if plugin_exists?(plugin)
       install_options = ['--no-ri', '--no-doc']
       install_options << "--version #{version}" if version
       install_options << "--pre" if pre?
       install_command = "#{gem_bin} install #{install_options.join(' ')} #{plugin}"
       success = false
-      spinner "installing plugin #{name.colorize(:cyan)}" do
+      spinner "Installing plugin #{name.colorize(:cyan)}" do
         stdout, stderr, status = Open3.capture3(install_command)
         unless stderr.empty?
           raise stderr
@@ -30,6 +30,25 @@ module Kontena::Cli::Plugins
       end
     rescue => exc
       puts exc.message
+    end
+
+    def plugin_exists?(name)
+      Kontena::PluginManager.instance.plugins.any? { |p| p.name == name}
+    end
+
+    def gem_bin
+      @gem_bin ||= which('gem')
+    end
+
+    def uninstall_previous(name)
+      uninstall_command = "#{gem_bin} uninstall -q #{name}"
+      success = false
+      spinner "Uninstalling previous version of plugin" do
+        stdout, stderr, status = Open3.capture3(uninstall_command)
+        unless stderr.empty?
+          raise stderr
+        end
+      end
     end
   end
 end

--- a/cli/lib/kontena/cli/plugins/list_command.rb
+++ b/cli/lib/kontena/cli/plugins/list_command.rb
@@ -1,13 +1,15 @@
+require_relative 'common'
+
 module Kontena::Cli::Plugins
   class ListCommand < Kontena::Command
+    include Common
 
     def execute
       titles = ['NAME', 'VERSION', 'DESCRIPTION']
       puts "%-40s %-10s %-40s" % titles
       Kontena::PluginManager.instance.plugins.each do |plugin|
-        puts "%-40s %-10s %-40s" % [plugin.name, plugin.version, plugin.description]
+        puts "%-40s %-10s %-40s" % [short_name(plugin.name), plugin.version, plugin.description]
       end
     end
-
   end
 end

--- a/cli/lib/kontena/cli/plugins/search_command.rb
+++ b/cli/lib/kontena/cli/plugins/search_command.rb
@@ -1,5 +1,8 @@
+require_relative 'common'
+
 module Kontena::Cli::Plugins
   class SearchCommand < Kontena::Command
+    include Common
 
     parameter '[NAME]', 'Search text'
 
@@ -8,8 +11,7 @@ module Kontena::Cli::Plugins
       exit_with_error("Cannot access plugin server") unless results
       puts "%-50s %-10s %-60s" % ['NAME', 'VERSION', 'DESCRIPTION']
       results.each do |item|
-        name = item['name'].sub('kontena-plugin-', '')
-        puts "%-50s %-10s %-60s" % [name, item['version'], item['info']]
+        puts "%-50s %-10s %-60s" % [short_name(item['name']), item['version'], item['info']]
       end
     end
 


### PR DESCRIPTION
This PR improves plugin install logic a bit: now install will first remove previous plugin versions and then install the requested plugin. Reason for doing this is that multiple versions of the same plugin might have conflict in a load path and because of this wrong libraries/files might get loaded.