### PR TITLE
Call weave attach async

### DIFF
--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -15,6 +15,7 @@ require_relative 'kontena/logging'
 require_relative 'kontena/websocket_client'
 
 require_relative 'kontena/network_adapters/weave'
+require_relative 'kontena/network_adapters/weave_executor'
 require_relative 'kontena/network_adapters/ipam_client'
 require_relative 'kontena/network_adapters/ipam_cleaner'
 

--- a/agent/lib/kontena/network_adapters/weave_executor.rb
+++ b/agent/lib/kontena/network_adapters/weave_executor.rb
@@ -1,0 +1,93 @@
+require_relative '../logging'
+require_relative '../helpers/image_helper'
+require_relative '../helpers/iface_helper'
+
+module Kontena::NetworkAdapters
+  class WeaveExecutor
+    include Celluloid
+    include Celluloid::Notifications
+    include Kontena::Logging
+    include Kontena::Helpers::ImageHelper
+
+    def initialize(autostart = true)
+      @images_exist = false
+      info 'initialized'
+      async.ensure_images if autostart
+    end
+
+    # @param [Array<String>] cmd
+    def execute(cmd)
+      sleep 0.5 until @images_exist
+      begin
+        container = Docker::Container.create(
+          'Image' => weave_exec_image,
+          'Cmd' => cmd,
+          'Volumes' => {
+            '/var/run/docker.sock' => {},
+            '/host' => {}
+          },
+          'Labels' => {
+            'io.kontena.container.skip_logs' => '1'
+          },
+          'Env' => [
+            'HOST_ROOT=/host',
+            "VERSION=#{weave_version}",
+            "WEAVE_DEBUG=#{ENV['WEAVE_DEBUG']}",
+          ],
+          'HostConfig' => {
+            'Privileged' => true,
+            'NetworkMode' => 'host',
+            'PidMode' => 'host',
+            'Binds' => [
+              '/var/run/docker.sock:/var/run/docker.sock',
+              '/:/host'
+            ]
+          }
+        )
+        retries = 0
+        response = {}
+        begin
+          response = container.tap(&:start).wait
+        rescue Docker::Error::NotFoundError => exc
+          error exc.message
+          return false
+        rescue => exc
+          retries += 1
+          error exc.message
+          sleep 0.5
+          retry if retries < 10
+
+          error exc.message
+          return false
+        end
+
+        if (status_code = response["StatusCode"]) == 0
+          debug "weaveexec ok: #{cmd}"
+        else
+          logs = container.streaming_logs(stdout: true, stderr: true)
+          error "weaveexec exit #{status_code}: #{cmd}\n#{logs}"
+        end
+        response
+      ensure
+        container.delete(force: true, v: true) if container
+      end
+    end
+
+
+    private
+
+    def weave_exec_image
+      "#{Weave::WEAVEEXEC_IMAGE}:#{Weave::WEAVE_VERSION}"
+    end
+
+    def weave_version
+      Weave::WEAVE_VERSION
+    end
+
+    def ensure_images
+      pull_image(weave_exec_image)
+      @images_exist = true
+    end
+
+  end
+end

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -72,7 +72,7 @@ module Kontena::Workers
     # @param [String] container_id
     # @param [String] overlay_cidr
     def attach_overlay(container_id, overlay_cidr)
-      network_adapter.exec(['--local', 'attach', overlay_cidr, '--rewrite-hosts', container_id])
+      network_adapter.attach_network(overlay_cidr, container_id)
     end
 
     def network_adapter

--- a/agent/spec/lib/kontena/network_adapters/weave_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_spec.rb
@@ -13,6 +13,26 @@ describe Kontena::NetworkAdapters::Weave do
 
   after(:each) { Celluloid.shutdown }
 
+  describe '#terminate' do
+    it 'terminates also executor pool if it is still alive' do
+      pool = double
+      expect(Kontena::NetworkAdapters::WeaveExecutor).to receive(:pool).and_return(pool)
+      expect(pool).to receive(:alive?).and_return(true)
+      expect(pool).to receive(:terminate)
+      subject = described_class.new(false)
+      subject.terminate
+    end
+
+    it 'does not attempt to terminate dead pool' do
+      pool = double
+      expect(Kontena::NetworkAdapters::WeaveExecutor).to receive(:pool).and_return(pool)
+      expect(pool).to receive(:alive?).and_return(false)
+      expect(pool).not_to receive(:terminate)
+      subject = described_class.new(false)
+      subject.terminate
+    end
+  end
+
   describe '#adapter_container' do
     it 'returns true if weave exec container' do
       container = spy(:container, :config => {'Image' => 'weaveworks/weaveexec:latest'})

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -102,9 +102,7 @@ describe Kontena::Workers::WeaveWorker do
     end
 
     it 'calls network_adapter' do
-      expect(adapter).to receive(:exec) {|*args|
-        expect(args[0]).to include('aaa', '10.81.1.1/16')
-      }
+      expect(adapter).to receive(:attach_network).with('10.81.1.1/16', 'aaa')
       subject.attach_overlay('aaa', '10.81.1.1/16')
     end
   end


### PR DESCRIPTION
Refactor weave execs into separate actor pool and do network attach asynchronously. This improves event handling since weave attach will not block anymore.