### PR TITLE
Use liquid templating for stack ymls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - osx
 sudo: required
 rvm:
-  - 2.0.0-p648
   - 2.1.10
   - 2.2.6
   - 2.3.1

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,7 +4,7 @@
 This is a command line tool for [Kontena](http://www.kontena.io).
 
 ## Installation
-> Prerequisities: [Ruby](https://www.ruby-lang.org/en/)
+> Prerequisities: [Ruby](https://www.ruby-lang.org/en/) version 2.1.0 or greater.
 
 Install it yourself as:
 

--- a/cli/examples/kontena-plugin-hello/kontena-plugin-hello.gemspec
+++ b/cli/examples/kontena-plugin-hello/kontena-plugin-hello.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'kontena-cli', '>= 0.16.0.pre2'
+  spec.add_runtime_dependency 'kontena-cli', '>= 1.0.0.pre2'
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "opto", "~> 1.5.3"
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "safe_yaml", "~> 1.0"
+  spec.add_runtime_dependency "liquid", "~> 4.0"
 end

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
   spec.add_runtime_dependency "hash_validator", "~> 0.7.0"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
-  spec.add_runtime_dependency "opto", "~> 1.5.3"
+  spec.add_runtime_dependency "opto", "~> 1.8.0"
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "safe_yaml", "~> 1.0"
   spec.add_runtime_dependency "liquid", "~> 4.0.0"

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "opto", "~> 1.5.3"
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "safe_yaml", "~> 1.0"
-  spec.add_runtime_dependency "liquid", "~> 4.0"
+  spec.add_runtime_dependency "liquid", "~> 4.0.0"
 end

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.1.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/cli/lib/kontena/cli/stack_command.rb
+++ b/cli/lib/kontena/cli/stack_command.rb
@@ -8,6 +8,7 @@ require_relative 'stacks/build_command'
 require_relative 'stacks/monitor_command'
 require_relative 'stacks/logs_command'
 require_relative 'stacks/registry_command'
+require_relative 'stacks/validate_command'
 
 class Kontena::Cli::StackCommand < Kontena::Command
 
@@ -21,6 +22,7 @@ class Kontena::Cli::StackCommand < Kontena::Command
   subcommand "monitor", "Monitor services in a stack", Kontena::Cli::Stacks::MonitorCommand
   subcommand "build", "Build images listed in a stack file and push them to an image registry", Kontena::Cli::Stacks::BuildCommand
   subcommand ["reg", "registry"], "Stack registry related commands", Kontena::Cli::Stacks::RegistryCommand
+  subcommand "validate", "Process and validate a stack file", Kontena::Cli::Stacks::ValidateCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/stacks/build_command.rb
+++ b/cli/lib/kontena/cli/stacks/build_command.rb
@@ -9,16 +9,23 @@ module Kontena::Cli::Stacks
     banner "Build images listed in a stack file and push them to your image registry"
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+
     option ['--no-cache'], :flag, 'Do not use cache when building the image', default: false
     option ['--no-push'], :flag, 'Do not push images to registry', default: false
     option ['--no-pull'], :flag, 'Do not attempt to pull a newer version of the image', default: false
     option ['--[no-]sudo'], :flag, 'Run docker using sudo', hidden: Kontena.on_windows?, environment_variable: 'KONTENA_SUDO', default: false
 
+    option ['-n', '--name'], 'NAME', 'Define stack name (by default comes from stack file)'
+    include Common::StackValuesFromOption
+
     parameter "[SERVICE] ...", "Services to build"
+
+    requires_current_master # the stack may use a vault resolver
+    requires_current_master_token
 
     def execute
       require_config_file(filename)
-      stack = stack_from_yaml(filename)
+      stack = stack_from_yaml(filename, name: name, values: values)
       services = stack['services']
 
       unless service_list.empty?

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -8,10 +8,13 @@ module Kontena::Cli::Stacks
 
     banner "Installs a stack to a grid on Kontena Master"
 
-    parameter "[FILE]", "Kontena stack file or a registry stack name (user/stack or user/stack:version)", default: "kontena.yml", attribute_name: :filename
+    include Common::StackFileOrNameParam
 
-    option ['-n', '--name'], 'NAME', 'Define stack name (by default comes from stack file)'
+    include Common::StackNameOption
     option '--deploy', :flag, 'Deploy after installation'
+
+    include Common::StackValuesFromOption
+
 
     requires_current_master
     requires_current_master_token
@@ -25,7 +28,8 @@ module Kontena::Cli::Stacks
         require_config_file(filename)
       end
 
-      stack = stack_from_yaml(filename, from_registry: from_registry, name: name)
+      stack = stack_from_yaml(filename, from_registry: from_registry, name: name, values: values)
+
       stack['name'] = name if name
       spinner "Creating stack #{pastel.cyan(stack['name'])} " do
         create_stack(stack)

--- a/cli/lib/kontena/cli/stacks/registry/push_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/push_command.rb
@@ -12,11 +12,15 @@ module Kontena::Cli::Stacks::Registry
     requires_current_account_token
 
     def execute
-      file = Kontena::Cli::Stacks::YAML::Reader.new(filename, skip_variables: true, replace_missing: "filler")
+      file = Kontena::Cli::Stacks::YAML::Reader.new(
+        filename,
+        skip_variables: true,
+        skip_validation: true
+      )
       file.execute
-      name = "#{file.yaml['stack']}:#{file.yaml['version']}"
+      name = "#{file.stack_name}:#{file.stack_version}"
       spinner("Pushing #{pastel.cyan(name)} to stacks registry") do
-        stacks_client.push(file.yaml['stack'], file.yaml['version'], file.raw_content)
+        stacks_client.push(file.stack_name, file.stack_version, file.raw_content)
       end
     end
   end

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -19,8 +19,8 @@ module Kontena::Cli::Stacks
     requires_current_master_token
 
     def execute
-      require_config_file(file)
-      stack = stack_from_yaml(file, name: name, values: values, from_registry: from_registry)
+      require_config_file(filename)
+      stack = stack_from_yaml(filename, name: name, values: values, from_registry: from_registry)
       spinner "Upgrading stack #{pastel.cyan(name)} " do
         update_stack(stack)
       end

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -9,7 +9,10 @@ module Kontena::Cli::Stacks
     banner "Upgrades a stack in a grid on Kontena Master"
 
     parameter "NAME", "Stack name"
-    parameter "[FILE]", "Kontena stack file", default: "kontena.yml"
+
+    include Common::StackFileOrNameParam
+    include Common::StackValuesFromOption
+
     option '--deploy', :flag, 'Deploy after upgrade'
 
     requires_current_master
@@ -17,7 +20,7 @@ module Kontena::Cli::Stacks
 
     def execute
       require_config_file(file)
-      stack = stack_from_yaml(file, name: name)
+      stack = stack_from_yaml(file, name: name, values: values, from_registry: from_registry)
       spinner "Upgrading stack #{pastel.cyan(name)} " do
         update_stack(stack)
       end

--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -1,0 +1,47 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class ValidateCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    banner "Validates a YAML file"
+
+    include Common::StackFileOrNameParam
+    include Common::StackNameOption
+
+    option '--values-to', '[FILE]', 'Output variable values as YAML to file'
+
+    include Common::StackValuesFromOption
+
+    requires_current_master # the stack may use a vault resolver
+    requires_current_master_token
+
+    def execute
+
+      if !File.exist?(filename) && filename =~ /\A[a-zA-Z0-9\_\.\-]+\/[a-zA-Z0-9\_\.\-]+(?::.*)?\z/
+        from_registry = true
+      else
+        from_registry = false
+        require_config_file(filename)
+      end
+
+      reader = reader_from_yaml(filename, from_registry: from_registry, name: name, values: values)
+      outcome = reader.execute
+      hint_on_validation_notifications(outcome[:notifications]) if outcome[:notifications].size > 0
+      abort_on_validation_errors(outcome[:errors]) if outcome[:errors].size > 0
+
+      if values_to
+        vals = reader.variables.to_h(values_only: true).reject {|k,_| k == 'STACK' || k == 'GRID' }
+        File.write(values_to, ::YAML.dump(vals))
+      end
+      result = reader.fully_interpolated_yaml.merge(
+        # simplest way to stringify keys in a hash
+        'variables' => JSON.parse(reader.variables.to_h(with_values: true, with_errors: true).to_json)
+      )
+      puts ::YAML.dump(result)
+    end
+  end
+end
+

--- a/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
@@ -1,14 +1,9 @@
-if RUBY_VERSION < '2.1'
-  require 'opto/extensions/hash_string_or_symbol_key'
-  using Opto::Extension::HashStringOrSymbolKey
-end
-
 module Kontena::Cli::Stacks
   module YAML
     class Prompt < Opto::Resolver
       include Kontena::Cli::Common
 
-      using Opto::Extension::HashStringOrSymbolKey unless RUBY_VERSION < '2.1'
+      using Opto::Extension::HashStringOrSymbolKey
 
       def enum?
         option.type == 'enum'

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Stacks
       include Kontena::Util
       include Kontena::Cli::Common
 
-      attr_reader :file, :raw_content, :result, :errors, :notifications, :variables, :yaml, :sections
+      attr_reader :file, :raw_content, :result, :errors, :notifications, :variables, :yaml
 
       def initialize(file, skip_validation: false, skip_variables: false, replace_missing: nil, from_registry: false)
         require 'yaml'

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -126,9 +126,18 @@ module Kontena::Cli::Stacks
 
       def load_yaml(interpolate = true)
         if interpolate
-          @yaml = ::YAML.safe_load(replace_dollar_dollars(interpolate(interpolate_liquid(raw_content, variables.to_h(values_only: true)))))
+          @yaml = ::YAML.safe_load(
+            replace_dollar_dollars(
+              interpolate(
+                interpolate_liquid(
+                  raw_content,
+                  variables.to_h(values_only: true)
+                )
+              )
+            )
+          )
         else
-          @yaml = ::YAML.safe_load(interpolate_liquid(raw_content, ENV.to_h))
+          @yaml = ::YAML.safe_load(raw_content, ENV.to_h)
         end
       rescue Psych::SyntaxError => e
         raise "Error while parsing #{file}".colorize(:red)+ " "+e.message

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -46,7 +46,7 @@ module Kontena::Cli::Stacks
         return @variables if @variables
         var_sect = yaml_section('variables')
         if var_sect
-          variables_hash = ::YAML.safe_load(replace_dollar_dollars(interpolate(interpolate_liquid(var_sect, ENV.to_h), use_opto: false)))['variables']
+          variables_hash = ::YAML.safe_load(replace_dollar_dollars(interpolate(var_sect), use_opto: false))['variables']
           @variables = Opto::Group.new(variables_hash, defaults: { from: :env, to: :env })
         else
           @variables = Opto::Group.new(defaults: { from: :env, to: :env })

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -6,9 +6,9 @@ module Kontena::Cli::Stacks
       include Kontena::Util
       include Kontena::Cli::Common
 
-      attr_reader :file, :raw_content, :result, :errors, :notifications, :variables, :yaml
+      attr_reader :file, :raw_content, :errors, :notifications
 
-      def initialize(file, skip_validation: false, skip_variables: false, replace_missing: nil, from_registry: false)
+      def initialize(file, skip_validation: false, skip_variables: false, from_registry: false, variables: nil)
         require 'yaml'
         require_relative 'service_extender'
         require_relative 'validator_v3'
@@ -34,40 +34,84 @@ module Kontena::Cli::Stacks
         @notifications = []
         @skip_validation  = skip_validation
         @skip_variables   = skip_variables
-        @replace_missing  = replace_missing
+        @variables        = variables
       end
 
-      def from_registry?
-        @from_registry == true
+      def internals_interpolated_yaml
+        @internals_interpolated_yaml ||= ::YAML.safe_load(
+          replace_dollar_dollars(
+            interpolate(
+              raw_content,
+              use_opto: false,
+              substitutions: {
+                'GRID' => env['GRID'],
+                'STACK' => env['STACK']
+              },
+              warnings: false
+            )
+          )
+        )
+      rescue Psych::SyntaxError => e
+        raise "Error while parsing #{file}".colorize(:red)+ " " + e.message
       end
+
+      def fully_interpolated_yaml
+        return @fully_interpolated_yaml if @fully_interpolated_yaml
+        vars = variables.to_h(values_only: true)
+        @fully_interpolated_yaml = ::YAML.safe_load(
+          replace_dollar_dollars(
+            interpolate(
+              interpolate_liquid(
+                raw_content,
+                vars
+              ),
+              use_opto: true,
+              raise_on_unknown: true
+            )
+          )
+        )
+      rescue Psych::SyntaxError => e
+        raise "Error while parsing #{file}".colorize(:red)+ " " + e.message
+      end
+
 
       # @return [Opto::Group]
       def variables
-        return @variables if @variables
-        var_sect = yaml_section('variables')
-        if var_sect
-          variables_hash = ::YAML.safe_load(
-            replace_dollar_dollars(
-              interpolate(
-                var_sect,
-                use_opto: false,
-                substitutions: {
-                  'GRID' => ENV['GRID'],
-                  'STACK' => ENV['STACK']
-                }
-              )
-            )
-          )['variables']
-          @variables = Opto::Group.new(variables_hash, defaults: { from: :env, to: :env })
-        else
-          @variables = Opto::Group.new(defaults: { from: :env, to: :env })
-        end
-        @variables
+        @variables ||= Opto::Group.new(
+          (internals_interpolated_yaml['variables'] || {}).merge('STACK' => { type: :string, value: env['STACK']}, 'GRID' => {type: :string, value: env['GRID']}),
+          defaults: {
+            from: :env,
+            to: :env
+          }
+        )
       end
 
-      def parse_variables
-        raise RuntimeError, "Variable validation failed: #{variables.errors.inspect}" unless variables.valid?
+      # @param [String] service_name
+      # @return [Hash]
+      def execute(service_name = nil)
+        process_variables unless skip_variables?
+        validate unless skip_validation?
+
+        result = {}
+        Dir.chdir(from_registry? ? Dir.pwd : File.dirname(File.expand_path(file))) do
+          result[:stack]         = internals_interpolated_yaml['stack']
+          result[:version]       = self.stack_version
+          result[:name]          = self.stack_name
+          result[:registry]      = @registry if from_registry?
+          result[:expose]        = internals_interpolated_yaml['expose']
+          result[:errors]        = errors unless skip_validation?
+          result[:notifications] = notifications
+          result[:services]      = errors.count == 0 ? parse_services(service_name) : {}
+          result[:variables]     = variables.to_h(values_only: true).reject { |k,_| variables.option(k).to.has_key?(:vault) || variables.option(k).from.has_key?(:vault) } unless skip_variables?
+          result[:vault_keys]    = extract_vault_keys(result[:services])
+        end
+        result
+      end
+
+
+      def process_variables
         variables.run
+        raise RuntimeError, "Variable validation failed: #{variables.errors.inspect}" unless variables.valid?
       end
 
       def interpolate_liquid(content, vars)
@@ -76,91 +120,31 @@ module Kontena::Cli::Stacks
         template.render(vars, strict_variables: true, strict_filters: true)
       end
 
-      ##
-      # @param [String] service_name
-      # @return [Hash]
-      def execute(service_name = nil)
-        load_yaml(false)
-        parse_variables unless skip_variables?
-        load_yaml
-        validate unless skip_validation?
-
-        result = {}
-        Dir.chdir(from_registry? ? Dir.pwd : File.dirname(File.expand_path(file))) do
-          result[:stack]         = yaml['stack']
-          result[:version]       = self.stack_version
-          result[:name]          = self.stack_name
-          result[:registry]      = @registry if from_registry?
-          result[:expose]        = yaml['expose']
-          result[:errors]        = errors unless skip_validation?
-          result[:notifications] = notifications
-          result[:services]      = errors.count == 0 ? parse_services(service_name) : {}
-          result[:variables]     = variables.to_h(values_only: true).reject { |k,_| variables.option(k).to.has_key?(:vault) } unless skip_variables?
-        end
-        result
-      end
-
       def stack_name
-        yaml = ::YAML.safe_load(yaml_section('stack').to_s)
-        if yaml
-          yaml['stack'].split('/').last.split(':').first if yaml['stack']
-        end
+        @stack_name ||= parse_stack_name(internals_interpolated_yaml['stack'].to_s)[:stack]
       end
 
       def stack_version
-        yaml['version'] || yaml['stack'].to_s[/:(.*)/, 1] || '1'
-      end
-
-      def yaml_section(section)
-        raw_content[/^(#{section}:.+?)^\S/m, 1]
-      end
-
-      private
-
-      # A hash such as { "${MYSQL_IMAGE}" => "MYSQL_IMAGE } where the key is the
-      # string to be substituted and value is the pure name part
-      # @return [Hash]
-      def yaml_substitutables
-        @content_variables ||= raw_content.scan(/((?<!\$)\$(?!\$)\{?(\w+)\}?)/m)
-      end
-
-      def load_yaml(interpolate = true)
-        if interpolate
-          @yaml = ::YAML.safe_load(
-            replace_dollar_dollars(
-              interpolate(
-                interpolate_liquid(
-                  raw_content,
-                  variables.to_h(values_only: true)
-                )
-              )
-            )
-          )
-        else
-          @yaml = ::YAML.safe_load(raw_content, ENV.to_h)
-        end
-      rescue Psych::SyntaxError => e
-        raise "Error while parsing #{file}".colorize(:red)+ " "+e.message
+        @stack_version ||= internals_interpolated_yaml['version'] || parse_stack_name(internals_interpolated_yaml['stack'].to_s)[:version] || '0.0.1'
       end
 
       # @return [Array] array of validation errors
       def validate
-        result = validator.validate(yaml)
+        result = validator.validate(fully_interpolated_yaml)
         store_failures(result)
         result
       end
 
       def skip_validation?
-        @skip_validation == true
+        !!@skip_validation
       end
 
       def skip_variables?
-        @skip_variables == true
+        !!@skip_variables
       end
 
-      def store_failures(data)
-        errors << { file => data[:errors] } unless data[:errors].empty?
-        notifications << { file => data[:notifications] } unless data[:notifications].empty?
+      def from_registry?
+        !!@from_registry
       end
 
       # @return [Kontena::Cli::Stacks::YAML::ValidatorV3]
@@ -175,7 +159,7 @@ module Kontena::Cli::Stacks
         if service_name.nil?
           services.each do |name, config|
             services[name] = process_config(config)
-            if process_service?(config)
+            if process_hash?(config)
               services[name].delete('only_if')
               services[name].delete('skip_if')
             else
@@ -189,12 +173,16 @@ module Kontena::Cli::Stacks
         end
       end
 
-      def process_service?(config)
-        return true unless config['skip_if'] || config['only_if']
+      # If the supplied hash contains skip_if/only_if conditionals, process that conditional and return true/false
+      #
+      # @param [Hash]
+      # @return [Boolean]
+      def process_hash?(hash)
+        return true unless hash['skip_if'] || hash['only_if']
         return true if skip_variables? || variables.empty?
 
-        skip_lambdas = normalize_ifs(config['skip_if'])
-        only_lambdas = normalize_ifs(config['only_if'])
+        skip_lambdas = normalize_ifs(hash['skip_if'])
+        only_lambdas = normalize_ifs(hash['only_if'])
 
         if skip_lambdas
           return false if skip_lambdas.any? { |s| s.call }
@@ -205,6 +193,73 @@ module Kontena::Cli::Stacks
         end
 
         true
+      end
+
+      # @param [Hash] service_config
+      def process_config(service_config)
+        normalize_env_vars(service_config)
+        merge_env_vars(service_config)
+        expand_build_context(service_config)
+        normalize_build_args(service_config)
+        if service_config.has_key?('extends')
+          service_config = extend_config(service_config)
+          service_config.delete('extends')
+        end
+        service_config
+      end
+
+      # @return [Hash] - services from YAML file
+      def services
+        @services ||= fully_interpolated_yaml['services']
+      end
+
+      def from_external_file(filename, service_name, from_registry: false)
+        outcome = Reader.new(filename, skip_validation: skip_validation?, skip_variables: true, from_registry: from_registry?, variables: variables).execute(service_name)
+        errors.concat outcome[:errors] unless errors.any? { |item| item.has_key?(filename) }
+        notifications.concat outcome[:notifications] unless notifications.any? { |item| item.has_key?(filename) }
+        outcome[:services]
+      end
+
+      private
+
+      ##
+      # @param [String] content - content of YAML file
+      def interpolate(content, use_opto: true, substitutions: {}, raise_on_unknown: false, warnings: true)
+        content.split(/[\r\n]/).map.with_index do |row, line_num|
+          # skip lines that opto may be interpolating
+          if row.strip.start_with?('interpolate:') || row.strip.start_with?('evaluate:')
+            row
+          else
+            row.gsub(/(?<!\$)\$(?!\$)\{?\w+\}?/) do |v| # searches $VAR and ${VAR} and not $$VAR
+              var = v.tr('${}', '')
+
+              if use_opto
+                opt = variables.option(var)
+                if opt.nil?
+                  raise RuntimeError, "Undeclared variable '#{var}' in #{file}:#{line_num} -- #{row}" if raise_on_unknown
+                  val = nil
+                else
+                  val = opt.value
+                end
+              else
+                val = substitutions[var]
+              end
+
+              if val && !val.to_s.empty?
+                val.to_s =~ /[\r\n\"\'\|]/ ? val.inspect : val.to_s
+              else
+                puts "Value for #{var} is not set. Substituting with an empty string." if warnings
+                ''
+              end
+            end
+          end
+        end.join("\n")
+      end
+
+      ##
+      # @param [String] text - content of yaml file
+      def replace_dollar_dollars(text)
+        text.gsub('$$', '$')
       end
 
       # Generates an array of lambdas that return true if a condition is true
@@ -235,58 +290,6 @@ module Kontena::Cli::Stacks
       end
 
       # @param [Hash] service_config
-      def process_config(service_config)
-        normalize_env_vars(service_config)
-        merge_env_vars(service_config)
-        expand_build_context(service_config)
-        normalize_build_args(service_config)
-        if service_config.has_key?('extends')
-          service_config = extend_config(service_config)
-          service_config.delete('extends')
-        end
-        service_config
-      end
-
-      # @return [Hash] - services from YAML file
-      def services
-        yaml['services']
-      end
-
-      ##
-      # @param [String] text - content of YAML file
-      def interpolate(text, use_opto: true, substitutions: ENV)
-        text.split(/[\r\n]/).map do |row|
-          # skip lines that opto is interpolating
-          if row.strip.start_with?('interpolate:') || row.strip.start_with?('evaluate:')
-            row
-          else
-            row.gsub(/(?<!\$)\$(?!\$)\{?\w+\}?/) do |v| # searches $VAR and ${VAR} and not $$VAR
-              var = v.tr('${}', '')
-
-              if use_opto
-                val = variables.value_of(var) || substitutions[var]
-              else
-                val = substitutions[var]
-              end
-
-              if val
-                val.to_s =~ /[\r\n\"\'\|]/ ? val.inspect : val
-              else
-                puts "Value for #{var} is not set. Substituting with an empty string." unless skip_validation?
-                @replace_missing || ''
-              end
-            end
-          end
-        end.join("\n")
-      end
-
-      ##
-      # @param [String] text - content of yaml file
-      def replace_dollar_dollars(text)
-        text.gsub('$$', '$')
-      end
-
-      # @param [Hash] service_config
       # @return [Hash] updated service config
       def extend_config(service_config)
         extended_service = extended_service(service_config['extends'])
@@ -314,12 +317,11 @@ module Kontena::Cli::Stacks
         end
       end
 
-      def from_external_file(filename, service_name, from_registry: false)
-        outcome = Reader.new(filename, skip_validation: @skip_validation, skip_variables: true, replace_missing: @replace_missing, from_registry: from_registry).execute(service_name)
-        errors.concat outcome[:errors] unless errors.any? { |item| item.has_key?(filename) }
-        notifications.concat outcome[:notifications] unless notifications.any? { |item| item.has_key?(filename) }
-        outcome[:services]
+      def store_failures(data)
+        errors << { file => data[:errors] } unless data[:errors].empty?
+        notifications << { file => data[:notifications] } unless data[:notifications].empty?
       end
+
 
       # @param [Hash] options - service config
       def normalize_env_vars(options)
@@ -343,7 +345,7 @@ module Kontena::Cli::Stacks
 
       # @param [String] path
       def read_env_file(path)
-        File.readlines(path).map { |line| line.strip }.delete_if { |line| line.start_with?('#') || line.empty? }
+        File.readlines(path).map { |line| line.strip }.reject { |line| line.start_with?('#') || line.empty? }
       end
 
       def expand_build_context(options)
@@ -366,6 +368,43 @@ module Kontena::Cli::Stacks
         end
       end
 
+      # Goes through an array of service hashes and extracts vault secret key names
+      # @param [Hash] services_array
+      # @return [Array] keys
+      def extract_vault_keys(services)
+        keys = []
+        services.each do |_, data|
+          Array(services['secrets']).each do |secret|
+            keys << secret['secret']
+          end
+        end
+        keys.uniq.compact
+      end
+
+      # Takes a stack name such as user/foo:1.0.0 and breaks it into components
+      # @param [String] stack_name
+      # @return [Hash] a hash with :user, :stack and :version
+      def parse_stack_name(stack_name)
+        return {} if stack_name.nil?
+        return {} if stack_name.empty?
+        name, version = stack_name.split(':', 2)
+        if name.include?('/')
+          user, stack = name.split('/', 2)
+        else
+          user = nil
+          stack = name
+        end
+        {
+          user: user,
+          stack: stack,
+          version: version
+        }
+      end
+
+
+      def env
+        ENV
+      end
     end
   end
 end

--- a/cli/spec/fixtures/kontena-with-env-file.yml
+++ b/cli/spec/fixtures/kontena-with-env-file.yml
@@ -5,7 +5,7 @@ wordpress:
   stateful: true
   env_file: .env
   environment:
-    WORDPRESS_DB_PASSWORD: %{project}_secret
+    WORDPRESS_DB_PASSWORD: ${project}_secret
   instances: 2
   deploy:
     strategy: ha

--- a/cli/spec/fixtures/kontena-with-env-file.yml
+++ b/cli/spec/fixtures/kontena-with-env-file.yml
@@ -5,7 +5,7 @@ wordpress:
   stateful: true
   env_file: .env
   environment:
-    WORDPRESS_DB_PASSWORD: ${project}_secret
+    WORDPRESS_DB_PASSWORD: %{project}_secret
   instances: 2
   deploy:
     strategy: ha

--- a/cli/spec/fixtures/kontena-with-variables.yml
+++ b/cli/spec/fixtures/kontena-with-variables.yml
@@ -2,7 +2,7 @@ wordpress:
   extends:
     file: docker-compose.yml
     service: wordpress
-  image: wordpress:$TAG
+  image: "wordpress:$TAG"
   stateful: true
   environment:
     - WORDPRESS_DB_PASSWORD=%{project}_secret

--- a/cli/spec/fixtures/kontena_build_v3.yml
+++ b/cli/spec/fixtures/kontena_build_v3.yml
@@ -4,7 +4,7 @@ services:
   mysql:
     stateful: true
     environment:
-      - MYSQL_ROOT_PASSWORD=${project}_secret
+      - MYSQL_ROOT_PASSWORD=${STACK}_secret
 
   webapp:
     image: webapp

--- a/cli/spec/fixtures/stack-with-invalid-liquid.yml
+++ b/cli/spec/fixtures/stack-with-invalid-liquid.yml
@@ -12,11 +12,11 @@ variables:
     value: 5
 
 services:
-  {% forx copy in (1..copies) %}
+  # {% forx copy in (1..copies) %}
   service-{{copy}}:
     image: foo:{{copy}}
     environment:
       - TEST_VAR="{{ grid_name }}"
-  {% endfor %}
+  # {% endfor %}
 
 

--- a/cli/spec/fixtures/stack-with-invalid-liquid.yml
+++ b/cli/spec/fixtures/stack-with-invalid-liquid.yml
@@ -1,0 +1,22 @@
+stack: user/stackname
+version: 0.1.1
+variables:
+  grid_name:
+    type: string
+    required: true
+    min_length: 10
+    empty_is_nil: true
+    value: "{{ GRID }} ${STACK}"
+  copies:
+    type: integer
+    value: 5
+
+services:
+  {% forx copy in (1..copies) %}
+  service-{{copy}}:
+    image: foo:{{copy}}
+    environment:
+      - TEST_VAR="{{ grid_name }}"
+  {% endfor %}
+
+

--- a/cli/spec/fixtures/stack-with-liquid.yml
+++ b/cli/spec/fixtures/stack-with-liquid.yml
@@ -12,10 +12,10 @@ variables:
     value: 5
 
 services:
-  {% for copy in (1..copies) %}
+  # {% for copy in (1..copies) %}
   service-{{copy}}:
     image: foo:{{copy}}
     environment:
       - TEST_VAR="{{ grid_name }}"
-  {% endfor %}
+  # {% endfor %}
 

--- a/cli/spec/fixtures/stack-with-liquid.yml
+++ b/cli/spec/fixtures/stack-with-liquid.yml
@@ -1,0 +1,21 @@
+stack: user/stackname
+version: 0.1.1
+variables:
+  grid_name:
+    type: string
+    required: true
+    min_length: 10
+    empty_is_nil: true
+    value: "{{ GRID }} ${STACK}"
+  copies:
+    type: integer
+    value: 5
+
+services:
+  {% for copy in (1..copies) %}
+  service-{{copy}}:
+    image: foo:{{copy}}
+    environment:
+      - TEST_VAR="{{ grid_name }}"
+  {% endfor %}
+

--- a/cli/spec/fixtures/stack-with-prompted-variables.yml
+++ b/cli/spec/fixtures/stack-with-prompted-variables.yml
@@ -3,7 +3,7 @@ version: 0.1.1
 variables:
   enum_test:
     type: enum
-    options: 
+    options:
       - Foo
       - Bar
       - Baz
@@ -13,7 +13,7 @@ variables:
     required: true
     min_length: 10
     empty_is_nil: true
-    from: 
+    from:
       env: WORDPRESS_DB_PASSWORD # first try from local env
       prompt: Enter a password for the wordpress instance  # then try from prompt
       random_string: # if prompt returned nil, generate a random string
@@ -31,16 +31,21 @@ variables:
       env: test_var
   TEST_ENV_VAR:      # the default from/to is to set/read env of the option name
     type: :string
+  TAG:
+    type: string
+  MYSQL_IMAGE:
+    type: string
+    empty_is_nil: false
 services:
   wordpress:
     extends:
       file: docker-compose_v2.yml
       service: wordpress
-    image: wordpress:$TAG
+    image: "wordpress:$TAG"
     stateful: true
     environment:
       - WORDPRESS_DB_PASSWORD=${STACK}_secret
-    secrets: 
+    secrets:
       - secret: WP_ADMIN_PASSWORD
         name: WORDPRESS_PASSWORD
         type: env
@@ -56,7 +61,7 @@ services:
       service: mysql
     image: ${MYSQL_IMAGE}
     stateful: true
-    secrets: 
+    secrets:
       - secret: WP_MYSQL_ROOT_PW
         name: MYSQL_PASSWORD
         type: env

--- a/cli/spec/fixtures/stack-with-variables.yml
+++ b/cli/spec/fixtures/stack-with-variables.yml
@@ -23,13 +23,18 @@ variables:
       env: test_var
   TEST_ENV_VAR:      # the default from/to is to set/read env of the option name
     type: string
+  TAG:
+    type: string
+  MYSQL_IMAGE:
+    type: string
+    empty_is_nil: false
 
 services:
   wordpress:
     extends:
       file: docker-compose_v2.yml
       service: wordpress
-    image: wordpress:$TAG
+    image: "wordpress:$TAG"
     stateful: true
     environment:
       - WORDPRESS_DB_PASSWORD=${STACK}_secret

--- a/cli/spec/kontena/cli/services/containers_command_spec.rb
+++ b/cli/spec/kontena/cli/services/containers_command_spec.rb
@@ -31,7 +31,7 @@ describe Kontena::Cli::Services::ContainersCommand do
       })
       expect {
         subject.run(['service-a'])
-      }.to_not raise_error(NoMethodError)
+      }.to_not raise_error
     end
 
     it 'to not throw on nil "overlay_cidr" property' do
@@ -42,7 +42,7 @@ describe Kontena::Cli::Services::ContainersCommand do
       })
       expect {
         subject.run(['service-a'])
-      }.to_not raise_error(NoMethodError)
+      }.to_not raise_error
     end
   end
 end

--- a/cli/spec/kontena/cli/stacks/build_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/build_command_spec.rb
@@ -3,6 +3,10 @@ require "kontena/cli/stacks/build_command"
 
 describe Kontena::Cli::Stacks::BuildCommand do
 
+  include RequirementsHelper
+
+  mock_current_master
+
   let(:subject) do
     described_class.new(File.basename($0))
   end
@@ -29,38 +33,39 @@ describe Kontena::Cli::Stacks::BuildCommand do
       }
     end
 
-    describe '#execute' do
-      before(:each) do
-        allow(subject).to receive(:require_config_file).with('kontena.yml').and_return(true)
-        allow(subject).to receive(:stack_from_yaml).with('kontena.yml').and_return(stack)
-        allow(subject).to receive(:system).and_return(true)
-      end
+    before(:each) do
+      allow(subject).to receive(:require_config_file).with('kontena.yml').and_return(true)
+      allow(subject).to receive(:stack_from_yaml).with('kontena.yml', hash_including(:name, :values)).and_return(stack)
+      allow(subject).to receive(:system).and_return(true)
+    end
 
-      it 'requires config file' do
-        expect(subject).to receive(:require_config_file).with('kontena.yml').and_return(true)
-        subject.run([])
-      end
+    expect_to_require_current_master
+    expect_to_require_current_master_token
 
-      it 'reads stack file' do
-        expect(subject).to receive(:stack_from_yaml).with('kontena.yml').and_return(stack)
-        subject.run([])
-      end
+    it 'requires config file' do
+      expect(subject).to receive(:require_config_file).with('kontena.yml').and_return(true)
+      subject.run([])
+    end
 
-      it 'builds docker image' do
-        expect(subject).to receive(:system).with('docker', 'build', '-t', 'registry.kontena.local/test:latest', '--pull', File.expand_path('.'))
-        subject.run([])
-      end
+    it 'reads stack file' do
+      expect(subject).to receive(:stack_from_yaml).with('kontena.yml', hash_including(:name, :values)).and_return(stack)
+      subject.run([])
+    end
 
-      it 'pushes docker image' do
-        expect(subject).to receive(:system).with('docker', 'push', 'registry.kontena.local/test:latest')
-        subject.run([])
-      end
+    it 'builds docker image' do
+      expect(subject).to receive(:system).with('docker', 'build', '-t', 'registry.kontena.local/test:latest', '--pull', File.expand_path('.'))
+      subject.run([])
+    end
 
-      it 'uses sudo when --sudo given' do
-        expect(subject).to receive(:system).with('sudo', 'docker', 'build', '-t', 'registry.kontena.local/test:latest', '--pull', File.expand_path('.')).and_return(true)
-        expect(subject).to receive(:system).with('sudo', 'docker', 'push', 'registry.kontena.local/test:latest').and_return(true)
-        subject.run(['--sudo'])
-      end
+    it 'pushes docker image' do
+      expect(subject).to receive(:system).with('docker', 'push', 'registry.kontena.local/test:latest')
+      subject.run([])
+    end
+
+    it 'uses sudo when --sudo given' do
+      expect(subject).to receive(:system).with('sudo', 'docker', 'build', '-t', 'registry.kontena.local/test:latest', '--pull', File.expand_path('.')).and_return(true)
+      expect(subject).to receive(:system).with('sudo', 'docker', 'push', 'registry.kontena.local/test:latest').and_return(true)
+      subject.run(['--sudo'])
     end
   end
 end

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -4,6 +4,8 @@ require "kontena/cli/stacks/install_command"
 describe Kontena::Cli::Stacks::InstallCommand do
 
   include ClientHelpers
+  include RequirementsHelper
+  mock_current_master
 
   describe '#execute' do
     let(:stack) do
@@ -16,6 +18,9 @@ describe Kontena::Cli::Stacks::InstallCommand do
         services: []
       }
     end
+
+    expect_to_require_current_master
+    expect_to_require_current_master_token
 
     before(:each) do
       allow(subject).to receive(:yaml_content).and_return("YAML content")
@@ -59,7 +64,7 @@ describe Kontena::Cli::Stacks::InstallCommand do
 
     it 'accepts a stack name as filename' do
       expect(File).to receive(:exist?).with('user/stack:1.0.0').and_return(false)
-      expect(subject).to receive(:stack_from_yaml).with('user/stack:1.0.0', from_registry: true, name: nil).and_return(stack)
+      expect(subject).to receive(:stack_from_yaml).with('user/stack:1.0.0', from_registry: true, name: nil, values: nil).and_return(stack)
       expect(client).to receive(:post).with(
         'grids/test-grid/stacks', stack
       )

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -4,6 +4,9 @@ require "kontena/cli/stacks/upgrade_command"
 describe Kontena::Cli::Stacks::UpgradeCommand do
 
   include ClientHelpers
+  include RequirementsHelper
+
+  mock_current_master
 
   describe '#execute' do
 
@@ -14,35 +17,28 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       }
     end
 
-    it 'requires api url' do
-      allow(subject).to receive(:require_config_file).and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-name').and_return(stack)
-      expect(described_class.requires_current_master?).to be_truthy
-      subject.run(['stack-name', './path/to/kontena.yml'])
+    before(:each) do
+      allow(File).to receive(:exist?).with('./path/to/kontena.yml').and_return(true)
     end
 
-    it 'requires token' do
-      allow(subject).to receive(:require_config_file).and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-name').and_return(stack)
-      expect(described_class.requires_current_master_token?).to be_truthy
-      subject.run(['stack-name', './path/to/kontena.yml'])
-    end
+    expect_to_require_current_master
+    expect_to_require_current_master_token
 
     it 'requires stack file' do
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-name').and_return(stack)
-      expect(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-name', values: nil, from_registry: false).and_return(stack)
+      expect(subject).to receive(:require_config_file).with('./path/to/kontena.yml').at_least(:once).and_return(true)
       subject.run(['stack-name', './path/to/kontena.yml'])
     end
 
     it 'uses kontena.yml as default stack file' do
       expect(subject).to receive(:require_config_file).with('kontena.yml').and_return(true)
-      expect(subject).to receive(:stack_from_yaml).with('kontena.yml', name: 'stack-name').and_return(stack)
+      expect(subject).to receive(:stack_from_yaml).with('kontena.yml', name: 'stack-name', values: nil, from_registry: nil).and_return(stack)
       subject.run(['stack-name'])
     end
 
     it 'sends stack to master' do
       allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a').and_return(stack)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a', values: nil, from_registry: false).and_return(stack)
       expect(client).to receive(:put).with(
         'stacks/test-grid/stack-a', anything
       )
@@ -51,7 +47,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
 
     it 'allows to override stack name' do
       allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-b').and_return(stack)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-b', values: nil, from_registry: false).and_return(stack)
       stack_b = stack
       stack_b[:name] = 'stack-b'
       expect(client).to receive(:put).with(
@@ -64,7 +60,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       context 'when given' do
         it 'triggers deploy' do
           allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a').and_return(stack)
+          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a', values: nil, from_registry: false).and_return(stack)
           allow(client).to receive(:put).with(
             'stacks/test-grid/stack-a', anything
           ).and_return({})
@@ -75,7 +71,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       context 'when not given' do
         it 'does not trigger deploy' do
           allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
-          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a').and_return(stack)
+          allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-a', values: nil, from_registry: false).and_return(stack)
           allow(client).to receive(:put).with(
             'stacks/test-grid/stack-a', anything
           ).and_return({})

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -200,7 +200,6 @@ describe Kontena::Cli::Stacks::YAML::Reader do
           .with('TAG')
           .and_return('4.1')
 
-        #STDERR.puts(subject.variables.to_h.inspect)
         expect {
           subject.execute
         }.to output("Value for MYSQL_IMAGE is not set. Substituting with an empty string.\n").to_stdout

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -396,8 +396,8 @@ describe Kontena::Cli::Stacks::YAML::Reader do
         allow(ENV).to receive(:to_h).and_return({'GRID' => 'foogrid'})
       end
 
-      it 'interpolates envs into variables' do
-        expect(subject.variables.value_of('grid_name')).to eq 'foogrid test'
+      it 'does not interpolate unknown envs into variables' do
+        expect(subject.variables.value_of('grid_name')).not_to eq 'foogrid test'
       end
 
       it 'interpolates variables into services' do

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../../../spec_helper'
 require 'kontena/cli/stacks/yaml/reader'
+require 'liquid'
 
 describe Kontena::Cli::Stacks::YAML::Reader do
   include FixturesHelpers

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -384,4 +384,23 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       expect(name).to eq('stackname')
     end
   end
+
+  context 'liquid' do
+    before(:each) do
+      allow(File).to receive(:read)
+        .with(absolute_yaml_path('kontena_v3.yml'))
+        .and_return(fixture('stack-with-liquid.yml'))
+      allow(ENV).to receive(:[]).with('STACK').and_return('test')
+      allow(ENV).to receive(:[]).with('GRID').and_return('test-grid')
+      allow(ENV).to receive(:to_h).and_return({'GRID' => 'foogrid'})
+    end
+
+    it 'interpolates envs into variables' do
+      expect(subject.variables.value_of('grid_name')).to eq 'foogrid test'
+    end
+
+    it 'interpolates variables into services' do
+      expect(subject.execute[:services].size).to eq 5
+    end
+  end
 end

--- a/cli/spec/support/requirements_helper.rb
+++ b/cli/spec/support/requirements_helper.rb
@@ -16,7 +16,7 @@ module RequirementsHelper
     def expect_to_require_current_grid
       describe "prerequisites" do
         it "should require current grid" do
-          expect(described_class.requires_current_current_grid?).to be_truthy
+          expect(described_class.requires_current_grid?).to be_truthy
         end
       end
     end
@@ -24,8 +24,26 @@ module RequirementsHelper
     def expect_to_require_current_master_token
       describe "prerequisites" do
         it "should require current master token" do
-          expect(described_class.requires_current_current_master_token?).to be_truthy
+          expect(described_class.requires_current_master_token?).to be_truthy
         end
+      end
+    end
+
+    def mock_current_master
+      before(:each) do
+        allow(Kontena::Cli::Config.instance).to receive(:current_master).and_return(
+          Kontena::Cli::Config::Server.new(
+            url: 'https://test.example.com',
+            name: 'master',
+            token: Kontena::Cli::Config::Token.new(access_token: 'foo', account: :master, parent: 'master', parent_type: :master),
+            grid: 'foogrid'
+          )
+        )
+        allow(Kontena::Cli::Config.instance).to receive(:require_current_master).and_return(true)
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(File.join(Dir.home, '.kontena_client.json')).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(File.join(Dir.home, '.kontena_client.json')).and_return("")
       end
     end
   end

--- a/docs/getting-started/installing/cli.md
+++ b/docs/getting-started/installing/cli.md
@@ -4,7 +4,7 @@ title: CLI
 
 ## Installing Kontena CLI
 
-> Prerequisites: You'll need Ruby version 2.0 or later installed on your system. For more details, see the official [Ruby installation docs](https://www.ruby-lang.org/en/documentation/installation/).
+> Prerequisites: You'll need Ruby version 2.1 or later installed on your system. For more details, see the official [Ruby installation docs](https://www.ruby-lang.org/en/documentation/installation/).
 
 
 You can install the Kontena CLI using the Rubygems package manager, which is included in Ruby.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -9,7 +9,7 @@ Follow these steps to get started with Kontena quickly.
 
 ## Step 1. Install Kontena CLI (command-line interface)
 
-> Prerequisites: You'll need Ruby version 2.0 or later installed on your system. For more details, see the official [Ruby installation docs](https://www.ruby-lang.org/en/documentation/installation/).
+> Prerequisites: You'll need Ruby version 2.1 or later installed on your system. For more details, see the official [Ruby installation docs](https://www.ruby-lang.org/en/documentation/installation/).
 
 You can install the Kontena CLI using the Rubygems package manager (which is included in Ruby).
 
@@ -136,8 +136,8 @@ You can then install and deploy the `wordpress` stack:
 
 ```
 $ kontena stack install --deploy kontena.yml
- [done] Creating stack wordpress      
- [done] Deploying stack wordpress     
+ [done] Creating stack wordpress
+ [done] Deploying stack wordpress
 ```
 
 The initial stack deployment may take some time while the host nodes pull the referenced Docker images.
@@ -146,8 +146,8 @@ After the stack deployment is finished you can verify that the wordpress and mys
 
 ```
 $ kontena stack ls
-NAME                                                         VERSION    SERVICES   STATE      EXPOSED PORTS                                     
-⊝ wordpress                                                  0.3.0      2          running    *:80->80/tcp                                      
+NAME                                                         VERSION    SERVICES   STATE      EXPOSED PORTS
+⊝ wordpress                                                  0.3.0      2          running    *:80->80/tcp
 ```
 
 You can use the `kontena stack` commands to view the resulting configuration of each deployed stack service:

--- a/docs/using-kontena/stacks.md
+++ b/docs/using-kontena/stacks.md
@@ -63,7 +63,7 @@ Download a specific version of the YAML stack file from the Kontena Stack Regist
 Upload the YAML stack file to the Kontena Cloud Stack Registry:
 
 ```
-[done] Pushing terom/wordpress:0.3.4 to stacks registry    
+[done] Pushing terom/wordpress:0.3.4 to stacks registry
 ```
 
 The `username/stackname` and version information are read from within the given YAML file.
@@ -77,7 +77,7 @@ By default, the `kontena.yml` file in the current directory is uploaded.
 Lists available stacks files having a name suffix matching the given search term.
 
 ```
-NAME                                     VERSION    DESCRIPTION                             
+NAME                                     VERSION    DESCRIPTION
 jussi/wordpress                          0.1.0      Todo-app bundle, all required services within the stack
 terom/wordpress                          0.3.5      Wordpress 4.6 + MariaDB 5.5
 ```
@@ -140,8 +140,8 @@ Install the stack from the YAML file to the master, creating a new named stack w
 Use the `--deploy` flag to simultaneously deploy the stack services to the grid, spinning up the Docker containers.
 
 ```
- [done] Creating stack wordpress-red      
- [done] Deploying stack wordpress-red     
+ [done] Creating stack wordpress-red
+ [done] Deploying stack wordpress-red
 ```
 
 The stack services will now be visible in `kontena service ls`, and the service containers will be running on the grid's host nodes.
@@ -157,6 +157,10 @@ Install and deploy the stack using the latest YAML file from the stack registry.
 
 Install and deploy the stack using the versioned YAML file from the stack registry.
 
+#### `kontena stack install --name wordpress-green --deploy --values-from production.yml terom/wordpress:4.6.1+mariadb5.`
+
+Install and deploy the stack using the versioned YAML file from the stack registry, read variable values from 'production.yml'.
+
 #### `kontena stack remove wordpress-red`
 
 Removes the installed stack and associated services, including any deployed containers.
@@ -164,7 +168,7 @@ Removes the installed stack and associated services, including any deployed cont
 ```
 Destructive command. To proceed, type "wordpress-red" or re-run this command with --force option.
 > Enter 'wordpress-red' to confirm:  wordpress-red
- [done] Removing stack wordpress-red      
+ [done] Removing stack wordpress-red
 ```
 
 This command also removes all data volumes associated with stateful services within the stack.
@@ -182,10 +186,10 @@ The following Kontena CLI commands can be used to inspect and monitor named stac
 List installed stacks for the current Grid, and their deployment state.
 
 ```
-NAME                                                         VERSION    SERVICES   STATE      EXPOSED PORTS                                     
-⊝ registry                                                   0.16.3     1          running                                                      
-⊝ wordpress                                                  0.3.0      2          running    *:80->80/tcp                                      
-⊝ wordpress-red                                              0.3.0      2          running    *:80->80/tcp        
+NAME                                                         VERSION    SERVICES   STATE      EXPOSED PORTS
+⊝ registry                                                   0.16.3     1          running
+⊝ wordpress                                                  0.3.0      2          running    *:80->80/tcp
+⊝ wordpress-red                                              0.3.0      2          running    *:80->80/tcp
 ```
 
 #### `kontena stack show wordpress`
@@ -229,9 +233,9 @@ wordpress:
 You can use the `kontena service` commands to view further details about the state of the services within a stack:
 
 ```
-NAME                                                         INSTANCES  STATEFUL STATE      EXPOSED PORTS                                     
-⊝ wordpress/wordpress                                        1 / 1      yes      running    0.0.0.0:80->80/tcp                                
-⊝ wordpress/mysql                                            1 / 1      yes      running      
+NAME                                                         INSTANCES  STATEFUL STATE      EXPOSED PORTS
+⊝ wordpress/wordpress                                        1 / 1      yes      running    0.0.0.0:80->80/tcp
+⊝ wordpress/mysql                                            1 / 1      yes      running
 ```
 
 The normal `kontena service show wordpress/wordpress` commands can be used to inspect the services within a stack.
@@ -263,6 +267,12 @@ nodes:
   ■■
 ```
 
+#### `kontena stack validate`
+
+Validate stack YAML files, inspect templating and variable substitution outcome or generate variable value files.
+
+* `kontena stack validate file.yml` notifies about invalid syntax or outputs the resulting YAML to STDOUT
+* `kontena stack validate --values-to answers.yml file.yml` generate a YAML from the variable values, to be used with `--values-from` option in some commands
 
 ## Linking services within the same stack
 


### PR DESCRIPTION
```yaml
---
stack: user/foo
variables:
  foo:
    type: string
    value: hello

services:
  bar:
    environment:
      # {% for num in (0...10) %}
      - FOO{{num}}={{foo}}/{{forloop.index}}
      # {% endfor %}
```

```ruby
# $ irb -r ./lib/kontena_cli.rb
>> Kontena::Cli::Stacks::YAML::Reader.new('./foo.yml').execute[:services]["BAR"]["environment"]
=> ["FOO0=hello/1", "FOO1=hello/2", "FOO2=hello/3", "FOO3=hello/4", "FOO4=hello/5", "FOO5=hello/6", "FOO6=hello/7", "FOO7=hello/8", "FOO8=hello/9", "FOO9=hello/10", "FOO10=hello/11"]
```

Current implementation status:

1. Variables section is read independently, liquid sees ENV
2. Rest of the YAML can use the variables inside liquid

TODO:

- [ ] 1. Some magic for things like `{{ service.mysql.hostnames | join ',' }}`
- [ ] 2. What should happen if a service is scaled using `kontena service scale`?
- [ ] 3. The reader is messy, complete rewrite wouldn't hurt (cleaned up a bit now)
- [X] 4. It's a bit weird that you have a different set of variables in different sections of the YAML. (there's not much that can be done about that)
- [ ] 5. Unknown variables will output an empty string, even with the "strict_variables: true" setting in liquid.
- [X] 6. There's no way to debug the interpolation/parsing output from the CLI.
