### PR TITLE
Agent: Update IPAM to 0.2.1, fixes

### DIFF
--- a/agent/spec/lib/kontena/network_adapters/ipam_client_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/ipam_client_spec.rb
@@ -143,7 +143,7 @@ describe Kontena::NetworkAdapters::IpamClient do
 
     it 'raises IpamError with proper error message from Hash' do
       error = Excon::Errors::HTTPStatusError.new("foo", request, response)
-      expect(response).to receive(:body).twice.and_return('{"error":"You are wrong"}')
+      expect(response).to receive(:body).twice.and_return('{"Error":"You are wrong"}')
       expect(response).to receive(:headers).and_return(headers)
 
       expect {


### PR DESCRIPTION
Accidentially pushed 3/4 commits directly to master, just pretend it never happened *whistle*

* Upgrade to `kontena/ipam-plugin:0.2.1`

    Fixes the IPAM RequestAddress method to randomize the allocated address, reducing etcd conflicts with subsequent retries and risk of request failure on timeout.

* Fix the `IpamClient` response error handling to correctly read the `{"Error": "..."}` JSON response key

    `Kontena::NetworkAdapters::IpamError: Failed to open TCP connection to localhost:2379 (Connection refused - connect(2) for "localhost" port 2379)` vs just `Kontena::NetworkAdapters::IpamError: Internal Server Error`

* Fix some broken debug logging