### PR TITLE
Validate that secrets exist in service create and update

### DIFF
--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -99,6 +99,18 @@ module GridServices
       end
     end
 
+    # Validates that the defined secrets exist
+    # @param [Grid] grid
+    # @param [Hash] secrets
+    def validate_secrets_exist(grid, secrets)
+      secrets.each do |s|
+        secret = grid.grid_secrets.find_by(name: s[:secret])
+        unless secret
+          add_error(:secrets, :not_found, "Secret #{s[:secret]} does not exist")
+        end
+      end
+    end
+
     module ClassMethods
 
       def common_validations

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -32,6 +32,9 @@ module GridServices
       if self.health_check && self.health_check[:interval] < self.health_check[:timeout]
         add_error(:health_check, :invalid, 'Interval has to be bigger than timeout')
       end
+      if self.secrets
+        validate_secrets_exist(self.grid, self.secrets)
+      end
     end
 
     def execute

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -25,6 +25,9 @@ module GridServices
       if self.health_check && self.health_check[:interval] < self.health_check[:timeout]
         add_error(:health_check, :invalid, 'Interval has to be bigger than timeout')
       end
+      if self.secrets
+        validate_secrets_exist(self.grid_service.grid, self.secrets)
+      end
     end
 
     def execute

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -341,5 +341,32 @@ describe GridServices::Create do
       ).run
       expect(outcome.success?).to be(false)
     end
+
+    it 'fails validating secret existence' do
+      outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          secrets: [
+            {secret: 'NON_EXISTING_SECRET', name: 'SOME_SECRET'}
+          ]
+      ).run
+      expect(outcome.success?).to be(false)
+    end
+
+    it 'validates secret existence' do
+      secret = GridSecret.create!(grid: grid, name: 'EXISTING_SECRET', value: 'secret')
+      outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          secrets: [
+            {secret: 'EXISTING_SECRET', name: 'SOME_SECRET'}
+          ]
+      ).run
+      expect(outcome.success?).to be(true)
+    end
   end
 end

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -72,6 +72,27 @@ describe GridServices::Update do
       expect(redis_service.health_check.port).to eq(80)
       expect(redis_service.health_check.protocol).to eq('http')
     end
+
+    it 'fails validating secret existence' do
+      outcome = described_class.new(
+          grid_service: redis_service,
+          secrets: [
+            {secret: 'NON_EXISTING_SECRET', name: 'SOME_SECRET'}
+          ]
+      ).run
+      expect(outcome.success?).to be(false)
+    end
+
+    it 'validates secret existence' do
+      GridSecret.create!(grid: grid, name: 'EXISTING_SECRET', value: 'secret')
+      outcome = described_class.new(
+          grid_service: redis_service,
+          secrets: [
+            {secret: 'EXISTING_SECRET', name: 'SOME_SECRET'}
+          ]
+      ).run
+      expect(outcome.success?).to be(true)
+    end
   end
 
   describe '#build_grid_service_hooks' do


### PR DESCRIPTION
fixes #1130 

Gives now following errors in case secrets are missing:
```
$ k stack install ~/code/stacks/missing_secret.yml 
 [fail] Creating stack secrets      
 [error] {"services"=>"Service create failed for service 'web': Secret MISSING_SECRET does not exist"}

$ k service create --secret SECRET:SECRET:env redis redis
 [fail] Creating redis service      
 [error] {"secrets"=>"Secret SECRET does not exist"}

$ k service update --secret SECRET:SECRET:SECRET redis redis
 [fail] Creating redis service      
 [error] {"secrets"=>"Secret SECRET does not exist"}
```
