### PR TITLE
Tell why plugin install failed

### DIFF
--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -21,13 +21,12 @@ module Kontena::Cli::Plugins
       install_options << "--version #{version}" if version
       install_options << "--pre" if pre?
       install_command = "#{gem_bin} install #{install_options.join(' ')} #{plugin}"
-      success = false
-      spinner "Installing plugin #{name.colorize(:cyan)}" do
+      stderr = spinner "Installing plugin #{name.colorize(:cyan)}" do |spin|
         stdout, stderr, status = Open3.capture3(install_command)
-        unless stderr.empty?
-          raise stderr
-        end
+        spin.fail unless stderr.empty?
+        stderr
       end
+      raise stderr unless stderr.empty?
     rescue => exc
       puts exc.message
     end
@@ -42,13 +41,12 @@ module Kontena::Cli::Plugins
 
     def uninstall_previous(name)
       uninstall_command = "#{gem_bin} uninstall -q #{name}"
-      success = false
-      spinner "Uninstalling previous version of plugin" do
+      stderr = spinner "Uninstalling previous version of plugin" do |spin|
         stdout, stderr, status = Open3.capture3(uninstall_command)
-        unless stderr.empty?
-          raise stderr
-        end
+        spin.fail unless stderr.empty?
+        stderr
       end
+      raise stderr unless stderr.empty?
     end
   end
 end

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -11,6 +11,7 @@ module Kontena::Cli::Plugins
     option '--pre', :flag, 'Allow pre-release of a plugin to be installed', default: false
 
     def execute
+      require 'shellwords'
       install_plugin(name)
     end
 
@@ -20,15 +21,13 @@ module Kontena::Cli::Plugins
       install_options = ['--no-ri', '--no-doc']
       install_options << "--version #{version}" if version
       install_options << "--pre" if pre?
-      install_command = "#{gem_bin} install #{install_options.join(' ')} #{plugin}"
-      stderr = spinner "Installing plugin #{name.colorize(:cyan)}" do |spin|
+      install_options << plugin
+      install_command = "#{gem_bin} install #{install_options.shelljoin}"
+      ENV["DEBUG"] && STDERR.puts("Running #{install_command}")
+      spinner "Installing plugin #{name.colorize(:cyan)}" do
         stdout, stderr, status = Open3.capture3(install_command)
-        spin.fail unless stderr.empty?
-        stderr
+        raise(RuntimeError, stderr) unless status.success?
       end
-      raise stderr unless stderr.empty?
-    rescue => exc
-      puts exc.message
     end
 
     def plugin_exists?(name)
@@ -40,13 +39,11 @@ module Kontena::Cli::Plugins
     end
 
     def uninstall_previous(name)
-      uninstall_command = "#{gem_bin} uninstall -q #{name}"
-      stderr = spinner "Uninstalling previous version of plugin" do |spin|
+      uninstall_command = "#{gem_bin} uninstall -q #{name.shellescape}"
+      spinner "Uninstalling previous version of plugin" do
         stdout, stderr, status = Open3.capture3(uninstall_command)
-        spin.fail unless stderr.empty?
-        stderr
+        raise(RuntimeError, stderr) unless status.success?
       end
-      raise stderr unless stderr.empty?
     end
   end
 end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -17,13 +17,12 @@ module Kontena::Cli::Plugins
       plugin = "kontena-plugin-#{name}"
       gem_bin = which('gem')
       uninstall_command = "#{gem_bin} uninstall -q #{plugin}"
-      success = false
-      spinner "Uninstalling plugin #{name.colorize(:cyan)}" do
+      stderr = spinner "Uninstalling plugin #{name.colorize(:cyan)}" do |spin|
         stdout, stderr, status = Open3.capture3(uninstall_command)
-        unless stderr.empty?
-          raise stderr
-        end
+        spin.fail unless stderr.empty?
+        stderr
       end
+      raise stderr unless stderr.empty?
     rescue => exc
       puts exc.message
     end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -9,6 +9,7 @@ module Kontena::Cli::Plugins
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
+      require 'shellwords'
       confirm unless forced?
       uninstall_plugin(name)
     end
@@ -16,15 +17,11 @@ module Kontena::Cli::Plugins
     def uninstall_plugin(name)
       plugin = "kontena-plugin-#{name}"
       gem_bin = which('gem')
-      uninstall_command = "#{gem_bin} uninstall -q #{plugin}"
+      uninstall_command = "#{gem_bin} uninstall -q #{plugin.shellescape}"
       stderr = spinner "Uninstalling plugin #{name.colorize(:cyan)}" do |spin|
         stdout, stderr, status = Open3.capture3(uninstall_command)
-        spin.fail unless stderr.empty?
-        stderr
+        raise(RuntimeError, stderr) unless status.success?
       end
-      raise stderr unless stderr.empty?
-    rescue => exc
-      puts exc.message
     end
   end
 end


### PR DESCRIPTION
Fixes #1508

```bash
$ chmod u-w /usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/
$ kontena plugin install aws

 [fail] Installing plugin aws
ERROR:  While executing gem ... (Errno::EACCES)
    Permission denied @ dir_s_mkdir - /usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/kontena-plugin-aws-0.2.3
```
