### PR TITLE
Agent: Fix Kontena::ServicePods::Creator to not configure weavewait for net=host containers

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -143,13 +143,14 @@ module Kontena::NetworkAdapters
       opts['Cmd'] = cmd
 
       modify_host_config(opts)
-      opts
-    end
 
-    # @param [Hash] opts
-    def modify_network_opts(opts)
-      opts['Labels']['io.kontena.container.overlay_cidr'] = @ipam_client.reserve_address('kontena')
-      opts['Labels']['io.kontena.container.overlay_network'] = 'kontena'
+      # IPAM
+      overlay_cidr = @ipam_client.reserve_address(DEFAULT_NETWORK)
+
+      info "Create container=#{opts['name']} in network=#{DEFAULT_NETWORK} with overlay_cidr=#{overlay_cidr}"
+
+      opts['Labels']['io.kontena.container.overlay_cidr'] = overlay_cidr
+      opts['Labels']['io.kontena.container.overlay_network'] = DEFAULT_NETWORK
 
       opts
     end
@@ -163,6 +164,7 @@ module Kontena::NetworkAdapters
       if dns && host_config['NetworkMode'].to_s != 'host'.freeze
         host_config['Dns'] = [dns]
       end
+
       opts['HostConfig'] = host_config
     end
 

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -42,10 +42,8 @@ module Kontena
             self.cleanup_container(service_container)
           end
         end
-        service_config = service_pod.service_config
+        service_config = config_container(service_pod)
 
-        Celluloid::Actor[:network_adapter].modify_create_opts(service_config)
-        Celluloid::Actor[:network_adapter].modify_network_opts(service_config) unless service_pod.net == 'host'
         debug "creating container: #{service_pod.name}"
         service_container = create_container(service_config)
         debug "container created: #{service_pod.name}"
@@ -136,6 +134,19 @@ module Kontena
         container.stop('timeout' => 10)
         container.wait
         container.delete(v: true)
+      end
+
+      # Docker create configuration for ServicePod
+      # @param [ServicePod] service_pod
+      # @return [Hash] Docker create API JSON object
+      def config_container(service_pod)
+        service_config = service_pod.service_config
+
+        unless service_pod.net == 'host'
+          network_adapter.modify_create_opts(service_config)
+        end
+
+        service_config
       end
 
       # @param [Hash] opts

--- a/agent/spec/lib/kontena/service_pods/creator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/creator_spec.rb
@@ -126,4 +126,84 @@ describe Kontena::ServicePods::Creator do
       expect(subject.recreate_service_container?(service_container)).to be_truthy
     end
   end
+
+  describe '#config_container' do
+    let(:network_adapter) { instance_double(Kontena::NetworkAdapters::Weave) }
+
+    before(:each) do
+      allow(subject).to receive(:network_adapter).and_return(network_adapter)
+    end
+
+    context "For a net=host ServicePod" do
+      let(:service_pod) {
+        Kontena::Models::ServicePod.new(
+          'service_id' => 'aa',
+          'service_name' => 'redis',
+          'instance_number' => 2,
+          'deploy_rev' => Time.now.utc.to_s,
+          'updated_at' => Time.now.utc.to_s,
+          'labels' => {
+            'io.kontena.service.id' => 'aa',
+            'io.kontena.service.instance_number' => '2',
+            'io.kontena.service.name' => 'redis-cache',
+          },
+          'stateful' => true,
+          'image_name' => 'redis:3.0',
+          'devices' => [],
+          'ports' => [],
+          'env' => [
+            'KONTENA_SERVICE_NAME=redis-cache'
+          ],
+          'net' => 'host',
+          'domainname' => 'testgrid.kontena.local'
+        )
+      }
+
+      subject { described_class.new(service_pod) }
+
+      it 'does not include weave-wait' do
+        expect(network_adapter).to_not receive(:modify_create_opts)
+
+        config = subject.config_container(service_pod)
+
+        expect(config.dig('HostConfig', 'NetworkMode')).to eq('host')
+        expect(config.dig('Entrypoint')).to be_nil
+      end
+    end
+
+    context "For a net=bridge ServicePod" do
+      let(:service_pod) {
+        Kontena::Models::ServicePod.new(
+          'service_id' => 'aa',
+          'service_name' => 'redis',
+          'instance_number' => 2,
+          'deploy_rev' => Time.now.utc.to_s,
+          'updated_at' => Time.now.utc.to_s,
+          'labels' => {
+            'io.kontena.service.id' => 'aa',
+            'io.kontena.service.instance_number' => '2',
+            'io.kontena.service.name' => 'redis-cache',
+          },
+          'stateful' => true,
+          'image_name' => 'redis:3.0',
+          'devices' => [],
+          'ports' => [],
+          'env' => [
+            'KONTENA_SERVICE_NAME=redis-cache'
+          ],
+          'net' => 'bridge',
+          'domainname' => 'testgrid.kontena.local'
+        )
+      }
+
+      subject { described_class.new(service_pod) }
+
+      it 'does not include weave-wait' do
+        expect(network_adapter).to receive(:modify_create_opts)
+
+        config = subject.config_container(service_pod)
+
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1371

```
kontena-agent | I, [2016-11-22T16:39:17.987290 #1]  INFO -- Kontena::ServicePods::Creator: creating service: null-redis-1
kontena-agent | I, [2016-11-22T16:39:17.987928 #1]  INFO -- Kontena::Workers::ImagePullWorker: pulling image: redis:latest
kontena-agent | I, [2016-11-22T16:39:21.583709 #1]  INFO -- Kontena::Workers::ImagePullWorker: pulled image: redis:latest
kontena-agent | D, [2016-11-22T16:39:21.599660 #1] DEBUG -- ServicePods::Creator: creating container: null-redis-1
kontena-agent | D, [2016-11-22T16:39:21.616598 #1] DEBUG -- ServicePods::Creator: container created: null-redis-1
kontena-agent | I, [2016-11-22T16:39:21.701941 #1]  INFO -- Kontena::ServicePods::Creator: service started: null-redis-1
kontena-agent | D, [2016-11-22T16:39:21.731156 #1] DEBUG -- Workers::LogWorker: /null-redis-1/{"io.kontena.container.deploy_rev"=>"2016-11-22 16:39:17 UTC", "io.kontena.container.id"=>"583474b5de35781865000095", "io.kontena.container.name"=>"null-redis-1", "io.kontena.container.pod"=>"null-redis-1", "io.kontena.container.service_revision"=>"1", "io.kontena.container.type"=>"container", "io.kontena.grid.name"=>"development", "io.kontena.service.id"=>"58347144de3578186500007a", "io.kontena.service.instance_number"=>"1", "io.kontena.service.name"=>"redis", "io.kontena.stack.name"=>"null"}
kontena-agent | D, [2016-11-22T16:39:21.735656 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /null-redis-1
kontena-agent | D, [2016-11-22T16:39:21.762000 #1] DEBUG -- Workers::WeaveWorker: did not find ip for container: /null-redis-1, not attaching to weave
```

```
core@core-01 ~ $ docker inspect -f '{{ .HostConfig.NetworkMode }}' null-redis-1
host
core@core-01 ~ $ docker exec -it null-redis-1 ip addr show weave
23: weave: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1410 qdisc noqueue state UP group default qlen 1000
    link/ether c6:3f:e0:48:25:8d brd ff:ff:ff:ff:ff:ff
    inet 10.81.0.1/16 scope global weave
       valid_lft forever preferred_lft forever
    inet6 fe80::c43f:e0ff:fe48:258d/64 scope link 
       valid_lft forever preferred_lft forever
core@core-01 ~ $ docker exec -it null-redis-1 ps auxf
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root        15  0.0  0.2  17496  2068 ?        Rs+  16:39   0:00 ps auxf
redis        1  0.2  0.9  33308  9240 ?        Ssl  16:39   0:00 redis-server *:
```