### PR TITLE
Boot em & celluloid with initializers

### DIFF
--- a/server/app/initializers/celluloid.rb
+++ b/server/app/initializers/celluloid.rb
@@ -1,1 +1,2 @@
 Celluloid.logger.level = Logger::ERROR if ENV['RACK_ENV'] == 'production'
+Celluloid.boot

--- a/server/app/initializers/eventmachine.rb
+++ b/server/app/initializers/eventmachine.rb
@@ -1,1 +1,4 @@
 EM.epoll
+
+Thread.new { EventMachine.run } unless EventMachine.reactor_running?
+sleep 0.01 until EventMachine.reactor_running?

--- a/server/app/jobs/cloud_websocket_connect_job.rb
+++ b/server/app/jobs/cloud_websocket_connect_job.rb
@@ -13,7 +13,6 @@ class CloudWebsocketConnectJob
 
   def perform
     sleep 0.1
-    start_em
     while running?
       update_connection
       sleep 30
@@ -74,11 +73,6 @@ class CloudWebsocketConnectJob
       @client.disconnect
       @client = nil
     end
-  end
-
-  def start_em
-    Thread.new { EventMachine.run } unless EventMachine.reactor_running?
-    sleep 0.01 until EventMachine.reactor_running?
   end
 
   protected

--- a/server/spec/jobs/cloud_websocket_connection_job_spec.rb
+++ b/server/spec/jobs/cloud_websocket_connection_job_spec.rb
@@ -12,11 +12,6 @@ describe CloudWebsocketConnectJob do
   }
 
   describe '#perform' do
-    it 'starts EventMachine' do
-      allow(subject.wrapped_object).to receive(:running?).and_return(false)
-      expect(subject.wrapped_object).to receive(:start_em).once.and_return(true)
-      subject.perform
-    end
 
     context 'when cloud enabled' do
       before(:each) do


### PR DESCRIPTION
There seems to be a very rare race condition when master boots up with eventmachine & celluloid actors. This PR tries to fix this situation by booting both of these inside an initializer.