### PR TITLE
Fix possible nil stack case in grid services API

### DIFF
--- a/server/app/routes/v1/grids/grid_services.rb
+++ b/server/app/routes/v1/grids/grid_services.rb
@@ -25,7 +25,9 @@ V1::GridsApi.route('grid_services') do |r|
       query = @grid.grid_services.includes(:grid).order_by(:_id.desc)
       unless r['stack'].to_s.empty?
         stack = @grid.stacks.find_by(name: r['stack'])
+        halt_request(404, {error: "Stack #{r['stack']} not found"}) unless stack
         query = query.where(stack_id: stack.id)
+
       end
       @grid_services = query.to_a
       render('grid_services/index')


### PR DESCRIPTION
There seems to be possibility in the API to request services of a non existing stack in which case the API will produce internal errors.
See: https://kontenacommunity.slack.com/archives/general/p1484031542001669

I'm not entirely sure what could cause the CLI to actually even request services of a missing stack, but it should not cause internal error anyway.

This PR fixes this by halting the request in controlled manner if the given stack is not found.