### PR TITLE
LB link removal removes service from lb

### DIFF
--- a/agent/lib/kontena/load_balancers/configurer.rb
+++ b/agent/lib/kontena/load_balancers/configurer.rb
@@ -15,6 +15,7 @@ module Kontena::LoadBalancers
       @etcd = Etcd.client(host: self.class.gateway, port: 2379)
       subscribe('lb:ensure_config', :on_ensure_config)
       subscribe('lb:remove_config', :on_remove_config)
+      subscribe('lb:remove_service', :on_remove_service)
       info 'initialized'
     end
 
@@ -24,6 +25,10 @@ module Kontena::LoadBalancers
 
     def on_remove_config(topic, event)
       self.remove_config(event)
+    end
+
+    def on_remove_service(topic, event)
+      self.remove_service(event)
     end
 
     # @param [Docker::Container] container
@@ -89,6 +94,31 @@ module Kontena::LoadBalancers
     rescue => exc
       error "#{exc.class.name}: #{exc.message}"
     end
+
+
+    # @param [Docker::Container] container
+    def remove_service(container)
+      service_name = container.service_name_for_lb
+      lsdir(ETCD_PREFIX).each do |key|
+        if key_exists?("#{key}/services")
+          # un-stacked lb
+          debug "ensuring service removal from un-stacked lb at: #{key}"
+          rmdir("#{key}/services/#{service_name}") rescue nil
+          rmdir("#{key}/tcp-services/#{service_name}") rescue nil
+        else
+          # stacked lb
+          lsdir(key).each do |lb|
+            debug "ensuring service removal from stacked lb at: #{lb}"
+            rmdir("#{lb}/services/#{service_name}") rescue nil
+            rmdir("#{lb}/tcp-services/#{service_name}") rescue nil
+          end
+        end
+      end
+    rescue => exc
+      error "#{exc.class.name}: #{exc.message}"
+    end
+
+
 
     # @param [String] key
     # @param [String, NilClass] value

--- a/agent/lib/kontena/load_balancers/configurer.rb
+++ b/agent/lib/kontena/load_balancers/configurer.rb
@@ -100,7 +100,7 @@ module Kontena::LoadBalancers
     def remove_service(container)
       service_name = container.service_name_for_lb
       lsdir(ETCD_PREFIX).each do |key|
-        if key_exists?("#{key}/services")
+        if key_exists?("#{key}/services") || key_exists?("#{key}/tcp-services")
           # un-stacked lb
           debug "ensuring service removal from un-stacked lb at: #{key}"
           rmdir("#{key}/services/#{service_name}") rescue nil

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -49,6 +49,8 @@ module Kontena
         debug "container created: #{service_pod.name}"
         if service_container.load_balanced? && service_container.instance_number == 1
           Celluloid::Notifications.publish('lb:ensure_config', service_container)
+        else
+          Celluloid::Notifications.publish('lb:remove_service', service_container)
         end
 
         service_container.start

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -49,7 +49,7 @@ module Kontena
         debug "container created: #{service_pod.name}"
         if service_container.load_balanced? && service_container.instance_number == 1
           Celluloid::Notifications.publish('lb:ensure_config', service_container)
-        else
+        elsif !service_container.load_balanced? && service_container.instance_number == 1
           Celluloid::Notifications.publish('lb:remove_service', service_container)
         end
 
@@ -170,6 +170,7 @@ module Kontena
         return false if service_container.config['Image'] != service_pod.image_name
         return false if container_outdated?(service_container)
         return false if image_outdated?(service_pod.image_name, service_container)
+        return false if labels_outdated?(service_pod.labels, service_container)
 
         true
       end
@@ -206,6 +207,14 @@ module Kontena
         service_container.autostart? &&
             !service_container.running? &&
             (!state['Error'].empty? || state['ExitCode'].to_i != 0)
+      end
+
+      # @param [Hash] labels Labels of the service pod
+      # @param [Docker::Container] service_container
+      def labels_outdated?(labels, service_container)
+        return true if labels['io.kontena.load_balancer.name'] != service_container.labels['io.kontena.load_balancer.name']
+
+        false
       end
 
       # @param [Docker::Container] service_container

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -186,12 +186,16 @@ describe Kontena::LoadBalancers::Configurer do
 
       expect(subject.wrapped_object).to receive(:key_exists?).
         with('/kontena/haproxy/stack1/services').and_return(false)
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/stack1/tcp-services').and_return(false)
       expect(subject.wrapped_object).to receive(:lsdir).
         with("#{etcd_prefix}/stack1").
         and_return(['/kontena/haproxy/stack1/lb1'])
 
       expect(subject.wrapped_object).to receive(:key_exists?).
         with('/kontena/haproxy/stack2/services').and_return(false)
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/stack2/tcp-services').and_return(false)
       expect(subject.wrapped_object).to receive(:lsdir).
         with("#{etcd_prefix}/stack2").
         and_return(['/kontena/haproxy/stack2/lb2'])
@@ -215,6 +219,8 @@ describe Kontena::LoadBalancers::Configurer do
 
       expect(subject.wrapped_object).to receive(:key_exists?).
         with('/kontena/haproxy/stack1/services').and_return(false)
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/stack1/tcp-services').and_return(false)
       expect(subject.wrapped_object).to receive(:lsdir).
         with("#{etcd_prefix}/stack1").
         and_return(['/kontena/haproxy/stack1/lb1'])

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -158,4 +158,80 @@ describe Kontena::LoadBalancers::Configurer do
       subject.remove_config(container)
     end
   end
+
+  describe "#remove_service" do
+    it 'removes service from null stacked lbs' do
+      expect(subject.wrapped_object).to receive(:lsdir).
+        and_return(['/kontena/haproxy/lb1', '/kontena/haproxy/lb2'])
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/lb1/services').and_return(true)
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/lb2/services').and_return(true)
+      # service should be removed from all lb's
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/lb1/services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/lb1/tcp-services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/lb2/services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/lb2/tcp-services/test-api")
+      subject.remove_service(container)
+    end
+
+    it 'removes service from stacked lbs' do
+      expect(subject.wrapped_object).to receive(:lsdir).
+        with("#{etcd_prefix}").
+        and_return(['/kontena/haproxy/stack1', '/kontena/haproxy/stack2'])
+
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/stack1/services').and_return(false)
+      expect(subject.wrapped_object).to receive(:lsdir).
+        with("#{etcd_prefix}/stack1").
+        and_return(['/kontena/haproxy/stack1/lb1'])
+
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/stack2/services').and_return(false)
+      expect(subject.wrapped_object).to receive(:lsdir).
+        with("#{etcd_prefix}/stack2").
+        and_return(['/kontena/haproxy/stack2/lb2'])
+
+      # service should be removed from all lb's
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/stack1/lb1/services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/stack1/lb1/tcp-services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/stack2/lb2/services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/stack2/lb2/tcp-services/test-api")
+      subject.remove_service(container)
+    end
+
+    it 'removes service from stacked and un-stacked lbs' do
+      expect(subject.wrapped_object).to receive(:lsdir).
+        with("#{etcd_prefix}").
+        and_return(['/kontena/haproxy/stack1', '/kontena/haproxy/lb2'])
+
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/stack1/services').and_return(false)
+      expect(subject.wrapped_object).to receive(:lsdir).
+        with("#{etcd_prefix}/stack1").
+        and_return(['/kontena/haproxy/stack1/lb1'])
+
+      expect(subject.wrapped_object).to receive(:key_exists?).
+        with('/kontena/haproxy/lb2/services').and_return(true)
+
+      # service should be removed from all lb's
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/stack1/lb1/services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/stack1/lb1/tcp-services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/lb2/services/test-api")
+      expect(subject.wrapped_object).to receive(:rmdir).
+        with("#{etcd_prefix}/lb2/tcp-services/test-api")
+      subject.remove_service(container)
+    end
+  end
 end

--- a/agent/spec/lib/kontena/service_pods/creator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/creator_spec.rb
@@ -84,7 +84,8 @@ describe Kontena::ServicePods::Creator do
         },
         config: {
           'Image' => service_pod.image_name
-        }
+        },
+        labels: {}
       )
       allow(Docker::Image).to receive(:get).and_return(spy(:image, info: {
         'Created' => (Time.now.utc + 1).to_s
@@ -168,6 +169,30 @@ describe Kontena::ServicePods::Creator do
 
         expect(config.dig('HostConfig', 'NetworkMode')).to eq('host')
         expect(config.dig('Entrypoint')).to be_nil
+      end
+    end
+
+    describe '#labels_outdated?' do
+      it 'returns true when labels are outdated' do
+        service_container = spy(:service_container,
+          labels: { 'io.kontena.load_balancer.name' => 'lb'}
+        )
+        expect(subject.labels_outdated?({}, service_container)).to be_truthy
+        expect(subject.labels_outdated?({ 'io.kontena.load_balancer.name' => 'lb2'}, service_container)).to be_truthy
+      end
+
+      it 'returns false with empty labels' do
+        service_container = spy(:service_container,
+          labels: {}
+        )
+        expect(subject.labels_outdated?({}, service_container)).to be_falsey
+      end
+
+      it 'returns false with up-to-date labels' do
+        service_container = spy(:service_container,
+          labels: { 'io.kontena.load_balancer.name' => 'lb'}
+        )
+        expect(subject.labels_outdated?({ 'io.kontena.load_balancer.name' => 'lb'}, service_container)).to be_falsey
       end
     end
 


### PR DESCRIPTION
When lb link is removed from the service, load balancer configuration was left behind.

This PR fixes that by issuing total service removal on all lb's when service is deployed with no links to loadbalancers.
fixes #1622 

```
$ k service create --link lb -e KONTENA_LB_VIRTUAL_PATH=/ nginx nginx && k service deploy nginx 
...
$ k etcd ls --recursive /kontena/haproxy
/kontena/haproxy
/kontena/haproxy/lb
/kontena/haproxy/lb/aliases
/kontena/haproxy/lb/certs
/kontena/haproxy/lb/services
/kontena/haproxy/lb/services/nginx
/kontena/haproxy/lb/services/nginx/upstreams
/kontena/haproxy/lb/services/nginx/upstreams/null-nginx-1
/kontena/haproxy/lb/services/nginx/balance
/kontena/haproxy/lb/services/nginx/virtual_path
/kontena/haproxy/lb/tcp-services
```
After unlinking and deployment:
```
$ k etcd ls --recursive /kontena/haproxy
/kontena/haproxy
/kontena/haproxy/lb
/kontena/haproxy/lb/aliases
/kontena/haproxy/lb/certs
/kontena/haproxy/lb/services
/kontena/haproxy/lb/tcp-services
```
