### PR TITLE
Fix registry & vpn stack deploy tracking

### DIFF
--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -1,8 +1,10 @@
+require_relative '../stacks/stacks_helper'
+
 module Kontena::Cli::Registry
   class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-    include Kontena::Cli::Services::ServicesHelper
+    include Kontena::Cli::Stacks::StacksHelper
 
     REGISTRY_VERSION = '2.2'
 
@@ -109,9 +111,7 @@ module Kontena::Cli::Registry
       client(token).post("grids/#{current_grid}/stacks", data)
       deployment = client(token).post("stacks/#{current_grid}/registry/deploy", {})
       spinner "Deploying #{data[:name].colorize(:cyan)} stack " do
-        deployment['service_deploys'].each do |service_deploy|
-          wait_for_deploy_to_finish(token, service_deploy)
-        end
+        wait_for_deploy_to_finish(deployment)
       end
       puts "\n"
       puts "Docker Registry #{REGISTRY_VERSION} is now running at registry.#{current_grid}.kontena.local."

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -1,10 +1,10 @@
-require_relative 'common'
+require_relative 'stacks_helper'
 
 module Kontena::Cli::Stacks
   class DeployCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-    include Common
+    include StacksHelper
 
     banner "Deploys all services of a stack that has been installed in a grid on Kontena Master"
 
@@ -23,34 +23,6 @@ module Kontena::Cli::Stacks
 
     def deploy_stack(name)
       client.post("stacks/#{current_grid}/#{name}/deploy", {})
-    end
-
-    # @param [Hash] deployment
-    # @return [Boolean]
-    def wait_for_deploy_to_finish(deployment, timeout = 600)
-      deployed = false
-      progress = []
-      states = %w(success error)
-      Timeout::timeout(timeout) do
-        until deployed
-          deployment = client.get("stacks/#{deployment['stack_id']}/deploys/#{deployment['id']}")
-          deployed = true if states.include?(deployment['state'])
-          sleep 1
-        end
-        if deployment['state'] == 'error'
-          deployment['service_deploys'].each do |service_deploy|
-            if service_deploy['state'] == 'error'
-              puts "        #{service_deploy['reason']}"
-            end
-          end
-
-          raise 'deploy failed'
-        end
-      end
-
-      deployed
-    rescue Timeout::Error
-      raise 'deploy timed out'
     end
   end
 end

--- a/cli/lib/kontena/cli/stacks/stacks_helper.rb
+++ b/cli/lib/kontena/cli/stacks/stacks_helper.rb
@@ -1,12 +1,11 @@
 
 module Kontena::Cli::Stacks
   module StacksHelper
-    
+
     # @param [Hash] deployment
     # @return [Boolean]
     def wait_for_deploy_to_finish(deployment, timeout = 600)
       deployed = false
-      progress = []
       states = %w(success error)
       Timeout::timeout(timeout) do
         until deployed

--- a/cli/lib/kontena/cli/stacks/stacks_helper.rb
+++ b/cli/lib/kontena/cli/stacks/stacks_helper.rb
@@ -1,0 +1,33 @@
+
+module Kontena::Cli::Stacks
+  module StacksHelper
+    
+    # @param [Hash] deployment
+    # @return [Boolean]
+    def wait_for_deploy_to_finish(deployment, timeout = 600)
+      deployed = false
+      progress = []
+      states = %w(success error)
+      Timeout::timeout(timeout) do
+        until deployed
+          deployment = client.get("stacks/#{deployment['stack_id']}/deploys/#{deployment['id']}")
+          deployed = true if states.include?(deployment['state'])
+          sleep 1
+        end
+        if deployment['state'] == 'error'
+          deployment['service_deploys'].each do |service_deploy|
+            if service_deploy['state'] == 'error'
+              puts "        #{service_deploy['reason']}"
+            end
+          end
+
+          raise 'deploy failed'
+        end
+      end
+
+      deployed
+    rescue Timeout::Error
+      raise 'deploy timed out'
+    end
+  end
+end

--- a/cli/lib/kontena/cli/vpn/create_command.rb
+++ b/cli/lib/kontena/cli/vpn/create_command.rb
@@ -1,8 +1,10 @@
+require_relative '../stacks/stacks_helper'
+
 module Kontena::Cli::Vpn
   class CreateCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-    include Kontena::Cli::Services::ServicesHelper
+    include Kontena::Cli::Stacks::StacksHelper
 
     option '--node', 'NODE', 'Node name where VPN is deployed'
     option '--ip', 'IP', 'Node ip-address to use in VPN service configuration'
@@ -46,9 +48,7 @@ module Kontena::Cli::Vpn
       client(token).post("grids/#{current_grid}/stacks", data)
       deployment = client(token).post("stacks/#{current_grid}/#{name}/deploy", {})
       spinner "Deploying #{pastel.cyan(name)} service " do
-        deployment['service_deploys'].each do |service_deploy|
-          wait_for_deploy_to_finish(token, service_deploy)
-        end
+        wait_for_deploy_to_finish(deployment)
       end
       spinner "Generating #{pastel.cyan(name)} keys (this will take a while) " do
         wait_for_configuration_to_finish(token)


### PR DESCRIPTION
Kontena cli 1.0.1 has a regression that causes cli to error on vpn/registry deploy tracking. This PR fixes these error by tracking a stack deployment object (was service deployment object).


Replaces #1536 