### PR TITLE
Call IPAM cleanup using API enpoints

### DIFF
--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -17,6 +17,7 @@ require_relative 'kontena/websocket_client'
 
 require_relative 'kontena/network_adapters/weave'
 require_relative 'kontena/network_adapters/ipam_client'
+require_relative 'kontena/network_adapters/ipam_cleaner'
 
 require_relative 'kontena/launchers/etcd'
 require_relative 'kontena/launchers/cadvisor'

--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -7,12 +7,11 @@ module Kontena::Launchers
     include Kontena::Logging
     include Kontena::Helpers::ImageHelper
 
-    CLEANUP_INTERVAL = (3*60) # Run cleanup every 3mins
-    CLEANUP_DELAY = 30
+
 
     IPAM_SERVICE_NAME = 'kontena-ipam-plugin'.freeze
 
-    IPAM_VERSION = ENV['IPAM_VERSION'] || 'latest'
+    IPAM_VERSION = ENV['IPAM_VERSION'] || '0.2'
     IPAM_IMAGE = ENV['IPAM_IMAGE'] || 'kontena/ipam-plugin'
 
     def initialize(autostart = true)
@@ -22,26 +21,7 @@ module Kontena::Launchers
       subscribe('network_adapter:start', :on_network_start)
       info 'initialized'
       async.ensure_image if autostart
-    end
-
-    def cleanup_ipam
-      debug "starting IPAM cleanup loop"
-      loop do
-        sleep CLEANUP_INTERVAL
-        ipam_client = Kontena::NetworkAdapters::IpamClient.new
-        cleanup_index = ipam_client.cleanup_index
-        debug "Got index #{cleanup_index} for IPAM cleanup. Waiting for pending deployments..."
-        sleep CLEANUP_DELAY
-        # Collect locally known addresses
-        debug "starting to collect locally known addresses"
-        local_addresses = []
-        Docker::Container.all(all: true).each do |container|
-          local_addresses << container.overlay_cidr
-        end
-        local_addresses.compact! # remove nils
-        debug "invoking cleanup with #{local_addresses.size} known addresses"
-        ipam_client.cleanup_network('kontena', local_addresses, cleanup_index)
-      end
+      Kontena::NetworkAdapters::IpamCleaner.supervise as: :ipam_cleaner
     end
 
     def ensure_image
@@ -61,7 +41,6 @@ module Kontena::Launchers
         sleep 1
       end
       Celluloid::Notifications.publish('ipam:start', nil)
-      async.cleanup_ipam
     end
 
     def image_exists?

--- a/agent/lib/kontena/network_adapters/ipam_cleaner.rb
+++ b/agent/lib/kontena/network_adapters/ipam_cleaner.rb
@@ -1,0 +1,50 @@
+require_relative '../logging'
+
+module Kontena::NetworkAdapters
+  class IpamCleaner
+    include Celluloid
+    include Celluloid::Notifications
+    include Kontena::Logging
+
+    CLEANUP_INTERVAL = (3*60) # Run cleanup every 3mins
+    CLEANUP_DELAY = 30
+
+    def initialize
+      subscribe('ipam:start', :on_ipam_start)
+      info 'initialized'
+    end
+
+    def on_ipam_start(topic, data)
+      debug "ipam signalled ready, starting cleanup loop"
+      self.async.cleanup_ipam
+    end
+
+    private
+
+    def cleanup_ipam
+      loop do
+        sleep CLEANUP_INTERVAL
+        ipam_client = Kontena::NetworkAdapters::IpamClient.new
+        cleanup_index = ipam_client.cleanup_index
+        debug "got index #{cleanup_index} for IPAM cleanup. Waiting for pending deployments for #{CLEANUP_DELAY} secs..."
+        sleep CLEANUP_DELAY
+        # Collect locally known addresses
+        addresses = collect_local_addresses
+        debug "invoking cleanup with #{addresses.size} known addresses"
+        ipam_client.cleanup_network('kontena', addresses, cleanup_index)
+      end
+    end
+
+    def collect_local_addresses
+      debug "starting to collect locally known addresses"
+      local_addresses = []
+      Docker::Container.all(all: true).each do |container|
+        local_addresses << container.overlay_cidr
+      end
+      local_addresses.compact! # remove nils
+      local_addresses
+    end
+
+  end
+
+end

--- a/agent/lib/kontena/network_adapters/ipam_client.rb
+++ b/agent/lib/kontena/network_adapters/ipam_client.rb
@@ -87,6 +87,25 @@ module Kontena::NetworkAdapters
       handle_error_response(error)
     end
 
+    def cleanup_index
+      response = @connection.get(:path => '/KontenaIPAM.Cleanup', :headers => HEADERS, :expects => [200])
+      parse_response(response).dig('EtcdIndex')
+    rescue Excon::Errors::HTTPStatusError => error
+      handle_error_response(error)
+    end
+
+    def cleanup_network(network, known_addresses, since_index)
+      data = {
+        "EtcdIndex": since_index,
+        "PoolID": network,
+        "Addresses": known_addresses
+      }.to_json
+
+      response = @connection.post(:path => '/KontenaIPAM.Cleanup', :body => data, :headers => HEADERS, :expects => [200])
+    rescue Excon::Errors::HTTPStatusError => error
+      handle_error_response(error)
+    end
+
     private
 
     # @param [Excon::Response] response

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -25,7 +25,6 @@ module Kontena::NetworkAdapters
       subscribe('agent:node_info', :on_node_info)
       subscribe('ipam:start', :on_ipam_start)
       async.ensure_images if autostart
-      #async.cleanup_ipam if autostart
     end
 
     # @return [String]
@@ -86,22 +85,6 @@ module Kontena::NetworkAdapters
       @started == true
     end
 
-    def cleanup_ipam
-      loop do
-        sleep 60 * 3 # 3mins
-        debug "starting ipam cleanup process"
-        ipam_container = Docker::Container.get('kontena-ipam-plugin') rescue nil
-        if ipam_container
-          local_addresses = []
-          Docker::Container.all(all: true).each do |container|
-            local_addresses << container.overlay_cidr
-          end
-          cmd = ['/app/bin/kontena-ipam-cleanup'] + local_addresses.compact
-          debug "executing cleanup with command: #{cmd}"
-          ipam_container.exec(cmd) { |stream, chunk| debug "#{stream}: #{chunk}" }
-        end
-      end
-    end
 
     # @param [Hash] opts
     def modify_create_opts(opts)


### PR DESCRIPTION
Moved the IPAM cleanup loop into IPAM launcher as it's really a task for Weave adapter.

Needs: https://github.com/kontena/kontena-docker-ipam-plugin/pull/61

As soon as we have IPAM release with the cleanup endpoint we should also pin the version and not to use `latest`.