### PR TITLE
docs (kontena.yml) reference health checks.

### DIFF
--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -131,6 +131,10 @@ hooks:
       cmd: grunt dist
 ```
 
+#### health_check
+
+See information about configuring service health checks in [Using Kontena: Health checks](../using-kontena/health-check.md).
+
 ### Supported Docker Compose keys
 
 #### image


### PR DESCRIPTION
kontena.yml reference is missing docs for health check. This PR is a quick fix to reference existing docs on those.