### PR TITLE
Stack service_instances resolver

### DIFF
--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -17,8 +17,12 @@ module Kontena::Cli::Stacks
       show_stack(name)
     end
 
+    def fetch_stack(name)
+      client.get("stacks/#{current_grid}/#{name}")
+    end
+
     def show_stack(name)
-      stack = client.get("stacks/#{current_grid}/#{name}")
+      stack = fetch_stack(name)
 
       puts "#{stack['name']}:"
       puts "  state: #{stack['state']}"

--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
@@ -1,0 +1,22 @@
+module Kontena::Cli::Stacks
+  module YAML
+    class Opto::Resolvers::ServiceInstances < Opto::Resolver
+      def resolve
+        read_command = Kontena::Cli::Stacks::ShowCommand.new([self.stack])
+        stack = read_command.fetch_stack(self.stack)
+        service = stack['services'].find { |s| s['name'] == hint }
+        if service
+          service['instances']
+        else
+          nil
+        end
+      rescue Kontena::Errors::StandardError
+        nil
+      end
+
+      def stack
+        ENV['STACK']
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -16,6 +16,7 @@ module Kontena::Cli::Stacks
         require_relative 'opto/vault_setter'
         require_relative 'opto/vault_resolver'
         require_relative 'opto/prompt_resolver'
+        require_relative 'opto/service_instances_resolver'
 
         @file = file
         @from_registry = from_registry

--- a/docs/references/kontena-yml-variables.md
+++ b/docs/references/kontena-yml-variables.md
@@ -407,6 +407,18 @@ from:
 
 You could set this value by using: `kontena vault write wordpress-admin-password p4ssw0rd1234`
 
+### `service_instances`
+
+Fetch value (service instances count) from given service instance. The hint is the service name within the stack.
+
+```
+from:
+  service_instances: wordpress
+```
+
+This resolver is handy if you want to change scaling after the stack has been deployed.
+
+
 ### `prompt`
 
 Ask the user interactively. The hint is the question text.


### PR DESCRIPTION
This resolver is handy if you don't want to overwrite service instances (scaling) when doing a stack upgrade.

Example:

```yaml
stack: jakolehm/mariadb-galera-cluster
variables:
  seed_instances:
    type: integer
    default: 1
    from: 
      service_instances: seed
services:
  seed:
    image: colinmollenhour/mariadb-galera-swarm:latest
    stateful: true
    instances: $seed_instances
```

Fixes #1671