### PR TITLE
Bump tty-prompt, introduce Kontena::LightPrompt for windows

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "excon", "~> 0.49.0"
-  spec.add_runtime_dependency "tty-prompt", "~> 0.9"
+  spec.add_runtime_dependency "tty-prompt", "~> 0.10"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "excon", "~> 0.49.0"
-  spec.add_runtime_dependency "tty-prompt", "~> 0.7.1"
+  spec.add_runtime_dependency "tty-prompt", "~> 0.9"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"

--- a/cli/lib/kontena/light_prompt.rb
+++ b/cli/lib/kontena/light_prompt.rb
@@ -43,7 +43,6 @@ module Kontena
 
     def initialize(options={})
       @prompt = TTY::Prompt.new(options)
-      @prompt.instance_variable_set :@pastel, Pastel.new(enabled: false)
     end
 
     def select(*args, &block)

--- a/cli/lib/kontena/light_prompt.rb
+++ b/cli/lib/kontena/light_prompt.rb
@@ -102,11 +102,3 @@ module Kontena
     end
   end
 end
-
-
-
-
-
-    
-
-

--- a/cli/lib/kontena/light_prompt.rb
+++ b/cli/lib/kontena/light_prompt.rb
@@ -1,0 +1,93 @@
+require 'tty-prompt'
+require 'pastel'
+
+module Kontena
+  class LightPrompt
+
+    attr_reader :prompt
+
+    extend Forwardable
+
+    class Menu
+      attr_reader :choices
+
+      def initialize
+        @choices = []
+      end
+
+      def choice(text, label)
+        choices << [text, label]
+      end
+
+      def add_quit_choice
+        choice('(done)', :done)
+      end
+
+      def remove_choice(value)
+        choices.reject! { |c| c.last == value }
+      end
+
+      def remove_choices(values)
+        values.each { |v| remove_choice(v) }
+      end
+    end
+
+    def initialize(options={})
+      @prompt = TTY::Prompt.new(options)
+      @prompt.instance_variable_set :@pastel, Pastel.new(enabled: false)
+    end
+
+    def select(*args, &block)
+      choice_collector = Menu.new
+      yield choice_collector
+
+      prompt.enum_select(*args) do |menu|
+        choice_collector.choices.each do |choice|
+          menu.choice choice.first, choice.last
+        end
+      end
+    end
+
+    def multi_select(*args, &block)
+      choice_collector = Menu.new
+      yield choice_collector
+      choice_collector.add_quit_choice
+
+      selections = []
+
+      loop do
+        choice_collector.remove_choices(selections)
+
+        answer = prompt.enum_select(*args) do |menu|
+          choice_collector.choices.each do |choice|
+            menu.choice choice.first, choice.last
+          end
+        end
+
+        break if answer == :done
+        selections << answer
+      end
+
+      selections
+    end
+
+
+    def_delegators :prompt, :ask, :yes?, :error
+
+    def method_missing(meth, *args)
+      prompt.send(meth, *args)
+    end
+
+    def respond_to_missing?(meth, privates = false)
+      prompt.respond_to?(meth, privates)
+    end
+  end
+end
+
+
+
+
+
+    
+
+

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -30,7 +30,7 @@ module Kontena
   end
 
   def self.simple_terminal?
-    ENV['KONTENA_SIMPLE_TERM'] || on_windows? || !$stdout.tty?
+    ENV['KONTENA_SIMPLE_TERM'] || !$stdout.tty?
   end
 
   def self.pastel

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -26,11 +26,20 @@ module Kontena
   end
 
   def self.pastel
-    @pastel ||= Pastel.new(enabled: $stdout.tty?)
+    @pastel ||= Pastel.new(enabled: (ENV['OS'] != 'Windows_NT' && $stdout.tty?))
   end
 
   def self.prompt
-    @prompt ||= TTY::Prompt.new(
+    return @prompt if @prompt
+    if ENV['OS'] == 'Windows_NT'
+      require_relative 'kontena/light_prompt'
+      klass = Kontena::LightPrompt
+    else
+      require 'tty-prompt'
+      klass = TTY::Prompt
+    end
+
+    @prompt = klass.new(
       active_color: :cyan,
       help_color: :white,
       error_color: :red,

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -25,13 +25,21 @@ module Kontena
     "kontena-cli/#{Kontena::Cli::VERSION}"
   end
 
+  def self.on_windows?
+    ENV['OS'] == 'Windows_NT' && RUBY_PLATFORM !~ /cygwin/
+  end
+
+  def self.simple_terminal?
+    ENV['KONTENA_SIMPLE_TERM'] || on_windows? || !$stdout.tty?
+  end
+
   def self.pastel
-    @pastel ||= Pastel.new(enabled: (ENV['OS'] != 'Windows_NT' && $stdout.tty?))
+    @pastel ||= Pastel.new(enabled: !simple_terminal?)
   end
 
   def self.prompt
     return @prompt if @prompt
-    if ENV['OS'] == 'Windows_NT'
+    if simple_terminal?
       require_relative 'kontena/light_prompt'
       klass = Kontena::LightPrompt
     else


### PR DESCRIPTION
Fixes #1401 

..by replacing all fancy menus with the simpler `enum_select` when on windows.

Colors work fine on windows, but unicode, reading keyboard and ascii control codes not so well.

The enum_select displays a list such as
```
1) foo
2) bar

Choose 1-2 :
``` 

For multi_selects it keeps asking until you answer the last option to indicate you're done with selecting. Each subsequent list will not include the selections you already picked for the array.


```
1) foofoo
...
20) (done)
```

Also bumped TTY::Prompt to 0.9.0.
