### PR TITLE
Stack expose

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -31,6 +31,7 @@ module Kontena
                   :net,
                   :hostname,
                   :domainname,
+                  :exposed,
                   :log_driver,
                   :log_opts,
                   :pid,
@@ -67,6 +68,7 @@ module Kontena
         @net = attrs['net'] || 'bridge'
         @hostname = attrs['hostname']
         @domainname = attrs['domainname']
+        @exposed = attrs['exposed']
         @log_driver = attrs['log_driver']
         @log_opts = attrs['log_opts']
         @pid = attrs['pid']
@@ -129,6 +131,7 @@ module Kontena
         labels['io.kontena.container.deploy_rev'] = self.deploy_rev.to_s
         labels['io.kontena.container.service_revision'] = self.service_revision.to_s
         labels['io.kontena.service.instance_number'] = self.instance_number.to_s
+        labels['io.kontena.service.exposed'] = '1' if self.exposed
         docker_opts['Labels'] = labels
         docker_opts['HostConfig'] = self.service_host_config
         #docker_opts['NetworkingConfig'] = build_networks unless self.networks.empty?
@@ -155,7 +158,7 @@ module Kontena
         end
 
         host_config['NetworkMode'] = self.net
-        host_config['DnsSearch'] = [self.domainname]
+        host_config['DnsSearch'] = [self.domainname, self.domainname.split('.', 2)[1]]
         host_config['CpuShares'] = self.cpu_shares if self.cpu_shares
         host_config['Memory'] = self.memory if self.memory
         host_config['MemorySwap'] = self.memory_swap if self.memory_swap

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -135,7 +135,6 @@ module Kontena::NetworkAdapters
       dns = interface_ip('docker0')
       if dns && host_config['NetworkMode'].to_s != 'host'.freeze
         host_config['Dns'] = [dns]
-        host_config['DnsSearch'] = [opts['Domainname']]
       end
       opts['HostConfig'] = host_config
     end

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -253,6 +253,7 @@ describe Kontena::Models::ServicePod do
 
     it 'sets DnsSearch' do
       expect(host_config['DnsSearch']).to include(subject.service_config['Domainname'])
+      expect(host_config['DnsSearch']).to include(subject.service_config['Domainname'].split(".", 2)[1])
     end
 
     it 'does not include CpuShares if not defined' do

--- a/agent/spec/lib/kontena/network_adapters/weave_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_spec.rb
@@ -129,7 +129,6 @@ describe Kontena::NetworkAdapters::Weave do
       }
       subject.modify_host_config(opts)
       expect(opts['HostConfig']['Dns']).to include(bridge_ip)
-      expect(opts['HostConfig']['DnsSearch']).to include(opts['Domainname'])
     end
 
     it 'does not add dns settings when NetworkMode=host' do

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -158,5 +158,30 @@ describe Kontena::Workers::WeaveWorker do
       expect(names).to include('redis-2.custom.foo.kontena.local')
       expect(names).to include('redis.custom.foo.kontena.local')
     end
+
+    it 'registers all dns names for non-default exposed stack' do
+      allow(container).to receive(:default_stack?).and_return(false)
+      allow(container).to receive(:config).and_return({
+        'Domainname' => 'custom.foo.kontena.local',
+        'Hostname' => 'redis-2'
+      })
+      allow(container).to receive(:labels).and_return({
+        'io.kontena.stack.name' => 'custom',
+        'io.kontena.grid.name' => 'foo',
+        'io.kontena.service.exposed' => '1',
+        'io.kontena.service.name' => 'redis',
+        'io.kontena.service.instance_number' => 2,
+        'io.kontena.container.name' => 'redis-2'
+      })
+      names = []
+      expect(subject.wrapped_object).to receive(:add_dns).exactly(4).times { |id, ip, name|
+        names << name
+      }
+      subject.register_container_dns(container)
+      expect(names).to include('redis-2.custom.foo.kontena.local')
+      expect(names).to include('redis.custom.foo.kontena.local')
+      expect(names).to include('custom.foo.kontena.local')
+      expect(names).to include('custom-2.foo.kontena.local')
+    end
   end
 end

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -115,6 +115,12 @@ class GridService
     self.state == 'stopped'
   end
 
+  # @return [Boolean]
+  def stack_exposed?
+    return false unless self.stack
+    self.stack.exposed_service?(self)
+  end
+
   def deploy_pending?
     self.grid_service_deploys.where(started_at: nil).count > 0
   end

--- a/server/app/models/stack.rb
+++ b/server/app/models/stack.rb
@@ -5,6 +5,7 @@ class Stack
 
   field :name, type: String
   field :version, type: String, default: '1'
+  field :expose, type: String
 
   belongs_to :grid
 
@@ -36,5 +37,10 @@ class Stack
     return :running if services.all?{ |s| s.running? }
 
     :partially_running
+  end
+
+  # @param [GridService] grid_service
+  def exposed_service?(grid_service)
+    self.expose.to_s == grid_service.name
   end
 end

--- a/server/app/models/stack_revision.rb
+++ b/server/app/models/stack_revision.rb
@@ -4,6 +4,7 @@ class StackRevision
 
   field :name, type: String
   field :version, type: Integer, default: 1
+  field :expose, type: String
   field :services, type: Array
 
   belongs_to :stack

--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -10,6 +10,12 @@ module Stacks
       end
     end
 
+    def validate_expose
+      if self.expose && !self.services.find{ |s| s[:name] == self.expose}
+        add_error(:expose, :not_found, "#{self.expose} is not defined in the services array")
+      end
+    end
+
     def sort_services(services)
       services.sort{ |a, b|
         a_links = a[:links] || []

--- a/server/app/mutations/stacks/create.rb
+++ b/server/app/mutations/stacks/create.rb
@@ -19,8 +19,12 @@ module Stacks
     end
 
     def validate
-      if grid.stacks.find_by(name: name)
+      if self.grid.stacks.find_by(name: name)
         add_error(:name, :exists, "#{name} already exists")
+        return
+      end
+      if self.services.size == 0
+        add_error(:services, :empty, "stack does not specify any services")
         return
       end
       validate_expose

--- a/server/app/mutations/stacks/create.rb
+++ b/server/app/mutations/stacks/create.rb
@@ -8,9 +8,14 @@ module Stacks
       model :current_user, class: User
       model :grid, class: Grid
       string :name, matches: /^(?!-)(\w|-)+$/ # do not allow "-" as a first character
+
       array :services do
         model :object, class: Hash
       end
+    end
+
+    optional do
+      string :expose
     end
 
     def validate
@@ -18,6 +23,11 @@ module Stacks
         add_error(:name, :exists, "#{name} already exists")
         return
       end
+      validate_expose
+      validate_services
+    end
+
+    def validate_services
       sort_services(self.services).each do |s|
         service = s.dup
         service.delete(:links)
@@ -42,7 +52,11 @@ module Stacks
         end
         return
       end
-      stack.stack_revisions.create(services: sort_services(services), version: 1)
+      stack.stack_revisions.create(
+        expose: stack.expose,
+        services: sort_services(services),
+        version: 1
+      )
       stack
     end
   end

--- a/server/app/mutations/stacks/update.rb
+++ b/server/app/mutations/stacks/update.rb
@@ -12,6 +12,10 @@ module Stacks
       end
     end
 
+    optional do
+      string :expose
+    end
+
     def validate
       sort_services(self.services).each do |s|
         service = s.dup
@@ -37,7 +41,11 @@ module Stacks
     end
 
     def execute
-      self.stack.stack_revisions.create(services: sort_services(self.services))
+      self.stack.expose = self.expose
+      self.stack.stack_revisions.create(
+        expose: self.stack.expose,
+        services: sort_services(self.services)
+      )
       self.stack.save
       self.stack.reload
     end

--- a/server/app/mutations/stacks/update.rb
+++ b/server/app/mutations/stacks/update.rb
@@ -17,6 +17,10 @@ module Stacks
     end
 
     def validate
+      if self.services.size == 0
+        add_error(:services, :empty, "stack does not specify any services")
+        return
+      end
       sort_services(self.services).each do |s|
         service = s.dup
         service[:current_user] = self.current_user

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -52,6 +52,7 @@ module Docker
         net: grid_service.net,
         hostname: build_hostname(grid_service, instance_number),
         domainname: build_domainname(grid_service),
+        exposed: grid_service.stack_exposed?,
         log_driver: grid_service.log_driver,
         log_opts: grid_service.log_opts,
         pid: grid_service.pid

--- a/server/app/views/v1/stacks/_stack.json.jbuilder
+++ b/server/app/views/v1/stacks/_stack.json.jbuilder
@@ -4,6 +4,7 @@ json.state stack.state
 json.created_at stack.created_at
 json.updated_at stack.updated_at
 json.version stack.version
+json.expose stack.expose
 json.services stack.grid_services.to_a do |grid_service|
   json.partial! 'app/views/v1/grid_services/grid_service', grid_service: grid_service
 end

--- a/server/spec/api/v1/grid_stacks_spec.rb
+++ b/server/spec/api/v1/grid_stacks_spec.rb
@@ -34,7 +34,7 @@ describe '/v1/grids/:grid/stacks' do
         post "/v1/grids/#{grid.name}/stacks", data.to_json, request_headers
         expect(response.status).to eq(201)
         expect(json_response.keys.sort).to eq(%w(
-          id created_at updated_at name version services state
+          id created_at updated_at name version services state expose
         ).sort)
       }.to change{ grid.reload.stacks.count }.by(1)
     end

--- a/server/spec/api/v1/grid_stacks_spec.rb
+++ b/server/spec/api/v1/grid_stacks_spec.rb
@@ -27,21 +27,16 @@ describe '/v1/grids/:grid/stacks' do
     AccessToken.create!(user: david, scopes: ['user'])
   end
 
-  describe 'POST' do
-    it 'creates new empty stack' do
-      expect {
-        data = { name: 'test-stack', services: [] }
-        post "/v1/grids/#{grid.name}/stacks", data.to_json, request_headers
-        expect(response.status).to eq(201)
-        expect(json_response.keys.sort).to eq(%w(
-          id created_at updated_at name version services state expose
-        ).sort)
-      }.to change{ grid.reload.stacks.count }.by(1)
-    end
+  let(:services) do
+    [
+      {name: 'redis', image: 'redis:3', stateful: true}
+    ]
+  end
 
+  describe 'POST' do
     it 'creates audit event' do
       expect {
-        data = { name: 'test-stack', services: [] }
+        data = { name: 'test-stack', services: services }
         post "/v1/grids/#{grid.name}/stacks", data.to_json, request_headers
         expect(response.status).to eq(201)
       }.to change{ AuditLog.count }.by(1)
@@ -50,13 +45,7 @@ describe '/v1/grids/:grid/stacks' do
     it 'creates new stack' do
       data = {
         name: 'test-stack',
-        services: [
-          {
-            name: 'app',
-            image: 'my/app:latest',
-            stateful: false
-          }
-        ]
+        services: services
       }
       expect {
         post "/v1/grids/#{grid.name}/stacks", data.to_json, request_headers
@@ -79,6 +68,12 @@ describe '/v1/grids/:grid/stacks' do
         post "/v1/grids/#{grid.name}/stacks", data.to_json, request_headers
         expect(response.status).to eq(201)
       }.to change{ StackRevision.count }.by(1)
+    end
+
+    it 'returns 422 error if services is empty' do
+      data = { name: 'test-stack', services: [] }
+      post "/v1/grids/#{grid.name}/stacks", data.to_json, request_headers
+      expect(response.status).to eq(422)
     end
 
     it 'return 422 for service validation failure' do

--- a/server/spec/api/v1/stacks_spec.rb
+++ b/server/spec/api/v1/stacks_spec.rb
@@ -57,7 +57,7 @@ describe '/v1/stacks' do
       get "/v1/stacks/#{stack.to_path}", nil, request_headers
       expect(response.status).to eq(200)
       expect(json_response.keys.sort).to eq(%w(
-        id created_at updated_at name version services state
+        id created_at updated_at name version services state expose
       ).sort)
       expect(json_response['services'].size).to eq(0)
     end
@@ -84,7 +84,7 @@ describe '/v1/stacks' do
       expect(response.status).to eq(200)
       expect(json_response['stacks'].size).to eq(grid.stacks.count)
       expect(json_response['stacks'][0].keys.sort).to eq(%w(
-        id created_at updated_at name version services state
+        id created_at updated_at name version services state expose
       ).sort)
     end
 

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -223,4 +223,16 @@ describe GridService do
       expect(grid_service.name_with_stack).to include("#{grid_service.stack.name}-")
     end
   end
+
+  describe '#stack_exposed?' do
+    it 'returns true if service is exposed via stack' do
+      stack = Stack.create!(name: 'redis', expose: 'redis')
+      service = GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8', stack: stack)
+      expect(service.stack_exposed?).to be_truthy
+    end
+
+    it 'returns false if service is not exposed via stack' do
+      expect(grid_service.stack_exposed?).to be_falsey
+    end
+  end
 end

--- a/server/spec/models/stack_revision_spec.rb
+++ b/server/spec/models/stack_revision_spec.rb
@@ -4,6 +4,7 @@ describe StackRevision do
   it { should be_timestamped_document }
   it { should have_fields(:version).of_type(Integer) }
   it { should have_fields(:services).of_type(Array) }
+  it { should have_fields(:expose).of_type(String) }
   it { should belong_to(:stack) }
 
   it { should have_index_for(stack_id: 1) }

--- a/server/spec/models/stack_spec.rb
+++ b/server/spec/models/stack_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 describe Stack do
 
   it { should be_timestamped_document }
-  it { should have_fields(:name, :version).of_type(String) }
+  it { should have_fields(:name, :version, :expose).of_type(String) }
   it { should belong_to(:grid) }
   it { should have_many(:stack_revisions)}
   it { should have_many(:grid_services)}


### PR DESCRIPTION
This PR introduces "expose" feature to a stack. Stack expose will expose single service to the grid dns namespace. 

Example, stack "elastic" that exposes "node" service will be registered to following additional dns addresses:
- `elastic.<grid>.kontena.local`
- `elastic-<instance_number>.<grid>.kontena.local`



