### PR TITLE
Fix service container names to drop null- prefix, and use stack.service-N

### DIFF
--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -68,7 +68,11 @@ class GridService
 
   # @return [String]
   def name_with_stack
-    "#{self.stack.name}-#{self.name}"
+    if default_stack?
+      self.name
+    else
+      "#{self.stack.name}-#{self.name}"
+    end
   end
 
   # @return [String]

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -71,7 +71,7 @@ class GridService
     if default_stack?
       self.name
     else
-      "#{self.stack.name}-#{self.name}"
+      "#{self.stack.name}.#{self.name}"
     end
   end
 

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -244,7 +244,7 @@ describe GridService do
       expect(grid_service.name_with_stack).to eq 'redis'
     end
     it 'returns stack service name with stack' do
-      expect(stack_service.name_with_stack).to eq 'stack-redis'
+      expect(stack_service.name_with_stack).to eq 'stack.redis'
     end
   end
 

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -35,9 +35,15 @@ describe GridService do
   let(:grid) do
     Grid.create(name: 'test-grid')
   end
+  let :stack do
+    Stack.create(grid: grid, name: 'stack')
+  end
 
   let(:grid_service) do
     GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8')
+  end
+  let(:stack_service) do
+    GridService.create!(grid: grid, stack: stack, name: 'redis', image_name: 'redis:2.8')
   end
 
   let(:stacked_service) do
@@ -234,8 +240,11 @@ describe GridService do
   end
 
   describe '#name_with_stack' do
-    it 'returns service name with stack' do
-      expect(grid_service.name_with_stack).to include("#{grid_service.stack.name}-")
+    it 'returns stackless service name without stack' do
+      expect(grid_service.name_with_stack).to eq 'redis'
+    end
+    it 'returns stack service name with stack' do
+      expect(stack_service.name_with_stack).to eq 'stack-redis'
     end
   end
 

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -27,7 +27,7 @@ describe Docker::ServiceCreator do
     let(:service_spec) { subject.service_spec(2, 'rev') }
 
     it 'includes service_name' do
-      expect(service_spec).to include(:service_name => "#{service.stack.name}-#{service.name}")
+      expect(service_spec).to include(:service_name => 'app')
     end
 
     it 'includes instance_number' do


### PR DESCRIPTION
Kontena 1.0 added stacks. As part of the internal implementation and server API, all existing stackless services were associated with a special `"null"` stack. This stack name is hidden from the CLI interface, but it was included in the Docker service container names on the agent. Thus, the existing 0.16 service container names change as they are re-deployed with 1.0, which leads to user confusion when using the `kontena container ...` commands:

```
CONTAINER ID                    IMAGE                           COMMAND                        CREATED              STATUS    
core-01/wordpress-mysql-1       mariadb:5.5                     "docker-entrypoint.sh mysqld"  1 hours ago          running   
core-01/wordpress-wordpress-1   wordpress:4.6.1                 "docker-entrypoint.sh apache"  1 hours ago          running   
core-01/null-redis-2            redis:latest                    "docker-entrypoint.sh redis-"  1 hours ago          running   
core-01/null-redis-3            redis:latest                    "docker-entrypoint.sh redis-"  1 hours ago          running   
core-01/null-redis-1            redis:latest                    "docker-entrypoint.sh redis-"  1 hours ago          running   
```

This fix reverts to the pre-1.0 container naming scheme for classic pre-1.0 stackless services. Re-deploying a 1.0.0 stackless service with this fix restores the original service container names:

```
CONTAINER ID                    IMAGE                                              COMMAND                        CREATED              STATUS    
core-01/redis-3                 redis:latest                                       "docker-entrypoint.sh redis-"  14 minutes ago       running   
core-01/redis-2                 redis:latest                                       "docker-entrypoint.sh redis-"  14 minutes ago       running   
core-01/redis-1                 redis:latest                                       "docker-entrypoint.sh redis-"  14 minutes ago       running   
```

This also changes the 1.0 stack service container naming schema to use `.` as a separator, to avoid conflicts between similarly named app/stack services:

```
CONTAINER ID                    IMAGE                                              COMMAND                        CREATED              STATUS    
core-01/wordpress.wordpress-1   wordpress:4.6.1                                    "docker-entrypoint.sh apache"  1 minutes ago        running   
core-01/wordpress.mysql-1       mariadb:5.5                                        "docker-entrypoint.sh mysqld"  1 minutes ago        running   
```

This fix changes the server `GridService#name_with_stack`. This method is only used for the server `Docker::ServiceCreator` -> agent RPC `/service_pods/create` `{ service_name: ... }`. The agent then AFAIK only uses that `ServicePod#service_name` for the Docker container names (service container and volume container).

## `stateful: true` data volume containers

The agent is okay when dealing with existing data volume containers using the old names:

```
3576f0b6264c        wordpress:4.6.1                                    "/w/w docker-entrypoi"    About a minute ago   Up About a minute         80/tcp                        wordpress.wordpress-1
c184fdb049bd        mariadb:5.5                                        "/w/w docker-entrypoi"    About a minute ago   Up About a minute         3306/tcp                      wordpress.mysql-1
7a7c033fd526        wordpress:4.6                                      "/bin/sh echo 'Data o"    8 weeks ago          Created                                                 wordpress-wordpress-1-volumes
09e74abf458c        3136ca77b3ea                                       "/bin/sh echo 'Data o"    8 weeks ago          Created                                                 wordpress-mysql-1-volumes
```

## `volumes_from` container names

This also supports all five naming schemes used for `service: volumes_from: ...` in Kontena <1.0, 1.0, and with this PR:

```yaml
development/wordpress/wordpress:
  stack: development/wordpress

development/wordpress/volumes_test:
  stack: development/wordpress
  volumes_from:
    - wordpress-%s
```

```ruby
      # volumes_from:
      #   - wordpress-%s
      #
      # The actual container name for a stackless service is:
      #   Kontena <1.0: wordpress-1
      #   Kontena  1.0: null-wordpress-1
      #   Kontena >1.0: wordpress-1
      #
      # The actual container name for a stack service is:
      #   Kontena  1.0: wordpress-wordpress-1
      #   Kontena >1.0: wordpress.wordpress-1

```

## Fixing container name overlap with stacks and services

Part of the reason for the `null-` prefix was to avoid overlap between a `kontena app` and `kontena stack` with the same name:

* `kontena app deploy --project-name wordpress` with `stack=null` `service=wordpress-wordpress`
* `kontena stack install --name wordpress wordpress` with `stack=wordpress` `service=wordpress`

The use of the `-` separator for the stack and service names also leads to Docker container name collisions:

* `kontena stack install --name web ..` with `stack=web` `service=server-apache`
* `kontena stack install --name web-server` with `stack=web-server` `service=apache`

This PR changes the `service.stack` separator, and thus fixes these issues. The `kontena app` `wordpress-wordpress-1` service container will not overlap with the `kontena stack` `wordpress.wordpress-1` container.

## Validating stack/service names

The existing code already prohibits the use of `.` in service names:

#### `kontena service create test.redis redis`
```
 [fail] Creating test.redis service      
 [error] {"name"=>"Name isn't in the right format"}
```

The same validation also holds for stack names, and service names within stacks.

## NOTE: DNS name may also overlap

Stackless service names also overlap with stack names in DNS, if the stack exposes a service: #1377

* `kontena service create wordpress ....` with `stack=null` `service=wordpress` collides with `stack=wordpress`

And the `-#{instance_number` can also leads to DNS collisions:

* `kontena service create mysql ...` with `stack=null service=mysql container=mysql-1`
* `kontena service create mysql-1 ...` with `stack=null service=mysql-1 container=mysql-1-1`

This is a separate issue, and not part of this PR.