### PR TITLE
Feature/master cli version check

### DIFF
--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -484,14 +484,18 @@ module Kontena
     end
 
     def check_version_and_warn(server_version)
-      return nil if server_version.nil?
       return nil if $VERSION_WARNING_ADDED
+      return nil unless server_version.to_s =~ /^\d+\.\d+\.\d+/
 
       unless server_version[/^(\d+\.\d+)/, 1] == Kontena::Cli::VERSION[/^(\d+\.\d+)/, 1] # Just compare x.y
-        at_exit do
-          warn Kontena.pastel.yellow("Server version is #{server_version}. You are using CLI version #{Kontena::Cli::VERSION}.")
-        end
+        add_version_warning(server_version)
         $VERSION_WARNING_ADDED = true
+      end
+    end
+
+    def add_version_warning(server_version)
+      at_exit do
+        warn Kontena.pastel.yellow("Warning: Server version is #{server_version}. You are using CLI version #{Kontena::Cli::VERSION}.")
       end
     end
 

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -474,21 +474,24 @@ module Kontena
     # @param [Excon::Response]
     # @return [Hash,String]
     def parse_response(response)
-      server_version = response.headers[X_KONTENA_VERSION]
-      if server_version
-        unless server_version[/^(\d+\.\d+)/, 1] == Kontena::Cli::VERSION[/^(\d+\.\d+)/, 1] # Just compare x.y
-          unless $VERSION_WARNING_ADDED # only do this once
-            at_exit do
-              warn Kontena.pastel.yellow("Server version is #{server_version}. You are using CLI version #{Kontena::Cli::VERSION}.")
-            end
-          end
-          $VERSION_WARNING_ADDED = true
-        end
-      end
+      check_version_and_warn(response.headers[X_KONTENA_VERSION])
+
       if response.headers[CONTENT_TYPE] =~ JSON_REGEX
         parse_json(response.body)
       else
         response.body
+      end
+    end
+
+    def check_version_and_warn(server_version)
+      return nil if server_version.nil?
+      return nil if $VERSION_WARNING_ADDED
+
+      unless server_version[/^(\d+\.\d+)/, 1] == Kontena::Cli::VERSION[/^(\d+\.\d+)/, 1] # Just compare x.y
+        at_exit do
+          warn Kontena.pastel.yellow("Server version is #{server_version}. You are using CLI version #{Kontena::Cli::VERSION}.")
+        end
+        $VERSION_WARNING_ADDED = true
       end
     end
 

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -304,13 +304,14 @@ describe Kontena::Client do
         allow(subject).to receive(:http_client).and_return(client)
         allow(client).to receive(:request).and_return(response)
         allow(response).to receive(:body).and_return("hello")
+        allow(response).to receive(:headers).and_return({})
       end
 
       it 'warns the user once if server version differs enough from master version' do
         bumped_version = cli_version.split('.')[0] + '.' + (cli_version.split('.')[1].to_i + 1).to_s + '.0' # 1.5.4 --> 1.6.0
         expect(response).to receive(:headers).at_least(:once).and_return({'X-Kontena-Version' => bumped_version})
         expect(subject).to receive(:check_version_and_warn).at_least(:once).and_call_original
-        expect(subject).to receive(:at_exit).once.and_return(true)
+        expect(subject).to receive(:add_version_warning).with(bumped_version).once.and_return(true)
         expect(subject.get("test")).to eq 'hello'
         expect(subject.get("test")).to eq 'hello'
       end
@@ -320,6 +321,7 @@ describe Kontena::Client do
         expect(response).to receive(:headers).at_least(:once).and_return({'X-Kontena-Version' => bumped_version})
         expect(subject).to receive(:check_version_and_warn).at_least(:once).and_call_original
         expect(subject).not_to receive(:at_exit)
+        expect(subject).not_to receive(:add_version_warning)
         expect(subject.get("test")).to eq 'hello'
       end
 
@@ -327,6 +329,7 @@ describe Kontena::Client do
         expect(response).to receive(:headers).at_least(:once).and_return({})
         allow(subject).to receive(:check_version_and_warn).at_least(:once).and_call_original
         expect(subject).not_to receive(:at_exit)
+        expect(subject).not_to receive(:add_version_warning)
         expect(subject.get("test")).to eq 'hello'
       end
     end

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -294,5 +294,41 @@ describe Kontena::Client do
         expect{subject.get('test')}.to raise_error(Kontena::Errors::StandardError, "You are wrong")
       end
     end
+
+    context 'version warning' do
+      let(:client) { double(:client) }
+      let(:response) { double(:response) }
+      let(:cli_version) { Kontena::Cli::VERSION }
+
+      before(:each) do
+        allow(subject).to receive(:http_client).and_return(client)
+        allow(client).to receive(:request).and_return(response)
+        allow(response).to receive(:body).and_return("hello")
+      end
+
+      it 'warns the user once if server version differs enough from master version' do
+        bumped_version = cli_version.split('.')[0] + '.' + (cli_version.split('.')[1].to_i + 1).to_s + '.0' # 1.5.4 --> 1.6.0
+        expect(response).to receive(:headers).at_least(:once).and_return({'X-Kontena-Version' => bumped_version})
+        expect(subject).to receive(:check_version_and_warn).at_least(:once).and_call_original
+        expect(subject).to receive(:at_exit).once.and_return(true)
+        expect(subject.get("test")).to eq 'hello'
+        expect(subject.get("test")).to eq 'hello'
+      end
+
+      it 'does not warn the user if server version does not differ too much' do
+        bumped_version = cli_version.split('.')[0] + '.' + cli_version.split('.')[1] + '.' + (cli_version.split('.')[2].to_i + 1).to_s # 1.5.4 --> 1.5.5
+        expect(response).to receive(:headers).at_least(:once).and_return({'X-Kontena-Version' => bumped_version})
+        expect(subject).to receive(:check_version_and_warn).at_least(:once).and_call_original
+        expect(subject).not_to receive(:at_exit)
+        expect(subject.get("test")).to eq 'hello'
+      end
+
+      it 'does not warn the user if server version is not there at all' do
+        expect(response).to receive(:headers).at_least(:once).and_return({})
+        allow(subject).to receive(:check_version_and_warn).at_least(:once).and_call_original
+        expect(subject).not_to receive(:at_exit)
+        expect(subject.get("test")).to eq 'hello'
+      end
+    end
   end
 end

--- a/server/app/middlewares/version_injector.rb
+++ b/server/app/middlewares/version_injector.rb
@@ -1,0 +1,14 @@
+class VersionInjector
+
+  X_KONTENA = 'X-Kontena-Version'.freeze
+
+  def initialize(app, version)
+    @app, @version = app, version
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    headers[X_KONTENA] = version
+    [status, headers, body]
+  end
+end

--- a/server/app/middlewares/version_injector.rb
+++ b/server/app/middlewares/version_injector.rb
@@ -1,5 +1,7 @@
 class VersionInjector
 
+  attr_reader :version
+
   X_KONTENA = 'X-Kontena-Version'.freeze
 
   def initialize(app, version)

--- a/server/server.rb
+++ b/server/server.rb
@@ -4,6 +4,7 @@ require 'pathname'
 require_relative 'app/boot'
 require_relative 'app/boot_jobs'
 require_relative 'app/middlewares/token_authentication'
+require_relative 'app/middlewares/version_injector'
 require_relative 'app/helpers/config_helper'
 
 require_glob __dir__ + '/app/routes/*.rb'
@@ -18,6 +19,7 @@ class Server < Roda
   use Rack::Attack
   use Rack::Static, urls: { "/code" => "app/views/static/code.html" }
   use TokenAuthentication, File.expand_path('../config/authentication.yml', __FILE__)
+  use VersionInjector, VERSION
 
   include Logging
   include ConfigHelper
@@ -69,7 +71,7 @@ class Server < Roda
         r.run OAuth2Api::TokensApi
       end
 
-      r.on 'authorize' do 
+      r.on 'authorize' do
         r.run OAuth2Api::AuthorizationApi
       end
     end

--- a/server/spec/api/root_spec.rb
+++ b/server/spec/api/root_spec.rb
@@ -10,4 +10,9 @@ describe '/' do
     get '/', nil, {}
     expect(json_response['version']).not_to be_nil
   end
+
+  it 'should add a X-Kontena-Version header' do
+    get '/', nil, {}
+    expect(response.headers['X-Kontena-Version']).to eq Server::VERSION
+  end
 end


### PR DESCRIPTION
Fixes #1632

Problems with this solution:
Does nothing if the server is not sending a version header (which it won't before this PR). 

Alternatives:
1. Query the server before talking to it.
2. Only check & complain when logging in. 
3. Restore the min_cli_version interceptor to master.
