### PR TITLE
Calm service delete polling interval

### DIFF
--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -17,6 +17,7 @@ module Kontena::Cli::Services
         client(token).delete("services/#{parse_service_id(name)}")
         removed = false
         until removed == true
+          sleep 1
           begin
             client(token).get("services/#{parse_service_id(name)}")
           rescue Kontena::Errors::StandardError => exc


### PR DESCRIPTION
Service delete on CLI was polling the service status as hard as it could. Added a bit of sleep to calm it down a bit.