### PR TITLE
Put the --name into $STACK (or fallback to stack name)

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -24,12 +24,12 @@ module Kontena::Cli::Stacks
       @stack_name ||= self.name || stack_name_from_yaml(filename)
     end
 
-    def stack_from_yaml(filename, from_registry: false)
+    def stack_from_yaml(filename, from_registry: false, name: nil)
       reader = Kontena::Cli::Stacks::YAML::Reader.new(filename, from_registry: from_registry)
       if reader.stack_name.nil?
         exit_with_error "Stack MUST have stack name in YAML top level field 'stack'! Aborting."
       end
-      set_env_variables(reader.stack_name, current_grid)      
+      set_env_variables(name || reader.stack_name, current_grid)
       outcome = reader.execute
 
       hint_on_validation_notifications(outcome[:notifications]) if outcome[:notifications].size > 0

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Stacks
         require_config_file(filename)
       end
 
-      stack = stack_from_yaml(filename, from_registry: from_registry)
+      stack = stack_from_yaml(filename, from_registry: from_registry, name: name)
       stack['name'] = name if name
       spinner "Creating stack #{pastel.cyan(stack['name'])} " do
         create_stack(stack)

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::Stacks
 
     def execute
       require_config_file(file)
-      stack = stack_from_yaml(file)
+      stack = stack_from_yaml(file, name: name)
       spinner "Upgrading stack #{pastel.cyan(name)} " do
         update_stack(stack)
       end

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -59,7 +59,7 @@ describe Kontena::Cli::Stacks::InstallCommand do
 
     it 'accepts a stack name as filename' do
       expect(File).to receive(:exist?).with('user/stack:1.0.0').and_return(false)
-      expect(subject).to receive(:stack_from_yaml).with('user/stack:1.0.0', from_registry: true).and_return(stack)
+      expect(subject).to receive(:stack_from_yaml).with('user/stack:1.0.0', from_registry: true, name: nil).and_return(stack)
       expect(client).to receive(:post).with(
         'grids/test-grid/stacks', stack
       )

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -16,33 +16,33 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
 
     it 'requires api url' do
       allow(subject).to receive(:require_config_file).and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-name').and_return(stack)
       expect(described_class.requires_current_master?).to be_truthy
       subject.run(['stack-name', './path/to/kontena.yml'])
     end
 
     it 'requires token' do
       allow(subject).to receive(:require_config_file).and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-name').and_return(stack)
       expect(described_class.requires_current_master_token?).to be_truthy
       subject.run(['stack-name', './path/to/kontena.yml'])
     end
 
     it 'requires stack file' do
       allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
-      expect(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
+      expect(subject).to receive(:require_config_file).with('./path/to/kontena.yml', name: 'stack-name').and_return(true)
       subject.run(['stack-name', './path/to/kontena.yml'])
     end
 
     it 'uses kontena.yml as default stack file' do
       expect(subject).to receive(:require_config_file).with('kontena.yml').and_return(true)
-      expect(subject).to receive(:stack_from_yaml).with('kontena.yml').and_return(stack)
+      expect(subject).to receive(:stack_from_yaml).with('kontena.yml', name: 'stack-name').and_return(stack)
       subject.run(['stack-name'])
     end
 
     it 'sends stack to master' do
       allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a').and_return(stack)
       expect(client).to receive(:put).with(
         'stacks/test-grid/stack-a', anything
       )
@@ -51,7 +51,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
 
     it 'allows to override stack name' do
       allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-b').and_return(stack)
       stack_b = stack
       stack_b[:name] = 'stack-b'
       expect(client).to receive(:put).with(
@@ -64,7 +64,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       context 'when given' do
         it 'triggers deploy' do
           allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a').and_return(stack)
           allow(client).to receive(:put).with(
             'stacks/test-grid/stack-a', anything
           ).and_return({})
@@ -75,7 +75,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       context 'when not given' do
         it 'does not trigger deploy' do
           allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
+          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a').and_return(stack)
           allow(client).to receive(:put).with(
             'stacks/test-grid/stack-a', anything
           ).and_return({})

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -29,8 +29,8 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
     end
 
     it 'requires stack file' do
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml').and_return(stack)
-      expect(subject).to receive(:require_config_file).with('./path/to/kontena.yml', name: 'stack-name').and_return(true)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-name').and_return(stack)
+      expect(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
       subject.run(['stack-name', './path/to/kontena.yml'])
     end
 


### PR DESCRIPTION
Fixes #1504

Default to putting the `--name` option or `NAME` parameter value into `ENV['STACK']` during interpolation.
