### PR TITLE
CLI: Fix kontena grid cloud-config network units

### DIFF
--- a/cli/lib/kontena/cli/grids/cloud_config_command.rb
+++ b/cli/lib/kontena/cli/grids/cloud_config_command.rb
@@ -30,8 +30,9 @@ module Kontena::Cli::Grids
         # use explicit value
       elsif peer_interface =~ /^([a-z]+)(\d+)$/
         default_interface_match = "#{$1}*"
+        warning "Guessing --default-interface-match=#{default_interface_match} from --peer-interface=#{peer_interface}, make sure that this matches the interface names used by the node platform"
       else
-        error "Unable to determine --default-interface-match from --peer-interface=#{peer_interface}, configure --default-interface-match= explicitly"
+        exit_with_error "Unable to determine --default-interface-match from --peer-interface=#{peer_interface}, configure --default-interface-match= explicitly"
       end
 
       require 'kontena/machine/cloud_config/node_generator'

--- a/cli/lib/kontena/cli/grids/cloud_config_command.rb
+++ b/cli/lib/kontena/cli/grids/cloud_config_command.rb
@@ -8,6 +8,7 @@ module Kontena::Cli::Grids
     parameter "NAME", "Grid name"
     option "--dns", "DNS",  "DNS server", multivalued: true
     option "--peer-interface", "IFACE", "Peer (private) network interface", default: "eth1"
+    option "--default-interface-match", "IFACE-GLOB", "Match default network interfaces", default: nil
     option "--docker-bip", "BIP", "Docker bridge ip", default: "172.17.43.1/16"
     option "--version", "VERSION", "Agent version", default: "latest"
 
@@ -25,6 +26,14 @@ module Kontena::Cli::Grids
         dns_servers = [default_dns, '8.8.8.8', '8.8.4.4']
       end
 
+      if default_interface_match
+        # use explicit value
+      elsif peer_interface =~ /^([a-z]+)(\d+)$/
+        default_interface_match = "#{$1}*"
+      else
+        error "Unable to determine --default-interface-match from --peer-interface=#{peer_interface}, configure --default-interface-match= explicitly"
+      end
+
       require 'kontena/machine/cloud_config/node_generator'
       generator = Kontena::Machine::CloudConfig::NodeGenerator.new
       config = generator.generate(
@@ -33,7 +42,8 @@ module Kontena::Cli::Grids
         peer_interface: peer_interface,
         dns_servers: dns_servers,
         docker_bip: docker_bip,
-        version: version
+        version: version,
+        match_default_network_name: default_interface_match,
       )
       puts config
     end

--- a/cli/lib/kontena/machine/cloud_config/cloudinit.yml
+++ b/cli/lib/kontena/machine/cloud_config/cloudinit.yml
@@ -19,8 +19,6 @@ write_files:
       fs.inotify.max_user_instances = 8192
 coreos:
   units:
-    - name: 10-weave.network
-      mask: true
     - name: 50-docker.network
       mask: true
     - name: 50-docker-veth.network

--- a/cli/lib/kontena/machine/cloud_config/cloudinit.yml
+++ b/cli/lib/kontena/machine/cloud_config/cloudinit.yml
@@ -33,7 +33,7 @@ coreos:
         DHCP=yes
         <% dns_servers.each do |dns| %>DNS=<%= dns %>
         <% end %>
-        DOMAINS=kontena.local
+        Domains=kontena.local
 
         [DHCP]
         UseMTU=true

--- a/cli/lib/kontena/machine/cloud_config/cloudinit.yml
+++ b/cli/lib/kontena/machine/cloud_config/cloudinit.yml
@@ -27,7 +27,7 @@ coreos:
       content: |
         # default should not match virtual Docker/weave bridge/veth network interfaces
         [Match]
-        Name=eth*
+        Name=<%= match_default_network_name %>
 
         [Network]
         DHCP=yes

--- a/cli/lib/kontena/machine/cloud_config/cloudinit.yml
+++ b/cli/lib/kontena/machine/cloud_config/cloudinit.yml
@@ -19,27 +19,28 @@ write_files:
       fs.inotify.max_user_instances = 8192
 coreos:
   units:
-    - name: 00-eth.network
-      runtime: true
+    - name: 10-weave.network
+      mask: true
+    - name: 50-docker.network
+      mask: true
+    - name: 50-docker-veth.network
+      mask: true
+    - name: zz-default.network
       content: |
+        # default should not match virtual Docker/weave bridge/veth network interfaces
         [Match]
         Name=eth*
+
         [Network]
         DHCP=yes
         <% dns_servers.each do |dns| %>DNS=<%= dns %>
         <% end %>
         DOMAINS=kontena.local
+
         [DHCP]
+        UseMTU=true
         UseDNS=false
 
-    - name: 10-weave.network
-      runtime: false
-      content: |
-        [Match]
-        Type=bridge
-        Name=weave*
-
-        [Network]
     - name: kontena-agent.service
       command: start
       enable: true


### PR DESCRIPTION
Fix `kontena grid cloud-config` for current #1264 CoreOS stable systemd-networkd issues.

This should match the cloud-config that the plugins are using for provisioning, and the `zz-default.network` `[Match] Name=eth*` matches what this command has always generated.

OTOH, the previous `00-eth.network` file matching `eth*` would NOT override the `zz-default.network`, so it is possible that this updated cloud-config would break networking, if the previous `00-eth.network` was not used, and this replaces the previously used `zz-default.network`.

## Usage

```
$ kontena grid cloud-config test > cloud-config.yaml
 [warn] Guessing --default-interface-match=eth* from --peer-interface=eth1, make sure that this matches the interface names used by the node platform
$ kontena grid cloud-config --peer-interface=em5p1 test > cloud-config.yaml
 [error] Unable to determine --default-interface-match from --peer-interface=em5p1, configure --default-interface-match= explicitly
$ kontena grid cloud-config --peer-interface=em5p1 --default-interface-match=em*p* test > cloud-config.yaml 
```

## Testing

Seems to work as intended for an existing node

```
core@hidden-river-52 ~ $ sudo coreos-cloudinit -from-file cloud-config.yaml
2017/01/04 16:12:26 Checking availability of "local-file"
2017/01/04 16:12:26 Fetching user-data from datasource of type "local-file"
2017/01/04 16:12:26 Fetching meta-data from datasource of type "local-file"
2017/01/04 16:12:26 Parsing user-data as cloud-config
2017/01/04 16:12:26 Merging cloud-config from meta-data and user-data
2017/01/04 16:12:26 Writing file to "/etc/kontena-agent.env"
2017/01/04 16:12:26 Wrote file to "/etc/kontena-agent.env"
2017/01/04 16:12:26 Wrote file /etc/kontena-agent.env to filesystem
2017/01/04 16:12:26 Writing file to "/etc/systemd/system/docker.service.d/50-kontena.conf"
2017/01/04 16:12:26 Wrote file to "/etc/systemd/system/docker.service.d/50-kontena.conf"
2017/01/04 16:12:26 Wrote file /etc/systemd/system/docker.service.d/50-kontena.conf to filesystem
2017/01/04 16:12:26 Writing file to "/etc/sysctl.d/99-inotify.conf"
2017/01/04 16:12:26 Wrote file to "/etc/sysctl.d/99-inotify.conf"
2017/01/04 16:12:26 Wrote file /etc/sysctl.d/99-inotify.conf to filesystem
2017/01/04 16:12:26 Updated /etc/environment
2017/01/04 16:12:26 Masking unit file "10-weave.network"
2017/01/04 16:12:26 Masking unit file "50-docker.network"
2017/01/04 16:12:26 Masking unit file "50-docker-veth.network"
2017/01/04 16:12:26 Writing unit "zz-default.network" to filesystem
2017/01/04 16:12:26 Writing file to "/etc/systemd/network/zz-default.network"
2017/01/04 16:12:26 Wrote file to "/etc/systemd/network/zz-default.network"
2017/01/04 16:12:26 Wrote unit "zz-default.network"
2017/01/04 16:12:26 Writing unit "kontena-agent.service" to filesystem
2017/01/04 16:12:26 Writing file to "/etc/systemd/system/kontena-agent.service"
2017/01/04 16:12:26 Wrote file to "/etc/systemd/system/kontena-agent.service"
2017/01/04 16:12:26 Wrote unit "kontena-agent.service"
2017/01/04 16:12:26 Enabling unit file "kontena-agent.service"
2017/01/04 16:12:26 Enabled unit "kontena-agent.service"
2017/01/04 16:12:26 Ensuring runtime unit file "etcd.service" is unmasked
2017/01/04 16:12:26 Ensuring runtime unit file "etcd2.service" is unmasked
2017/01/04 16:12:26 Ensuring runtime unit file "fleet.service" is unmasked
2017/01/04 16:12:26 Ensuring runtime unit file "locksmithd.service" is unmasked
2017/01/04 16:12:26 Restarting systemd-networkd
2017/01/04 16:12:27 Restarted systemd-networkd (done)
2017/01/04 16:12:27 Calling unit command "start" on "kontena-agent.service"'
2017/01/04 16:12:27 Result of "start" on "kontena-agent.service": done
core@hidden-river-52 ~ $ networkctl 
IDX LINK             TYPE               OPERATIONAL SETUP     
  1 lo               loopback           carrier     unmanaged 
  2 eth0             ether              routable    configuring
  3 eth1             ether              routable    configuring
  4 docker0          ether              no-carrier  unmanaged 
  5 datapath         ether              degraded    unmanaged 
  7 weave            ether              routable    unmanaged 
  8 dummy0           ether              off         unmanaged 
 10 vethwe-datapath  ether              degraded    unmanaged 
 11 vethwe-bridge    ether              degraded    unmanaged 
 12 vxlan-6784       ether              degraded    unmanaged 

10 links listed.
core@hidden-river-52 ~ $ ls -laR /{etc,lib,run}/systemd/network/
/etc/systemd/network/:
total 36
drwxr-xr-x. 2 root root 4096 Jan  4 16:12 .
drwxr-xr-x. 6 root root 4096 Jan  3 12:08 ..
lrwxrwxrwx. 1 root root    9 Jan  4 16:12 10-weave.network -> /dev/null
lrwxrwxrwx. 1 root root    9 Jan  4 16:12 50-docker-veth.network -> /dev/null
lrwxrwxrwx. 1 root root    9 Jan  4 16:12 50-docker.network -> /dev/null
-rw-r--r--. 1 root root  213 Jan  4 16:12 zz-default.network

/lib/systemd/network/:
total 104
drwxr-xr-x.  2 root root 4096 Dec  7 09:53 .
drwxr-xr-x. 13 root root 4096 Dec  7 09:51 ..
-rw-r--r--.  1 root root   31 Dec  7 09:31 50-docker-veth.network
-rw-r--r--.  1 root root   44 Dec  7 09:31 50-docker.network
-rw-r--r--.  1 root root   33 Dec  7 09:21 50-flannel.network
-rw-r--r--.  1 root root  605 Dec  7 09:28 80-container-host0.network
-rw-r--r--.  1 root root  678 Dec  7 09:28 80-container-ve.network
-rw-r--r--.  1 root root  664 Dec  7 09:28 80-container-vz.network
-rw-r--r--.  1 root root  277 Dec  7 09:31 98-virtio.link
-rw-r--r--.  1 root root   80 Dec  7 09:28 99-default.link
-rw-r--r--.  1 root root  109 Dec  7 09:31 yy-pxe.network
-rw-r--r--.  1 root root  108 Dec  7 09:31 yy-vmware.network
-rw-r--r--.  1 root root   55 Dec  7 09:31 zz-default.network

/run/systemd/network/:
total 16
drwxr-xr-x.  2 root root 140 Jan  4 16:11 .
drwxr-xr-x. 18 root root 460 Jan  4 16:12 ..
-rw-r--r--.  1 root root 165 Jan  3 12:08 00-56:b4:c1:6f:d7:54.network
-rw-r--r--.  1 root root 299 Jan  3 12:08 00-86:57:db:26:05:99.network
-rw-r--r--.  1 root root 120 Jan  4 16:11 00-eth.network
-rw-r--r--.  1 root root  43 Jan  3 12:08 99-public-interface.network
lrwxrwxrwx.  1 root root  22 Jan  3 12:08 resolv.conf -> ../resolve/resolv.conf
```