### PR TITLE
Add grid token back to node json

### DIFF
--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -31,6 +31,7 @@ json.grid do
     json.id grid.to_path
     json.name grid.name
     json.initial_size grid.initial_size
+    json.token grid.token
     json.stats do
       json.statsd grid.stats['statsd']
     end


### PR DESCRIPTION
So that older provision plugins still work.