### PR TITLE
Cli: log client requests/responses at DEBUG level

### DIFF
--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -323,7 +323,7 @@ module Kontena
       # Store the response into client.last_response
       @last_response = http_client.request(request_options)
 
-      parse_response(@last_response)
+      ret = parse_response(@last_response)
     rescue Excon::Errors::Unauthorized
       if token
         logger.debug 'Server reports access token expired'
@@ -340,6 +340,10 @@ module Kontena
       logger.debug "Request #{error.request[:method].upcase} #{error.request[:path]}: #{error.response.status} #{error.response.reason_phrase}: #{error.response.body}"
 
       handle_error_response(error.response)
+
+    else
+      logger.debug "#{http_method.upcase} #{path}: #{body.inspect} -> #{@last_response.status} #{@last_response.reason_phrase}: #{ret.inspect}"
+      return ret
     end
 
     # Build a token refresh request param hash

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -342,7 +342,7 @@ module Kontena
       handle_error_response(error.response)
 
     else
-      logger.debug "#{http_method.upcase} #{path}: #{body.inspect} -> #{@last_response.status} #{@last_response.reason_phrase}: #{ret.inspect}"
+      logger.debug "#{http_method.upcase} #{path}: #{(body || query).inspect} -> #{@last_response.status} #{@last_response.reason_phrase}: #{ret.inspect}"
       return ret
     end
 


### PR DESCRIPTION
Helps a lot when figuring out what a command is actually doing:

#### `DEBUG=1 bundle exec bin/kontena stack registry remove --force test/redis`
```
D, [2016-11-29T12:20:47.655272 #6982] DEBUG -- CLIENT: DELETE /stack/test/redis: {} -> 204 No Content: ""
```

#### `DEBUG=1 kontena stack registry remove --force test/redis:1.0`
```
D, [2016-11-29T12:20:51.917360 #6989] DEBUG -- CLIENT: DELETE /stack/test/redis/version/1.0: {} -> 204 No Content: ""
```