### PR TITLE
Fix agent Weave ipam_ready? state

### DIFF
--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -1,4 +1,5 @@
 require_relative '../helpers/image_helper'
+require_relative '../helpers/wait_helper'
 
 module Kontena::Launchers
   class IpamPlugin
@@ -6,8 +7,7 @@ module Kontena::Launchers
     include Celluloid::Notifications
     include Kontena::Logging
     include Kontena::Helpers::ImageHelper
-
-
+    include Kontena::Helpers::WaitHelper
 
     IPAM_SERVICE_NAME = 'kontena-ipam-plugin'.freeze
 
@@ -37,9 +37,7 @@ module Kontena::Launchers
 
     def start(info)
       create_container(@image_name, info)
-      while !running?
-        sleep 1
-      end
+      wait(message: "IPAM running") { running? }
       Celluloid::Notifications.publish('ipam:start', nil)
     end
 

--- a/agent/lib/kontena/network_adapters/ipam_cleaner.rb
+++ b/agent/lib/kontena/network_adapters/ipam_cleaner.rb
@@ -19,8 +19,6 @@ module Kontena::NetworkAdapters
       self.async.run
     end
 
-    private
-
     def run
       loop do
         sleep CLEANUP_INTERVAL

--- a/agent/lib/kontena/network_adapters/ipam_cleaner.rb
+++ b/agent/lib/kontena/network_adapters/ipam_cleaner.rb
@@ -16,23 +16,34 @@ module Kontena::NetworkAdapters
 
     def on_ipam_start(topic, data)
       debug "ipam signalled ready, starting cleanup loop"
-      self.async.cleanup_ipam
+      self.async.run
     end
 
     private
 
-    def cleanup_ipam
+    def run
       loop do
         sleep CLEANUP_INTERVAL
-        ipam_client = Kontena::NetworkAdapters::IpamClient.new
-        cleanup_index = ipam_client.cleanup_index
-        debug "got index #{cleanup_index} for IPAM cleanup. Waiting for pending deployments for #{CLEANUP_DELAY} secs..."
-        sleep CLEANUP_DELAY
-        # Collect locally known addresses
-        addresses = collect_local_addresses
-        debug "invoking cleanup with #{addresses.size} known addresses"
-        ipam_client.cleanup_network('kontena', addresses, cleanup_index)
+
+        begin
+          self.cleanup_ipam
+        rescue => exc
+          error "#{exc.class.name}: #{exc.message}"
+          debug exc.backtrace.join("\n")
+        end
       end
+    end
+
+    def cleanup_ipam
+      ipam_client = Kontena::NetworkAdapters::IpamClient.new
+      cleanup_index = ipam_client.cleanup_index
+      debug "got index #{cleanup_index} for IPAM cleanup. Waiting for pending deployments for #{CLEANUP_DELAY} secs..."
+      sleep CLEANUP_DELAY
+
+      # Collect locally known addresses
+      addresses = collect_local_addresses
+      debug "invoking cleanup with #{addresses.size} known addresses"
+      ipam_client.cleanup_network('kontena', addresses, cleanup_index)
     end
 
     def collect_local_addresses
@@ -44,7 +55,5 @@ module Kontena::NetworkAdapters
       local_addresses.compact! # remove nils
       local_addresses
     end
-
   end
-
 end

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -23,7 +23,6 @@ module Kontena::NetworkAdapters
     def initialize(autostart = true)
       @images_exist = false
       @started = false
-      @ipam_running = false
 
       info 'initialized'
       subscribe('agent:node_info', :on_node_info)
@@ -89,7 +88,7 @@ module Kontena::NetworkAdapters
 
     def network_ready?
       return false unless running?
-      return false unless ipam_running?
+      return false unless Actor[:ipam_plugin_launcher].running?
       true
     end
 
@@ -99,11 +98,6 @@ module Kontena::NetworkAdapters
       return false if weave.nil?
       return false unless weave.running?
       true
-    end
-
-    # @return [Boolean]
-    def ipam_running?
-      @ipam_running
     end
 
     # @return [Boolean]
@@ -180,7 +174,6 @@ module Kontena::NetworkAdapters
     def on_ipam_start(topic, data)
       ensure_default_pool
       Celluloid::Notifications.publish('network:ready', nil)
-      @ipam_running = true
     end
 
     # Ensure that the host weave bridge is exposed using the given CIDR address,

--- a/agent/spec/lib/kontena/network_adapters/weave_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_spec.rb
@@ -96,6 +96,14 @@ describe Kontena::NetworkAdapters::Weave do
   end
 
   describe '#network_ready?' do
+    let :ipam_plugin_launcher do
+      instance_double(Kontena::Launchers::IpamPlugin)
+    end
+
+    before do
+      allow(Celluloid::Actor).to receive(:[]).with(:ipam_plugin_launcher).and_return(ipam_plugin_launcher)
+    end
+
     it 'return false is weave not running' do
       expect(subject.wrapped_object).to receive(:running?).and_return(false)
       expect(subject.network_ready?).to be_falsey
@@ -103,13 +111,13 @@ describe Kontena::NetworkAdapters::Weave do
 
     it 'return false is weave running but ipam not' do
       expect(subject.wrapped_object).to receive(:running?).and_return(true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(false)
+      expect(ipam_plugin_launcher).to receive(:running?).and_return(false)
       expect(subject.network_ready?).to be_falsey
     end
 
     it 'return true is weave and ipam running' do
       expect(subject.wrapped_object).to receive(:running?).and_return(true)
-      expect(subject.wrapped_object).to receive(:ipam_running?).and_return(true)
+      expect(ipam_plugin_launcher).to receive(:running?).and_return(true)
       expect(subject.network_ready?).to be_truthy
     end
   end


### PR DESCRIPTION
See #1395

The Agent `Weave#ipam_ready?` relies on the `@ipam_running = true` state set on the Celluloid `ipam:start` event. However, this is only sent once during the agent startup, which means that a crashing Weave actor will re-initialize the `@ipam_running = false` state. This leads to fatal cascading errors and a broken client after any errors in e.g. `ServicePods::Creator` -> `Weave#modify_create_opts` -> `IpamClient#reserve_address`, since any further `Weave#wait_network_ready?` operations will just time out: https://gist.github.com/jakolehm/eaf57bbe4f28446d114dc9794bd98814

There's two approaches to fixing this:

* Check the `@ipam_running = Actor[:ipam_plugin_launcher].running?` when initializing

* Replace the `@ipam_running` state with just `Actor[:ipam_plugin_launcher].running?`

The later is perhaps easier to implement robustly, but the IPAM should be prepared to get a LOT of `/IpamPlugin.Active` calls now :)