### PR TITLE
Remove exact docker patch version from Ubuntu install docs

### DIFF
--- a/docs/getting-started/installing/ubuntu.md
+++ b/docs/getting-started/installing/ubuntu.md
@@ -29,7 +29,7 @@ $ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 
 $ echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" | sudo tee -a /etc/apt/sources.list.d/docker.list
 $ sudo apt-get update
 $ sudo apt-get install apt-transport-https ca-certificates linux-image-extra-$(uname -r) linux-image-extra-virtual
-$ sudo apt-get install docker-engine=1.12.2-0~trusty
+$ sudo apt-get install docker-engine=1.12.*
 ```
 
 ## Installing Kontena Master

--- a/docs/getting-started/installing/ubuntu.md
+++ b/docs/getting-started/installing/ubuntu.md
@@ -41,7 +41,7 @@ Kontena Master is an orchestrator component that manages Kontena Grids/Nodes. In
 
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/kontena.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-server
 ```
@@ -50,7 +50,7 @@ $ sudo apt-get install kontena-server
 
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/kontena.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-server
 ```
@@ -123,7 +123,7 @@ Now you can go ahead and install the `kontena-agent` Ubuntu package using the ap
 
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee -a /etc/apt/sources.list.d/kontena.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee /etc/apt/sources.list.d/kontena.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-agent
 ```
@@ -132,7 +132,7 @@ $ sudo apt-get install kontena-agent
 
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list.d/kontena.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee /etc/apt/sources.list.d/kontena.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-agent
 ```

--- a/docs/getting-started/installing/ubuntu.md
+++ b/docs/getting-started/installing/ubuntu.md
@@ -123,7 +123,7 @@ Now you can go ahead and install the `kontena-agent` Ubuntu package using the ap
 
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu xenial main" | sudo tee -a /etc/apt/sources.list.d/kontena.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-agent
 ```
@@ -132,7 +132,7 @@ $ sudo apt-get install kontena-agent
 
 ```
 $ wget -qO - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
-$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
+$ echo "deb http://dl.bintray.com/kontena/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list.d/kontena.list
 $ sudo apt-get update
 $ sudo apt-get install kontena-agent
 ```


### PR DESCRIPTION
Instructions now install latest 1.12.x Docker engine version. Also the apt repo is written to a separate sources.list file.