### PR TITLE
Fix kontena stack upgrade command

### DIFF
--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Stacks
     include Common
 
     parameter "NAME", "Stack name"
-    parameter "FILE", "Kontena stack file"
+    parameter "[FILE]", "Kontena stack file", default: "kontena.yml"
     option '--deploy', :flag, 'Deploy after upgrade'
 
     def execute
@@ -18,7 +18,7 @@ module Kontena::Cli::Stacks
       spinner "Upgrading stack #{pastel.cyan(name)} " do
         update_stack(token, stack)
       end
-      Kontena.run("stack deploy #{name}")
+      Kontena.run("stack deploy #{name}") if deploy?
     end
 
     def update_stack(token, stack)

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -15,19 +15,34 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
     end
 
     it 'requires api url' do
-      allow(subject).to receive(:stack_from_yaml).with('kontena.yml').and_return(stack)
+      allow(subject).to receive(:require_config_file).and_return(true)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
       expect(subject).to receive(:require_api_url).once
       subject.run(['stack-name', './path/to/kontena.yml'])
     end
 
     it 'requires token' do
-      allow(subject).to receive(:stack_from_yaml).with('kontena.yml').and_return(stack)
+      allow(subject).to receive(:require_config_file).and_return(true)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
       expect(subject).to receive(:require_token).and_return(token)
       subject.run(['stack-name', './path/to/kontena.yml'])
     end
 
+    it 'requires stack file' do
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+      allow(subject).to receive(:require_token).and_return(token)
+      expect(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
+      subject.run(['stack-name', './path/to/kontena.yml'])
+    end
+
+    it 'uses kontena.yml as default stack file' do
+      allow(subject).to receive(:require_token).and_return(token)
+      expect(subject).to receive(:require_config_file).with('kontena.yml').and_return(true)
+      expect(subject).to receive(:stack_from_yaml).with('kontena.yml').and_return(stack)
+      subject.run(['stack-name'])
+    end
+
     it 'sends stack to master' do
-      
       allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
       allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
       expect(client).to receive(:put).with(
@@ -45,6 +60,31 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
         'stacks/test-grid/stack-b', anything
       )
       subject.run(['stack-b',  './path/to/kontena.yml'])
+    end
+
+    context '--deploy option' do
+      context 'when given' do
+        it 'triggers deploy' do
+          allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
+          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+          allow(client).to receive(:put).with(
+            'stacks/test-grid/stack-a', anything
+          ).and_return({})
+          expect(Kontena).to receive(:run).with("stack deploy stack-a").once
+          subject.run(['--deploy', 'stack-a', './path/to/kontena.yml'])
+        end
+      end
+      context 'when not given' do
+        it 'does not trigger deploy' do
+          allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
+          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+          allow(client).to receive(:put).with(
+            'stacks/test-grid/stack-a', anything
+          ).and_return({})
+          expect(Kontena).not_to receive(:run).with("stack deploy stack-a")
+          subject.run(['stack-a', './path/to/kontena.yml'])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR will fix `kontena stack upgrade` command to handle `--deploy` option correctly. Before deploy was triggered every time.

Also upgrade command uses now `kontena.yml` as default stack file.