### PR TITLE
Better deployment errors for "Cannot find applicable node for service instance ..."

### DIFF
--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -32,10 +32,13 @@ class GridServiceDeployer
   def selected_nodes
     nodes = []
     self.instance_count.times do |i|
-      node = self.scheduler.select_node(
-        self.grid_service, i + 1, self.nodes
-      )
-      nodes << node if node
+      begin
+        nodes << self.scheduler.select_node(
+          self.grid_service, i + 1, self.nodes
+        )
+      rescue Scheduler::Error
+
+      end
     end
     self.nodes.each{|n| n.schedule_counter = 0}
 

--- a/server/app/services/scheduler/error.rb
+++ b/server/app/services/scheduler/error.rb
@@ -1,0 +1,5 @@
+module Scheduler
+  class Error < StandardError
+
+  end
+end

--- a/server/app/services/scheduler/filter/affinity.rb
+++ b/server/app/services/scheduler/filter/affinity.rb
@@ -37,10 +37,13 @@ module Scheduler
       end
 
       # @param [String] affinity
-      # @return [String, NilClass]
+      # @raise [Scheduler::Error] invalid filter
+      # @return [Array<(String, String, String)>, NilClass]
       def split_affinity(affinity)
         if match = affinity.match(/^(.+)(==|!=)(.+)/)
           match.to_a[1..-1]
+        else
+          raise Scheduler::Error, "Invalid affinity filter: #{affinity}"
         end
       end
 

--- a/server/app/services/scheduler/filter/affinity.rb
+++ b/server/app/services/scheduler/filter/affinity.rb
@@ -6,35 +6,34 @@ module Scheduler
       # @param [GridService] service
       # @param [Integer] instance_number
       # @param [Array<HostNode>] nodes
+      # @raise [Scheduler::Error]
       def for_service(service, instance_number, nodes)
         return nodes if service.affinity.nil? || service.affinity.size == 0
 
-        candidates = nodes.dup
-        nodes.each do |node|
-          service.affinity.each do |affinity|
-            affinity = affinity % [instance_number.to_s]
-            key, comparator, value = split_affinity(affinity)
+        service.affinity.each do |affinity|
+          affinity = affinity % [instance_number.to_s]
+          key, comparator, value = split_affinity(affinity)
+
+          nodes = nodes.select { |node|
             if key == 'node'
-              unless node_match?(node, comparator, value)
-                candidates.delete(node)
-              end
+              node_match?(node, comparator, value)
             elsif key == 'service'
-              unless service_match?(node, comparator, value)
-                candidates.delete(node)
-              end
+              service_match?(node, comparator, value)
             elsif key == 'container'
-              unless container_match?(node, comparator, value)
-                candidates.delete(node)
-              end
+              container_match?(node, comparator, value)
             elsif key == 'label'
-              unless label_match?(node, comparator, value)
-                candidates.delete(node)
-              end
+              label_match?(node, comparator, value)
+            else
+              raise StandardError, "Unknown affility filter: #{key}"
             end
+          }
+
+          if nodes.empty?
+            raise Scheduler::Error, "Did not find any nodes for affinity filter: #{affinity}"
           end
         end
 
-        candidates
+        nodes
       end
 
       # @param [String] affinity

--- a/server/app/services/scheduler/filter/affinity.rb
+++ b/server/app/services/scheduler/filter/affinity.rb
@@ -24,7 +24,7 @@ module Scheduler
             elsif key == 'label'
               label_match?(node, comparator, value)
             else
-              raise StandardError, "Unknown affility filter: #{key}"
+              raise StandardError, "Unknown affinity filter: #{key}"
             end
           }
 

--- a/server/app/services/scheduler/filter/dependency.rb
+++ b/server/app/services/scheduler/filter/dependency.rb
@@ -37,6 +37,9 @@ module Scheduler
             candidates.delete(node)
           end
         end
+        if candidates.empty?
+          raise Scheduler::Error, "Did not find any nodes for service dependency volumes_from: #{volumes}"
+        end
       end
 
       # @param [Array<HostNode>] candidates
@@ -54,6 +57,9 @@ module Scheduler
           if match.empty?
             candidates.delete(node)
           end
+        end
+        if candidates.empty?
+          raise Scheduler::Error, "Did not find any nodes for service dependency net: #{net}"
         end
       end
 

--- a/server/app/services/scheduler/filter/memory.rb
+++ b/server/app/services/scheduler/filter/memory.rb
@@ -23,6 +23,10 @@ module Scheduler
           reject_candidate?(c, memory, service, instance_number)
         }
 
+        if candidates.empty?
+          raise Scheduler::Error, "Did not find any nodes with sufficient free memory: #{memory}"
+        end
+
         candidates
       end
 

--- a/server/app/services/scheduler/filter/port.rb
+++ b/server/app/services/scheduler/filter/port.rb
@@ -22,6 +22,10 @@ module Scheduler
           end
         end
 
+        if candidates.empty?
+          raise Scheduler::Error, "Did not find any nodes with unused ports: #{ports}"
+        end
+
         candidates
       end
 

--- a/server/spec/services/grid_service_scheduler_spec.rb
+++ b/server/spec/services/grid_service_scheduler_spec.rb
@@ -27,7 +27,7 @@ describe GridServiceScheduler do
   describe '#filter_nodes' do
     it 'filters every node' do
       subject.filters.each do |filter|
-        expect(filter).to receive(:for_service).once.with(grid_service, 'foo-1', anything)
+        expect(filter).to receive(:for_service).once.with(grid_service, 'foo-1', anything).and_call_original
       end
       subject.filter_nodes(grid_service, 'foo-1', nodes)
     end

--- a/server/spec/services/scheduler/filter/affinity_spec.rb
+++ b/server/spec/services/scheduler/filter/affinity_spec.rb
@@ -60,8 +60,7 @@ describe Scheduler::Filter::Affinity do
       it 'returns none if node labels are nil' do
         nodes.each{|n| n.labels = nil}
         service = double(:service, affinity: ['label==ssd'])
-        filtered = subject.for_service(service, 1, nodes)
-        expect(filtered.size).to eq(0)
+        expect{subject.for_service(service, 1, nodes)}.to raise_error(Scheduler::Error)
       end
     end
 
@@ -138,6 +137,11 @@ describe Scheduler::Filter::Affinity do
         expect(filtered.size).to eq(1)
         expect(filtered).to eq([nodes[1]])
       end
+    end
+
+    it "raises on unknown affinity filter" do
+      service = double(:service, affinity: ['nodes==test'])
+      expect{subject.for_service(service, 1, nodes)}.to raise_error(StandardError)
     end
   end
 end

--- a/server/spec/services/scheduler/filter/affinity_spec.rb
+++ b/server/spec/services/scheduler/filter/affinity_spec.rb
@@ -11,6 +11,19 @@ describe Scheduler::Filter::Affinity do
     nodes
   end
 
+  describe '#split_affinity' do
+    it "raises for an invalid comperator" do
+      expect{subject.split_affinity('foo=bar')}.to raise_error(Scheduler::Error, /Invalid affinity filter: foo=bar/)
+    end
+
+    it "returns three parts for eq" do
+      expect(subject.split_affinity('foo==bar')).to eq ['foo', '==', 'bar']
+    end
+    it "returns three partsfor neq" do
+      expect(subject.split_affinity('foo!=bar')).to eq ['foo', '!=', 'bar']
+    end
+  end
+
   describe '#for_service' do
     it 'returns all nodes if service does not have any affinities defined' do
       service = double(:service, affinity: [])
@@ -142,6 +155,11 @@ describe Scheduler::Filter::Affinity do
     it "raises on unknown affinity filter" do
       service = double(:service, affinity: ['nodes==test'])
       expect{subject.for_service(service, 1, nodes)}.to raise_error(StandardError, /Unknown affinity filter: nodes/)
+    end
+
+    it "raises on invalid affinity filter" do
+      service = double(:service, affinity: ['foo=bar'])
+      expect{subject.for_service(service, 1, nodes)}.to raise_error(StandardError, /Invalid affinity filter: foo=bar/)
     end
   end
 end

--- a/server/spec/services/scheduler/filter/affinity_spec.rb
+++ b/server/spec/services/scheduler/filter/affinity_spec.rb
@@ -141,7 +141,7 @@ describe Scheduler::Filter::Affinity do
 
     it "raises on unknown affinity filter" do
       service = double(:service, affinity: ['nodes==test'])
-      expect{subject.for_service(service, 1, nodes)}.to raise_error(StandardError)
+      expect{subject.for_service(service, 1, nodes)}.to raise_error(StandardError, /Unknown affinity filter: nodes/)
     end
   end
 end

--- a/server/spec/services/scheduler/filter/dependency_spec.rb
+++ b/server/spec/services/scheduler/filter/dependency_spec.rb
@@ -52,8 +52,7 @@ describe Scheduler::Filter::Dependency do
   describe '#filter_candidates_by_volume' do
     it 'finds no candidates if no volumes match' do
       logstash_service.volumes_from = ['mysql-service-%s']
-      subject.filter_candidates_by_volume(nodes, logstash_service, 2)
-      expect(nodes).to eq([])
+      expect{subject.filter_candidates_by_volume(nodes, logstash_service, 2)}.to raise_error(Scheduler::Error)
     end
 
     it 'returns correct candidates for service that belongs to default stack' do
@@ -111,8 +110,7 @@ describe Scheduler::Filter::Dependency do
       )
       mysql_logstash_service.volumes_from = ['foo-%s']
       candidates = nodes.dup
-      subject.filter_candidates_by_volume(candidates, mysql_logstash_service, 3)
-      expect(candidates).to eq([])
+      expect{subject.filter_candidates_by_volume(candidates, mysql_logstash_service, 3)}.to raise_error(Scheduler::Error)
     end
   end
 

--- a/server/spec/services/scheduler/filter/memory_spec.rb
+++ b/server/spec/services/scheduler/filter/memory_spec.rb
@@ -31,8 +31,7 @@ describe Scheduler::Filter::Memory do
 
     it 'returns none of the nodes if node memory is not available' do
       test_service.update_attribute(:memory, 512.megabytes)
-      filtered = subject.for_service(test_service, 1, nodes)
-      expect(filtered).to eq([])
+      expect{subject.for_service(test_service, 1, nodes)}.to raise_error(Scheduler::Error)
     end
   end
 

--- a/server/spec/services/scheduler/filter/port_spec.rb
+++ b/server/spec/services/scheduler/filter/port_spec.rb
@@ -86,8 +86,7 @@ describe Scheduler::Filter::Port do
         )
       end
 
-      filtered = subject.for_service(service, 1, nodes)
-      expect(filtered.size).to eq(0)
+      expect{subject.for_service(service, 1, nodes)}.to raise_error(Scheduler::Error)
     end
   end
 end


### PR DESCRIPTION
Currently service deployments can fail with "Cannot find applicable node for service instance ..." for a number of reasons. This PR fixes the server `GridServiceScheduler` and `Scheduler::Filter::*` to return more useful error messages.

* Change `GridServiceScheduler#select_node` to raise an `Scheduler::Error` instead of returning nil
* Change `GridServiceScheduler#filter_nodes` to raise `Scheduler::Error` if any filter returns an empty array
* Change `Scheduler::Filter::Affinity` to test each affinity filter in turn, and raise if one does not match any nodes
* Change `Scheduler::Filter::Affinity` to raise on unknown filter keys
* Change remaining `Scheduler::Filter::*` to include the filter condition in the error

Fixes  #1028  #1524

## Examples

* `Cannot find applicable node for service instance development/test/test-1: Did not find any nodes for affinity filter node==core-03`
* `Cannot find applicable node for service instance development/test2/test-1: Did not find any nodes for service dependency volumes_from: ["test2-1"]`
* `Cannot find applicable node for service instance development/test/test-1: Did not find any nodes with unused ports: [80]`
* `Cannot find applicable node for service instance development/test/test-1: Did not find any nodes with sufficient free memory: 8589934592`

There is also a fallback for filters that just return an empty list:

* Cannot find applicable node for service instance development/test/test-1: Filter Scheduler::Filter::* did not return any nodes

## TODO
* Refactor filtering code to give more specific errors (such as the changes for the affinity filter)
* Improve the filtering algorithm to give better errors for filters that do match some nodes, but where the combination of multiple filters fails to match any nodes