### PR TITLE
Dont update existing stack services

### DIFF
--- a/server/app/mutations/stacks/update.rb
+++ b/server/app/mutations/stacks/update.rb
@@ -51,28 +51,24 @@ module Stacks
         new_rev = latest_rev.dup
         new_rev.revision += 1
         new_rev.save
-        create_or_update_services(self.stack_instance, sort_services(self.services))
+        create_new_services(self.stack_instance, sort_services(self.services))
       end
       self.stack_instance.reload
     end
 
     # @param [Stack] stack
     # @param [Array<Hash>]
-    def create_or_update_services(stack, services)
+    def create_new_services(stack, services)
       services.each do |s|
         service = s.dup
         existing_service = stack.grid_services.where(:name => service[:name]).first
-        if existing_service
-          service[:grid_service] = existing_service
-          outcome = GridServices::Update.run(service)
-        else
+        if !existing_service
           service[:grid] = stack.grid
           service[:stack] = stack
           outcome = GridServices::Create.run(service)
-        end
-
-        unless outcome.success?
-          handle_service_outcome_errors(service[:name], outcome.errors.message, :update)
+          unless outcome.success?
+            handle_service_outcome_errors(service[:name], outcome.errors.message, :update)
+          end
         end
       end
     end

--- a/server/spec/mutations/stacks/update_spec.rb
+++ b/server/spec/mutations/stacks/update_spec.rb
@@ -30,7 +30,7 @@ describe Stacks::Update do
       outcome = subject.run
       expect(outcome.success?).to be_truthy
       expect(outcome.result.stack_revisions.count).to eq(2)
-      expect(stack.reload.grid_services.first.image_name).to eq('redis:3.0')
+      expect(stack.reload.grid_services.first.image_name).to eq('redis:2.8')
     end
 
     it 'does not increase version automatically' do


### PR DESCRIPTION
Currently updating a stack will also trigger update of stack service definitions. This might not be clear for a user when update might automatically trigger service deploys. This PR changes logic so that stack update will only initialize new services but not update (or remove) existing ones.  