### PR TITLE
Fix agent to avoid DNS lookups for localhost with a missing /etc/hosts

### DIFF
--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -83,7 +83,8 @@ module Kontena::Launchers
         'Cmd' => ["bundle", "exec", "thin", "-a", "127.0.0.1", "-p", "2275", "-e", "production", "start"],
         'Env' => [
           "NODE_ID=#{info['node_number']}",
-          "LOG_LEVEL=#{ENV['LOG_LEVEL'] || 1}"
+          "LOG_LEVEL=#{ENV['LOG_LEVEL'] || 1}",
+          "ETCD_ENDPOINT=http://127.0.0.1:2379",
         ],
         'HostConfig' => {
           'NetworkMode' => 'host',

--- a/agent/lib/kontena/network_adapters/ipam_client.rb
+++ b/agent/lib/kontena/network_adapters/ipam_client.rb
@@ -15,7 +15,7 @@ module Kontena::NetworkAdapters
   class IpamClient
     include Kontena::Logging
 
-    IPAM_URL = 'http://localhost:2275'.freeze
+    IPAM_URL = 'http://127.0.0.1:2275'.freeze
 
     HEADERS = { "Content-Type" => "application/json" }
 

--- a/agent/spec/lib/kontena/launchers/ipam_launcer_spec.rb
+++ b/agent/spec/lib/kontena/launchers/ipam_launcer_spec.rb
@@ -81,7 +81,7 @@ describe Kontena::Launchers::IpamPlugin do
         "Volumes" => {"/run/docker/plugins"=>{}, "/var/run/docker.sock"=>{}},
         "StopSignal"=>"SIGTTIN",
         "Cmd"=>["bundle", "exec", "thin", "-a", "127.0.0.1", "-p", "2275", "-e", "production", "start"],
-        'Env' => ['NODE_ID=1', "LOG_LEVEL=1"],
+        'Env' => ['NODE_ID=1', "LOG_LEVEL=1", 'ETCD_ENDPOINT=http://127.0.0.1:2379'],
         'HostConfig' => {
           'NetworkMode' => 'host',
           'RestartPolicy' => {'Name' => 'always'},
@@ -103,7 +103,7 @@ describe Kontena::Launchers::IpamPlugin do
         "Volumes" => {"/run/docker/plugins"=>{}, "/var/run/docker.sock"=>{}},
         "StopSignal"=>"SIGTTIN",
         "Cmd"=>["bundle", "exec", "thin", "-a", "127.0.0.1", "-p", "2275", "-e", "production", "start"],
-        'Env' => ['NODE_ID=1', "LOG_LEVEL=1"],
+        'Env' => ['NODE_ID=1', "LOG_LEVEL=1", 'ETCD_ENDPOINT=http://127.0.0.1:2379'],
         'HostConfig' => {
           'NetworkMode' => 'host',
           'RestartPolicy' => {'Name' => 'always'},


### PR DESCRIPTION
Apparently some versions/installs of CoreOS do not have any `/etc/hosts` file, which leads to an empty `/etc/hosts` file in any Docker `--net=host` container. This may leave the `kontena-ipam-plugin` unable to resolve the etcd `localhost` name.

Fix this by using `127.0.0.1` instead, both for the `kontena-ipam` `ETCD_ENDPOINT` as well as the agent's `IpamClient` connections.