### PR TITLE
Remove launching of weave plugin and unnecessary weave detach call

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -267,18 +267,6 @@ module Kontena::NetworkAdapters
       info "using trusted subnets: #{trusted_subnets.join(',')}" if trusted_subnets && !already_started?
       post_start(info)
 
-      # Start the weavemesh plugin
-      plugin = nil
-      until plugin && plugin.running? do
-        exec_params = [
-          '--local', 'launch-plugin'
-        ]
-        self.exec(exec_params)
-        plugin = Docker::Container.get('weaveplugin') rescue nil
-        wait = Time.now.to_f + 10.0
-        sleep 0.5 until (plugin && plugin.running?) || (wait < Time.now.to_f)
-
-      end
       Celluloid::Notifications.publish('network_adapter:start', info) unless already_started?
 
       @started = true
@@ -326,8 +314,7 @@ module Kontena::NetworkAdapters
       overlay_cidr = event.Actor.attributes['io.kontena.container.overlay_cidr']
       overlay_network = event.Actor.attributes['io.kontena.container.overlay_network']
       if overlay_cidr
-        debug "detaching weave network for container #{event.id}"
-        self.exec(['--local', 'detach', event.id])
+        debug "releasing weave network address for container #{event.id}"
         @ipam_client.release_address(overlay_network, overlay_cidr)
       end
     end


### PR DESCRIPTION
The weave docker plugin launch was left over and now unnecessary as docker plugin networking proved to be not usable.

Weave detach is also "unnecessary" since at the time we get to call the `detach` the container is already gone.

fixes #1319 and #1320 