### PR TITLE
Ensure all network parts are running in Weave.running?

### DIFF
--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -1,0 +1,26 @@
+require_relative '../logging'
+
+module Kontena
+  module Helpers
+    module WaitHelper
+      include Kontena::Logging
+
+      def wait(timeout = 300, message = nil, &block)
+        wait = Time.now.to_f + timeout
+        until (value = network_adapter.running?) || (wait < Time.now.to_f)
+          value = yield if block
+          sleep 0.5
+          debug "************" + message if message
+        end
+        return value
+      end
+
+      def wait!(timeout = 300, message = nil, &block)
+        unless wait(timeout, message, &block)
+          raise StandarError, "Timeout while: #{message}"
+        end
+      end
+
+    end
+  end
+end

--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -8,7 +8,8 @@ module Kontena
       def wait(timeout = 300, message = nil, &block)
         wait_until = Time.now.to_f + timeout
         loop do
-          value = yield if block
+          raise ArgumentError, 'no block given' unless block_given?
+          value = yield
           return value if value || !still_waiting?(wait_until)
           debug message if message
           sleep 0.5

--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -6,19 +6,24 @@ module Kontena
       include Kontena::Logging
 
       def wait(timeout = 300, message = nil, &block)
-        wait = Time.now.to_f + timeout
-        until (value = network_adapter.running?) || (wait < Time.now.to_f)
+        wait_until = Time.now.to_f + timeout
+        loop do
           value = yield if block
+          return value if value || !still_waiting?(wait_until)
+          debug message if message
           sleep 0.5
-          debug "************" + message if message
         end
-        return value
+      end
+
+      def still_waiting?(wait_until)
+        wait_until < Time.now.to_f
       end
 
       def wait!(timeout = 300, message = nil, &block)
         unless wait(timeout, message, &block)
           raise StandarError, "Timeout while: #{message}"
         end
+        true
       end
 
     end

--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -5,26 +5,45 @@ module Kontena
     module WaitHelper
       include Kontena::Logging
 
-      def wait(timeout = 300, message = nil, &block)
+
+      ##
+      # Wait until given block returns truthy value
+      #
+      # @param timeout [Fixnum] How long to wait
+      # @param interval [Fixnum] At what interval is the block yielded
+      # @param [String] Message for debugging
+      # @param [Block] Block to yield
+      # @return [Object] Last return value of the block
+      def wait(timeout: 300, interval: 0.5, message: nil, &block)
         wait_until = Time.now.to_f + timeout
         loop do
           raise ArgumentError, 'no block given' unless block_given?
           value = yield
-          return value if value || !still_waiting?(wait_until)
+          return value if value || !__still_waiting?(wait_until)
           debug message if message
-          sleep 0.5
+          sleep interval
         end
       end
 
-      def still_waiting?(wait_until)
-        wait_until < Time.now.to_f
-      end
-
-      def wait!(timeout = 300, message = nil, &block)
-        unless wait(timeout, message, &block)
-          raise StandarError, "Timeout while: #{message}"
+      ##
+      # Wait until given block returns truthy value
+      #
+      # @param timeout [Fixnum] How long to wait
+      # @param interval [Fixnum] At what interval is the block yielded
+      # @param [String] Message for debugging
+      # @param [Block] Block to yield
+      # @return [Object] Last return value of the block
+      # @raise [Timeout::Error] If block does not return truthy value within given timeout
+      def wait!(timeout: 300, interval: 0.5, message: nil, &block)
+        unless wait(timeout: timeout, interval: interval, message: message, &block)
+          raise Timeout::Error, "Timeout while: #{message}"
         end
         true
+      end
+
+
+      def __still_waiting?(wait_until)
+        wait_until < Time.now.to_f
       end
 
     end

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -5,11 +5,8 @@ module Kontena
   module Helpers
     module WeaveHelper
 
-      # @return [Boolean]
-      def weave_running?
-        weave = Docker::Container.get('weave') rescue nil
-        return false if weave.nil?
-        weave.info['State']['Running'] == true
+      def network_adapter
+        Actor[:network_adapter]
       end
 
       def weave_api_ready?

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -12,6 +12,11 @@ module Kontena
         weave.info['State']['Running'] == true
       end
 
+      def weave_api_ready?
+        response = dns_client.get(path: '/status')
+        response.status == 200
+      end
+
       # @param [String] container_id
       # @param [String] ip
       # @param [String] name

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -6,7 +6,16 @@ module Kontena
     module WeaveHelper
 
       def network_adapter
-        Actor[:network_adapter]
+        Celluloid::Actor[:network_adapter]
+      end
+
+      def wait_weave_running?(timeout = 10, &block)
+        wait = Time.now.to_f + timeout
+        until (running = network_adapter.running?) || (wait < Time.now.to_f)
+          yield if block # debugging
+          sleep 0.5
+        end
+        return running
       end
 
       def weave_api_ready?

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -1,21 +1,27 @@
 require 'docker'
 require_relative 'iface_helper'
+require_relative 'wait_helper'
+
 
 module Kontena
   module Helpers
     module WeaveHelper
+      include WaitHelper
 
       def network_adapter
         Celluloid::Actor[:network_adapter]
       end
 
-      def wait_weave_running?(timeout = 10, &block)
-        wait = Time.now.to_f + timeout
-        until (running = network_adapter.running?) || (wait < Time.now.to_f)
-          yield if block # debugging
-          sleep 0.5
-        end
-        return running
+      def wait_weave_running?
+        wait!(300, "waiting for weave running") {
+          network_adapter.running?
+        }
+      end
+
+      def wait_network_ready?
+        wait!(300, "waiting for all network components running") {
+          network_adapter.network_ready?
+        }
       end
 
       def weave_api_ready?

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -13,20 +13,23 @@ module Kontena
       end
 
       def wait_weave_running?
-        wait!(300, "waiting for weave running") {
+        wait!(timeout: 300, message: 'waiting for weave running') {
           network_adapter.running?
         }
       end
 
       def wait_network_ready?
-        wait!(300, "waiting for all network components running") {
+        wait!(timeout: 300, message: 'waiting for all network components running') {
           network_adapter.network_ready?
         }
       end
 
       def weave_api_ready?
-        response = dns_client.get(path: '/status')
+        # getting status should be pretty fast, set low timeouts to fail faster
+        response = dns_client.get(path: '/status', :connect_timeout => 5, :read_timeout => 5)
         response.status == 200
+      rescue Excon::Error
+        false
       end
 
       # @param [String] container_id

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -79,9 +79,14 @@ module Kontena::NetworkAdapters
     # @return [Boolean]
     def running?
       return false unless weave_container_running?
-      return false unless ipam_running?
       return false unless weave_api_ready?
       return false unless interface_ip('weave')
+      true
+    end
+
+    def network_ready?
+      return false unless running?
+      return false unless ipam_running?
       true
     end
 

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -1,6 +1,7 @@
 require_relative '../logging'
 require_relative '../helpers/node_helper'
 require_relative '../helpers/iface_helper'
+require_relative '../helpers/weave_helper'
 
 module Kontena::NetworkAdapters
   class Weave
@@ -8,6 +9,7 @@ module Kontena::NetworkAdapters
     include Celluloid::Notifications
     include Kontena::Helpers::NodeHelper
     include Kontena::Helpers::IfaceHelper
+    include Kontena::Helpers::WeaveHelper
     include Kontena::Logging
 
     WEAVE_VERSION = ENV['WEAVE_VERSION'] || '1.7.2'
@@ -81,6 +83,11 @@ module Kontena::NetworkAdapters
       return false unless weave_api_ready?
       return false unless interface_ip('weave')
       true
+    end
+
+    def weave_api_ready?
+      response = dns_client.get(path: '/status')
+      response.status == 200
     end
 
     # @return [Boolean]

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -76,11 +76,22 @@ module Kontena::NetworkAdapters
 
     # @return [Boolean]
     def running?
-      weave = Docker::Container.get('weave') rescue nil
-      return false if weave.nil?
-      weave.running? && ipam_running?
+      return false unless weave_container_running?
+      return false unless ipam_running?
+      return false unless weave_api_ready?
+      return false unless interface_ip('weave')
+      true
     end
 
+    # @return [Boolean]
+    def weave_container_running?
+      weave = Docker::Container.get('weave') rescue nil
+      return false if weave.nil?
+      return false unless weave.running?
+      true
+    end
+
+    # @return [Boolean]
     def ipam_running?
       @ipam_running
     end

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -2,12 +2,14 @@ require 'docker'
 require 'celluloid'
 require_relative 'common'
 require_relative '../logging'
+require_relative '../helpers/weave_helper'
 
 module Kontena
   module ServicePods
     class Creator
       include Kontena::Logging
       include Common
+      include Kontena::Helpers::WeaveHelper
 
       attr_reader :service_pod, :image_credentials
 
@@ -27,7 +29,7 @@ module Kontena
         end
         service_container = get_container(service_pod.service_id, service_pod.instance_number)
 
-        sleep 1 until Celluloid::Actor[:network_adapter].running?
+        wait_network_ready?
 
         if service_container
           if service_uptodate?(service_container)

--- a/agent/lib/kontena/workers/container_starter_worker.rb
+++ b/agent/lib/kontena/workers/container_starter_worker.rb
@@ -23,7 +23,7 @@ module Kontena::Workers
     end
 
     def start
-      sleep 1 until weave_running?
+      sleep 1 until network_adapter.running?
       Docker::Container.all(all: true).each do |container|
         self.ensure_container_running(container)
       end
@@ -37,5 +37,6 @@ module Kontena::Workers
         end
       end
     end
+    
   end
 end

--- a/agent/lib/kontena/workers/container_starter_worker.rb
+++ b/agent/lib/kontena/workers/container_starter_worker.rb
@@ -23,7 +23,7 @@ module Kontena::Workers
     end
 
     def start
-      sleep 1 until network_adapter.running?
+      wait_weave_running?
       Docker::Container.all(all: true).each do |container|
         self.ensure_container_running(container)
       end
@@ -37,6 +37,6 @@ module Kontena::Workers
         end
       end
     end
-    
+
   end
 end

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -21,7 +21,7 @@ module Kontena::Workers
     end
 
     def start
-      wait_weave_running? { debug "waiting for weave running before attaching network to containers" }
+      wait_weave_running?
       info 'attaching network to existing containers'
       Docker::Container.all(all: false).each do |container|
         self.weave_attach(container)
@@ -29,7 +29,7 @@ module Kontena::Workers
     end
 
     def on_dns_add(topic, event)
-      wait_weave_running? { debug "waiting for weave running?" }
+      wait_weave_running?
       add_dns(event[:id], event[:ip], event[:name])
     end
 
@@ -37,13 +37,12 @@ module Kontena::Workers
     # @param [Docker::Event] event
     def on_container_event(topic, event)
       if event.status == 'start'
-        wait_weave_running? { debug "waiting for weave running before handling start event" }
+        wait_weave_running?
         container = Docker::Container.get(event.id) rescue nil
         if container
           self.weave_attach(container)
         end
       elsif event.status == 'restart'
-        wait_weave_running? { debug "waiting for weave running before handling restart event" }
         if network_adapter.router_image?(event.from)
           self.start
         end

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -12,7 +12,7 @@ describe Kontena::Helpers::WaitHelper do
 
   describe 'wait' do
     it 'returns true immediately' do
-      expect(Kernel).not_to receive(:sleep)
+      expect(subject).not_to receive(:sleep)
       value = subject.wait { true }
       expect(value).to be_truthy
     end
@@ -30,6 +30,12 @@ describe Kontena::Helpers::WaitHelper do
       expect(subject).to receive(:sleep).once
       value = subject.wait(2, 'foo') { false }
       expect(value).to be_falsey
+    end
+
+    it 'raises if no block given' do
+      expect {
+        subject.wait
+      }.to raise_error(ArgumentError)
     end
   end
 

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -1,0 +1,63 @@
+require_relative '../../../spec_helper'
+
+describe Kontena::Helpers::WaitHelper do
+
+  let(:klass) {
+    Class.new { include Kontena::Helpers::WaitHelper }
+  }
+
+  let(:subject) {
+    klass.new
+  }
+
+  describe 'wait' do
+    it 'returns true immediately' do
+      expect(Kernel).not_to receive(:sleep)
+      value = subject.wait { true }
+      expect(value).to be_truthy
+    end
+
+    it 'sleeps between retries' do
+      expect(subject).to receive(:still_waiting?).and_return(true, true, false)
+      expect(subject).to receive(:sleep).twice
+      value = subject.wait(2) { false }
+      expect(value).to be_falsey
+    end
+
+    it 'debugs given message' do
+      expect(subject).to receive(:still_waiting?).and_return(true, false)
+      expect(subject).to receive(:debug).with('foo')
+      expect(subject).to receive(:sleep).once
+      value = subject.wait(2, 'foo') { false }
+      expect(value).to be_falsey
+    end
+  end
+
+  describe '#wait!' do
+    it 'return true when wait gives true' do
+      expect(subject).to receive(:wait).and_return(true)
+      value = subject.wait! { true }
+      expect(value).to be_truthy
+    end
+
+    it 'raises when wait return false' do
+      expect(subject).to receive(:wait).and_return(false)
+      expect {
+        subject.wait! { false }
+      }.to raise_error
+    end
+  end
+
+  describe 'still_waiting?' do
+    it 'return true if more waiting needed' do
+      wait_until = Time.now.to_f - 1.0
+      expect(subject.still_waiting?(wait_until)).to be_truthy
+    end
+
+    it 'return true if more waiting needed' do
+      wait_until = Time.now.to_f + 1.0
+      expect(subject.still_waiting?(wait_until)).to be_falsey
+    end
+  end
+
+end

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -18,17 +18,17 @@ describe Kontena::Helpers::WaitHelper do
     end
 
     it 'sleeps between retries' do
-      expect(subject).to receive(:still_waiting?).and_return(true, true, false)
+      expect(subject).to receive(:__still_waiting?).and_return(true, true, false)
       expect(subject).to receive(:sleep).twice
-      value = subject.wait(2) { false }
+      value = subject.wait(timeout: 2) { false }
       expect(value).to be_falsey
     end
 
     it 'debugs given message' do
-      expect(subject).to receive(:still_waiting?).and_return(true, false)
+      expect(subject).to receive(:__still_waiting?).and_return(true, false)
       expect(subject).to receive(:debug).with('foo')
       expect(subject).to receive(:sleep).once
-      value = subject.wait(2, 'foo') { false }
+      value = subject.wait(timeout:2, interval:0.5, message: 'foo') { false }
       expect(value).to be_falsey
     end
 
@@ -49,20 +49,20 @@ describe Kontena::Helpers::WaitHelper do
     it 'raises when wait return false' do
       expect(subject).to receive(:wait).and_return(false)
       expect {
-        subject.wait! { false }
-      }.to raise_error
+        subject.wait!(message: 'foo') { false }
+      }.to raise_error(Timeout::Error, "Timeout while: foo")
     end
   end
 
-  describe 'still_waiting?' do
+  describe '#__still_waiting?' do
     it 'return true if more waiting needed' do
       wait_until = Time.now.to_f - 1.0
-      expect(subject.still_waiting?(wait_until)).to be_truthy
+      expect(subject.__still_waiting?(wait_until)).to be_truthy
     end
 
     it 'return true if more waiting needed' do
       wait_until = Time.now.to_f + 1.0
-      expect(subject.still_waiting?(wait_until)).to be_falsey
+      expect(subject.__still_waiting?(wait_until)).to be_falsey
     end
   end
 

--- a/agent/spec/lib/kontena/network_adapters/weave_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_spec.rb
@@ -45,19 +45,65 @@ describe Kontena::NetworkAdapters::Weave do
     end
   end
 
-  describe '#running?' do
-    it 'returns true if weave and ipam is running' do
-      weave = spy(:weave, :running? => true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
-      allow(Docker::Container).to receive(:get).with('weave').and_return(weave)
-      expect(subject.running?).to be_truthy
+  describe '#weave_container_running?' do
+    it 'returns false if weave does not exist' do
+      weave = spy(:weave, :running? => false)
+      allow(Docker::Container).to receive(:get).with('weave') {
+        raise Docker::Error::NotFoundError.new
+      }
+      expect(subject.weave_container_running?).to be_falsey
     end
 
     it 'returns false if weave is not running' do
       weave = spy(:weave, :running? => false)
       allow(Docker::Container).to receive(:get).with('weave').and_return(weave)
+      expect(subject.weave_container_running?).to be_falsey
+    end
+
+    it 'returns true if weave is not running' do
+      weave = spy(:weave, :running? => true)
+      allow(Docker::Container).to receive(:get).with('weave').and_return(weave)
+      expect(subject.weave_container_running?).to be_truthy
+    end
+  end
+
+  describe '#running?' do
+    it 'return false if weave container not running' do
+      expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(false)
       expect(subject.running?).to be_falsey
     end
+
+    it 'return false if weave container running but ipam not' do
+      expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(false)
+      expect(subject.running?).to be_falsey
+    end
+
+    it 'return false if weave container and ipam running but weave api not ready' do
+      expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:weave_api_ready?).and_return(false)
+      expect(subject.running?).to be_falsey
+    end
+
+
+    it 'return false if weave container, ipam and weave api running but weave bridge not configured' do
+      expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:weave_api_ready?).and_return(true)
+      expect(subject.wrapped_object).to receive(:interface_ip).and_return(nil)
+      expect(subject.running?).to be_falsey
+    end
+
+    it 'returns true only if all components running' do
+      expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:weave_api_ready?).and_return(true)
+      expect(subject.wrapped_object).to receive(:interface_ip).and_return('10.81.0.1')
+      expect(subject.running?).to be_truthy
+    end
+
+
 
     it 'returns false if weave is running but ipam not running' do
       weave = spy(:weave, :running? => true)
@@ -66,13 +112,7 @@ describe Kontena::NetworkAdapters::Weave do
       expect(subject.running?).to be_falsey
     end
 
-    it 'returns false if weave does not exist' do
-      weave = spy(:weave, :running? => false)
-      allow(Docker::Container).to receive(:get).with('weave') {
-        raise Docker::Error::NotFoundError.new
-      }
-      expect(subject.running?).to be_falsey
-    end
+
   end
 
   describe '#config_changed?' do

--- a/agent/spec/lib/kontena/network_adapters/weave_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_spec.rb
@@ -73,23 +73,15 @@ describe Kontena::NetworkAdapters::Weave do
       expect(subject.running?).to be_falsey
     end
 
-    it 'return false if weave container running but ipam not' do
+    it 'return false if weave container running but weave api not ready' do
       expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(false)
-      expect(subject.running?).to be_falsey
-    end
-
-    it 'return false if weave container and ipam running but weave api not ready' do
-      expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
       expect(subject.wrapped_object).to receive(:weave_api_ready?).and_return(false)
       expect(subject.running?).to be_falsey
     end
 
 
-    it 'return false if weave container, ipam and weave api running but weave bridge not configured' do
+    it 'return false if weave container and weave api running but weave bridge not configured' do
       expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
       expect(subject.wrapped_object).to receive(:weave_api_ready?).and_return(true)
       expect(subject.wrapped_object).to receive(:interface_ip).and_return(nil)
       expect(subject.running?).to be_falsey
@@ -97,22 +89,29 @@ describe Kontena::NetworkAdapters::Weave do
 
     it 'returns true only if all components running' do
       expect(subject.wrapped_object).to receive(:weave_container_running?).and_return(true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
       expect(subject.wrapped_object).to receive(:weave_api_ready?).and_return(true)
       expect(subject.wrapped_object).to receive(:interface_ip).and_return('10.81.0.1')
       expect(subject.running?).to be_truthy
     end
+  end
 
-
-
-    it 'returns false if weave is running but ipam not running' do
-      weave = spy(:weave, :running? => true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(false)
-      allow(Docker::Container).to receive(:get).with('weave').and_return(weave)
-      expect(subject.running?).to be_falsey
+  describe '#network_ready?' do
+    it 'return false is weave not running' do
+      expect(subject.wrapped_object).to receive(:running?).and_return(false)
+      expect(subject.network_ready?).to be_falsey
     end
 
+    it 'return false is weave running but ipam not' do
+      expect(subject.wrapped_object).to receive(:running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(false)
+      expect(subject.network_ready?).to be_falsey
+    end
 
+    it 'return true is weave and ipam running' do
+      expect(subject.wrapped_object).to receive(:running?).and_return(true)
+      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
+      expect(subject.network_ready?).to be_truthy
+    end
   end
 
   describe '#config_changed?' do


### PR DESCRIPTION
fixes #1314 

This PR enhances the weave `running?` check so that it checks all "components" of the overlay network are operational.