### PR TITLE
Garbage collect orphan service containers

### DIFF
--- a/server/app/jobs/container_cleanup_job.rb
+++ b/server/app/jobs/container_cleanup_job.rb
@@ -12,12 +12,12 @@ class ContainerCleanupJob
 
   def perform
     info 'starting to cleanup stale containers'
-    sleep 0.1
     loop do
+      sleep 1.minute.to_i
       if leader?
         destroy_deleted_containers
+        terminate_ghost_containers
       end
-      sleep 1.minute.to_i
     end
   end
 
@@ -25,5 +25,29 @@ class ContainerCleanupJob
     Container.deleted.where(:deleted_at.lt => 1.minutes.ago).each do |c|
       c.destroy
     end
+  end
+
+  def terminate_ghost_containers
+    Container.unscoped.where(:grid_service_id.ne => nil).each do |c|
+      if c.grid_service.nil?
+        terminate_ghost_container(c)
+      end
+    end
+  end
+
+  # @param [Docker::Container] container
+  def terminate_ghost_container(container)
+    if container.host_node
+      info "terminating #{container.to_path}"
+      terminator = Docker::ServiceTerminator.new(container.host_node)
+      terminator.request_terminate_service(
+        container.grid_service_id.to_s, container.instance_number, {lb: true}
+      )
+    else
+      info "removing #{container.to_path} because host node not found"
+      container.destroy
+    end
+  rescue => exc
+    error "#{exc.class.name}: #{exc.message}"
   end
 end

--- a/server/spec/jobs/container_cleanup_job_spec.rb
+++ b/server/spec/jobs/container_cleanup_job_spec.rb
@@ -8,6 +8,9 @@ describe ContainerCleanupJob do
   let(:node1) { HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago) }
   let(:node2) { HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.seconds.ago) }
   let(:node3) { HostNode.create!(name: "node-3", connected: true, last_seen_at: 3.seconds.ago) }
+  let(:service) do
+    GridService.create!(name: 'test', image_name: 'test:latest', grid: grid)
+  end
   let(:subject) { described_class.new(false) }
 
   describe '#destroy_deleted_containers' do
@@ -27,6 +30,36 @@ describe ContainerCleanupJob do
       expect {
         subject.destroy_deleted_containers
       }.to change{ Container.unscoped.count }.by(0)
+    end
+  end
+
+  describe '#terminate_ghost_containers' do
+    it 'terminates containers that does not have a service anymore' do
+      container = Container.create!(
+        name: 'foo-1', host_node: node2, grid: grid, deleted_at: 1.minutes.ago,
+        grid_service_id: GridService.new.id
+      )
+      expect(subject.wrapped_object).to receive(:terminate_ghost_container).with(container)
+      subject.terminate_ghost_containers
+    end
+
+    it 'does not terminate container that has a service' do
+      container = Container.create!(
+        name: 'foo-1', host_node: node2, grid: grid, deleted_at: 1.minutes.ago,
+        grid_service_id: service.id
+      )
+      expect(subject.wrapped_object).not_to receive(:terminate_ghost_container)
+      subject.terminate_ghost_containers
+    end
+
+    it 'removes a container that does not have a host node' do
+      container = Container.create!(
+        name: 'foo-1', host_node: HostNode.new.id, grid: grid, deleted_at: 1.minutes.ago,
+        grid_service_id: GridService.new.id
+      )
+      expect {
+        subject.terminate_ghost_containers
+      }.to change { Container.unscoped.count }.by(-1)
     end
   end
 end

--- a/server/spec/jobs/container_cleanup_job_spec.rb
+++ b/server/spec/jobs/container_cleanup_job_spec.rb
@@ -5,9 +5,9 @@ describe ContainerCleanupJob do
   after(:each) { Celluloid.shutdown }
 
   let(:grid) { Grid.create!(name: 'test-grid') }
-  let(:node1) { HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago) }
-  let(:node2) { HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.seconds.ago) }
-  let(:node3) { HostNode.create!(name: "node-3", connected: true, last_seen_at: 3.seconds.ago) }
+  let(:node1) { HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago, grid: grid) }
+  let(:node2) { HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.seconds.ago, grid: grid) }
+  let(:node3) { HostNode.create!(name: "node-3", connected: true, last_seen_at: 3.seconds.ago, grid: grid) }
   let(:service) do
     GridService.create!(name: 'test', image_name: 'test:latest', grid: grid)
   end
@@ -45,7 +45,7 @@ describe ContainerCleanupJob do
 
     it 'does not terminate container that has a service' do
       container = Container.create!(
-        name: 'foo-1', host_node: node2, grid: grid, deleted_at: 1.minutes.ago,
+        name: 'foo-1', host_node: node2, grid: grid,
         grid_service_id: service.id
       )
       expect(subject.wrapped_object).not_to receive(:terminate_ghost_container)
@@ -54,12 +54,50 @@ describe ContainerCleanupJob do
 
     it 'removes a container that does not have a host node' do
       container = Container.create!(
-        name: 'foo-1', host_node: HostNode.new.id, grid: grid, deleted_at: 1.minutes.ago,
+        name: 'foo-1', host_node: HostNode.new.id, grid: grid,
         grid_service_id: GridService.new.id
       )
       expect {
         subject.terminate_ghost_containers
       }.to change { Container.unscoped.count }.by(-1)
+    end
+  end
+
+  describe '#terminate_ghost_container' do
+    let(:terminator) do
+      double(:terminator)
+    end
+
+    it 'forces lb config removal if no replacement service exist' do
+      container = Container.create!(
+        name: 'foo-1', host_node: node2, grid: grid,
+        grid_service_id: GridService.new.id,
+        labels: {
+          'io;kontena;service;name' => 'invalid',
+          'io;kontena;stack;name' => 'invalid'
+        }
+      )
+      allow(subject.wrapped_object).to receive(:service_terminator).and_return(terminator)
+      expect(terminator).to receive(:request_terminate_service).with(
+        container.grid_service_id, container.instance_number, {lb: true}
+      )
+      subject.terminate_ghost_container(container)
+    end
+
+    it 'does not force lb config removal if replacement service exist' do
+      container = Container.create!(
+        name: 'foo-1', host_node: node2, grid: grid,
+        grid_service_id: GridService.new.id,
+        labels: {
+          'io;kontena;service;name' => service.name,
+          'io;kontena;stack;name' => service.stack.name
+        }
+      )
+      allow(subject.wrapped_object).to receive(:service_terminator).and_return(terminator)
+      expect(terminator).to receive(:request_terminate_service).with(
+        container.grid_service_id, container.instance_number, {lb: false}
+      )
+      subject.terminate_ghost_container(container)
     end
   end
 end


### PR DESCRIPTION
There is possibility to remove a service so that nodes still have service containers in place and they miss a remove. This PR fixes these situations by doing a garbage collection for service containers that still exist in the master db and their service definition is gone.