### PR TITLE
If master deploy returns :provider set it to config server.provider

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -16,9 +16,7 @@ module Kontena
 
         cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}"]
         spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do
-          Retriable.retriable do
-            Kontena.run(cmd.shelljoin)
-          end
+          Kontena.run(cmd.shelljoin)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -12,10 +12,12 @@ module Kontena
         return unless config.current_master.name == command.result[:name]
         return unless command.result[:provider]
 
-        cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}".shellescape]
+        require 'shellwords'
+
+        cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}"]
         spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do
           Retriable.retriable do
-            Kontena.run(*cmd)
+            Kontena.run(cmd.shelljoin)
           end
         end
       end

--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -1,0 +1,25 @@
+module Kontena
+  module Callbacks
+    class SetServerProviderAfterDeploy < Kontena::Callback
+
+      include Kontena::Cli::Common
+
+      matches_commands 'master create'
+
+      def after
+        return unless command.exit_code == 0
+        return unless config.current_master
+        return unless config.current_master.name == command.result[:name]
+        return unless command.result[:provider]
+
+        cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}".shellescape]
+        spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do
+          Retriable.retriable do
+            Kontena.run(*cmd)
+          end
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Sets master config `server.provider` to the :provider returned by provisioning plugins.

This is needed by the `kontena master ssh` in #1205 to figure out if the provider is vagrant.

![image](https://cloud.githubusercontent.com/assets/224971/22067597/a30e28fc-dd9a-11e6-929f-e780c9dd2c32.png)

-->

![image](https://cloud.githubusercontent.com/assets/224971/22067620/b6129ec4-dd9a-11e6-83a3-12bb7c2ad736.png)
