### PR TITLE
Agent: Cache weave ps at WeaveWorker startup for container migration

### DIFF
--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -14,13 +14,13 @@ module Kontena::Workers
 
       subscribe('dns:add', :on_dns_add)
 
+      @migrate_containers = nil # initialized by #start
+
       if network_adapter.running?
         self.start
       else
         subscribe('network_adapter:start', :on_weave_start)
       end
-
-      @migrate_containers = nil # initialized by #start
     end
 
     def on_weave_start(topic, data)

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -11,10 +11,16 @@ module Kontena::Workers
 
     def initialize
       info 'initialized'
-      @migrate_containers = nil # XXX: also needed for container:event start
 
-      subscribe('network_adapter:start', :on_weave_start)
       subscribe('dns:add', :on_dns_add)
+
+      if network_adapter.running?
+        self.start
+      else
+        subscribe('network_adapter:start', :on_weave_start)
+      end
+
+      @migrate_containers = nil # initialized by #start
     end
 
     def on_weave_start(topic, data)

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -80,27 +80,38 @@ describe Kontena::Workers::WeaveWorker do
   end
 
   describe '#attach_overlay' do
-    context "For a new container" do
+    before do
+      allow(network_adapter).to receive(:get_containers).and_return(migrate_containers)
+      allow(Docker::Container).to receive(:all).and_return([])
+
+      subject.start
+    end
+
+    context "For a new container that is not yet running" do
       let(:container) do
         double(Docker::Container,
-          id: '12345',
+          id: '123456789ABCDEF',
           name: 'test',
           overlay_cidr: '10.81.128.1/16',
           overlay_suffix: '16',
         )
       end
 
+      let :migrate_containers do
+        { }
+      end
+
       it 'calls network_adapter.attach_container' do
-        expect(network_adapter).to receive(:attach_container).with('12345', '10.81.128.1/16')
+        expect(network_adapter).to receive(:attach_container).with('123456789ABCDEF', '10.81.128.1/16')
 
         subject.attach_overlay(container)
       end
     end
 
-    context "For an old container" do
+    context "For an old container that is still running" do
       let(:container) do
         double(Docker::Container,
-          id: '12345',
+          id: '123456789ABCDEF',
           name: 'test',
           overlay_cidr: '10.81.1.1/19',
           overlay_ip: '10.81.1.1',
@@ -108,8 +119,35 @@ describe Kontena::Workers::WeaveWorker do
         )
       end
 
+      let :migrate_containers do
+        { '123456789ABC' => ['10.81.1.1/19']}
+      end
+
       it 'calls network_adapter.migrate_container' do
-        expect(network_adapter).to receive(:migrate_container).with('12345', '10.81.1.1/16')
+        expect(network_adapter).to receive(:migrate_container).with('123456789ABCDEF', '10.81.1.1/16', ['10.81.1.1/19'])
+
+        subject.attach_overlay(container)
+      end
+    end
+
+    context "For an old container that has already been migrated" do
+      let(:container) do
+        double(Docker::Container,
+          id: '123456789ABCDEF',
+          name: 'test',
+          overlay_cidr: '10.81.1.1/19',
+          overlay_ip: '10.81.1.1',
+          overlay_suffix: '19',
+        )
+      end
+
+      let :migrate_containers do
+        #{ '123456789ABC' => ['10.81.1.1/16']}
+        { }
+      end
+
+      it 'calls network_adapter.attach_container' do
+        expect(network_adapter).to receive(:attach_container).with('123456789ABCDEF', '10.81.1.1/16')
 
         subject.attach_overlay(container)
       end

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -10,7 +10,12 @@ describe Kontena::Workers::WeaveWorker do
   after(:each) { Celluloid.shutdown }
 
   before(:each) do
-    allow(subject.wrapped_object).to receive(:network_adapter).and_return(network_adapter)
+    allow(Celluloid::Actor).to receive(:[]).and_call_original
+    allow(Celluloid::Actor).to receive(:[]).with(:network_adapter).and_return(network_adapter)
+
+    # initialize without calling start()
+    allow(network_adapter).to receive(:running?).and_return(false).once
+    subject
   end
 
   describe '#on_weave_start' do


### PR DESCRIPTION
Calling `weaveexec ps` for large numbers of containers is surprisingly slow, migrating >100 service containers can take ~6 minutes:

```
I, [2016-11-23T14:31:37.416612 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=e1c4e9b032a37f407b2ccdcec84bd95a8aa1f068a2a27949a390d345ab739b50 to cidr=10.81.10.95/16
W, [2016-11-23T14:31:38.106023 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=e1c4e9b032a37f407b2ccdcec84bd95a8aa1f068a2a27949a390d345ab739b50 from cidr=10.81.10.95/19
I, [2016-11-23T14:31:39.330565 #1] INFO -- Kontena::NetworkAdapters::Weave: Attach container=e1c4e9b032a37f407b2ccdcec84bd95a8aa1f068a2a27949a390d345ab739b50 at cidr=10.81.10.95/16
I, [2016-11-23T14:31:39.687663 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=200bde7335ed9f258379316755b9dc6af6f9cb3cab80687e39660723990f1052 to cidr=10.81.10.92/16
W, [2016-11-23T14:31:40.497002 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=200bde7335ed9f258379316755b9dc6af6f9cb3cab80687e39660723990f1052 from cidr=10.81.10.92/19
I, [2016-11-23T14:31:41.836367 #1] INFO -- Kontena::NetworkAdapters::Weave: Attach container=200bde7335ed9f258379316755b9dc6af6f9cb3cab80687e39660723990f1052 at cidr=10.81.10.92/16
...
I, [2016-11-23T14:37:13.900166 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=577c45919691757dd6b86969d1cf4e778f330fd66201a40bda9c48755d06732b to cidr=10.81.1.8/16
W, [2016-11-23T14:37:14.480095 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=577c45919691757dd6b86969d1cf4e778f330fd66201a40bda9c48755d06732b from cidr=10.81.1.8/19
I, [2016-11-23T14:37:15.699544 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=577c45919691757dd6b86969d1cf4e778f330fd66201a40bda9c48755d06732b at cidr=10.81.1.8/16
I, [2016-11-23T14:37:15.757170 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=c04d967d84b4547c6dd51b707a7bb45656557e27d8b1632dfdfc4c8bad9bbd07 to cidr=10.81.1.5/16
W, [2016-11-23T14:37:16.490592 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=c04d967d84b4547c6dd51b707a7bb45656557e27d8b1632dfdfc4c8bad9bbd07 from cidr=10.81.1.5/19
I, [2016-11-23T14:37:17.702822 #1] INFO -- Kontena::NetworkAdapters::Weave: Attach container=c04d967d84b4547c6dd51b707a7bb45656557e27d8b1632dfdfc4c8bad9bbd07 at cidr=10.81.1.5/16
```

This also impacts performance on subsequent startups, for migrated containers that still have the old labels (have not yet been re-deployed):

```
I, [2016-11-23T14:50:06.328960 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=e1c4e9b032a37f407b2ccdcec84bd95a8aa1f068a2a27949a390d345ab739b50 to cidr=10.81.10.95/16
I, [2016-11-23T14:50:07.046820 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=e1c4e9b032a37f407b2ccdcec84bd95a8aa1f068a2a27949a390d345ab739b50 at cidr=10.81.10.95/16
I, [2016-11-23T14:50:07.397508 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=200bde7335ed9f258379316755b9dc6af6f9cb3cab80687e39660723990f1052 to cidr=10.81.10.92/16
I, [2016-11-23T14:50:08.069038 #1] INFO -- Kontena::NetworkAdapters::Weave: Attach container=200bde7335ed9f258379316755b9dc6af6f9cb3cab80687e39660723990f1052 at cidr=10.81.10.92/16
....

I, [2016-11-23T14:52:47.384559 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=577c45919691757dd6b86969d1cf4e778f330fd66201a40bda9c48755d06732b to cidr=10.81.1.8/16
I, [2016-11-23T14:52:48.401059 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=577c45919691757dd6b86969d1cf4e778f330fd66201a40bda9c48755d06732b at cidr=10.81.1.8/16
I, [2016-11-23T14:52:48.433866 #1]  INFO -- Kontena::NetworkAdapters::Weave: Migrate container=c04d967d84b4547c6dd51b707a7bb45656557e27d8b1632dfdfc4c8bad9bbd07 to cidr=10.81.1.5/16
I, [2016-11-23T14:52:49.201151 #1] INFO -- Kontena::NetworkAdapters::Weave: Attach container=c04d967d84b4547c6dd51b707a7bb45656557e27d8b1632dfdfc4c8bad9bbd07 at cidr=10.81.1.5/16
```

This improves WeaveWorker performance by caching the attached overlay_cidr addresses of all running containers at startup, and using that to migrate containers:

```
kontena-agent | D, [2016-11-24T13:45:23.108629 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec stream: ["--local", "ps"]
kontena-agent | D, [2016-11-24T13:45:23.111706 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /null-redis-3
kontena-agent | D, [2016-11-24T13:45:23.121753 #1] DEBUG -- Workers::WeaveWorker: Scanned 11 existing containers for potential migration: {"752a3b486e62"=>["10.81.128.104/19"], "e13d0d0db14f"=>["10.81.128.33/19"], "b3bdb7f5b32d"=>["10.81.128.82/19"], "ade4b6f831da"=>["10.81.128.69/19"], "73754bc5b0f1"=>["10.81.128.99/19"], "dfbf62e97780"=>["10.81.128.5/19"], "898e6787f599"=>["10.81.128.109/19"], "0e79aa77bf3b"=>["10.81.128.18/19"], "9f438d23f43d"=>["10.81.128.100/19"], "6620e2e88424"=>["10.81.128.49/19"], "653e4574f253"=>["10.81.128.3/16"]}
kontena-agent | I, [2016-11-24T13:45:23.132672 #1]  INFO -- Kontena::Workers::WeaveWorker: attaching network to existing containers
kontena-agent | D, [2016-11-24T13:45:23.156016 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /null-redis-2
kontena-agent | D, [2016-11-24T13:45:23.157397 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-agent without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:23.162077 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /null-redis-1
kontena-agent | D, [2016-11-24T13:45:23.202806 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /kontena-ipam-plugin
kontena-agent | D, [2016-11-24T13:45:23.211583 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-10 with overlay_cidr=10.81.128.104/19 from ["10.81.128.104/19"] to 10.81.128.104/16
kontena-agent | W, [2016-11-24T13:45:23.214619 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=752a3b486e62461eed477d791817896dc1ceb6f927fccc15ecd1fe8f0e2a052e from cidr=10.81.128.104/19
kontena-agent | D, [2016-11-24T13:45:23.222925 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /registry-api-1
kontena-agent | D, [2016-11-24T13:45:23.246103 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /kontena-etcd
kontena-agent | D, [2016-11-24T13:45:23.264793 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /weaveplugin
kontena-agent | D, [2016-11-24T13:45:23.276286 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /weave
kontena-agent | D, [2016-11-24T13:45:23.306351 #1] DEBUG -- Workers::ContainerLogWorker: starting to stream logs from /kontena-cadvisor
kontena-agent | D, [2016-11-24T13:45:23.633779 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.104/19", "752a3b486e62461eed477d791817896dc1ceb6f927fccc15ecd1fe8f0e2a052e"]
kontena-agent | 10.81.128.104
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:23.644367 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=752a3b486e62461eed477d791817896dc1ceb6f927fccc15ecd1fe8f0e2a052e at cidr=10.81.128.104/16
kontena-agent | D, [2016-11-24T13:45:23.689115 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-9 with overlay_cidr=10.81.128.33/19 from ["10.81.128.33/19"] to 10.81.128.33/16
kontena-agent | W, [2016-11-24T13:45:23.689840 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=e13d0d0db14f494a1734b80d94fa9f7e06c75b8f371bad61be56c55d70c38f2c from cidr=10.81.128.33/19
kontena-agent | D, [2016-11-24T13:45:24.581930 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.33/19", "e13d0d0db14f494a1734b80d94fa9f7e06c75b8f371bad61be56c55d70c38f2c"]
kontena-agent | 10.81.128.33
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:24.620248 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=e13d0d0db14f494a1734b80d94fa9f7e06c75b8f371bad61be56c55d70c38f2c at cidr=10.81.128.33/16
kontena-agent | D, [2016-11-24T13:45:24.692178 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-8 with overlay_cidr=10.81.128.82/19 from ["10.81.128.82/19"] to 10.81.128.82/16
kontena-agent | W, [2016-11-24T13:45:24.692679 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=b3bdb7f5b32db02b10f565fd20d3ae445b4c89ea1760b922bec3da6553dcdc0b from cidr=10.81.128.82/19
kontena-agent | D, [2016-11-24T13:45:24.950432 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.104/16", "--rewrite-hosts", "752a3b486e62461eed477d791817896dc1ceb6f927fccc15ecd1fe8f0e2a052e"]
kontena-agent | 10.81.128.104
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:25.345981 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.82/19", "b3bdb7f5b32db02b10f565fd20d3ae445b4c89ea1760b922bec3da6553dcdc0b"]
kontena-agent | 10.81.128.82
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:25.354492 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=b3bdb7f5b32db02b10f565fd20d3ae445b4c89ea1760b922bec3da6553dcdc0b at cidr=10.81.128.82/16
kontena-agent | D, [2016-11-24T13:45:25.430908 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-7 with overlay_cidr=10.81.128.69/19 from ["10.81.128.69/19"] to 10.81.128.69/16
kontena-agent | W, [2016-11-24T13:45:25.430908 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=ade4b6f831dab0525f2bab3a0ca0994dce0e276c9dd50669810508481eaa9d43 from cidr=10.81.128.69/19
kontena-agent | D, [2016-11-24T13:45:25.708841 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.33/16", "--rewrite-hosts", "e13d0d0db14f494a1734b80d94fa9f7e06c75b8f371bad61be56c55d70c38f2c"]
kontena-agent | 10.81.128.33
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:26.122753 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.69/19", "ade4b6f831dab0525f2bab3a0ca0994dce0e276c9dd50669810508481eaa9d43"]
kontena-agent | 10.81.128.69
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:26.196888 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=ade4b6f831dab0525f2bab3a0ca0994dce0e276c9dd50669810508481eaa9d43 at cidr=10.81.128.69/16
kontena-agent | D, [2016-11-24T13:45:26.286162 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-6 with overlay_cidr=10.81.128.99/19 from ["10.81.128.99/19"] to 10.81.128.99/16
kontena-agent | W, [2016-11-24T13:45:26.286366 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=73754bc5b0f1ce5fc890a01631e79c7a7943a06a00f61c335a66408329e82233 from cidr=10.81.128.99/19
kontena-agent | D, [2016-11-24T13:45:26.581018 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.82/16", "--rewrite-hosts", "b3bdb7f5b32db02b10f565fd20d3ae445b4c89ea1760b922bec3da6553dcdc0b"]
kontena-agent | 10.81.128.82
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:27.007192 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.99/19", "73754bc5b0f1ce5fc890a01631e79c7a7943a06a00f61c335a66408329e82233"]
kontena-agent | 10.81.128.99
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:27.022534 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=73754bc5b0f1ce5fc890a01631e79c7a7943a06a00f61c335a66408329e82233 at cidr=10.81.128.99/16
kontena-agent | D, [2016-11-24T13:45:27.076199 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-5 with overlay_cidr=10.81.128.5/19 from ["10.81.128.5/19"] to 10.81.128.5/16
kontena-agent | W, [2016-11-24T13:45:27.076556 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=dfbf62e97780c31557cbd25926bb1d518c5f327aca5d30752f297722ef15671f from cidr=10.81.128.5/19
kontena-agent | D, [2016-11-24T13:45:27.507613 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.69/16", "--rewrite-hosts", "ade4b6f831dab0525f2bab3a0ca0994dce0e276c9dd50669810508481eaa9d43"]
kontena-agent | 10.81.128.69
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:28.074489 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.5/19", "dfbf62e97780c31557cbd25926bb1d518c5f327aca5d30752f297722ef15671f"]
kontena-agent | 10.81.128.5
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:28.091128 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=dfbf62e97780c31557cbd25926bb1d518c5f327aca5d30752f297722ef15671f at cidr=10.81.128.5/16
kontena-agent | D, [2016-11-24T13:45:28.162607 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-4 with overlay_cidr=10.81.128.109/19 from ["10.81.128.109/19"] to 10.81.128.109/16
kontena-agent | W, [2016-11-24T13:45:28.162877 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=898e6787f599e54326c712afec68cb306e63fd559e46e4738fb82bf1888f9502 from cidr=10.81.128.109/19
kontena-agent | D, [2016-11-24T13:45:28.475517 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.99/16", "--rewrite-hosts", "73754bc5b0f1ce5fc890a01631e79c7a7943a06a00f61c335a66408329e82233"]
kontena-agent | 10.81.128.99
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:29.125607 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.109/19", "898e6787f599e54326c712afec68cb306e63fd559e46e4738fb82bf1888f9502"]
kontena-agent | 10.81.128.109
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:29.153506 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=898e6787f599e54326c712afec68cb306e63fd559e46e4738fb82bf1888f9502 at cidr=10.81.128.109/16
kontena-agent | D, [2016-11-24T13:45:29.241338 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-3 with overlay_cidr=10.81.128.18/19 from ["10.81.128.18/19"] to 10.81.128.18/16
kontena-agent | W, [2016-11-24T13:45:29.241612 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=0e79aa77bf3b640ab17f3d6e3e3e6914ffdf7ccd9072a75ed024a912b4b8c448 from cidr=10.81.128.18/19
kontena-agent | D, [2016-11-24T13:45:29.250989 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.5/16", "--rewrite-hosts", "dfbf62e97780c31557cbd25926bb1d518c5f327aca5d30752f297722ef15671f"]
kontena-agent | 10.81.128.5
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:29.707330 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.18/19", "0e79aa77bf3b640ab17f3d6e3e3e6914ffdf7ccd9072a75ed024a912b4b8c448"]
kontena-agent | 10.81.128.18
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:29.725092 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=0e79aa77bf3b640ab17f3d6e3e3e6914ffdf7ccd9072a75ed024a912b4b8c448 at cidr=10.81.128.18/16
kontena-agent | D, [2016-11-24T13:45:29.780367 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-2 with overlay_cidr=10.81.128.100/19 from ["10.81.128.100/19"] to 10.81.128.100/16
kontena-agent | W, [2016-11-24T13:45:29.781011 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=9f438d23f43d731d90d33831bdd29e35c05ad7ada1ec9a0d7c99e25893ce3d47 from cidr=10.81.128.100/19
kontena-agent | D, [2016-11-24T13:45:30.293342 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.109/16", "--rewrite-hosts", "898e6787f599e54326c712afec68cb306e63fd559e46e4738fb82bf1888f9502"]
kontena-agent | 10.81.128.109
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:30.773413 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.18/16", "--rewrite-hosts", "0e79aa77bf3b640ab17f3d6e3e3e6914ffdf7ccd9072a75ed024a912b4b8c448"]
kontena-agent | 10.81.128.18
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:30.819305 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.100/19", "9f438d23f43d731d90d33831bdd29e35c05ad7ada1ec9a0d7c99e25893ce3d47"]
kontena-agent | 10.81.128.100
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:30.827939 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=9f438d23f43d731d90d33831bdd29e35c05ad7ada1ec9a0d7c99e25893ce3d47 at cidr=10.81.128.100/16
kontena-agent | D, [2016-11-24T13:45:30.884967 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-1 with overlay_cidr=10.81.128.49/19 from ["10.81.128.49/19"] to 10.81.128.49/16
kontena-agent | W, [2016-11-24T13:45:30.885164 #1]  WARN -- Kontena::NetworkAdapters::Weave: Migrate container=6620e2e88424b56d8f5bd94ae810b91d86d03e2ffb5b9c72c55f3d040f523e7f from cidr=10.81.128.49/19
kontena-agent | D, [2016-11-24T13:45:31.320519 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "detach", "10.81.128.49/19", "6620e2e88424b56d8f5bd94ae810b91d86d03e2ffb5b9c72c55f3d040f523e7f"]
kontena-agent | 10.81.128.49
kontena-agent | 
kontena-agent | I, [2016-11-24T13:45:31.338340 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=6620e2e88424b56d8f5bd94ae810b91d86d03e2ffb5b9c72c55f3d040f523e7f at cidr=10.81.128.49/16
kontena-agent | D, [2016-11-24T13:45:31.359081 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-ipam-plugin without overlay_cidr
kontena-agent | I, [2016-11-24T13:45:31.458511 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=653e4574f253f572f9c584b279ec5d64dc602cac8f7e646ac8de606df7277316 at cidr=10.81.128.3/16
kontena-agent | D, [2016-11-24T13:45:31.461141 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-etcd without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:31.499046 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/weaveplugin without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:31.506629 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/weave without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:31.509644 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-cadvisor without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:32.092966 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.100/16", "--rewrite-hosts", "9f438d23f43d731d90d33831bdd29e35c05ad7ada1ec9a0d7c99e25893ce3d47"]
kontena-agent | 10.81.128.100
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:32.426449 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.49/16", "--rewrite-hosts", "6620e2e88424b56d8f5bd94ae810b91d86d03e2ffb5b9c72c55f3d040f523e7f"]
kontena-agent | 10.81.128.49
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:32.696033 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.3/16", "--rewrite-hosts", "653e4574f253f572f9c584b279ec5d64dc602cac8f7e646ac8de606df7277316"]
kontena-agent | 10.81.128.3
kontena-agent | 
```

This should be effectively zero-cost for subsequence containers after initial migration:

```
kontena-agent | D, [2016-11-24T13:45:42.491161 #1] DEBUG -- Workers::WeaveWorker: Scanned 10 existing containers for potential migration: {"752a3b486e62"=>["10.81.128.104/16"], "e13d0d0db14f"=>["10.81.128.33/16"], "b3bdb7f5b32d"=>["10.81.128.82/16"], "73754bc5b0f1"=>["10.81.128.99/16"], "dfbf62e97780"=>["10.81.128.5/16"], "898e6787f599"=>["10.81.128.109/16"], "0e79aa77bf3b"=>["10.81.128.18/16"], "9f438d23f43d"=>["10.81.128.100/16"], "6620e2e88424"=>["10.81.128.49/16"], "653e4574f253"=>["10.81.128.3/16"]}
kontena-agent | I, [2016-11-24T13:45:42.491346 #1]  INFO -- Kontena::Workers::WeaveWorker: attaching network to existing containers
kontena-agent | D, [2016-11-24T13:45:42.557102 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-10 with overlay_cidr=10.81.128.104/19 from ["10.81.128.104/16"] to 10.81.128.104/16
kontena-agent | I, [2016-11-24T13:45:42.558432 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=752a3b486e62461eed477d791817896dc1ceb6f927fccc15ecd1fe8f0e2a052e at cidr=10.81.128.104/16
kontena-agent | D, [2016-11-24T13:45:42.629995 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-9 with overlay_cidr=10.81.128.33/19 from ["10.81.128.33/16"] to 10.81.128.33/16
kontena-agent | I, [2016-11-24T13:45:42.642451 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=e13d0d0db14f494a1734b80d94fa9f7e06c75b8f371bad61be56c55d70c38f2c at cidr=10.81.128.33/16
kontena-agent | D, [2016-11-24T13:45:42.977849 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-8 with overlay_cidr=10.81.128.82/19 from ["10.81.128.82/16"] to 10.81.128.82/16
kontena-agent | I, [2016-11-24T13:45:42.978093 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=b3bdb7f5b32db02b10f565fd20d3ae445b4c89ea1760b922bec3da6553dcdc0b at cidr=10.81.128.82/16
kontena-agent | D, [2016-11-24T13:45:43.171054 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-7 with overlay_cidr=10.81.128.69/19 (not attached) -> 10.81.128.69/16
kontena-agent | I, [2016-11-24T13:45:43.181331 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=ade4b6f831dab0525f2bab3a0ca0994dce0e276c9dd50669810508481eaa9d43 at cidr=10.81.128.69/16
kontena-agent | D, [2016-11-24T13:45:43.316584 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-6 with overlay_cidr=10.81.128.99/19 from ["10.81.128.99/16"] to 10.81.128.99/16
kontena-agent | I, [2016-11-24T13:45:43.318413 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=73754bc5b0f1ce5fc890a01631e79c7a7943a06a00f61c335a66408329e82233 at cidr=10.81.128.99/16
kontena-agent | D, [2016-11-24T13:45:43.437350 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-5 with overlay_cidr=10.81.128.5/19 from ["10.81.128.5/16"] to 10.81.128.5/16
kontena-agent | I, [2016-11-24T13:45:43.437552 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=dfbf62e97780c31557cbd25926bb1d518c5f327aca5d30752f297722ef15671f at cidr=10.81.128.5/16
kontena-agent | D, [2016-11-24T13:45:43.535171 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-4 with overlay_cidr=10.81.128.109/19 from ["10.81.128.109/16"] to 10.81.128.109/16
kontena-agent | I, [2016-11-24T13:45:43.536579 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=898e6787f599e54326c712afec68cb306e63fd559e46e4738fb82bf1888f9502 at cidr=10.81.128.109/16
kontena-agent | D, [2016-11-24T13:45:43.681601 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-3 with overlay_cidr=10.81.128.18/19 from ["10.81.128.18/16"] to 10.81.128.18/16
kontena-agent | I, [2016-11-24T13:45:43.681884 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=0e79aa77bf3b640ab17f3d6e3e3e6914ffdf7ccd9072a75ed024a912b4b8c448 at cidr=10.81.128.18/16
kontena-agent | D, [2016-11-24T13:45:43.756633 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-2 with overlay_cidr=10.81.128.100/19 from ["10.81.128.100/16"] to 10.81.128.100/16
kontena-agent | I, [2016-11-24T13:45:43.756830 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=9f438d23f43d731d90d33831bdd29e35c05ad7ada1ec9a0d7c99e25893ce3d47 at cidr=10.81.128.100/16
kontena-agent | D, [2016-11-24T13:45:43.854037 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.104/16", "--rewrite-hosts", "752a3b486e62461eed477d791817896dc1ceb6f927fccc15ecd1fe8f0e2a052e"]
kontena-agent | 10.81.128.104
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:43.877089 #1] DEBUG -- Workers::WeaveWorker: Migrate container=/null-redis-1 with overlay_cidr=10.81.128.49/19 from ["10.81.128.49/16"] to 10.81.128.49/16
kontena-agent | I, [2016-11-24T13:45:43.893199 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=6620e2e88424b56d8f5bd94ae810b91d86d03e2ffb5b9c72c55f3d040f523e7f at cidr=10.81.128.49/16
kontena-agent | D, [2016-11-24T13:45:43.905519 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-ipam-plugin without overlay_cidr
kontena-agent | I, [2016-11-24T13:45:44.003288 #1]  INFO -- Kontena::NetworkAdapters::Weave: Attach container=653e4574f253f572f9c584b279ec5d64dc602cac8f7e646ac8de606df7277316 at cidr=10.81.128.3/16
kontena-agent | D, [2016-11-24T13:45:44.020580 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-etcd without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:44.048733 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/weaveplugin without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:44.069443 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/weave without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:44.079375 #1] DEBUG -- Workers::WeaveWorker: skip start for container=/kontena-cadvisor without overlay_cidr
kontena-agent | D, [2016-11-24T13:45:44.120488 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.33/16", "--rewrite-hosts", "e13d0d0db14f494a1734b80d94fa9f7e06c75b8f371bad61be56c55d70c38f2c"]
kontena-agent | 10.81.128.33
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:44.731966 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.82/16", "--rewrite-hosts", "b3bdb7f5b32db02b10f565fd20d3ae445b4c89ea1760b922bec3da6553dcdc0b"]
kontena-agent | 10.81.128.82
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:44.947512 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.69/16", "--rewrite-hosts", "ade4b6f831dab0525f2bab3a0ca0994dce0e276c9dd50669810508481eaa9d43"]
kontena-agent | 10.81.128.69
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:45.523346 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.99/16", "--rewrite-hosts", "73754bc5b0f1ce5fc890a01631e79c7a7943a06a00f61c335a66408329e82233"]
kontena-agent | 10.81.128.99
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:45.717005 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.5/16", "--rewrite-hosts", "dfbf62e97780c31557cbd25926bb1d518c5f327aca5d30752f297722ef15671f"]
kontena-agent | 10.81.128.5
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:46.430048 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.109/16", "--rewrite-hosts", "898e6787f599e54326c712afec68cb306e63fd559e46e4738fb82bf1888f9502"]
kontena-agent | 10.81.128.109
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:46.648721 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.18/16", "--rewrite-hosts", "0e79aa77bf3b640ab17f3d6e3e3e6914ffdf7ccd9072a75ed024a912b4b8c448"]
kontena-agent | 10.81.128.18
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:47.296626 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.100/16", "--rewrite-hosts", "9f438d23f43d731d90d33831bdd29e35c05ad7ada1ec9a0d7c99e25893ce3d47"]
kontena-agent | 10.81.128.100
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:47.508107 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.49/16", "--rewrite-hosts", "6620e2e88424b56d8f5bd94ae810b91d86d03e2ffb5b9c72c55f3d040f523e7f"]
kontena-agent | 10.81.128.49
kontena-agent | 
kontena-agent | D, [2016-11-24T13:45:47.821373 #1] DEBUG -- NetworkAdapters::WeaveExecutor: weaveexec ok: ["--local", "attach", "10.81.128.3/16", "--rewrite-hosts", "653e4574f253f572f9c584b279ec5d64dc602cac8f7e646ac8de606df7277316"]
kontena-agent | 10.81.128.3
kontena-agent | 
```

This could be extended to skip the attach for containers that already have the correct CIDR attached, per `weaveexec ps`.

## TODO

* specs
* verify for robustness across crashes, errors etc