### PR TITLE
CLI: Fix kontena stack logs duplicated options/parameters

### DIFF
--- a/cli/lib/kontena/cli/stacks/logs_command.rb
+++ b/cli/lib/kontena/cli/stacks/logs_command.rb
@@ -7,19 +7,12 @@ module Kontena::Cli::Stacks
     banner "Shows logs from services in a stack"
 
     parameter "NAME", "Stack name"
-    option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
-    option ["-l", "--lines"], "LINES", "How many lines to show", default: '100'
-    option "--since", "SINCE", "Show logs since given timestamp"
 
     requires_current_master
     requires_current_master_token
 
     def execute
-      query_params = {}
-      query_params[:limit] = lines if lines
-      query_params[:since] = since if since
-
-      show_logs("stacks/#{current_grid}/#{name}/container_logs", query_params) do |log|
+      show_logs("stacks/#{current_grid}/#{name}/container_logs") do |log|
         show_log(log)
       end
     end


### PR DESCRIPTION
The CLI `LogHelper` already defines the necessary options and query parameters. Defining them in the command class just duplicates them:

```
Usage:
    kontena stack logs [OPTIONS] NAME

  Shows logs from services in a stack

Parameters:
    NAME                          Stack name

Options:
    --grid GRID                   Specify grid to use
    -t, --tail                    Tail (follow) logs (default: false)
    --lines LINES                 Number of lines to show from the end of the logs (default: 100)
    --since SINCE                 Show logs since given timestamp
    -t, --tail                    Tail (follow) logs (default: false)
    -l, --lines LINES             How many lines to show (default: "100")
    --since SINCE                 Show logs since given timestamp
    -h, --help                    print help
```