### PR TITLE
Agent: fix cAdvisor stats to ignore systemd Docker container mount cgroups

### DIFF
--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -49,9 +49,12 @@ module Kontena::Workers
       info 'starting collection'
 
       if response = get("/api/v1.2/subcontainers")
-        response.each do |stat|
-          next unless stat[:namespace] == 'docker'
-          next if stat['name'].ends_with? '.mount'
+        response.each do |data|
+          next unless data[:namespace] == 'docker'
+
+          # Skip systemd mount units that confuse cadvisor
+          # @see https://github.com/kontena/kontena/issues/1656
+          next if data[:name].end_with? '.mount'
 
           send_container_stats(data)
         end

--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -65,7 +65,7 @@ module Kontena::Workers
     def collect_container_stats(container_id)
       retries = 3
       begin
-        response = client.get(:path => "/api/v1.2/docker/#{container_id}")
+        response = client.get(:path => "/api/v1.2/containers/docker/#{container_id}")
         if response.status == 200
           JSON.parse(response.body, symbolize_names: true) rescue nil
         else

--- a/agent/spec/fixtures/container_stats.json
+++ b/agent/spec/fixtures/container_stats.json
@@ -1,5 +1,4 @@
 {
-	"/system.slice/docker-dcc8a5ef41be9527779a6e81589f5a09d792653fb7f1c3213ee4537381ec1b07.scope": {
 		"id": "a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e",
 		"name": "/system.slice/docker-a675a5cd5f36ba747c9495f3dbe0de1d5f388a2ecd2aaf5feb00794e22de6c5e.scope",
 		"aliases": [
@@ -72,5 +71,4 @@
 				"usage": 18911232
 			}]
 		}]
-	}
 }

--- a/agent/spec/lib/kontena/workers/stats_workers_spec.rb
+++ b/agent/spec/lib/kontena/workers/stats_workers_spec.rb
@@ -31,10 +31,10 @@ describe Kontena::Workers::StatsWorker do
 
     it 'ignores systemd mount cgroups' do
       expect(subject.wrapped_object).to receive(:get).once.with('/api/v1.2/subcontainers').and_return([
-        { namespace: 'docker', id: 'id', name: '/docker/id' },
-        { namespace: 'docker', id: 'id', name: '/system.slice/var-lib-docker-containers-id-shm.mount' },
+        { namespace: 'docker', id: 'id1', name: '/docker/id' },
+        { namespace: 'docker', id: 'id2', name: '/system.slice/var-lib-docker-containers-id-shm.mount' },
       ])
-      expect(subject.wrapped_object).to receive(:send_container_stats).once { |args| expect(args[:id]).to eq 'id' }
+      expect(subject.wrapped_object).to receive(:send_container_stats).once { |args| expect(args[:id]).to eq 'id1' }
       subject.collect_stats
     end
 


### PR DESCRIPTION
Fixes #1656

This replaces the `/api/v1.2/docker/...` queries with a single `/api/v1.2/subcontainers` query, which returns all containers that cAdvisor knows about. This response includes both `/docker/*` and `/system.slice/var-lib-docker-containers-*-shm.mount` entries for each Docker container.

The agent ignores the `*.mount` entries that have zero-valued stats.