### PR TITLE
Install plugins without shelling out and put them under .kontena/gems

### DIFF
--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -12,7 +12,7 @@ require 'kontena_cli'
 STDOUT.sync = true
 
 begin
-  Kontena::PluginManager.instance.load_plugins
+  Kontena::PluginManager.instance.init
   Kontena::MainCommand.run
 rescue Excon::Errors::SocketError => exc
   if exc.message.include?('Unable to verify certificate')

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -11,38 +11,22 @@ module Kontena::Cli::Plugins
     option '--pre', :flag, 'Allow pre-release of a plugin to be installed', default: false
 
     def execute
-      require 'shellwords'
-      install_plugin(name)
-    end
-
-    def install_plugin(name)
-      plugin = "kontena-plugin-#{name}"
-      uninstall_previous(plugin) if plugin_exists?(plugin)
-      install_options = ['--no-ri', '--no-doc']
-      install_options << "--version #{version}" if version
-      install_options << "--pre" if pre?
-      install_options << plugin
-      install_command = "#{gem_bin} install #{install_options.shelljoin}"
       ENV["DEBUG"] && STDERR.puts("Running #{install_command}")
-      spinner "Installing plugin #{name.colorize(:cyan)}" do
-        stdout, stderr, status = Open3.capture3(install_command)
-        raise(RuntimeError, stderr) unless status.success?
+      installed = spinner "Installing plugin #{name.colorize(:cyan)}" do |spin|
+        begin
+          Kontena::PluginManager.instance.install_plugin(name, pre: pre?, version: version)
+        rescue => ex
+          puts ex.message
+          spin.fail
+        end
       end
-    end
 
-    def plugin_exists?(name)
-      Kontena::PluginManager.instance.plugins.any? { |p| p.name == name}
-    end
-
-    def gem_bin
-      @gem_bin ||= which('gem')
-    end
-
-    def uninstall_previous(name)
-      uninstall_command = "#{gem_bin} uninstall -q #{name.shellescape}"
-      spinner "Uninstalling previous version of plugin" do
-        stdout, stderr, status = Open3.capture3(uninstall_command)
-        raise(RuntimeError, stderr) unless status.success?
+      Array(installed).each do |gem|
+        if gem.name.start_with?('kontena-plugin-')
+          puts Kontena.pastel.green("Installed plugin #{gem.name.sub('kontena-plugin-', '')} version #{gem.version}")
+        else
+          puts Kontena.pastel.cyan("Installed dependency #{gem.name} version #{gem.version}")
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Plugins
         begin
           Kontena::PluginManager.instance.uninstall_plugin(name)
         rescue => ex
-          puts ex.message
+          puts Kontena.pastel.red(ex.message)
           spin.fail
         end
       end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -9,18 +9,14 @@ module Kontena::Cli::Plugins
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
-      require 'shellwords'
       confirm unless forced?
-      uninstall_plugin(name)
-    end
-
-    def uninstall_plugin(name)
-      plugin = "kontena-plugin-#{name}"
-      gem_bin = which('gem')
-      uninstall_command = "#{gem_bin} uninstall -q #{plugin.shellescape}"
-      stderr = spinner "Uninstalling plugin #{name.colorize(:cyan)}" do |spin|
-        stdout, stderr, status = Open3.capture3(uninstall_command)
-        raise(RuntimeError, stderr) unless status.success?
+      spinner "Uninstalling plugin #{name.colorize(:cyan)}" do |spin|
+        begin
+          Kontena::PluginManager.instance.uninstall_plugin(name)
+        rescue => ex
+          puts ex.message
+          spin.fail
+        end
       end
     end
   end

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -2,27 +2,45 @@ require 'singleton'
 
 module Kontena
   class PluginManager
+
+    module SayOverride
+      def say(*args)
+      end
+    end
+
     include Singleton
 
     CLI_GEM = 'kontena-cli'.freeze
     MIN_CLI_VERSION = '0.15.99'.freeze
 
-    attr_reader :plugins
+    def init
+      plugins
+      use_dummy_ui unless ENV["DEBUG"]
+      true
+    end
 
-    def initialize
-      @plugins = []
+    def without_safe(&block)
+      SafeYAML::OPTIONS[:default_mode] = :unsafe if Object.const_defined?(:SafeYAML)
+      yield
+    ensure
+      SafeYAML::OPTIONS[:default_mode] = :safe if Object.const_defined?(:SafeYAML)
+    end
+
+    def plugins
+      @plugins ||= load_plugins
     end
 
     # @return [Array<Gem::Specification>]
     def load_plugins
+      plugins = []
       Gem::Specification.to_a.each do |spec|
         spec.require_paths.to_a.each do |require_path|
           plugin = File.join(spec.gem_dir, require_path, 'kontena_cli_plugin.rb')
-          if File.exist?(plugin) && !@plugins.find{ |p| p.name == spec.name }
+          if File.exist?(plugin) && !plugins.find{ |p| p.name == spec.name }
             begin
               if spec_has_valid_dependency?(spec)
                 load(plugin)
-                @plugins << spec
+                plugins << spec
               else
                 plugin_name = spec.name.sub('kontena-plugin-', '')
                 STDERR.puts " [#{Kontena.pastel.red('error')}] Plugin #{Kontena.pastel.cyan(plugin_name)} (#{spec.version}) is not compatible with the current cli version."
@@ -39,9 +57,116 @@ module Kontena
           end
         end
       end
-      @plugins
+      plugins
     rescue => exc
       STDERR.puts exc.message
+    end
+
+    def prefix(plugin_name)
+      return plugin_name if plugin_name.to_s.start_with?('kontena-plugin-')
+      "kontena-plugin-#{plugin_name}"
+    end
+
+    def dummy_ui
+      Gem::StreamUI.new(StringIO.new, StringIO.new, StringIO.new, false)
+    end
+
+    def use_dummy_ui
+      require 'rubygems/user_interaction'
+      Gem::DefaultUserInteraction.ui = dummy_ui
+    end
+
+    def install_plugin(plugin_name, pre: false, version: nil)
+      require 'rubygems/dependency_installer'
+      require 'rubygems/requirement'
+
+      cmd = Gem::DependencyInstaller.new(
+        document: false,
+        force: true,
+        prerelease: pre,
+        minimal_deps: true
+      )
+      plugin_version = version.nil? ? Gem::Requirement.default : Gem::Requirement.new(version)
+      without_safe { cmd.install(prefix(plugin_name), plugin_version) }
+      cleanup_plugin(plugin_name)
+      cmd.installed_gems
+    end
+
+    def uninstall_plugin(plugin_name)
+      require 'rubygems/uninstaller'
+      cmd = Gem::Uninstaller.new(
+        "kontena-plugin-#{plugin_name}",
+        all: true,
+        executables: true,
+        force: true
+      )
+      cmd.uninstall
+    end
+
+    def search_plugins(pattern = nil)
+      client = Excon.new('https://rubygems.org')
+      response = client.get(
+        path: "/api/v1/search.json?query=#{prefix(pattern)}",
+        headers: {
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
+        }
+      )
+
+      JSON.parse(response.body) rescue nil
+    end
+
+    def gem_versions(plugin_name)
+      client = Excon.new('https://rubygems.org')
+      response = client.get(
+        path: "/api/v1/versions/#{prefix(plugin_name)}.json",
+        headers: {
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
+        }
+      )
+      versions = JSON.parse(response.body)
+      versions.map { |version| Gem::Version.new(version["number"]) }.sort.reverse
+    end
+
+    def latest_version(plugin_name, pre: false)
+      return gem_versions(plugin_name).first if pre
+      gem_versions.find { |version| !version.prerelease? }
+    end
+
+    def installed_version(plugin_name)
+      search = prefix(plugin_name)
+      installed = plugins.find {|plugin| plugin.name == search }
+      installed ? installed.version : nil
+    end
+
+    def upgrade_plugin(plugin_name, pre: false)
+      installed = installed_version(plugin_name)
+      if installed.prerelease?
+        pre = true
+      end
+
+      if installed
+        latest = latest_version(plugin_name, pre)
+        if latest > installed
+          install_plugin(plugin_name, version: latest.to_s)
+        end
+      else
+        raise "Plugin #{plugin_name} not installed"
+      end
+    end
+
+    def cleanup_plugin(plugin_name)
+      require 'rubygems/commands/cleanup_command'
+      cmd = Gem::Commands::CleanupCommand.new
+      cmd.extend SayOverride
+      options = ['--norc']
+      options += ['-q', '--no-verbose'] unless ENV["DEBUG"]
+      cmd.handle_options options
+      without_safe { cmd.execute }
+    rescue Gem::SystemExitException => e
+      return true if e.exit_code == 0
+      raise
     end
 
     # @param [Gem::Specification] spec

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -107,7 +107,7 @@ module Kontena
     def uninstall_plugin(plugin_name)
       require 'rubygems/uninstaller'
       cmd = Gem::Uninstaller.new(
-        "kontena-plugin-#{plugin_name}",
+        prefix(plugin_name),
         all: true,
         executables: true,
         force: true

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -14,9 +14,21 @@ module Kontena
     MIN_CLI_VERSION = '0.15.99'.freeze
 
     def init
+      ENV["GEM_HOME"] = install_dir
+      Gem.paths = ENV
       plugins
       use_dummy_ui unless ENV["DEBUG"]
       true
+    end
+
+    def install_dir
+      return @install_dir if @install_dir
+      install_dir = File.join(Dir.home, '.kontena', 'gems', RUBY_VERSION)
+      unless File.directory?(install_dir)
+        require 'fileutils'
+        FileUtils.mkdir_p(install_dir, mode: 0700)
+      end
+      @install_dir = install_dir
     end
 
     def without_safe(&block)

--- a/cli/spec/kontena/plugin_manager_spec.rb
+++ b/cli/spec/kontena/plugin_manager_spec.rb
@@ -5,14 +5,14 @@ describe Kontena::PluginManager do
 
   let(:subject) { described_class.instance }
 
+  before(:each) { subject.init }
   describe '#load_plugins' do
     it 'includes hello plugin' do
-      plugins = subject.load_plugins
-      expect(plugins.any?{ |p| p.name == 'kontena-plugin-hello' }).to be_truthy
+      expect(subject.plugins.any?{ |p| p.name == 'kontena-plugin-hello' }).to be_truthy
     end
 
     it 'allows plugin to register as a sub-command' do
-      plugins = subject.load_plugins
+      plugins = subject.init
       main = Kontena::MainCommand.new(File.basename($0))
       expect {
         main.run(['hello'])
@@ -31,7 +31,7 @@ describe Kontena::PluginManager do
         s.version     = '0.1.0'
         s.add_runtime_dependency 'kontena-cli', '>= 0.16.0'
       end
-      expect(subject.spec_has_valid_dependency?(spec)).to be_truthy
+      expect(subject.send(:spec_has_valid_dependency?, spec)).to be_truthy
     end
 
     it 'returns true if spec dependency > than MIN_CLI_VERSION and is prerelease' do
@@ -40,7 +40,7 @@ describe Kontena::PluginManager do
         s.version     = '0.1.0'
         s.add_runtime_dependency 'kontena-cli', '>= 0.16.0.pre2'
       end
-      expect(subject.spec_has_valid_dependency?(spec)).to be_truthy
+      expect(subject.send(:spec_has_valid_dependency?, spec)).to be_truthy
     end
 
     it 'returns false if spec dependency < than MIN_CLI_VERSION' do
@@ -49,7 +49,7 @@ describe Kontena::PluginManager do
         s.version     = '0.1.0'
         s.add_runtime_dependency 'kontena-cli', '>= 0.15.0'
       end
-      expect(subject.spec_has_valid_dependency?(spec)).to be_falsey
+      expect(subject.send(:spec_has_valid_dependency?, spec)).to be_falsey
     end
 
     it 'returns false if spec dependency < than MIN_CLI_VERSION and is prerelease' do
@@ -58,7 +58,7 @@ describe Kontena::PluginManager do
         s.version     = '0.1.0'
         s.add_runtime_dependency 'kontena-cli', '>= 0.15.0.beta1'
       end
-      expect(subject.spec_has_valid_dependency?(spec)).to be_falsey
+      expect(subject.send(:spec_has_valid_dependency?, spec)).to be_falsey
     end
   end
 end


### PR DESCRIPTION
This will allow installing plugins without sudo and it plays nicer with funny installations where `gem` command does not point to the same ruby as the kontena-cli installation.

