### PR TITLE
Make ContainerLogWorker safer

### DIFF
--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -152,6 +152,13 @@ module Docker
       end
     end
 
+    # Should logs for this container be skipped?
+    #
+    # @return [Boolean]
+    def skip_logs?
+      self.labels['io.kontena.container.skip_logs'] == '1'
+    end
+
     # Container IP address within the overlay network.
     # Will be missing/nil if container is not attached to the overlay network.
     #

--- a/agent/spec/lib/docker/container_spec.rb
+++ b/agent/spec/lib/docker/container_spec.rb
@@ -116,4 +116,19 @@ describe Docker::Container do
       expect(subject.default_stack?).to be_falsey
     end
   end
+
+  describe '#skip_logs?' do
+    it 'return true is skip_logs label is set' do
+      allow(subject).to receive(:labels).and_return({
+        'io.kontena.container.skip_logs' => '1'
+      })
+      expect(subject.skip_logs?).to be_truthy
+    end
+
+    it 'return false is skip_logs label is not set' do
+      allow(subject).to receive(:labels).and_return({})
+      expect(subject.skip_logs?).to be_falsey
+    end
+
+  end
 end

--- a/agent/spec/lib/kontena/workers/container_log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_log_worker_spec.rb
@@ -15,6 +15,12 @@ describe Kontena::Workers::ContainerLogWorker do
       subject.start
     end
 
+    it 'terminates itself if container goes MIA' do
+      expect(container).to receive(:streaming_logs).and_raise(Docker::Error::NotFoundError)
+      expect(subject.wrapped_object).to receive(:terminate)
+      subject.start
+    end
+
     it 'starts to stream logs from given timestamp' do
       since = (Time.now - 60).to_i
       expect(container).to receive(:streaming_logs).once.with(hash_including('since' => since, 'tail' => 'all'))


### PR DESCRIPTION
This PR enhances the error handling of log workers to withstand container gone missing in action. This can happen for example with very short living weave exec containers.

Also adjusted the LogWorker to actually skip logs for containers where label `io.kontena.container.skip_logs` is set. For now this is set only to weave exec container.

fixes #1127 