### PR TITLE
Agent: Fix WeaveWorker wait on destroy event

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -209,7 +209,7 @@ module Kontena::NetworkAdapters
 
     def ensure_default_pool()
       info 'network and ipam ready, ensuring default network existence'
-      @default_pool = @ipam_client.reserve_pool('kontena', '10.81.0.0/16', '10.81.128.0/17')
+      @default_pool = @ipam_client.reserve_pool(DEFAULT_NETWORK, '10.81.0.0/16', '10.81.128.0/17')
     end
 
     # @param [Hash] info

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -321,13 +321,14 @@ module Kontena::NetworkAdapters
       self.attach_container(container_id, cidr)
     end
 
-    def detach_network(event)
-      overlay_cidr = event.Actor.attributes['io.kontena.container.overlay_cidr']
-      overlay_network = event.Actor.attributes['io.kontena.container.overlay_network']
-      if overlay_cidr
-        debug "releasing weave network address for container #{event.id}"
-        @ipam_client.release_address(overlay_network, overlay_cidr)
-      end
+    # Remove container from weave network
+    #
+    # @param [String] container_id may not exist anymore
+    # @param [Hash] labels Docker container labels
+    def remove_container(container_id, overlay_network, overlay_cidr)
+      info "Remove container=#{container_id} from network=#{overlay_network} at cidr=#{overlay_cidr}"
+
+      @ipam_client.release_address(overlay_network, overlay_cidr)
     end
 
     private

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -29,8 +29,11 @@ module Kontena::NetworkAdapters
       subscribe('agent:node_info', :on_node_info)
       subscribe('ipam:start', :on_ipam_start)
       async.ensure_images if autostart
+
+      @ipam_client = IpamClient.new
+
+      # Default size of pool is number of CPU cores, 2 for 1 core machine
       @executor_pool = WeaveExecutor.pool(args: [autostart])
-      # ^ Default size of pool is number of CPU cores, 2 for 1 core machine
     end
 
     def finalizer
@@ -175,7 +178,6 @@ module Kontena::NetworkAdapters
     end
 
     def on_ipam_start(topic, data)
-      @ipam_client = IpamClient.new
       ensure_default_pool
       Celluloid::Notifications.publish('network:ready', nil)
       @ipam_running = true


### PR DESCRIPTION
Fixes #1369

* Always initialize the `Weave@ipam_client`
* Cleanup the `WeaveWorker` wait logic to wait closer to the actual operation

    Hopefully make it more obvious when the wait is needed and when it isn't. Consider moving the wait right into the `Weave` actor itself?

* Also trap errors in `on_destroy_destroy`

```
kontena-agent | D, [2016-11-22T15:55:39.853177 #1] DEBUG -- RpcServer: rpc request: Kontena::Rpc::ServicePodsApi#terminate ["583446fede3578427000002a", 1, {"lb"=>true}]
kontena-agent | I, [2016-11-22T15:55:39.867025 #1]  INFO -- Kontena::ServicePods::Terminator: terminating service: /null-redis-1
kontena-agent | D, [2016-11-22T15:55:40.090674 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:40.598484 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:41.122169 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:41.632621 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:42.145753 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:42.681548 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:43.197776 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:43.729727 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:44.263652 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:44.803471 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:45.344866 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:45.855873 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:46.390916 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:46.905207 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:47.437354 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:47.972975 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:48.499063 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:49.035475 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:49.568937 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:50.101425 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:50.633696 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:51.169857 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:51.698412 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:52.156886 #1] DEBUG -- Workers::LogWorker: /kontena-ipam-plugin/{}
kontena-agent | D, [2016-11-22T15:55:52.157401 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-ipam-plugin without overlay_cidr
kontena-agent | D, [2016-11-22T15:55:52.209964 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:52.735588 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:53.269115 #1] DEBUG -- Workers::WeaveWorker: waiting for all network components running
kontena-agent | D, [2016-11-22T15:55:53.396375 #1] DEBUG -- NetworkAdapters::IpamCleaner: ipam signalled ready, starting cleanup loop
kontena-agent | I, [2016-11-22T15:55:53.396646 #1]  INFO -- Kontena::NetworkAdapters::Weave: network and ipam ready, ensuring default network existence
kontena-agent | D, [2016-11-22T15:55:53.399834 #1] DEBUG -- NetworkAdapters::IpamClient: reserving pool kontena with subnet 10.81.0.0/16 and iprange 10.81.128.0/17
kontena-agent | I, [2016-11-22T15:55:53.803584 #1]  INFO -- Kontena::NetworkAdapters::Weave: Remove container=6a496cd20a8a4c6ad365ca059958d322d168ade80b300b45b51a3f79fd2f7e65 from network=kontena at cidr=10.81.128.5/16
kontena-agent | D, [2016-11-22T15:55:53.803584 #1] DEBUG -- NetworkAdapters::IpamClient: releasing address 10.81.128.5/16 for network kontena
kontena-agent | D, [2016-11-22T15:55:53.826794 #1] DEBUG -- NetworkAdapters::IpamClient: response: 200/{}
```