### PR TITLE
Change default cadvisor image to official

### DIFF
--- a/agent/lib/kontena/launchers/cadvisor.rb
+++ b/agent/lib/kontena/launchers/cadvisor.rb
@@ -6,8 +6,8 @@ module Kontena::Launchers
     include Celluloid::Notifications
     include Kontena::Logging
 
-    CADVISOR_VERSION = ENV['CADVISOR_VERSION'] || '0.23.2'
-    CADVISOR_IMAGE = ENV['CADVISOR_IMAGE'] || 'kontena/cadvisor'
+    CADVISOR_VERSION = ENV['CADVISOR_VERSION'] || 'v0.24.1'
+    CADVISOR_IMAGE = ENV['CADVISOR_IMAGE'] || 'google/cadvisor'
 
     def initialize(autostart = true)
       info 'initialized'
@@ -89,7 +89,7 @@ module Kontena::Launchers
 
     # @return [Hash]
     def volume_mappings
-      if default_image?
+      if kontena_image?
         {
           '/host' => {}
         }
@@ -105,7 +105,7 @@ module Kontena::Launchers
 
     # @return [Array<String>]
     def volume_binds
-      if default_image?
+      if kontena_image?
         ['/:/host:rw']
       else
         [
@@ -118,7 +118,7 @@ module Kontena::Launchers
     end
 
     # @return [Boolean]
-    def default_image?
+    def kontena_image?
       CADVISOR_IMAGE == 'kontena/cadvisor'
     end
   end

--- a/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
+++ b/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
@@ -33,25 +33,26 @@ describe Kontena::Launchers::Cadvisor do
   end
 
   describe '#volume_mappings' do
-    it 'returns only one mapping by default (for nsenter)' do
+    it 'returns only one mapping for kontena cadvisor image (for nsenter)' do
+      allow(subject.wrapped_object).to receive(:kontena_image?).and_return(true)
       expect(subject.volume_mappings.keys).to eq(['/host'])
     end
 
-    it 'returns cadvisor default mappings when custom image is used' do
-      allow(subject.wrapped_object).to receive(:default_image?).and_return(false)
+    it 'returns cadvisor default mappings when non-kontena image is used' do
+      allow(subject.wrapped_object).to receive(:kontena_image?).and_return(false)
       expect(subject.volume_mappings.keys).to eq(['/rootfs', '/var/run', '/sys', '/var/lib/docker'])
     end
   end
 
-  describe '#default_image?' do
+  describe '#kontena_image?' do
     it 'returns true when kontena/cadvisor is used' do
       stub_const("#{described_class.name}::CADVISOR_IMAGE", 'kontena/cadvisor')
-      expect(subject.default_image?).to be_truthy
+      expect(subject.kontena_image?).to be_truthy
     end
 
     it 'returns false when custom image is used' do
       stub_const("#{described_class.name}::CADVISOR_IMAGE", 'google/cadvisor')
-      expect(subject.default_image?).to be_falsey
+      expect(subject.kontena_image?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
Our own cAdvisor image uses `nsenter` to move the cAdvisor process to host side. This seems to cause some instabilities with docker and weave. See https://github.com/weaveworks/weave/issues/2559#issuecomment-267553417

The official cAdvisor image does not seem to suffer from this and hence this change back to the original image. cAdvisor has also fixed the original `du -sh` hogging all CPU in https://github.com/google/cadvisor/releases/tag/v0.23.3 which was the main reason to switch to custom image using nsenter.

Tested this with Ubuntu/aufs which AFAIK had the worst symptoms with `du -sh` with 100+ container and did not see any issues. Also testing with CoreOS beta (1235.2.0, docker 1.12.3) works without any issues.

Fixes #1567 