### PR TITLE
Install self-signed cert locally

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/40_install_ssl_certificate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/40_install_ssl_certificate_after_deploy.rb
@@ -1,0 +1,32 @@
+module Kontena
+  module Callbacks
+    class InstallSslCertificateAfterDeploy < Kontena::Callback
+
+      include Kontena::Cli::Common
+
+      matches_commands 'master create'
+
+      def after
+        return unless command.exit_code == 0
+        return unless command.result.kind_of?(Hash)
+        return unless command.result.has_key?(:ssl_certificate)
+        return unless command.result.has_key?(:public_ip)
+
+        cert_dir = File.join(Dir.home, '.kontena/certs')
+        unless File.directory?(cert_dir)
+          require 'fileutils'
+          FileUtils.mkdir_p(cert_dir)
+        end
+
+        cert_file = File.join(cert_dir, "#{command.result[:public_ip]}.pem")
+
+        spinner "Installing SSL certificate to #{cert_file}" do
+          File.unlink(cert_file) if File.exist?(cert_file)
+          File.write(cert_file, command.result[:ssl_certificate])
+        end
+      end
+    end
+  end
+end
+
+

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -197,16 +197,6 @@ module Kontena
         config.require_current_master.url
       end
 
-      def ensure_custom_ssl_ca(url)
-        return if Excon.defaults[:ssl_ca_file]
-
-        uri = URI::parse(url)
-        cert_file = File.join(Dir.home, "/.kontena/certs/#{uri.host}.pem")
-        if File.exist?(cert_file)
-          Excon.defaults[:ssl_ca_file] = cert_file
-        end
-      end
-
       def current_grid=(grid)
         config.current_grid=(grid)
       end

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -51,14 +51,20 @@ module Kontena
       @logger.progname = 'CLIENT'
 
       @options[:default_headers] ||= {}
-      Excon.defaults[:ssl_verify_peer] = false if ignore_ssl_errors?
+
+      cert_file = File.join(Dir.home, "/.kontena/certs/#{uri.host}.pem")
+      unless File.exist?(cert_file) && File.readable?(cert_file)
+        cert_file = nil
+      end
 
       @http_client = Excon.new(
         api_url,
         omit_default_port: true,
         connect_timeout: ENV["EXCON_CONNECT_TIMEOUT"] ? ENV["EXCON_CONNECT_TIMEOUT"].to_i : 5,
         read_timeout:    ENV["EXCON_READ_TIMEOUT"]    ? ENV["EXCON_READ_TIMEOUT"].to_i    : 30,
-        write_timeout:   ENV["EXCON_WRITE_TIMEOUT"]   ? ENV["EXCON_WRITE_TIMEOUT"].to_i   : 5
+        write_timeout:   ENV["EXCON_WRITE_TIMEOUT"]   ? ENV["EXCON_WRITE_TIMEOUT"].to_i   : 5,
+        ssl_verify_peer: ignore_ssl_errors? ? false : true,
+        ssl_ca_file:     cert_file
       )
 
       @default_headers = {

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -52,20 +52,27 @@ module Kontena
 
       @options[:default_headers] ||= {}
 
-      cert_file = File.join(Dir.home, "/.kontena/certs/#{uri.host}.pem")
-      unless File.exist?(cert_file) && File.readable?(cert_file)
-        cert_file = nil
-      end
-
-      @http_client = Excon.new(
-        api_url,
+      excon_opts = {
         omit_default_port: true,
         connect_timeout: ENV["EXCON_CONNECT_TIMEOUT"] ? ENV["EXCON_CONNECT_TIMEOUT"].to_i : 5,
         read_timeout:    ENV["EXCON_READ_TIMEOUT"]    ? ENV["EXCON_READ_TIMEOUT"].to_i    : 30,
         write_timeout:   ENV["EXCON_WRITE_TIMEOUT"]   ? ENV["EXCON_WRITE_TIMEOUT"].to_i   : 5,
-        ssl_verify_peer: ignore_ssl_errors? ? false : true,
-        ssl_ca_file:     cert_file
-      )
+        ssl_verify_peer: ignore_ssl_errors? ? false : true
+      }
+
+      cert_file = File.join(Dir.home, "/.kontena/certs/#{uri.host}.pem")
+      if File.exist?(cert_file) && File.readable?(cert_file)
+        excon_opts[:ssl_ca_file] = cert_file
+        key = OpenSSL::X509::Certificate.new(File.read(cert_file))
+        if key.issuer.to_s == "/C=FI/O=Test/OU=Test/CN=Test"
+          logger.debug "Key looks like a self-signed cert made by Kontena CLI, setting verify_peer_host to 'Test'"
+          excon_opts[:ssl_verify_peer_host] = 'Test'
+        end
+      end
+
+      logger.debug "Excon opts: #{excon_opts.inspect}"
+
+      @http_client = Excon.new(api_url, excon_opts)
 
       @default_headers = {
         ACCEPT => CONTENT_JSON,

--- a/cli/lib/kontena/machine/cert_helper.rb
+++ b/cli/lib/kontena/machine/cert_helper.rb
@@ -4,6 +4,10 @@ module Kontena
   module Machine
     module CertHelper
 
+      def certificate_public_key(cert)
+        cert[/(-----BEGIN CERTIFICATE-----.+?-----END CERTIFICATE-----)/m, 1]
+      end
+
       def generate_self_signed_cert
         key = OpenSSL::PKey::RSA.new(2048)
         public_key = key.public_key


### PR DESCRIPTION
Implements #1228 if the provisioining plugins return the cert in the result response hash. 

It also fixes a problem with having multiple instances of Kontena::Client. The current version pollutes Excon.defaults which will have effect on subsequently created instances of excon. This version only sets configuration for the current instance.

It is a bit questionable though:

The `generate_self_signed_cert` method, which I have not touched here, sets the certificate hostname for all generated certs to "Test". If your master url is not `https://Test/` the cert will never work without disabling ssl peer verification.

Because of this, it's required to fake the hostname of the master using `:ssl_verify_peer_host => "Test"`  when a cert file with a subject-string that looks like one generated by `generate_self_signed_cert` is used, otherwise you will get an error saying: `hostname "10.0.0.1" does not match the server certificate (OpenSSL::SSL::SSLError)`

With the current version, even if you are crafty enough to ssh into the master and copy the certificate from there, it's not possible to actually use the certificate unless you trick the server hostname to be "Test" using `/etc/hosts` or something like that. The only way to utilize the cli-generated self signed certs is to use `IGNORE_SSL_ERRORS=true`.

Another issue with this implementation is that it doesn't work if you use something else than the public ip to access your master.

Securitywise it feels a bit fishy to trust all certificate files that belong to "Test", but I don't know how you could end up having a file called `master_ip.pem` in your `~/.kontena/certs/` directory, it's only done for files loaded from there.

The change required for plugins looks like this:

```ruby
# master_provisioner.rb:
    ssl_cert = generate_self_signed_cert
    public_cert = certificate_public_key(ssl_cert)
# ...
      {
        name: name.sub('kontena-master-', ''),
        public_ip: public_ip['address'],
        code: opts[:initial_admin_code],
        provider: 'packet',
        version: master_version,
        ssl_certificate: public_cert
      }
```
