### PR TITLE
server: Fix EventMachine to abort on exceptions

### DIFF
--- a/server/app/initializers/eventmachine.rb
+++ b/server/app/initializers/eventmachine.rb
@@ -1,4 +1,13 @@
 EM.epoll
 
-Thread.new { EventMachine.run } unless EventMachine.reactor_running?
-sleep 0.01 until EventMachine.reactor_running?
+if EventMachine.reactor_running?
+  # Fail if some require'd library (such as faye-websocket) has already started EM without exception handling
+  abort "EventMachine is already running, refusing to start"
+else
+  # Run EventMachine, and abort on exceptions
+  Thread.new {
+    Thread.current.abort_on_exception = true
+    EventMachine.run
+  }
+  sleep 0.01 until EventMachine.reactor_running?
+end


### PR DESCRIPTION
Fixes #1603 for server

Closes #1630

With `Thread.current.abort_on_exception = true`, uncaught exceptions in the EM thread will crash the process, and puma will restart the worker, allowing the server to recover.

With the previous lack of `abort_on_exception`, things like mongo connection errors could cause the server's websocket backend to get stuck and behave in weird ways without logging any errors.

## Testing

Injecting a tactical fault into a part of the websocket backend that doesn't have explicit exception handling:

```diff
--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -139,6 +139,8 @@ class WebsocketBackend
   ##
   # @param [Array] data
   def handle_rpc_response(data)
+    raise "pretend mongo died" if data.inspect =~ /crash/
+
     MongoPubsub.publish_async("rpc_client:#{data[1]}", {message: data})
   end
```

Allows the server to restart and log the resulting RPC response -> mongo error case:

```
[388] - Worker 0 (pid: 391) booted, phase: 0
I, [2017-01-05T14:10:22.453965 #391]  INFO -- WebsocketBackend: node opened connection: core-01, labels: []
I, [2017-01-05T14:10:28.328900 #391]  INFO -- Cloud::WebsocketClient: cloud connection opened to wss://socket.kontena.io
D, [2017-01-05T14:10:30.868747 #391] DEBUG -- TokenAuthentication: Access token found
127.0.0.1 - - [05/Jan/2017:14:10:30 +0200] "POST /v1/services/development/null/redis/restart HTTP/1.1" 200 2 0.0800
I, [2017-01-05T14:10:30.926835 #391]  INFO -- WebsocketBackend: node closed connection: core-01
I, [2017-01-05T14:10:30.927193 #391]  INFO -- Cloud::WebsocketClient: cloud connection closed with code: 1006
D, [2017-01-05T14:10:30.929338 #391] DEBUG -- : Terminating 41 actors...
W, [2017-01-05T14:10:30.931049 #391]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:receiving
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.931233 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:watch}, status=:sleeping
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.931499 #391]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:receiving
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.931602 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:watch}, status=:sleeping
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.932365 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:tail!}, status=:receiving
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.932695 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:perform}, status=:sleeping
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.932858 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:perform}, status=:receiving
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.932986 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:perform}, status=:sleeping
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.933755 #391]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:receiving
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.934149 #391]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:receiving
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.934250 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:watch}, status=:sleeping
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.935834 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:watch}, status=:sleeping
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.937084 #391]  WARN -- : Terminating task: type=:finalizer, meta={:method_name=>:__shutdown__}, status=:receiving
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
W, [2017-01-05T14:10:30.937371 #391]  WARN -- : Terminating task: type=:call, meta={:method_name=>:perform}, status=:sleeping
	Celluloid::TaskFiber backtrace unavailable. Please try `Celluloid.task_class = Celluloid::TaskThread` if you need backtraces here.
I, [2017-01-05T14:10:31.815364 #493]  INFO -- ContainerCleanupJob: starting to cleanup stale containers
I, [2017-01-05T14:10:31.816537 #493]  INFO -- MongoPubsub: starting to tail collection
I, [2017-01-05T14:10:31.817148 #493]  INFO -- DistributedLockCleanupJob: starting to cleanup stale locks
I, [2017-01-05T14:10:31.820640 #493]  INFO -- NodeCleanupJob: starting to cleanup stale connections
I, [2017-01-05T14:10:31.821311 #493]  INFO -- NodeCleanupJob: starting to cleanup stale nodes
I, [2017-01-05T14:10:31.821590 #493]  INFO -- ServiceBalancerJob: starting to watch services
I, [2017-01-05T14:10:31.822340 #493]  INFO -- LeaderElectorJob: participating leader elections
I, [2017-01-05T14:10:31.884129 #493]  INFO -- LeaderElectorJob: won election ♚
[388] - Worker 0 (pid: 493) booted, phase: 0
I, [2017-01-05T14:10:32.036218 #493]  INFO -- WebsocketBackend: node opened connection: core-01, labels: []
/home/kontena/kontena/kontena/server/app/middlewares/websocket_backend.rb:142:in `handle_rpc_response': pretend mongo died (RuntimeError)
	from /home/kontena/kontena/kontena/server/app/middlewares/websocket_backend.rb:104:in `block in on_message'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/eventmachine-1.0.8/lib/eventmachine.rb:976:in `block in run_deferred_callbacks'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/eventmachine-1.0.8/lib/eventmachine.rb:973:in `times'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/eventmachine-1.0.8/lib/eventmachine.rb:973:in `run_deferred_callbacks'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/eventmachine-1.0.8/lib/eventmachine.rb:193:in `run_machine'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/eventmachine-1.0.8/lib/eventmachine.rb:193:in `run'
	from /home/kontena/kontena/kontena/server/app/initializers/eventmachine.rb:10:in `block in <top (required)>'
I, [2017-01-05T14:10:38.116914 #493]  INFO -- Cloud::WebsocketClient: cloud connection opened to wss://socket.kontena.io
```

The server restarts, and is able to continue working:

```
tehobari:~/kontena/kontena/cli :: bundle exec bin/kontena etcd ls /kontena/
/kontena
/kontena/haproxy
/kontena/ipam
/kontena/log_worker
/kontena/test
tehobari:~/kontena/kontena/cli :: bundle exec bin/kontena etcd set /kontena/test/crash crash
 [error] Internal Server Error
tehobari:~/kontena/kontena/cli :: bundle exec bin/kontena etcd ls /kontena/
/kontena
/kontena/haproxy
/kontena/ipam
/kontena/log_worker
/kontena/test
```