### PR TITLE
Fix server /v1/services JSON `dns`

### DIFF
--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -11,7 +11,7 @@ json.cmd grid_service.cmd
 json.entrypoint grid_service.entrypoint
 json.net grid_service.net
 if grid_service.default_stack?
-  json.dns "#{grid_service.name_with_stack}.#{grid_service.grid.name}.kontena.local"
+  json.dns "#{grid_service.name}.#{grid_service.grid.name}.kontena.local"
 else
   json.dns "#{grid_service.name}.#{grid_service.stack.name}.#{grid_service.grid.name}.kontena.local"
 end


### PR DESCRIPTION
Fixes  #1485

```yaml
development/null/redis:
  stack: development/null
  status: running
  image: redis:latest
  revision: 1
  stateful: no
  scaling: 3
  strategy: ha
  deploy_opts:
    min_health: 0.8
  dns: redis.development.kontena.local
  net: bridge
  instances:
    ...
```