### PR TITLE
Agent: Fix WaitHelper timeout

### DIFF
--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -19,7 +19,7 @@ module Kontena
         loop do
           raise ArgumentError, 'no block given' unless block_given?
           value = yield
-          return value if value || !__still_waiting?(wait_until)
+          return value if value || Time.now.to_f > wait_until
           debug message if message
           sleep interval
         end
@@ -40,12 +40,6 @@ module Kontena
         end
         true
       end
-
-
-      def __still_waiting?(wait_until)
-        wait_until > Time.now.to_f
-      end
-
     end
   end
 end

--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -43,7 +43,7 @@ module Kontena
 
 
       def __still_waiting?(wait_until)
-        wait_until < Time.now.to_f
+        wait_until > Time.now.to_f
       end
 
     end

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -55,13 +55,23 @@ describe Kontena::Helpers::WaitHelper do
   end
 
   describe '#__still_waiting?' do
-    it 'return true if more waiting needed' do
-      wait_until = Time.now.to_f - 1.0
+    let :time_now do
+      Time.now
+    end
+
+    it 'return true if still waiting for the wait_until' do
+      wait_until = time_now.to_f + 1.0
+
+      allow(Time).to receive(:now).and_return(time_now + 0.5)
+
       expect(subject.__still_waiting?(wait_until)).to be_truthy
     end
 
-    it 'return true if more waiting needed' do
-      wait_until = Time.now.to_f + 1.0
+    it 'return false if past the wait_until' do
+      wait_until = time_now.to_f + 1.0
+
+      allow(Time).to receive(:now).and_return(time_now + 1.5)
+
       expect(subject.__still_waiting?(wait_until)).to be_falsey
     end
   end

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -11,24 +11,42 @@ describe Kontena::Helpers::WaitHelper do
   }
 
   describe 'wait' do
+    let :time_now do
+      Time.now
+    end
+
     it 'returns true immediately' do
       expect(subject).not_to receive(:sleep)
       value = subject.wait { true }
       expect(value).to be_truthy
     end
 
-    it 'sleeps between retries' do
-      expect(subject).to receive(:__still_waiting?).and_return(true, true, false)
-      expect(subject).to receive(:sleep).twice
-      value = subject.wait(timeout: 2) { false }
-      expect(value).to be_falsey
+    it 'sleeps between retries and logs debug' do
+      expect(Time).to receive(:now).and_return(time_now).once
+      expect(Time).to receive(:now).and_return(time_now + 0.5).once
+      expect(subject).to receive(:sleep).once
+      expect(subject).to receive(:debug).with('foo')
+      expect(subject).to_not receive(:sleep)
+
+      @loop = 0
+      value = subject.wait(timeout: 2, message: 'foo') { (@loop += 1) > 1 }
+
+      expect(value).to be_truthy
     end
 
-    it 'debugs given message' do
-      expect(subject).to receive(:__still_waiting?).and_return(true, false)
-      expect(subject).to receive(:debug).with('foo')
+    it 'sleeps between retries before timing out' do
+      expect(Time).to receive(:now).and_return(time_now).once
+      expect(Time).to receive(:now).and_return(time_now + 0.5).once
       expect(subject).to receive(:sleep).once
-      value = subject.wait(timeout:2, interval:0.5, message: 'foo') { false }
+      expect(Time).to receive(:now).and_return(time_now + 1.0).once
+      expect(subject).to receive(:sleep).once
+      expect(Time).to receive(:now).and_return(time_now + 1.5).once
+      expect(subject).to receive(:sleep).once
+      expect(Time).to receive(:now).and_return(time_now + 2.001).once
+      expect(subject).to_not receive(:sleep)
+
+      value = subject.wait(timeout: 2) { false }
+
       expect(value).to be_falsey
     end
 
@@ -53,27 +71,4 @@ describe Kontena::Helpers::WaitHelper do
       }.to raise_error(Timeout::Error, "Timeout while: foo")
     end
   end
-
-  describe '#__still_waiting?' do
-    let :time_now do
-      Time.now
-    end
-
-    it 'return true if still waiting for the wait_until' do
-      wait_until = time_now.to_f + 1.0
-
-      allow(Time).to receive(:now).and_return(time_now + 0.5)
-
-      expect(subject.__still_waiting?(wait_until)).to be_truthy
-    end
-
-    it 'return false if past the wait_until' do
-      wait_until = time_now.to_f + 1.0
-
-      allow(Time).to receive(:now).and_return(time_now + 1.5)
-
-      expect(subject.__still_waiting?(wait_until)).to be_falsey
-    end
-  end
-
 end


### PR DESCRIPTION
Fixes #1360 

The agent would not wait for the full 300 second timeout during startup.