### PR TITLE
Agent: Fix WebsocketClient reconnect

### DIFF
--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -156,7 +156,7 @@ module Kontena
     def start_em
       EM.epoll
       Thread.new {
-        Thread.abort_on_exception = true
+        Thread.current.abort_on_exception = true
         EventMachine.run
       } unless EventMachine.reactor_running?
       sleep 0.01 until EventMachine.reactor_running?

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -155,7 +155,10 @@ module Kontena
 
     def start_em
       EM.epoll
-      Thread.new { EventMachine.run } unless EventMachine.reactor_running?
+      Thread.new {
+        Thread.abort_on_exception = true
+        EventMachine.run
+      } unless EventMachine.reactor_running?
       sleep 0.01 until EventMachine.reactor_running?
     end
   end

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -121,6 +121,7 @@ module Kontena
 
     # @param [Faye::WebSocket::API::Event] event
     def on_close(event)
+      @ping_timer = nil
       @close_timer.cancel if @close_timer
       @close_timer = nil
       @connected = false
@@ -169,8 +170,7 @@ module Kontena
       return unless @ping_timer.nil?
 
       @ping_timer = EM::Timer.new(2) do
-        @ping_timer = nil
-
+        # @ping_timer remains nil until re-connected to prevent further keepalives while closing
         if @connected
           info 'did not receive pong, closing connection'
           close
@@ -193,7 +193,7 @@ module Kontena
       @close_timer = EM::Timer.new(CLOSE_TIMEOUT) do
         if @ws
           @ws.remove_all_listeners
-          
+
           # fake it
           on_close Faye::WebSocket::Event.create('close', :code => 1006, :reason => "Close timeout")
         end

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -165,6 +165,8 @@ module Kontena
       return unless @ping_timer.nil?
 
       @ping_timer = EM::Timer.new(2) do
+        @ping_timer = nil
+
         if @connected
           info 'did not receive pong, closing connection'
           ws.close(1000)

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -197,6 +197,7 @@ module Kontena
         if @ws
           warn "Hit close timeout, abandoning existing websocket connection"
 
+          # ignore events from the abandoned connection
           @ws.remove_all_listeners
 
           # fake it

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -200,11 +200,11 @@ module Kontena
       ws.close(1000)
 
       @close_timer = EM::Timer.new(CLOSE_TIMEOUT) do
-        if @ws
+        if ws
           warn "Hit close timeout, abandoning existing websocket connection"
 
           # ignore events from the abandoned connection
-          @ws.remove_all_listeners
+          ws.remove_all_listeners
 
           # fake it
           on_close Faye::WebSocket::Event.create('close', :code => 1006, :reason => "Close timeout")

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -6,7 +6,13 @@ module Kontena
     include Kontena::Logging
 
     KEEPALIVE_TIME = 30
-    CLOSE_TIMEOUT = 30
+
+    if defined? Faye::Websocket::Client.CLOSE_TIMEOUT
+      # use a slightly longer timeout as a fallback
+      CLOSE_TIMEOUT = Faye::Websocket::Client.CLOSE_TIMEOUT + 5
+    else
+      CLOSE_TIMEOUT = 30
+    end
 
     attr_reader :api_uri,
                 :api_token,

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -191,8 +191,12 @@ module Kontena
       ws.close(1000)
 
       @close_timer = EM::Timer.new(CLOSE_TIMEOUT) do
-        # fake it
-        on_close Faye::WebSocket::Event.create('close', :code => 1006, :reason => "Close timeout")
+        if @ws
+          @ws.remove_all_listeners
+          
+          # fake it
+          on_close Faye::WebSocket::Event.create('close', :code => 1006, :reason => "Close timeout")
+        end
       end
     end
   end

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -68,11 +68,6 @@ describe Kontena::WebsocketClient do
   describe '#on_close' do
     let(:event) { Faye::WebSocket::API::CloseEvent.new('close', {}) }
 
-    it 'publishes event' do
-      expect(Celluloid::Notifications).to receive(:publish)
-      subject.on_close(event)
-    end
-
     it 'sets connected to false' do
       subject.on_open(spy)
       expect {
@@ -97,6 +92,19 @@ describe Kontena::WebsocketClient do
       event = Faye::WebSocket::API::CloseEvent.new('close', code: 4010)
       expect(subject).to receive(:handle_invalid_version).once
       subject.on_close(event)
+    end
+  end
+
+  describe '#close' do
+    let :ws do
+      instance_double(Faye::WebSocket::Client)
+    end
+
+    it 'publishes event' do
+      allow(subject).to receive(:ws).and_return(ws)
+      expect(Celluloid::Notifications).to receive(:publish).with('websocket:disconnect', nil)
+      expect(ws).to receive(:close).with(1000)
+      subject.close
     end
   end
 


### PR DESCRIPTION
Fixes #1601 

* Fix Agent to abort on errors in the EventMachine thread

    Previously these would be silently ignored, and the websocket client would just stop working.

* Fix leaking `@ping_timer` that prevented keepalive/reconnect from triggering after a reconnect

    The @ping_timer remains until closed, so as to avoid extra keepalives while closing.

* Implement `#close` method with force-close timeout

    Forces a `@ws.on :close` event after a timeout, which causes the `@ws` to be thrown away and replaced with a new one.

    This is effectively a user-side version of the upstream https://github.com/faye/faye-websocket-ruby/commit/07be5a24ef446db5d7e461ca1eaa9fa6aa7b7f21 commit, but with stronger guarantees.

    This may leak the abandoned websocket client sockets if the server never TCP RSTs them. Fixing that would need to figure out how to force-close the `Faye::WebSocket::Client`'s internal EM connection.

* Stop sending Websocket messages immediately on the keepalive close

    The `QueueWorker` will keep hold of any messages, and then re-send them after reconnecting. It's probably best to minimize the number of messages sent on the dead websocket, that will most likely end up getting dropped.

TODO specs?

## Example

Testing with `ip ro add/del blackhole 192.168.66.1/32`

```
kontena-agent | D, [2016-12-30T13:40:10.647665 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:11.070912 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:12.073107 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:12.459706 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:13.074962 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:13.645983 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:13.908269 #1] DEBUG -- WebsocketClient: verify-connection tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:13.909178 #1] DEBUG -- WebsocketClient: verify_connection: @ping_timer=
kontena-agent | D, [2016-12-30T13:40:14.076385 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:15.078673 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | I, [2016-12-30T13:40:15.911645 #1]  INFO -- Kontena::WebsocketClient: did not receive pong, closing connection
kontena-agent | I, [2016-12-30T13:40:15.916687 #1]  INFO -- Kontena::Workers::QueueWorker: stopped processing of msg queue
kontena-agent | I, [2016-12-30T13:40:15.919133 #1]  INFO -- Kontena::Workers::LogWorker: stopped log streaming
kontena-agent | D, [2016-12-30T13:40:16.080114 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:17.082237 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:18.084099 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:18.910061 #1] DEBUG -- WebsocketClient: verify-connection tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:18.910449 #1] DEBUG -- WebsocketClient: verify_connection: @ping_timer=#<EventMachine::Timer:0x00565518c2d828>
kontena-agent | D, [2016-12-30T13:40:19.084680 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | D, [2016-12-30T13:40:20.086466 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=true
kontena-agent | W, [2016-12-30T13:40:20.921435 #1]  WARN -- Kontena::WebsocketClient: Hit close timeout, abandoning existing websocket connection
kontena-agent | I, [2016-12-30T13:40:20.923993 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:21.087955 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:21.088610 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:21.174002 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:22.174663 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:22.175565 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:22.230152 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:23.231309 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:23.233078 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:23.284991 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:23.911556 #1] DEBUG -- WebsocketClient: verify-connection tick: connected?=false
kontena-agent | D, [2016-12-30T13:40:24.286559 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:24.287392 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:24.334933 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:25.336393 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:25.337118 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:25.398034 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:26.399181 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:26.399547 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:26.431377 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:27.432953 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:27.433607 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:27.516533 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:28.524151 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:28.526196 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:28.548311 #1]  INFO -- Kontena::WebsocketClient: connection closed with code: 1006
kontena-agent | D, [2016-12-30T13:40:28.913249 #1] DEBUG -- WebsocketClient: verify-connection tick: connected?=false
kontena-agent | D, [2016-12-30T13:40:29.549401 #1] DEBUG -- WebsocketClient: ensure-connect tick: connected?=false
kontena-agent | I, [2016-12-30T13:40:29.550106 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://192.168.66.1:9292
kontena-agent | I, [2016-12-30T13:40:29.604503 #1]  INFO -- Kontena::WebsocketClient: connection established
kontena-agent | D, [2016-12-30T13:40:29.627441 #1] DEBUG -- RpcServer: rpc notification: Kontena::Rpc::AgentApi#master_info [{"version"=>"1.0.3"}]
kontena-agent | I, [2016-12-30T13:40:29.629762 #1]  INFO -- Kontena::Workers::QueueWorker: started to process msg queue
kontena-agent | I, [2016-12-30T13:40:29.631893 #1]  INFO -- Kontena::Workers::NodeInfoWorker: publishing node information
kontena-agent | I, [2016-12-30T13:40:29.640915 #1]  INFO -- Kontena::Workers::LogWorker: started log streaming
kontena-agent | D, [2016-12-30T13:40:29.653758 #1] DEBUG -- RpcServer: rpc notification: Kontena::Rpc::AgentApi#node_info [{"id"=>"XI4K:NPOL:EQJ4:S4V7:EN3B:DHC5:KZJD:F3U2:PCAN:46EV:IO4A:63S5", "connected"=>true, "created_at"=>"2016-10-27T08:15:31.084Z", "updated_at"=>"2016-12-30T12:05:30.471Z", "last_seen_at"=>"2016-12-30T13:40:29.615Z", "name"=>"core-01", "os"=>"CoreOS 1185.5.0 (MoreOS)", "engine_root_dir"=>"/var/lib/docker", "driver"=>"overlay", "kernel_version"=>"4.7.3-coreos-r3", "labels"=>nil, "mem_total"=>1045471232, "mem_limit"=>0, "cpus"=>1, "public_ip"=>"82.181.116.101", "private_ip"=>"192.168.66.101", "agent_version"=>"1.0.3", "docker_version"=>"1.11.2", "peer_ips"=>["192.168.66.103"], "node_number"=>1, "initial_member"=>true, "grid"=>{"id"=>"development", "name"=>"development", "initial_size"=>1, "token"=>"tBsoco4sBClMtIOD/bHeIqS1KYM0kZMG7B960jNWWQXMOxqhOf8W1QgiNJlW9u6B/qS+rfS2ZLpC/ZJsyPNj0A==", "stats"=>{"statsd"=>nil}, "trusted_subnets"=>[]}, "resource_usage"=>{"memory"=>{"total"=>1045471232, "free"=>77860864, "buffers"=>25952256, "cached"=>231133184, "active"=>547962880, "inactive"=>134123520, "used"=>967610368}, "load"=>{"1m"=>0.69970703125, "5m"=>0.5859375, "15m"=>0.51611328125}, "filesystem"=>[{"name"=>"/var/lib/docker", "free"=>11573723136, "available"=>10690527232, "used"=>5144670208, "total"=>16718393344}]}}]
kontena-agent | D, [2016-12-30T13:40:29.680681 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:29.682186 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:29.684115 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:29.685798 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:29.744114 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:29.804550 #1] DEBUG -- WebsocketClient: send message with ws?=true...
kontena-agent | D, [2016-12-30T13:40:29.854067 #1] DEBUG -- WebsocketClient: send message with ws?=true...
```