### PR TITLE
Resolve reverse dependency order before service remove

### DIFF
--- a/server/app/jobs/stack_remove_worker.rb
+++ b/server/app/jobs/stack_remove_worker.rb
@@ -1,6 +1,9 @@
+require_relative '../mutations/stacks/sort_helper'
+
 class StackRemoveWorker
   include Celluloid
   include Logging
+  include Stacks::SortHelper
 
   def perform(stack_id)
     stack = Stack.find_by(id: stack_id)
@@ -17,7 +20,8 @@ class StackRemoveWorker
   end
 
   def remove_stack(stack)
-    stack.grid_services.order_by(created_at: 1).each do |service|
+    services = sort_services(stack.grid_services.to_a).reverse
+    services.each do |service|
       outcome = GridServices::Delete.run(grid_service: service)
       if outcome.success?
         begin

--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -1,5 +1,9 @@
+require_relative 'sort_helper'
+
 module Stacks
   module Common
+
+    include SortHelper
 
     # @param [String] service_name
     # @param [Hash] messages
@@ -14,20 +18,6 @@ module Stacks
       if self.expose && !self.services.find{ |s| s[:name] == self.expose}
         add_error(:expose, :not_found, "#{self.expose} is not defined in the services array")
       end
-    end
-
-    def sort_services(services)
-      services.sort{ |a, b|
-        a_links = a[:links] || []
-        b_links = b[:links] || []
-        if a_links.any?{ |l| l[:name] == b[:name] }
-          1
-        elsif b_links.any?{ |l| l[:name] == a[:name] }
-          -1
-        else
-          a_links.size <=> b_links.size
-        end
-      }
     end
 
     def self.included(base)

--- a/server/app/mutations/stacks/sort_helper.rb
+++ b/server/app/mutations/stacks/sort_helper.rb
@@ -1,0 +1,30 @@
+module Stacks
+  module SortHelper
+
+    # @param [Array<GridService,Hash>]
+    # @return [Array<GridService,Hash>]
+    def sort_services(services)
+      services.sort{ |a, b|
+        a_links = __links_for_service(a)
+        b_links = __links_for_service(b)
+        if a_links.any?{ |l| l[:name] == b[:name] }
+          1
+        elsif b_links.any?{ |l| l[:name] == a[:name] }
+          -1
+        else
+          a_links.size <=> b_links.size
+        end
+      }
+    end
+
+    # @param [Array<GridService,Hash>]
+    # @return [Array<Hash>]
+    def __links_for_service(service)
+      if service.is_a?(GridService)
+        service.grid_service_links.map{ |l| { name: l.grid_service.name } }
+      else
+        service[:links] || []
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR resolves issue where a stack has internal dependencies and services are not listed in dependency order inside a stack yml. For example following stack:

```
stack: redis-sentinel
version: 0.1.0
expose: lb
services:
  node:
    image: redis:3.0-alpine
    instances: 5
    stateful: true
    health_check:
      protocol: tcp
      port: 6379
    environment:
      KONTENA_LB_MODE: tcp
      KONTENA_LB_EXTERNAL_PORT: 6379
      KONTENA_LB_INTERNAL_PORT: 6379
      KONTENA_LB_CUSTOM_SETTINGS: |
        option tcp-check
        tcp-check connect
        tcp-check send PING\r\n
        tcp-check expect string +PONG
        tcp-check send info\ replication\r\n
        tcp-check expect string role:master
        tcp-check send QUIT\r\n
        tcp-check expect string +OK
    links:
      - lb

  monitor:
    image: kontena/redis-sentinel:3.0-alpine
    instances: 5
    stateful: true
    environment:
      - MASTER_NAME=mymaster
      - QUORUM=3
      - DOWN_AFTER=5000
      - FAILOVER_TIMEOUT=30000
      - MASTER=node-1
      - SLAVES=node-2;node-3;node-4;node-5
    depends_on:
      - node

  lb:
    image: kontena/lb:latest
    instances: 2
    health_check:
      protocol: tcp
      port: 6379
```

should first remove `monitor`, then `node` and finally `lb` services.