### PR TITLE
Improve how agent rpc server handles requests

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -37,7 +37,8 @@ module Kontena
                   :pid,
                   :hooks,
                   :secrets,
-                  :networks
+                  :networks,
+                  :wait_for_port
 
       # @param [Hash] attrs
       def initialize(attrs = {})
@@ -75,6 +76,7 @@ module Kontena
         @hooks = attrs['hooks'] || []
         @secrets = attrs['secrets'] || []
         @networks = attrs['networks'] || []
+        @wait_for_port = attrs['wait_for_port']
       end
 
       # @return [Boolean]

--- a/agent/lib/kontena/rpc/agent_api.rb
+++ b/agent/lib/kontena/rpc/agent_api.rb
@@ -1,9 +1,6 @@
-require_relative '../helpers/port_helper'
-
 module Kontena
   module Rpc
     class AgentApi
-      include Kontena::Helpers::PortHelper
 
       # @param [Hash] data
       def master_info(data)
@@ -16,15 +13,6 @@ module Kontena
       def node_info(data)
         Celluloid::Notifications.publish('agent:node_info', data)
         {}
-      end
-
-      ##
-      # @param [String] ip
-      # @param [String] port
-      # @param [Float] timeout
-      # @return [Hash]
-      def port_open?(ip, port, timeout = 2.0)
-        {open: container_port_open?(ip, port, timeout)}
       end
 
       private

--- a/agent/lib/kontena/rpc/service_pods_api.rb
+++ b/agent/lib/kontena/rpc/service_pods_api.rb
@@ -13,15 +13,19 @@ module Kontena
       # @return [Hash]
       def create(service)
         service_spec = Kontena::Models::ServicePod.new(service)
-        Kontena::ServicePods::Creator.perform_async(service_spec)
-        {}
+        service_container = Kontena::ServicePods::Creator.new(service_spec).perform
+        if service_container
+          { id: service_container.id }
+        else
+          { id: nil }
+        end
       end
 
       # @param [String] service_id
       # @param [Integer] instance_number
       # @return [Hash]
       def start(service_id, instance_number)
-        Kontena::ServicePods::Starter.perform_async(service_id, instance_number)
+        Kontena::ServicePods::Starter.new(service_id, instance_number).perform
         {}
       end
 
@@ -29,7 +33,7 @@ module Kontena
       # @param [Integer] instance_number
       # @return [Hash]
       def stop(service_id, instance_number)
-        Kontena::ServicePods::Stopper.perform_async(service_id, instance_number)
+        Kontena::ServicePods::Stopper.new(service_id, instance_number).perform
         {}
       end
 
@@ -37,7 +41,7 @@ module Kontena
       # @param [Integer] instance_number
       # @return [Hash]
       def restart(service_id, instance_number)
-        Kontena::ServicePods::Restarter.perform_async(service_id, instance_number)
+        Kontena::ServicePods::Restarter.new(service_id, instance_number).perform
         {}
       end
 
@@ -46,7 +50,7 @@ module Kontena
       # @param [Hash] opts
       # @return [Hash]
       def terminate(service_id, instance_number, opts = {})
-        Kontena::ServicePods::Terminator.perform_async(service_id, instance_number, opts)
+        Kontena::ServicePods::Terminator.new(service_id, instance_number, opts).perform
         {}
       end
     end

--- a/agent/lib/kontena/rpc_server.rb
+++ b/agent/lib/kontena/rpc_server.rb
@@ -46,7 +46,7 @@ module Kontena
           send_message(ws_client, [1, msg_id, {code: 500, message: "#{exc.class.name}: #{exc.message}", backtrace: exc.backtrace}, nil])
         end
       else
-        send_message(ws_client, [1, msg_id, {error: 'service not implemented'}, nil])
+        send_message(ws_client, [1, msg_id, {code: 501, error: 'service not implemented'}, nil])
       end
     end
 

--- a/agent/lib/kontena/rpc_server.rb
+++ b/agent/lib/kontena/rpc_server.rb
@@ -6,6 +6,7 @@ require_relative 'logging'
 
 module Kontena
   class RpcServer
+    include Celluloid
     include Kontena::Logging
 
     HANDLERS = {
@@ -28,7 +29,7 @@ module Kontena
     ##
     # @param [Array] message msgpack-rpc request array
     # @return [Array]
-    def handle_request(message)
+    def handle_request(ws_client, message)
       msg_id = message[1]
       handler = message[2].split('/')[1]
       method = message[2].split('/')[2]
@@ -36,17 +37,23 @@ module Kontena
         begin
           debug "rpc request: #{klass.name}##{method} #{message[3]}"
           result = klass.new.send(method, *message[3])
-          return [1, msg_id, nil, result]
+          send_message(ws_client, [1, msg_id, nil, result])
         rescue RpcServer::Error => exc
-          return [1, msg_id, {code: exc.code, message: exc.message, backtrace: exc.backtrace}, nil]
+          send_message(ws_client, [1, msg_id, {code: exc.code, message: exc.message, backtrace: exc.backtrace}, nil])
         rescue => exc
           error "#{exc.class.name}: #{exc.message}"
           error exc.backtrace.join("\n")
-          return [1, msg_id, {code: 500, message: "#{exc.class.name}: #{exc.message}", backtrace: exc.backtrace}, nil]
+          send_message(ws_client, [1, msg_id, {code: 500, message: "#{exc.class.name}: #{exc.message}", backtrace: exc.backtrace}, nil])
         end
       else
-        return [1, msg_id, {error: 'service not implemented'}, nil]
+        send_message(ws_client, [1, msg_id, {error: 'service not implemented'}, nil])
       end
+    end
+
+    # @param [WebsocketClient] ws_client
+    # @param [Array, Hash] msg
+    def send_message(ws_client, msg)
+      ws_client.send_message(MessagePack.dump(msg).bytes)
     end
 
     ##

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -69,19 +69,6 @@ module Kontena
         self.run_hooks(service_container, 'post_start')
 
         service_container
-      rescue => exc
-        error "#{exc.class.name}: #{exc.message}"
-        error "#{exc.backtrace.join("\n")}" if exc.backtrace
-      end
-
-      # @return [Celluloid::Future]
-      def perform_async
-        Celluloid::Future.new { self.perform }
-      end
-
-      # @param [ServicePod] service_pod
-      def self.perform_async(service_pod)
-        self.new(service_pod).perform_async
       end
 
       # @param [Docker::Container] service_container

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -227,12 +227,15 @@ module Kontena
       # @param [Docker::Container] service_container
       # @param [String] deploy_rev
       def notify_master(service_container, deploy_rev)
-        data = {
-          id: service_container.id,
-          status: 'deployed',
-          deploy_rev: deploy_rev
+        msg = {
+          event: 'container:event',
+          data: {
+            id: service_container.id,
+            status: 'deployed',
+            deploy_rev: deploy_rev
+          }
         }
-        Celluloid::Actor[:event_worker].async.send_notification(data)
+        Celluloid::Actor[:queue_worker].send_message(msg)
       end
 
       # @param [Docker::Container] service_container

--- a/agent/lib/kontena/service_pods/restarter.rb
+++ b/agent/lib/kontena/service_pods/restarter.rb
@@ -32,17 +32,6 @@ module Kontena
 
         service_container
       end
-
-      # @return [Celluloid::Future]
-      def perform_async
-        Celluloid::Future.new { self.perform }
-      end
-
-      # @param [String] service_id
-      # @param [Integer] instance_number
-      def self.perform_async(service_id, instance_number)
-        self.new(service_id, instance_number).perform_async
-      end
     end
   end
 end

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -29,17 +29,6 @@ module Kontena
 
         service_container
       end
-
-      # @return [Celluloid::Future]
-      def perform_async
-        Celluloid::Future.new { self.perform }
-      end
-
-      # @param [String] service_id
-      # @param [Integer] instance_number
-      def self.perform_async(service_id, instance_number)
-        self.new(service_id, instance_number).perform_async
-      end
     end
   end
 end

--- a/agent/lib/kontena/service_pods/stopper.rb
+++ b/agent/lib/kontena/service_pods/stopper.rb
@@ -29,17 +29,6 @@ module Kontena
 
         service_container
       end
-
-      # @return [Celluloid::Future]
-      def perform_async
-        Celluloid::Future.new { self.perform }
-      end
-
-      # @param [String] service_id
-      # @param [Integer] instance_number
-      def self.perform_async(service_id, instance_number)
-        self.new(service_id, instance_number).perform_async
-      end
     end
   end
 end

--- a/agent/lib/kontena/service_pods/terminator.rb
+++ b/agent/lib/kontena/service_pods/terminator.rb
@@ -38,9 +38,6 @@ module Kontena
         end
 
         service_container
-      rescue => exc
-        error exc.message
-        error exc.backtrace.join("\n")
       end
 
       # @param [Docker::Container] service_container

--- a/agent/lib/kontena/service_pods/terminator.rb
+++ b/agent/lib/kontena/service_pods/terminator.rb
@@ -55,18 +55,6 @@ module Kontena
           service_container.instance_number == 1 &&
           @opts['lb'] == true
       end
-
-      # @return [Celluloid::Future]
-      def perform_async
-        Celluloid::Future.new { self.perform }
-      end
-
-      # @param [String] service_id
-      # @param [Integer] instance_number
-      # @param [Hash] opts
-      def self.perform_async(service_id, instance_number, opts = {})
-        self.new(service_id, instance_number, opts).perform_async
-      end
     end
   end
 end

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -70,7 +70,7 @@ module Kontena
       }
       @ws = Faye::WebSocket::Client.new(self.api_uri, nil, {headers: headers})
 
-      Celluloid::Notifications.publish('websocket:connect', self)
+      notify_actors('websocket:connect', self)
 
       @ws.on :open do |event|
         on_open(event)
@@ -100,9 +100,13 @@ module Kontena
       error "failed to send message: #{exc.message}"
     end
 
+    # @param [String] method
+    # @param [Array] params
     def send_notification(method, params)
       data = MessagePack.dump([2, method, params]).bytes
       send_message(data)
+    rescue => exc
+      error "failed to send notification: #{exc.message}"
     end
 
     # @param [Faye::WebSocket::API::Event] event
@@ -111,7 +115,7 @@ module Kontena
       info 'connection established'
       @connected = true
       @connecting = false
-      Celluloid::Notifications.publish('websocket:connect', event)
+      notify_actors('websocket:open', event)
     end
 
     # @param [Faye::WebSocket::API::Event] event
@@ -120,7 +124,7 @@ module Kontena
       if request_message?(data)
         rpc_server.async.handle_request(self, data)
       elsif notification_message?(data)
-        rpc_server.handle_notification(data)
+        rpc_server.async.handle_notification(data)
       end
     rescue => exc
       error exc.message
@@ -172,6 +176,7 @@ module Kontena
       Docker.info['ID']
     end
 
+    # @return [Array<String>]
     def labels
       Docker.info['Labels'].to_a.join(',')
     end
@@ -199,7 +204,7 @@ module Kontena
       return if @close_timer
 
       # stop sending messages, queue them up until reconnected
-      Celluloid::Notifications.publish('websocket:disconnect', nil)
+      notify_actors('websocket:disconnect', nil)
 
       # send close frame; this will get stuck if the server is not replying
       ws.close(1000)
@@ -215,6 +220,10 @@ module Kontena
           on_close Faye::WebSocket::Event.create('close', :code => 1006, :reason => "Close timeout")
         end
       end
+    end
+
+    def notify_actors(event, value)
+      Celluloid::Notifications.publish(event, value)
     end
   end
 end

--- a/agent/spec/lib/kontena/rpc/agent_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/agent_api_spec.rb
@@ -5,21 +5,6 @@ describe Kontena::Rpc::AgentApi do
   before(:each) { Celluloid.boot }
   after(:each) { Celluloid.shutdown }
 
-  describe '#port_open?' do
-    it 'returns {open: false} if port is not open' do
-      expect(subject.port_open?('100.64.2.2', 6379, 0.01)).to eq({open: false})
-    end
-
-    it 'returns {open: true} if port is listening' do
-      begin
-        server = TCPServer.new 18232
-        expect(subject.port_open?('127.0.0.1', 18232, 0.01)).to eq({open: true})
-      ensure
-        server.close if server
-      end
-    end
-  end
-
   describe '#master_info' do
     it 'sends publishes event' do
       info = {'version' => '0.10.0'}

--- a/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
@@ -36,30 +36,38 @@ describe Kontena::Rpc::ServicePodsApi do
     }
   end
 
+  let(:executor) do
+    double(:executor)
+  end
+
   describe '#create' do
     it 'calls service pod creator' do
-      expect(Kontena::ServicePods::Creator).to receive(:perform_async)
+      expect(Kontena::ServicePods::Creator).to receive(:new).and_return(executor)
+      expect(executor).to receive(:perform)
       subject.create(data)
     end
   end
 
   describe '#start' do
     it 'calls service pod starter' do
-      expect(Kontena::ServicePods::Starter).to receive(:perform_async)
+      expect(Kontena::ServicePods::Starter).to receive(:new).and_return(executor)
+      expect(executor).to receive(:perform)
       subject.start('service_id', 2)
     end
   end
 
   describe '#stop' do
     it 'calls service pod stopper' do
-      expect(Kontena::ServicePods::Stopper).to receive(:perform_async)
+      expect(Kontena::ServicePods::Stopper).to receive(:new).and_return(executor)
+      expect(executor).to receive(:perform)
       subject.stop('service_id', 2)
     end
   end
 
   describe '#restart' do
     it 'calls service pod restarter' do
-      expect(Kontena::ServicePods::Restarter).to receive(:perform_async)
+      expect(Kontena::ServicePods::Restarter).to receive(:new).and_return(executor)
+      expect(executor).to receive(:perform)
       subject.restart('service_id', 2)
     end
   end

--- a/agent/spec/lib/kontena/rpc_server_spec.rb
+++ b/agent/spec/lib/kontena/rpc_server_spec.rb
@@ -16,7 +16,7 @@ describe Kontena::RpcServer do
     stub_const("Kontena::RpcServer::HANDLERS", {'hello' => HelloWorld})
     Celluloid.boot
   end
-  
+
   after(:each) { Celluloid.shutdown }
 
   describe '#handle_request' do
@@ -27,7 +27,7 @@ describe Kontena::RpcServer do
 
     it 'responses with error if handler not found' do
       expect(subject.wrapped_object).to receive(:send_message).with(
-        ws_client, [1, 99, {:error=>"service not implemented"}, nil]
+        ws_client, [1, 99, {code: 501, error: "service not implemented"}, nil]
       )
       subject.handle_request(ws_client, [1, 99, '/foo/bar', ['world']])
     end

--- a/agent/spec/lib/kontena/rpc_server_spec.rb
+++ b/agent/spec/lib/kontena/rpc_server_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../../spec_helper'
+
+describe Kontena::RpcServer do
+
+  class HelloWorld
+    def hello(msg)
+      { msg: "hello #{msg}" }
+    end
+  end
+
+  let(:ws_client) do
+    double(:ws_client)
+  end
+
+  before(:each) do
+    stub_const("Kontena::RpcServer::HANDLERS", {'hello' => HelloWorld})
+  end
+
+  describe '#handle_request' do
+    it 'calls handler and sends response back to ws_client' do
+      expect(subject.wrapped_object).to receive(:send_message).with(ws_client, [1, 99, nil, {msg: 'hello world'}])
+      subject.handle_request(ws_client, [1, 99, '/hello/hello', ['world']])
+    end
+
+    it 'responses with error if handler not found' do
+      expect(subject.wrapped_object).to receive(:send_message).with(
+        ws_client, [1, 99, {:error=>"service not implemented"}, nil]
+      )
+      subject.handle_request(ws_client, [1, 99, '/foo/bar', ['world']])
+    end
+  end
+end

--- a/agent/spec/lib/kontena/rpc_server_spec.rb
+++ b/agent/spec/lib/kontena/rpc_server_spec.rb
@@ -14,7 +14,10 @@ describe Kontena::RpcServer do
 
   before(:each) do
     stub_const("Kontena::RpcServer::HANDLERS", {'hello' => HelloWorld})
+    Celluloid.boot
   end
+  
+  after(:each) { Celluloid.shutdown }
 
   describe '#handle_request' do
     it 'calls handler and sends response back to ws_client' do

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -55,7 +55,8 @@ module Docker
         exposed: grid_service.stack_exposed?,
         log_driver: grid_service.log_driver,
         log_opts: grid_service.log_opts,
-        pid: grid_service.pid
+        pid: grid_service.pid,
+        wait_for_port: grid_service.deploy_opts.wait_for_port
       }
       spec[:env] = build_env(instance_number)
       spec[:secrets] = build_secrets
@@ -82,7 +83,7 @@ module Docker
     ##
     # @return [RpcClient]
     def client
-      RpcClient.new(host_node.node_id, 5)
+      RpcClient.new(host_node.node_id, 300)
     end
 
     ##

--- a/server/app/services/docker/service_terminator.rb
+++ b/server/app/services/docker/service_terminator.rb
@@ -30,7 +30,7 @@ module Docker
     ##
     # @return [RpcClient]
     def client
-      RpcClient.new(host_node.node_id, 30)
+      RpcClient.new(host_node.node_id, 60)
     end
   end
 end


### PR DESCRIPTION
This PR has following improvements:

- RpcServer is now pool of actors
- WebsocketClient is passed to RpcServer actor and actor is called with async
- ServicePod requests return only after they have completed
- server can wait request to finish (no polling)
- wait for port functionality has been moved to agent side