### PR TITLE
Container exec/logs/inspect tries to guess full container name

### DIFF
--- a/cli/lib/kontena/cli/containers/container_id_param.rb
+++ b/cli/lib/kontena/cli/containers/container_id_param.rb
@@ -13,11 +13,7 @@ module Kontena::Cli::Containers
               ENV["DEBUG"] && STDERR.puts("Invalid response from master: #{containers.inspect}")
               exit_with_error('Invalid response from master')
             end
-            targets = containers['containers'].select do |c|
-              c['name'].end_with?(container_id) ||
-              c['name'].end_with?(container_id + "-1") ||
-              c['name'] =~ /\A\w+\-#{container_id}(?:\-\d+)/
-            end.map { |c| "#{c['node']['name']}/#{c['name']}" }
+            targets = containers['containers'].select {|c| c['name'] == container_id }.map { |c| "#{c['node']['name']}/#{c['name']}" }
             if targets.empty?
               signal_usage_error "Container not found"
             elsif targets.size == 1

--- a/cli/lib/kontena/cli/containers/container_id_param.rb
+++ b/cli/lib/kontena/cli/containers/container_id_param.rb
@@ -1,0 +1,34 @@
+module Kontena::Cli::Containers
+  module ContainerIdParam
+    def self.included(where)
+      where.parameter "CONTAINER_ID", "Container id" do |container_id|
+        if container_id
+          client.request(http_method: :get, path: "containers/#{current_grid}/#{container_id}", expects: [200, 404])
+          if client.last_response.status == 200
+            container_id
+          else
+            ENV["DEBUG"] && STDERR.puts("Container not found with name '#{container_id}', trying to resolve..")
+            containers = Kontena.run('container list --return', returning: :result)
+            unless containers.kind_of?(Hash) && containers['containers']
+              ENV["DEBUG"] && STDERR.puts("Invalid response from master: #{containers.inspect}")
+              exit_with_error('Invalid response from master')
+            end
+            targets = containers['containers'].select do |c|
+              c['name'].end_with?(container_id) ||
+              c['name'].end_with?(container_id + "-1") ||
+              c['name'] =~ /\A\w+\-#{container_id}(?:\-\d+)/
+            end.map { |c| "#{c['node']['name']}/#{c['name']}" }
+            if targets.empty?
+              signal_usage_error "Container not found"
+            elsif targets.size == 1
+              ENV["DEBUG"] && STDERR.puts("Assuming intended target to be '#{targets.first}'")
+              targets.first
+            elsif target.size > 1
+              signal_usage_error "Container not found, did you mean one of: #{targets.join(', ')}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -1,20 +1,32 @@
 require_relative '../grid_options'
+require_relative 'container_id_param'
 
 module Kontena::Cli::Containers
   class ExecCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "CONTAINER_ID", "Container id"
+    include Kontena::Cli::Containers::ContainerIdParam
+
     parameter "CMD ...", "Command"
 
+    requires_current_master
+    requires_current_master_token
+
+    def exec(payload, container_id)
+      client.post("containers/#{current_grid}/#{container_id}/exec", payload)
+    rescue Kontena::Errors::StandardError => ex
+      if ex.message =~ /Not [Ff]ound/
+        if new_target = resolve(container_id)
+          return exec(payload, new_target)
+        end
+      end
+      raise ex, ex.message
+    end
+
     def execute
-      require_api_url
-      token = require_token
-
       payload = {cmd: ["sh", "-c", Shellwords.join(cmd_list)]}
-      result = client(token).post("containers/#{current_grid}/#{container_id}/exec", payload)
-
+      result = exec(payload, container_id)
       puts result[0].join(" ") unless result[0].size == 0
       STDERR.puts result[1].join(" ") unless result[1].size == 0
       exit result[2]

--- a/cli/lib/kontena/cli/containers/inspect_command.rb
+++ b/cli/lib/kontena/cli/containers/inspect_command.rb
@@ -1,15 +1,17 @@
+require_relative 'container_id_param'
+
 module Kontena::Cli::Containers
   class InspectCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "CONTAINER_ID", "Container id"
+    include Kontena::Cli::Containers::ContainerIdParam
+
+    requires_current_master
+    requires_current_master_token
 
     def execute
-      require_api_url
-      token = require_token
-
-      result = client(token).get("containers/#{current_grid}/#{container_id}/inspect")
+      result = client.get("containers/#{current_grid}/#{container_id}/inspect")
       puts JSON.pretty_generate(result)
     end
   end

--- a/cli/lib/kontena/cli/containers/list_command.rb
+++ b/cli/lib/kontena/cli/containers/list_command.rb
@@ -7,14 +7,15 @@ module Kontena::Cli::Containers
     include Kontena::Cli::GridOptions
 
     option ['--all', '-a'], :flag, 'Show all containers'
+    option '--return', :flag, "Return results", hidden: true
+
+    requires_current_master
+    requires_current_master_token
 
     def execute
-      require_api_url
-      token = require_token
-
-      params = '?'
-      params << 'all=1' if all?
-      result = client(token).get("containers/#{current_grid}#{params}")
+      params = all? ? '?all=1' : ''
+      result = client.get("containers/#{current_grid}#{params}")
+      return result if return?
       containers = result['containers']
       id_column = longest_string_in_array(containers.map {|c| "#{c['node']['name']}/#{c['name']}"})
       image_column = longest_string_in_array(containers.map {|c| c['image'] })

--- a/cli/lib/kontena/cli/containers/logs_command.rb
+++ b/cli/lib/kontena/cli/containers/logs_command.rb
@@ -1,20 +1,30 @@
 require_relative '../grid_options'
 require_relative '../helpers/log_helper'
+require_relative 'container_id_param'
 
 module Kontena::Cli::Containers
-  class LogsCommand < Clamp::Command
+  class LogsCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 
-    parameter "CONTAINER_ID", "Container id"
+    include Kontena::Cli::Containers::ContainerIdParam
+
+    requires_current_master
+    requires_current_master_token
 
     def execute
-      require_api_url
-
       show_logs("containers/#{current_grid}/#{container_id}/logs") do |log|
         show_log(log)
       end
+    rescue Kontena::Errors::StandardError => ex
+      if ex.message =~ /Not [Ff]ound/
+        if new_target = resolve(container_id)
+          self.container_id = container_id
+          return exec(payload, new_target)
+        end
+      end
+      raise ex, ex.message
     end
   end
 end

--- a/cli/spec/kontena/cli/containers/list_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/list_command_spec.rb
@@ -8,7 +8,7 @@ describe Kontena::Cli::Containers::ListCommand do
   context "for a single container with logs" do
 
     it "fetches containers" do
-      expect(client).to receive(:get).with('containers/test-grid?').and_return({'containers' => []})
+      expect(client).to receive(:get).with('containers/test-grid').and_return({'containers' => []})
 
       subject.run([])
     end


### PR DESCRIPTION
Fixes #1563

Makes `kontena container exec`, `kontena container logs` and `kontena container inspect` to try finding `{any_node_name}/container_id` if the user supplied container_id was not found.

Returns an error if multiple matches are found.
