### PR TITLE
Interpolate STACK and GRID inside variable definitions

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -236,7 +236,7 @@ module Kontena::Cli::Stacks
             if val
               val
             else
-              puts "Value for #{var} is not set. Substituting with an empty string." unless skip_validation?
+              puts "Value for #{var} is not set. Substituting with #{@replace_missing.to_s == '' ? "an empty string" : "'#{@replace_missing}'"}." unless skip_validation?
               @replace_missing.to_s
             end
           end

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -226,18 +226,18 @@ module Kontena::Cli::Stacks
       # @param [String] text - content of YAML file
       def interpolate(text, filler = nil)
         text.gsub(/(?<!\$)\$(?!\$)\{?\w+\}?/) do |v| # searches $VAR and ${VAR} and not $$VAR
-          if filler
+          var = v.tr('${}', '')
+          if var == 'STACK' || var == 'GRID'
+            ENV[var]
+          elsif filler
             filler
-          elsif @replace_missing
-            @replace_missing
           else
-            var = v.tr('${}', '')
             val = ENV[var]
             if val
               val
             else
               puts "Value for #{var} is not set. Substituting with an empty string." unless skip_validation?
-              ''
+              @replace_missing.to_s
             end
           end
         end


### PR DESCRIPTION
This is possible now:

```
variables:
  foo:
    type: string
    from:
      vault: ${STACK}-foo-password
```

These two envs are always set before yaml parsing by the CLI in #1475

Fixes #1473
