### PR TITLE
Add .netrc file to CLI Docker image

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -10,6 +10,10 @@ RUN apk update && \
   gem install kontena-cli --no-rdoc --no-ri -v ${CLI_VERSION} && \
   adduser kontena -D -h /home/kontena -s /bin/sh && \
   echo "gem: --user-install" > /home/kontena/.gemrc && \
+  chmod a+rx /root && \
+  touch /root/.netrc && \
+  chmod 777 /root/.netrc && \
+  ln -s /root/.netrc /home/kontena/.netrc && \
   chown -R kontena.kontena /home/kontena && \
   chmod +sx /usr/local/bin/docker
 


### PR DESCRIPTION
When using Drone CI, Drone tries to write data to `/root/.netrc` file. That returns error because CLI container is run by `kontena` user and permission is denied. This PR adds `.netrc` file into `/root` directory and gives access to kontena user to it.

Related discussion on Drone forum: http://discourse.drone.io/t/netrc-permission-denied/171