### PR TITLE
ServicesHelper needs token for get_service

### DIFF
--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -34,7 +34,8 @@ module Kontena::Cli::Stacks
 
     # @param [String] service_id
     def show_service(service_id)
-      service = get_service(service_id)
+      token = require_token
+      service = get_service(token, service_id)
       pad = '    '.freeze
       puts "#{pad}#{service['name']}:"
       puts "#{pad}  image: #{service['image']}"


### PR DESCRIPTION
```
/Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/cli/services/services_helper.rb:35:in `get_service': wrong number of arguments (given 1, expected 2) (ArgumentError)
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/cli/stacks/show_command.rb:37:in `show_service'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/cli/stacks/show_command.rb:31:in `block in show_stack'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/cli/stacks/show_command.rb:30:in `each'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/cli/stacks/show_command.rb:30:in `show_stack'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/cli/stacks/show_command.rb:17:in `execute'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/command.rb:187:in `run'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/clamp-1.1.1/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/command.rb:187:in `run'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/clamp-1.1.1/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/lib/kontena/command.rb:187:in `run'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/clamp-1.1.1/lib/clamp/command.rb:132:in `run'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/gems/kontena-cli-1.0.0.pre3/bin/kontena:16:in `<top (required)>'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/bin/kontena:22:in `load'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/bin/kontena:22:in `<main>'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/bin/ruby_executable_hooks:15:in `eval'
	from /Users/jussi/.rvm/gems/ruby-2.3.1@edge/bin/ruby_executable_hooks:15:in `<main>'
```