### PR TITLE
Add SSL_IGNORE_ERRORS env during callbacks

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -16,6 +16,11 @@ module Kontena
         return unless command.result.has_key?(:code)
         return unless command.result.has_key?(:name)
 
+        # If plugins generate self-signed cert, most of the upcoming callbacks will
+        # fail without this. This can be made bit more clever once all the plugins
+        # return the generated self-signed certificate.
+        ENV['SSL_IGNORE_ERRORS'] = 'true'
+
         # In case there already is a server with the same name add random characters to name
         if config.find_server(command.result[:name])
           command.result[:name] = "#{command.result[:name]}-#{SecureRandom.hex(2)}"
@@ -33,7 +38,7 @@ module Kontena
           ENV["DEBUG"] && puts("Trying to request / from #{new_master.url}")
           client = Kontena::Client.new(new_master.url, nil, ignore_ssl_errors: true)
           client.get('/')
-        rescue 
+        rescue
           ENV["DEBUG"] && puts("HTTPS test failed: #{$!} #{$!.message}")
           unless retried
             new_master.url = "http://#{command.result[:public_ip]}"


### PR DESCRIPTION
Now that all the plugins do not yet return the generated self-signed certificate it is impossible for the master creation to succeed. The auth and config callbacks will fail since the global `:ssl_verify_peer` is true.

Once all the plugins return the self-signed certificate this can be pretty much removed. The callbacks interact with the master both with direct HTTP and via commands so it's difficult to set this any other way during the callbacks.

fixes #1412 