### PR TITLE
Ensure service container has grid_service_id

### DIFF
--- a/server/app/services/agent/container_info_mapper.rb
+++ b/server/app/services/agent/container_info_mapper.rb
@@ -51,15 +51,12 @@ module Agent
     def create_service_container(node_id, info)
       labels = info['Config']['Labels'] || {}
       container_id = info['Id']
-      service_id = labels['io.kontena.service.id']
       node = grid.host_nodes.find_by(node_id: node_id)
-      service = grid.grid_services.find_by(id: service_id)
       container = grid.containers.build(
         container_id: container_id,
         name: labels['io.kontena.container.name'],
         container_type: labels['io.kontena.container.type'] || 'container',
-        grid_service: service,
-        grid_service_id: service_id,
+        grid_service_id: labels['io.kontena.service.id'],
         host_node: node
       )
       if labels['io.kontena.container.id']

--- a/server/app/services/agent/container_info_mapper.rb
+++ b/server/app/services/agent/container_info_mapper.rb
@@ -51,13 +51,15 @@ module Agent
     def create_service_container(node_id, info)
       labels = info['Config']['Labels'] || {}
       container_id = info['Id']
+      service_id = labels['io.kontena.service.id']
       node = grid.host_nodes.find_by(node_id: node_id)
-      service = grid.grid_services.find_by(id: labels['io.kontena.service.id'])
+      service = grid.grid_services.find_by(id: service_id)
       container = grid.containers.build(
         container_id: container_id,
         name: labels['io.kontena.container.name'],
         container_type: labels['io.kontena.container.type'] || 'container',
         grid_service: service,
+        grid_service_id: service_id,
         host_node: node
       )
       if labels['io.kontena.container.id']


### PR DESCRIPTION
When removing stack (and related services) when deploy is ongoing agent may send container info for container which grid service does not exist anymore. Service container is then created without `grid_service_id` and container clean up job fails to clean up that container.
https://github.com/kontena/kontena/blob/master/server/app/jobs/container_cleanup_job.rb#L31

With his PR `grid_service_id` is always added for container so that this ghost container can be removed properly later.