### PR TITLE
Option default is now suggestion for prompts

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
   spec.add_runtime_dependency "hash_validator", "~> 0.7.0"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
-  spec.add_runtime_dependency "opto", "~> 1.4"
+  spec.add_runtime_dependency "opto", "~> 1.5"
 end


### PR DESCRIPTION
Updated opto to use default as last resort.

Enums now have "(Other)" which prompts for manual answer if enum's `can_be_other: true` setting is enabled.

Also the cursor will be on the selection that has the option's default value in enum selection menu.

