### PR TITLE
kontena node ssh --any: default to first connected node

### DIFF
--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -3,9 +3,8 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "NODE_ID", "Node id"
+    parameter "[NODE_ID]", "SSH to Grid node, or first connected node"
     parameter "[COMMANDS] ...", "Run command on host"
-
     option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
     option ["-u", "--user"], "USER", "Login as a user", default: "core"
     option "--private-ip", :flag, "Connect to node's private IP address"
@@ -15,7 +14,12 @@ module Kontena::Cli::Nodes
     requires_current_grid
 
     def execute
-      node = client.get("nodes/#{current_grid}/#{node_id}")
+      if node_id
+        node = client.get("grids/#{current_grid}/nodes/#{node_id}")
+      else
+        nodes = client.get("grids/#{current_grid}/nodes")['nodes']
+        node = nodes.select{ |node| node['connected'] }.first
+      end
 
       provider = Array(node["labels"]).find{ |l| l.start_with?('provider=')}.to_s.split('=').last
 

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -3,8 +3,9 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "[NODE_ID]", "SSH to Grid node, or first connected node"
+    parameter "[NODE_ID]", "SSH to Grid node, or --any"
     parameter "[COMMANDS] ...", "Run command on host"
+    option ["-a", "--any"], :flag, "Connect to first connected node"
     option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
     option ["-u", "--user"], "USER", "Login as a user", default: "core"
     option "--private-ip", :flag, "Connect to node's private IP address"
@@ -16,9 +17,11 @@ module Kontena::Cli::Nodes
     def execute
       if node_id
         node = client.get("grids/#{current_grid}/nodes/#{node_id}")
-      else
+      elsif any?
         nodes = client.get("grids/#{current_grid}/nodes")['nodes']
         node = nodes.select{ |node| node['connected'] }.first
+      else
+        exit_with_error "No host node given, nor --any"
       end
 
       provider = Array(node["labels"]).find{ |l| l.start_with?('provider=')}.to_s.split('=').last

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -3,9 +3,9 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "[NODE_ID]", "SSH to Grid node, or --any"
+    parameter "[NODE_ID]", "SSH to Grid node. Use --any to connect to the first available node"
     parameter "[COMMANDS] ...", "Run command on host"
-    option ["-a", "--any"], :flag, "Connect to first connected node"
+    option ["-a", "--any"], :flag, "Connect to first available node"
     option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
     option ["-u", "--user"], "USER", "Login as a user", default: "core"
     option "--private-ip", :flag, "Connect to node's private IP address"
@@ -21,7 +21,7 @@ module Kontena::Cli::Nodes
         nodes = client.get("grids/#{current_grid}/nodes")['nodes']
         node = nodes.select{ |node| node['connected'] }.first
       else
-        exit_with_error "No host node given, nor --any"
+        exit_with_error "No node name given. Use --any to connect to the first available node"
       end
 
       provider = Array(node["labels"]).find{ |l| l.start_with?('provider=')}.to_s.split('=').last

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -15,6 +15,8 @@ module Kontena::Cli::Nodes
     requires_current_grid
 
     def execute
+      exit_with_error "Cannot combine --any with a node name" if node_id && any?
+
       if node_id
         node = client.get("grids/#{current_grid}/nodes/#{node_id}")
       elsif any?


### PR DESCRIPTION
This is convenient when debugging a grid with plugin-generated names for nodes, and using `kontena node ssh ...` to run commands. You are not going to remember the node names, so you always have to first run `kontena node ls` to copy-paste some node name for `kontena node ssh`.

Instead, just run `kontena node ssh --any`.

## Testing
#### `kontena node ls`
```
Name                                                                   Status     Initial    Labels                                  
billowing-sky-30                                                       online     yes        region=ams2,az=ams2,provider=digitalocean
snowy-night-25                                                         online     no         region=ams2,az=ams2,provider=digitalocean
lively-pond-83                                                         online     no         region=ams2,az=ams2,provider=digitalocean
```

#### `kontena node ssh`
```
Last login: Mon Nov 21 13:35:06 UTC 2016 from 82.181.116.101 on pts/1
CoreOS stable (1185.3.0)
core@billowing-sky-30 ~ $ 
```