### PR TITLE
Don't re-deploy dependant services on stack deploy

### DIFF
--- a/server/app/jobs/stack_deploy_worker.rb
+++ b/server/app/jobs/stack_deploy_worker.rb
@@ -22,8 +22,12 @@ class StackDeployWorker
     stack.reload
     services = sort_services(stack.grid_services.to_a)
     services.each do |service|
-      service_deploy = deploy_service(service, stack_deploy)
-      raise "service #{service.to_path} deploy failed" if service_deploy.nil? || service_deploy.error?
+      unless service.depending_on_other_services?
+        service_deploy = deploy_service(service, stack_deploy)
+        raise "service #{service.to_path} deploy failed" if service_deploy.nil? || service_deploy.error?
+      else
+        info "skipping deployment of #{service_deploy.to_path} because it will be deployed by dependencies"
+      end
     end
 
     stack_deploy.success!

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -251,4 +251,22 @@ describe GridService do
       expect(grid_service.stack_exposed?).to be_falsey
     end
   end
+
+  describe '#depending_on_other_services?' do
+    it 'returns false by default' do
+      expect(subject.depending_on_other_services?).to be_falsey
+    end
+
+    it 'returns true if service affinity' do
+      subject.affinity = ['service==foobar']
+      expect(subject.depending_on_other_services?).to be_truthy
+      subject.affinity = ['service!=foobar']
+      expect(subject.depending_on_other_services?).to be_truthy
+    end
+
+    it 'returns true if volumes_from' do
+      subject.volumes_from = ['foobar-%i']
+      expect(subject.depending_on_other_services?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
If stack service is dependant of another service it should not be deployed directly because dependency will trigger deploy automatically.