### PR TITLE
Enhanced deployment tracking

### DIFF
--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -232,6 +232,9 @@ module Kontena
               deployed = true if deployment['finished_at']
               sleep 1
             end
+            if deployment['state'] == 'error'
+              raise Kontena::Errors::StandardError.new(500, deployment['reason'])
+            end
           end
 
           deployed

--- a/server/app/models/grid_service_deploy.rb
+++ b/server/app/models/grid_service_deploy.rb
@@ -1,10 +1,15 @@
 class GridServiceDeploy
   include Mongoid::Document
   include Mongoid::Timestamps
+  include Mongoid::Enum
+
+
 
   field :started_at, type: DateTime
   field :finished_at, type: DateTime
   field :reason, type: String
+  enum :deploy_state, [:created, :ongoing, :success, :error], default: :created
+
 
   index({ grid_service_id: 1 })
   index({ created_at: 1 })

--- a/server/app/models/grid_service_deploy.rb
+++ b/server/app/models/grid_service_deploy.rb
@@ -3,13 +3,10 @@ class GridServiceDeploy
   include Mongoid::Timestamps
   include Mongoid::Enum
 
-
-
   field :started_at, type: DateTime
   field :finished_at, type: DateTime
   field :reason, type: String
   enum :deploy_state, [:created, :ongoing, :success, :error], default: :created
-
 
   index({ grid_service_id: 1 })
   index({ created_at: 1 })

--- a/server/app/views/v1/grid_service_deploys/_grid_service_deploy.json.jbuilder
+++ b/server/app/views/v1/grid_service_deploys/_grid_service_deploy.json.jbuilder
@@ -3,4 +3,5 @@ json.created_at @grid_service_deploy.created_at
 json.started_at @grid_service_deploy.started_at
 json.finished_at @grid_service_deploy.finished_at
 json.service_id @grid_service_deploy.grid_service.to_path
+json.state @grid_service_deploy.deploy_state
 json.reason @grid_service_deploy.reason


### PR DESCRIPTION
This PR enhances the service deployment tracking to catch also errors. This way the deployment waiting on the cli side can be terminated and proper error shown to users.

fixes (partially) #1275 