### PR TITLE
Use YAML.safe_load to avoid possible code execution

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_runtime_dependency "psych", "> 2.0.14"
   spec.add_runtime_dependency "excon", "~> 0.49.0"
   spec.add_runtime_dependency "tty-prompt", "~> 0.7.1"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -25,12 +25,12 @@ module Kontena::Cli::Apps
       end
 
       if File.exist?('Procfile')
-        procfile = ::YAML.load(File.read('Procfile'))
+        procfile = ::YAML.safe_load(File.read('Procfile'))
       else
         procfile = {}
       end
 
-      app_env = create_env_file(app_json['env']) if app_json['env'] 
+      app_env = create_env_file(app_json['env']) if app_json['env']
       addons = app_json['addons'] || []
 
       if File.exist?(docker_compose_file)

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Apps
       end
 
       if File.exist?('Procfile')
-        procfile = ::YAML.safe_load(File.read('Procfile'))
+        procfile = ::YAML.safe_load(File.read('Procfile'), [Symbol])
       else
         procfile = {}
       end

--- a/cli/lib/kontena/cli/apps/kontena_yml_generator.rb
+++ b/cli/lib/kontena/cli/apps/kontena_yml_generator.rb
@@ -45,7 +45,7 @@ module Kontena::Cli::Apps
     end
 
     def yml_services(file)
-      yml = ::YAML.load(file)
+      yml = ::YAML.safe_load(file)
       if yml['version'] == '2'
         yml['services']
       else

--- a/cli/lib/kontena/cli/apps/kontena_yml_generator.rb
+++ b/cli/lib/kontena/cli/apps/kontena_yml_generator.rb
@@ -45,7 +45,7 @@ module Kontena::Cli::Apps
     end
 
     def yml_services(file)
-      yml = ::YAML.safe_load(file)
+      yml = ::YAML.safe_load(file, [Symbol])
       if yml['version'] == '2'
         yml['services']
       else

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -52,7 +52,7 @@ module Kontena::Cli::Apps
         interpolate(content)
         replace_dollar_dollars(content)
         begin
-          @yaml = ::YAML.load(content)
+          @yaml = ::YAML.safe_load(content)
         rescue Psych::SyntaxError => e
           raise "Error while parsing #{file}".colorize(:red)+ " "+e.message
         end

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -52,7 +52,7 @@ module Kontena::Cli::Apps
         interpolate(content)
         replace_dollar_dollars(content)
         begin
-          @yaml = ::YAML.safe_load(content)
+          @yaml = ::YAML.safe_load(content, [Symbol])
         rescue Psych::SyntaxError => e
           raise "Error while parsing #{file}".colorize(:red)+ " "+e.message
         end

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -41,7 +41,7 @@ module Kontena::Cli::Master::Config
         JSON.parse(data)
       when 'yaml', 'yml'
         require 'yaml'
-        YAML.load(data)
+        YAML.safe_load(data)
       else
         exit_with_error "Unknown input format '#{self.format}'"
       end

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -41,7 +41,7 @@ module Kontena::Cli::Master::Config
         JSON.parse(data)
       when 'yaml', 'yml'
         require 'yaml'
-        YAML.safe_load(data)
+        YAML.safe_load(data, [Symbol])
       else
         exit_with_error "Unknown input format '#{self.format}'"
       end

--- a/cli/lib/kontena/cli/stacks/registry/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/show_command.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Stacks::Registry
     def execute
       require 'semantic'
       unless versions?
-        stack = ::YAML.load(stacks_client.show(stack_name, stack_version))
+        stack = ::YAML.safe_load(stacks_client.show(stack_name, stack_version))
         puts "#{stack['stack']}:"
         puts "  #{"latest_" unless stack_version}version: #{stack['version']}"
         puts "  expose: #{stack['expose'] || '-'}"

--- a/cli/lib/kontena/cli/stacks/registry/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/show_command.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Stacks::Registry
     def execute
       require 'semantic'
       unless versions?
-        stack = ::YAML.safe_load(stacks_client.show(stack_name, stack_version))
+        stack = ::YAML.safe_load(stacks_client.show(stack_name, stack_version), [Symbol])
         puts "#{stack['stack']}:"
         puts "  #{"latest_" unless stack_version}version: #{stack['version']}"
         puts "  expose: #{stack['expose'] || '-'}"

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -44,7 +44,7 @@ module Kontena::Cli::Stacks
         return @variables if @variables
         if yaml && yaml.has_key?('variables')
           variables_yaml = yaml['variables'].to_yaml
-          variables_hash = ::YAML.load(replace_dollar_dollars(interpolate(variables_yaml, use_opto: false)))
+          variables_hash = ::YAML.safe_load(replace_dollar_dollars(interpolate(variables_yaml, use_opto: false)))
           @variables = Opto::Group.new(variables_hash, defaults: { from: :env, to: :env })
         else
           @variables = Opto::Group.new(defaults: { from: :env, to: :env })
@@ -82,7 +82,7 @@ module Kontena::Cli::Stacks
       end
 
       def stack_name
-        yaml = ::YAML.load(raw_content)
+        yaml = ::YAML.safe_load(raw_content)
         yaml['stack'].split('/').last.split(':').first if yaml['stack']
       end
 
@@ -101,9 +101,9 @@ module Kontena::Cli::Stacks
 
       def load_yaml(interpolate = true)
         if interpolate
-          @yaml = ::YAML.load(replace_dollar_dollars(interpolate(raw_content)))
+          @yaml = ::YAML.safe_load(replace_dollar_dollars(interpolate(raw_content)))
         else
-          @yaml = ::YAML.load(raw_content)
+          @yaml = ::YAML.safe_load(raw_content)
         end
       rescue Psych::SyntaxError => e
         raise "Error while parsing #{file}".colorize(:red)+ " "+e.message

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -44,7 +44,7 @@ module Kontena::Cli::Stacks
         return @variables if @variables
         if yaml && yaml.has_key?('variables')
           variables_yaml = yaml['variables'].to_yaml
-          variables_hash = ::YAML.safe_load(replace_dollar_dollars(interpolate(variables_yaml, use_opto: false)))
+          variables_hash = ::YAML.safe_load(replace_dollar_dollars(interpolate(variables_yaml, use_opto: false)), [Symbol])
           @variables = Opto::Group.new(variables_hash, defaults: { from: :env, to: :env })
         else
           @variables = Opto::Group.new(defaults: { from: :env, to: :env })
@@ -82,7 +82,7 @@ module Kontena::Cli::Stacks
       end
 
       def stack_name
-        yaml = ::YAML.safe_load(raw_content)
+        yaml = ::YAML.safe_load(raw_content, [Symbol])
         yaml['stack'].split('/').last.split(':').first if yaml['stack']
       end
 
@@ -101,9 +101,9 @@ module Kontena::Cli::Stacks
 
       def load_yaml(interpolate = true)
         if interpolate
-          @yaml = ::YAML.safe_load(replace_dollar_dollars(interpolate(raw_content)))
+          @yaml = ::YAML.safe_load(replace_dollar_dollars(interpolate(raw_content)), [Symbol])
         else
-          @yaml = ::YAML.safe_load(raw_content)
+          @yaml = ::YAML.safe_load(raw_content, [Symbol])
         end
       rescue Psych::SyntaxError => e
         raise "Error while parsing #{file}".colorize(:red)+ " "+e.message

--- a/cli/lib/kontena/scripts/completer
+++ b/cli/lib/kontena/scripts/completer
@@ -72,7 +72,7 @@ class Helper
 
   def yml_services
     if File.exist?('kontena.yml')
-      yaml = YAML.load(File.read('kontena.yml'))
+      yaml = YAML.safe_load(File.read('kontena.yml'))
       services = yaml['services']
       services.keys
     end

--- a/cli/lib/kontena/scripts/completer
+++ b/cli/lib/kontena/scripts/completer
@@ -72,7 +72,7 @@ class Helper
 
   def yml_services
     if File.exist?('kontena.yml')
-      yaml = YAML.safe_load(File.read('kontena.yml'))
+      yaml = YAML.safe_load(File.read('kontena.yml'), [Symbol])
       services = yaml['services']
       services.keys
     end

--- a/cli/lib/kontena/stacks_cache.rb
+++ b/cli/lib/kontena/stacks_cache.rb
@@ -23,7 +23,7 @@ module Kontena
       end
 
       def load
-        YAML.load(read)
+        YAML.safe_load(read)
       end
 
       def write(content)
@@ -78,7 +78,7 @@ module Kontena
         else
           dputs "Retrieving #{stack.stack}:#{stack.version} from registry"
           content = client.pull(stack.stack, stack.version)
-          yaml    = ::YAML.load(content)
+          yaml    = ::YAML.safe_load(content)
           new_stack = CachedStack.new(yaml['stack'], yaml['version'])
           if new_stack.cached?
             dputs "Already cached"

--- a/cli/lib/kontena/stacks_cache.rb
+++ b/cli/lib/kontena/stacks_cache.rb
@@ -23,7 +23,7 @@ module Kontena
       end
 
       def load
-        YAML.safe_load(read)
+        YAML.safe_load(read, [Symbol])
       end
 
       def write(content)
@@ -78,7 +78,7 @@ module Kontena
         else
           dputs "Retrieving #{stack.stack}:#{stack.version} from registry"
           content = client.pull(stack.stack, stack.version)
-          yaml    = ::YAML.safe_load(content)
+          yaml    = ::YAML.safe_load(content, [Symbol])
           new_stack = CachedStack.new(yaml['stack'], yaml['version'])
           if new_stack.cached?
             dputs "Already cached"

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -106,7 +106,7 @@ describe Kontena::Cli::Apps::DeployCommand do
           allow(subject).to receive(:current_dir).and_return("kontena-test")
           services['wordpress']['environment'] = ['MYSQL_ADMIN_PASSWORD=password']
           services['wordpress']['env_file'] = %w(/path/to/env_file .env)
-          allow(YAML).to receive(:load).and_return(services)
+          allow(YAML).to receive(:safe_load).and_return(services)
 
           expect(File).to receive(:readlines).with('/path/to/env_file').and_return(env_vars)
           expect(File).to receive(:readlines).with('.env').and_return(dot_env)
@@ -127,7 +127,7 @@ describe Kontena::Cli::Apps::DeployCommand do
           allow(subject).to receive(:current_dir).and_return("kontena-test")
           services['wordpress']['environment'] = ['MYSQL_ADMIN_PASSWORD=password']
           services['wordpress']['env_file'] = '/path/to/env_file'
-          allow(YAML).to receive(:load).and_return(services)
+          allow(YAML).to receive(:safe_load).and_return(services)
 
           expect(File).to receive(:readlines).with('/path/to/env_file').and_return(env_vars)
 
@@ -145,7 +145,7 @@ describe Kontena::Cli::Apps::DeployCommand do
       it 'merges external links to links' do
         allow(subject).to receive(:current_dir).and_return("kontena-test")
         services['wordpress']['external_links'] = ['loadbalancer:loadbalancer']
-        allow(YAML).to receive(:load).and_return(services)
+        allow(YAML).to receive(:safe_load).and_return(services)
         data = {
           'name' => 'kontena-test-wordpress',
           'image' => 'wordpress:latest',


### PR DESCRIPTION
It's better to use safe_load to avoid a situation where a crafted yaml could execute code when parsing.
