### PR TITLE
Document Stacks

### DIFF
--- a/docs/core-concepts/architecture.md
+++ b/docs/core-concepts/architecture.md
@@ -48,3 +48,15 @@ A Service is composed of containers based on the same image file. In addition to
 Kontena's built-in support for Service-level statistics and logging is very useful since it is often difficult to get an overview and understand a complex system by just inspecting individual containers. In addition, Kontena's Services make all statistics and log data persistent. This is essential due to the fact that individual containers do not store this information persistently.
 
 As with any container orchestration technology, Kontena supports the creation of stateless Services: web servers, REST API servers and in-memory object caches. In addition, Kontena has support for stateful Services such as traditional and distributed databases and batch and streaming data processing. The support for stateful Services is one of the key differentiators between Kontena and other container orchestration technologies.
+
+## Stacks
+
+An individual service is rarely useful on its own.
+Modern microservice architectures will decompose applications into many smaller services, and even monolithic web applications will typically require some external services such as a database.
+Deploying these applications requires careful management of the different combinations of services, and the ability for those services to communicate amongst themselves.
+Deploying a re-usable application into different environments may require the use of configuration variables to customize the application.
+Kontena Stacks are used to distribute, deploy and run pre-packaged and reusable collections of multiple services with any associated configuration.
+
+Each Kontena Stack can be distributed as a YAML file via the ***Stack Registry***, deployed as a Stack via the ***Kontena Master***, and run as ***Service Containers*** in a per-stack namespace within the ***Grid***.
+The use of a per-stack namespace allows simple communication between the services within a stack, while also allowing multiple instances of the same stack to be run within the same ***Grid***.
+Stacks can also use services exposed by other stacks deployed to the same grid.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -154,8 +154,8 @@ You can use the `kontena stack` commands to view the resulting configuration of 
 
 ```
 $ kontena service show wordpress/wordpress
-development/wordpress/wordpress:
-  stack: development/wordpress
+test/wordpress/wordpress:
+  stack: test/wordpress
   status: running
   image: wordpress:4.6
   revision: 2
@@ -164,7 +164,7 @@ development/wordpress/wordpress:
   strategy: ha
   deploy_opts:
     min_health: 0.8
-  dns: wordpress.wordpress.development.kontena.local
+  dns: wordpress.wordpress.test.kontena.local
   secrets:
     - secret: wordpress-mysql-password
       name: WORDPRESS_DB_PASSWORD
@@ -180,8 +180,8 @@ development/wordpress/wordpress:
     wordpress-wordpress-1:
       rev: 2016-11-28 13:51:02 UTC
       service_rev: 2
-      node: core-01
-      dns: wordpress-1.wordpress.development.kontena.local
+      node: hidden-moon-99
+      dns: wordpress-1.wordpress.test.kontena.local
       ip: 10.81.128.115
       public ip: 192.0.2.1
       status: running
@@ -190,7 +190,7 @@ development/wordpress/wordpress:
 
 To test the wordpress service, you must connect to the IP address of the host node publishing the wordpress service on TCP port 80.
 You can use the public IP address of the host node running the service instance displayed as part of the `kontena service show` output.
-**Note:** For the special case of using Vagrant for the Kontena setup, you must use the *private* IP address of the node running the `wordpress/wordpress` service: `kontena node show ... | grep 'private ip'`.
+**Note:** For the special case of using Vagrant for the Kontena setup, you must use the *private* IP address of the node running the `wordpress/wordpress` service: `kontena node show hidden-moon-99 | grep 'private ip'`.
 
 For more complex examples of application deployment on Kontena, please see the following examples:
 

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -27,6 +27,111 @@ The following Kontena CLI commands operate on the Kontena Cloud stack registry:
 * `kontena stack search` - Search for stack files in the stack registry
 * `kontena stack info` - Show info about a stack in the stack registry
 
+#### `kontena stack pull terom/wordpress`
+
+Download the YAML stack file from the Kontena Cloud Stack Registry:
+
+```
+stack: terom/wordpress
+version: 0.3.0
+variables:
+  wordpress-mysql-root:
+    type: string
+    from:
+      vault: wordpress-mysql-root
+      random_string: 32
+    to:
+      vault: wordpress-mysql-root
+  wordpress-mysql-password:
+    type: string
+    from:
+      vault: wordpress-mysql-password
+      random_string: 32
+    to:
+      vault: wordpress-mysql-password
+services:
+  wordpress:
+    image: wordpress:4.6
+    stateful: true
+    ports:
+      - 80:80
+    environment:
+      WORDPRESS_DB_HOST: mysql
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    secrets:
+      - secret: wordpress-mysql-password
+        name: WORDPRESS_DB_PASSWORD
+        type: env
+  mysql:
+    image: mariadb:5.5
+    stateful: true
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+    secrets:
+      - secret: wordpress-mysql-root
+        name: MYSQL_ROOT_PASSWORD
+        type: env
+      - secret: wordpress-mysql-password
+        name: MYSQL_PASSWORD
+        type: env
+```
+
+You can write the YAML to a local file using either `-f kontena.yml`, or your shell's `> kontena.yml` syntax.
+
+#### `kontena stack push examples/wordpress/kontena.ymlexamples/wordpress/kontena.yml`
+
+Upload the YAML stack file to the Kontena Cloud Stack Registry:
+
+```
+Successfully pushed terom/wordpress:0.3.1 to Stacks registry
+```
+
+The `username/stackname` and version information are read from the given YAML file, which defaults to the `kontena.yml` file in the current directory.
+
+#### `kontena stack search wordpress`
+
+Lists available stacks having a name suffix matching the given search term.
+
+```
+terom/wordpress
+```
+
+Omit the search term to list all available stacks.
+
+#### `kontena stack info terom/wordpress`
+
+Lists available versions for a given stack.
+
+```
+CURRENT VERSION
+-----------------
+* Version: 0.3.3
+
+AVAILABLE VERSIONS
+-------------------
+0.3.3
+0.3.2
+```
+
+#### `bundle exec bin/kontena stack push -d terom/wordpress:0.3.2`
+
+```
+About to delete terom/wordpress:0.3.2 from the registry
+> Destructive command. You can skip this prompt by running this command with --force option. Are you sure? Yes
+Stack terom/wordpress:0.3.2 deleted successfully
+```
+
+#### `kontena stack push -d terom/wordpress`
+
+```
+About to delete an entire stack and all of its versions from the registry
+Destructive command. To proceed, type "terom/wordpress" or re-run this command with --force option.
+> Enter 'terom/wordpress' to confirm:  terom/wordpress
+Stack terom/wordpress deleted successfully
+```
+
 ### Stack files
 The following Kontena CLI commands operate on local stack files:
 

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -4,20 +4,27 @@ title: Stacks
 
 # Stacks
 
-Kontena YAML stack files can be distributed the Kontena Stack Registry, and installed to the Kontena Master for deployment to the Grid.
-The Kontena master deploys each stack as a collection of services containers running on the Host Nodes.
-The service containers for each stack run in a separate `$stack.$grid.kontena.local` DNS namespace.
+Kontena Stacks are pre-packaged and reusable collections of Kontena services with associated configuration in the form of a YAML file.
+These Kontena Stack files can be distributed via the Kontena Stack Registry, and installed to the Kontena Master for deployment to the Grid.
+The Kontena Master deploys each stack as a set of Kontena Services, running as Docker containers on the host nodes.
+The service containers run the Docker images referenced in the stack file.
 
+Multiple instances of a stack file can be installed on the same Kontena grid, assigning an unique name to each deployed stack.
+The service containers for each stack are run within a separate `$stack.$grid.kontena.local` DNS namespace.
+The service containers can connect to the bare DNS names of other services in the same stack.
+Stacks can also expose a service, allowing other stacks to use the bare DNS name of the exposing stack to connect to the exposed service.
+
+## Usage
 The following Kontena CLI commands operate on stack files and the stack registry:
 
 * `kontena stack build` - Build Docker images referenced by a stack file
-* `kontena stack push` - Push a stack file to the stack registry
 * `kontena stack pull` - Pull a stack file from the stack registry
+* `kontena stack push` - Push a stack file to the stack registry
+* `kontena stack push -d` - Delete a stack file from the stack registry
 * `kontena stack search` - Search for stack files in the stack registry
 * `kontena stack info` - Show info about a stack in the stack registry
-* `kontena stack delete` - Delete a stack in the stack registry
 
-The following Kontena CLI commands operate on stacks deployed to the grid:
+The following Kontena CLI commands operate on named stacks deployed to the grid:
 
 * `kontena stack list` - List stacks deployed to the Grid
 * `kontena stack show` - Show stack details from the Grid

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -137,7 +137,7 @@ The following Kontena CLI commands are used to install local stack files to the 
 #### `kontena stack install --name wordpress-red --deploy wordpress/kontena.yml`
 
 Install the stack from the YAML file to the master, creating a new named stack with associated services.
-Use the `--deploy` flag to simultaneously deploy the stack services to the grid, running the Docker containers.
+Use the `--deploy` flag to simultaneously deploy the stack services to the grid, spinning up the Docker containers.
 
 ```
  [done] Creating stack wordpress-red      
@@ -145,6 +145,7 @@ Use the `--deploy` flag to simultaneously deploy the stack services to the grid,
 ```
 
 The stack services will now be visible in `kontena service ls`, and the service containers will be running on the grid's host nodes.
+If you omit the `kontena stack install --deploy` flag, then you must run `kontena stacl deploy wordpress-red` separately.
 
 Assuming the new `wordpress-red/wordpress` container is running on the host node at `192.168.66.102`, you can use `http://192.168.66.102:80/` to access the installed wordpress service.
 

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -148,6 +148,14 @@ The stack services will now be visible in `kontena service ls`, and the service 
 
 Assuming the new `wordpress-red/wordpress` container is running on the host node at `192.168.66.102`, you can use `http://192.168.66.102:80/` to access the installed wordpress service.
 
+#### `kontena stack install --name wordpress-green --deploy terom/wordpress`
+
+Install and deploy the stack using the latest YAML file from the stack registry.
+
+#### `kontena stack install --name wordpress-green --deploy terom/wordpress:4.6.1+mariadb5.`
+
+Install and deploy the stack using the versioned YAML file from the stack registry.
+
 #### `kontena stack remove wordpress-red`
 
 Removes the installed stack and associated services, including any deployed containers.

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -4,7 +4,9 @@ title: Stacks
 
 # Stacks
 
-Kontena YAML stack files can be distributed the Kontena Stack Registry, and installed to the Kontena Master for deployment to the Grid as a collection of services containers running on the Host Nodes.
+Kontena YAML stack files can be distributed the Kontena Stack Registry, and installed to the Kontena Master for deployment to the Grid.
+The Kontena master deploys each stack as a collection of services containers running on the Host Nodes.
+The service containers for each stack run in a separate `$stack.$grid.kontena.local` DNS namespace.
 
 The following Kontena CLI commands operate on stack files and the stack registry:
 

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -21,11 +21,11 @@ Kontena Stacks can be distributed as YAML files via the ***Stack Registry***, de
 ### Stack Registry
 The following Kontena CLI commands operate on the Kontena Cloud stack registry:
 
-* `kontena stack pull` - Pull a stack file from the stack registry
-* `kontena stack push` - Push a stack file to the stack registry
-* `kontena stack push -d` - Delete a stack file from the stack registry
-* `kontena stack search` - Search for stack files in the stack registry
-* `kontena stack info` - Show info about a stack in the stack registry
+* `kontena stack registry push` - Push a stack into the stacks registry
+* `kontena stack registry pull` - Pull a stack from the stacks registry
+* `kontena stack registry search` - Search for stacks in the stacks registry
+* `kontena stack registry info` - Show info about a stack in the stacks registry
+* `kontena stack registry remove` - Remove a stack (or version) from the stacks registry
 
 #### `kontena cloud login`
 
@@ -38,7 +38,7 @@ Authenticated to Kontena Cloud at https://cloud-api.kontena.io as terom
 
 Stack files can be be downloaded and searched from the stack registry without any login.
 
-#### `kontena stack pull terom/wordpress`
+#### `kontena stack registry pull terom/wordpress`
 
 Download the newest version of the YAML stack file from the Kontena Stack Registry.
 
@@ -48,68 +48,76 @@ You can write the YAML to a local file using either your shell's `> kontena.yml`
 Wrote 999 bytes to kontena.yml
 ```
 
-#### `kontena stack pull terom/wordpress:0.3.3`
+#### `kontena stack registry pull terom/wordpress:0.3.3`
 
 Download a specific version of the YAML stack file from the Kontena Stack Registry.
 
-#### `kontena stack push examples/wordpress/kontena.yml`
+#### `kontena stack registry push wordpress/kontena.yml`
 
 Upload the YAML stack file to the Kontena Cloud Stack Registry:
 
 ```
-Successfully pushed terom/wordpress:0.3.1 to Stacks registry
+[done] Pushing terom/wordpress:0.3.4 to stacks registry    
 ```
 
 The `username/stackname` and version information are read from within the given YAML file.
-By defaulf, the `kontena.yml` file in the current directory is uploaded.
+By default, the `kontena.yml` file in the current directory is uploaded.
 
-#### `kontena stack search wordpress`
+#### `kontena stack registry search wordpress`
 
-Lists available stacks having a name suffix matching the given search term.
+
+`kontena stack search wordpress`
+
+Lists available stacks files having a name suffix matching the given search term.
 
 ```
-terom/wordpress
+NAME                                     VERSION    DESCRIPTION                             
+jussi/wordpress                          0.1.0      Todo-app bundle, all required services within the stack
+terom/wordpress                          0.3.5      Wordpress 4.6 + MariaDB 5.5
 ```
 
 Omit the search term to list all available stacks.
 
-#### `kontena stack info terom/wordpress`
+#### `kontena stack registry show terom/wordpress`
 
-Lists available versions for a given stack.
+Lists information and available versions of a given stack file.
 
 ```
-CURRENT VERSION
------------------
-* Version: 0.3.3
-
-AVAILABLE VERSIONS
--------------------
-0.3.3
-0.3.2
+terom/wordpress:
+  latest_version: 0.3.5
+  expose: -
+  description: Wordpress 4.6 + MariaDB 5.5
+  available_versions:
+    - 0.3.5
+    - 0.3.4
+    - 0.3.3
+    - 0.3.2
 ```
 
-#### `bundle exec bin/kontena stack push -d terom/wordpress:0.3.2`
+#### `kontena stack registry remove terom/wordpress:0.3.3`
 
 Delete a specific version of a stack file uploaded to the stack registry.
 
 ```
-About to delete terom/wordpress:0.3.2 from the registry
+About to delete terom/wordpress:0.3.3 from the stacks registry
 > Destructive command. You can skip this prompt by running this command with --force option. Are you sure? Yes
-Stack terom/wordpress:0.3.2 deleted successfully
-```
+ [done] Removing terom/wordpress from the registry
+ ```
 
 A deleted stack file version cannot be re-uploaded, but you can upload the stack file with a newer version number.
 
-#### `kontena stack push -d terom/wordpress`
+#### `kontena stack registry remove terom/redis`
+
+Delete all versions of a stack file from the stack registry.
 
 ```
-About to delete an entire stack and all of its versions from the registry
-Destructive command. To proceed, type "terom/wordpress" or re-run this command with --force option.
-> Enter 'terom/wordpress' to confirm:  terom/wordpress
-Stack terom/wordpress deleted successfully
+About to delete an entire stack and all of its versions from the stacks registry
+Destructive command. To proceed, type "terom/redis" or re-run this command with --force option.
+> Enter 'terom/redis' to confirm:  terom/redis
+ [done] Removing terom/redis from the registry
 ```
 
-A deleted stack cannot be restored, but you can re-upload the stack file with a newer version number.
+A deleted stack file can be re-upload with a newer version number.
 
 ### Stack files
 The following Kontena CLI commands operate on local stack files:

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -15,21 +15,30 @@ The service containers can connect to the bare DNS names of other services in th
 Stacks can also expose a service, allowing other stacks to use the bare DNS name of the exposing stack to connect to the exposed service.
 
 ## Usage
-The following Kontena CLI commands operate on stack files and the stack registry:
 
-* `kontena stack build` - Build Docker images referenced by a stack file
+Kontena Stacks can be distributed as YAML files via the ***Stack Registry***, deployed via the ***Kontena Master*** to run as ***Service Containers*** within the ***Grid***.
+
+### Stack Registry
+The following Kontena CLI commands operate on the Kontena Cloud stack registry:
+
 * `kontena stack pull` - Pull a stack file from the stack registry
 * `kontena stack push` - Push a stack file to the stack registry
 * `kontena stack push -d` - Delete a stack file from the stack registry
 * `kontena stack search` - Search for stack files in the stack registry
 * `kontena stack info` - Show info about a stack in the stack registry
 
+### Stack files
+The following Kontena CLI commands operate on local stack files:
+
+* `kontena stack build` - Build and push Docker images referenced by a stack file
+* `kontena stack install` - Create a stack on the Kontena Master
+* `kontena stack upgrade` - Upgrade a stack within the Grid
+
+### Deployed Stacks
 The following Kontena CLI commands operate on named stacks deployed to the grid:
 
-* `kontena stack list` - List stacks deployed to the Grid
+* `kontena stack list` - List installed stacks
 * `kontena stack show` - Show stack details from the Grid
-* `kontena stack install` - Deploy a stack to the Kontena Master
-* `kontena stack upgrade` - Upgrade a stack within the Grid
 * `kontena stack deploy` - Deploy a stack to the Grid
 * `kontena stack logs` - Show logs from stack services
 * `kontena stack monitor` - Monitor stack services

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -16,8 +16,9 @@ Stacks can also expose a service, allowing other stacks to use the bare DNS name
 
 The Kontena Services associated with a stack are shown as `stackname/servicename` in the CLI.
 Traditional Kontena Services created using `kontena service create` are not associated with a stack, and are shown without any `stackname` prefix.
-Like Kontena Services, Kontena Stacks are also Grid-specific.
-The `kontena stack` commands operate on the current grid, unless using the `--grid` option.
+
+Like Kontena Services, Kontena Stacks are also grid-specific.
+The `kontena stack` commands operate on the current grid, unless using the `--grid` option to temporarily operate on a different grid.
 
 ## Usage
 
@@ -132,6 +133,32 @@ The following Kontena CLI commands are used to install local stack files to the 
 * `kontena stack upgrade` - Upgrade a stack within the Grid
 * `kontena stack deploy` - Deploy a stack to the Grid
 * `kontena stack remove` - Remove a deployed stack
+
+#### `kontena stack install --name wordpress-red --deploy wordpress/kontena.yml`
+
+Install the stack from the YAML file to the master, creating a new named stack with associated services.
+Use the `--deploy` flag to simultaneously deploy the stack services to the grid, running the Docker containers.
+
+```
+ [done] Creating stack wordpress-red      
+ [done] Deploying stack wordpress-red     
+```
+
+The stack services will now be visible in `kontena service ls`, and the service containers will be running on the grid's host nodes.
+
+Assuming the new `wordpress-red/wordpress` container is running on the host node at `192.168.66.102`, you can use `http://192.168.66.102:80/` to access the installed wordpress service.
+
+#### `kontena stack remove wordpress-red`
+
+Removes the installed stack and associated services, including any deployed containers.
+
+```
+Destructive command. To proceed, type "wordpress-red" or re-run this command with --force option.
+> Enter 'wordpress-red' to confirm:  wordpress-red
+ [done] Removing stack wordpress-red      
+```
+
+This command also removes all data volumes associated with stateful services within the stack.
 
 ### Deployed Stacks
 The following Kontena CLI commands can be used to inspect and monitor named stacks deployed to the grid:

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -1,0 +1,25 @@
+---
+title: Stacks
+---
+
+# Stacks
+
+Kontena YAML stack files can be distributed the Kontena Stack Registry, and installed to the Kontena Master for deployment to the Grid as a collection of services containers running on the Host Nodes.
+
+The following Kontena CLI commands operate on stack files and the stack registry:
+
+* `kontena stack build` - Build Docker images referenced by a stack file
+* `kontena stack push` - Push a stack file to the stack registry
+* `kontena stack pull` - Pull a stack file from the stack registry
+* `kontena stack search` - Search for stack files in the stack registry
+
+The following Kontena CLI commands operate on stacks deployed to the grid:
+
+* `kontena stack list` - List stacks deployed to the Grid
+* `kontena stack show` - Show stack details from the Grid
+* `kontena stack install` - Deploy a stack to the Kontena Master
+* `kontena stack upgrade` - Upgrade a stack within the Grid
+* `kontena stack deploy` - Deploy a stack to the Grid
+* `kontena stack logs` - Show logs from stack services
+* `kontena stack monitor` - Monitor stack services
+* `kontena stack remove` - Remove a deployed stack

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -262,3 +262,23 @@ nodes:
   core-01 (2 instances)
   ■■
 ```
+
+## details
+
+### Linking services within the same stack
+
+Because each stack is deployed using a separate DNS namespace, services within the same stack can use the bare DNS names of other services in the same stack for communication.
+There is no need to explicitly link services within the same stack.
+
+For the example `wordpress` and `mysql` services in the `wordpress` stack deployed to the `test` grid, Kontena will use the `wordpress.test.kontena.local` DNS domain.
+Each service container will be registered with an instance hostname and service alias within the stack's domain, and configured to resolve hostnames from the stack's domain.
+Any service within the stack can be configured to use the bare `mysql` DNS name to resolve the overlay network IP address of the `mysql-1.wordpress.kontena.local` container via the `mysql.wordpress.kontena.local` service alias.
+
+Each deployed stack will have an separate DNS namespace, including multiple deployed copies of the same stack file.
+The `wordpress` container in one stack will always use the `mysql` service in the same stack.
+
+## Exposing services between stacks
+
+Each stack can also expose a service for use by other stacks.
+
+TODO: `exposed: ...`

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -27,60 +27,32 @@ The following Kontena CLI commands operate on the Kontena Cloud stack registry:
 * `kontena stack search` - Search for stack files in the stack registry
 * `kontena stack info` - Show info about a stack in the stack registry
 
+#### `kontena cloud login`
+
+The stack registry uses your Kontena Cloud OAuth credentials to upload stack files.
+You must upload any stack files named using the same username prefix as you have used when registering to the Kontena Cloud:
+
+```
+Authenticated to Kontena Cloud at https://cloud-api.kontena.io as terom
+```
+
+Stack files can be be downloaded and searched from the stack registry without any login.
+
 #### `kontena stack pull terom/wordpress`
 
-Download the YAML stack file from the Kontena Cloud Stack Registry:
+Download the newest version of the YAML stack file from the Kontena Stack Registry.
+
+You can write the YAML to a local file using either your shell's `> kontena.yml` syntax, or the `-F kontena.yml` option:
 
 ```
-stack: terom/wordpress
-version: 0.3.0
-variables:
-  wordpress-mysql-root:
-    type: string
-    from:
-      vault: wordpress-mysql-root
-      random_string: 32
-    to:
-      vault: wordpress-mysql-root
-  wordpress-mysql-password:
-    type: string
-    from:
-      vault: wordpress-mysql-password
-      random_string: 32
-    to:
-      vault: wordpress-mysql-password
-services:
-  wordpress:
-    image: wordpress:4.6
-    stateful: true
-    ports:
-      - 80:80
-    environment:
-      WORDPRESS_DB_HOST: mysql
-      WORDPRESS_DB_USER: wordpress
-      WORDPRESS_DB_NAME: wordpress
-    secrets:
-      - secret: wordpress-mysql-password
-        name: WORDPRESS_DB_PASSWORD
-        type: env
-  mysql:
-    image: mariadb:5.5
-    stateful: true
-    environment:
-      MYSQL_DATABASE: wordpress
-      MYSQL_USER: wordpress
-    secrets:
-      - secret: wordpress-mysql-root
-        name: MYSQL_ROOT_PASSWORD
-        type: env
-      - secret: wordpress-mysql-password
-        name: MYSQL_PASSWORD
-        type: env
+Wrote 999 bytes to kontena.yml
 ```
 
-You can write the YAML to a local file using either `-f kontena.yml`, or your shell's `> kontena.yml` syntax.
+#### `kontena stack pull terom/wordpress:0.3.3`
 
-#### `kontena stack push examples/wordpress/kontena.ymlexamples/wordpress/kontena.yml`
+Download a specific version of the YAML stack file from the Kontena Stack Registry.
+
+#### `kontena stack push examples/wordpress/kontena.yml`
 
 Upload the YAML stack file to the Kontena Cloud Stack Registry:
 
@@ -88,7 +60,8 @@ Upload the YAML stack file to the Kontena Cloud Stack Registry:
 Successfully pushed terom/wordpress:0.3.1 to Stacks registry
 ```
 
-The `username/stackname` and version information are read from the given YAML file, which defaults to the `kontena.yml` file in the current directory.
+The `username/stackname` and version information are read from within the given YAML file.
+By defaulf, the `kontena.yml` file in the current directory is uploaded.
 
 #### `kontena stack search wordpress`
 
@@ -117,11 +90,15 @@ AVAILABLE VERSIONS
 
 #### `bundle exec bin/kontena stack push -d terom/wordpress:0.3.2`
 
+Delete a specific version of a stack file uploaded to the stack registry.
+
 ```
 About to delete terom/wordpress:0.3.2 from the registry
 > Destructive command. You can skip this prompt by running this command with --force option. Are you sure? Yes
 Stack terom/wordpress:0.3.2 deleted successfully
 ```
+
+A deleted stack file version cannot be re-uploaded, but you can upload the stack file with a newer version number.
 
 #### `kontena stack push -d terom/wordpress`
 
@@ -131,6 +108,8 @@ Destructive command. To proceed, type "terom/wordpress" or re-run this command w
 > Enter 'terom/wordpress' to confirm:  terom/wordpress
 Stack terom/wordpress deleted successfully
 ```
+
+A deleted stack cannot be restored, but you can re-upload the stack file with a newer version number.
 
 ### Stack files
 The following Kontena CLI commands operate on local stack files:

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -14,6 +14,8 @@ The following Kontena CLI commands operate on stack files and the stack registry
 * `kontena stack push` - Push a stack file to the stack registry
 * `kontena stack pull` - Pull a stack file from the stack registry
 * `kontena stack search` - Search for stack files in the stack registry
+* `kontena stack info` - Show info about a stack in the stack registry
+* `kontena stack delete` - Delete a stack in the stack registry
 
 The following Kontena CLI commands operate on stacks deployed to the grid:
 

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -279,6 +279,11 @@ The `wordpress` container in one stack will always use the `mysql` service in th
 
 ## Exposing services between stacks
 
-Each stack can also expose a service for use by other stacks.
+Each stack can also expose a service for use by other stacks using the top-level `expose: ` entry in the YAML stack file.
+Other services in different stacks can use the bare DNS name of the stack itself to connect to the exposed service.
 
-TODO: `exposed: ...`
+For example, the internal Kontena Registry is deployed as a `registry` stack that exposes the internal `api` service.
+The `registry.test.kontena.local` DNS name is an alias for the `api-1.registry.test.kontena.local` service container.
+Other service containers and the host nodes can use the bare `registry` DNS name to connect to the Kontena Registry.
+
+To expose multiple services from a stack, expose a Kontena load-balancer service within the stack, linked to each of the services to expose.


### PR DESCRIPTION
* Update the quickstart example to use a simple wordpress+mysql stack

    Should we use `kontena stack pull` to fetch the stackfile, or directly `kontena stack install examples/wordpress`?

    Getting the private IP address for vagrant is rather difficult ATM, but the `WORDPRESS_DB_HOST=%{project}-mysql.kontena.local` part is nicely simplified, and the auto-generated vault secrets are :+1: 

* Brief architecture section

* Stacks page

 * Document most `kontena stack ...` commands
 * Document some of the stack DNS namespace details
 * Mention the stack expose mechanism

## TODO

* Document remaining `kontena stack ...` commands with examples
  * `kontena stack build`
  * `kontena stack upgrade`
* Document the YAML stack file fields in full - probably copy-pasta from the existing `kontena app` -> `kontena.yml` reference?
* Stacks extends
* Stack load balancer linking
* Iter-stack linking?
* Publishing different services from multiple stacks via a single `strategy: daemon` kontena-lb service
