### PR TITLE
[WIP] Support canary deployment with lb

### DIFF
--- a/agent/lib/kontena/load_balancers/registrator.rb
+++ b/agent/lib/kontena/load_balancers/registrator.rb
@@ -55,7 +55,7 @@ module Kontena::LoadBalancers
       ip = container.overlay_ip
       return if lb.nil? || ip.nil?
 
-      service_name = container.service_name_for_lb
+      service_name = container.env_hash['KONTENA_LB_SERVICE_ALIAS'] || container.service_name_for_lb
       name = container.labels['io.kontena.container.name']
       port = container.labels['io.kontena.load_balancer.internal_port'] || '80'
       mode = container.labels['io.kontena.load_balancer.mode'] || 'http'

--- a/agent/lib/kontena/service_pods/terminator.rb
+++ b/agent/lib/kontena/service_pods/terminator.rb
@@ -23,13 +23,13 @@ module Kontena
       def perform
         service_container = get_container(self.service_id, self.instance_number)
         if service_container
-          if remove_from_load_balancer?(service_container)
-            remove_from_load_balancer(service_container)
-          end
           info "terminating service: #{service_container.name}"
           service_container.stop('timeout' => 10)
           service_container.wait
           service_container.delete(v: true)
+          if remove_from_load_balancer?(service_container)
+            remove_from_load_balancer(service_container)
+          end
         end
         data_container = get_container(self.service_id, self.instance_number, 'volume')
         if data_container

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -53,6 +53,24 @@ describe Kontena::LoadBalancers::Configurer do
       end
     end
 
+    it 'sets default values to etcd under alias' do
+      storage = {}
+      allow(etcd).to receive(:set) do |key, value|
+        storage[key] = value[:value]
+      end
+      expect(container).to receive(:env_hash).and_return({'KONTENA_LB_SERVICE_ALIAS' => 'alias'})
+      subject.ensure_config(container)
+      expected_values = {
+        "#{etcd_prefix}/lb/services/alias/balance" => 'roundrobin',
+        "#{etcd_prefix}/lb/services/alias/custom_settings" => nil,
+        "#{etcd_prefix}/lb/services/alias/virtual_path" => '/',
+        "#{etcd_prefix}/lb/services/alias/virtual_hosts" => nil,
+      }
+      expected_values.each do |k, v|
+        expect(storage[k]).to eq(v)
+      end
+    end
+
     it 'sets tcp values to etcd' do
       container.env_hash['KONTENA_LB_MODE'] = 'tcp'
       storage = {}


### PR DESCRIPTION
This PR implements support for canary deployments behind the loadbalancer. See the docs change for example.

Not sure if the check for existing upstreams is the best way to determine if the whole service config should be removed or not. Other option is to keep track of the aliased services in etcd and only remove the config when last service gets removed.

