### PR TITLE
Set puma workers based on available CPU cores

### DIFF
--- a/docs/references/environment-variables.md
+++ b/docs/references/environment-variables.md
@@ -10,8 +10,8 @@ toc_order: 2
 - `MONGODB_URI`: MongoDB connection uri (required)
 - `VAULT_KEY`: secret key for the Kontena Vault (required)
 - `VAULT_IV`: initialization vector for the Kontena Vault (required)
-- `WEB_CONCURRENCY`: number of forked master api processes (default: 1)
-- `MAX_THREADS`: number of threads inside single master api process (default: 8)
+- `WEB_CONCURRENCY`: number of forked master api worker processes (default: Number of CPU cores available)
+- `MAX_THREADS`: number of threads inside single master api worker process (default: 8)
 - `LOG_LEVEL`: logging level
 - `ACME_ENDPOINT`: acme endpoint for Let's Encrypt
 - `AUTH_API_URL`: specifies authentication server url (default: https://auth.kontena.io)

--- a/server/config/puma.rb
+++ b/server/config/puma.rb
@@ -1,8 +1,13 @@
-workers Integer(ENV['WEB_CONCURRENCY'] || 1)
+require 'etc'
+
+workers Integer(ENV['WEB_CONCURRENCY'] || Etc.nprocessors)
 threads_count = Integer(ENV['MAX_THREADS'] || 8)
 threads threads_count, threads_count
-on_worker_boot do
-  require_relative '../app/boot'
-  require_relative '../app/services/mongodb/migrator'
-  Mongodb::Migrator.new.migrate
+on_worker_boot do |worker_num|
+  # Run migrations only on first worker, worker_num is zero based
+  if worker_num == 0
+    require_relative '../app/boot'
+    require_relative '../app/services/mongodb/migrator'
+    Mongodb::Migrator.new.migrate
+  end
 end

--- a/server/config/puma.rb
+++ b/server/config/puma.rb
@@ -4,10 +4,7 @@ workers Integer(ENV['WEB_CONCURRENCY'] || Etc.nprocessors)
 threads_count = Integer(ENV['MAX_THREADS'] || 8)
 threads threads_count, threads_count
 on_worker_boot do |worker_num|
-  # Run migrations only on first worker, worker_num is zero based
-  if worker_num == 0
-    require_relative '../app/boot'
-    require_relative '../app/services/mongodb/migrator'
-    Mongodb::Migrator.new.migrate
-  end
+  require_relative '../app/boot'
+  require_relative '../app/services/mongodb/migrator'
+  Mongodb::Migrator.new.migrate
 end


### PR DESCRIPTION

On a 4 core setup (docker-machine) results into 4 worker processes as expected. :)
```
$ docker top server_api_1
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
nobody              20212               20197               0                   17:39               ?                   00:00:00            puma 3.6.0 (tcp://0.0.0.0:9292) [app]
nobody              20239               20212               1                   17:39               ?                   00:00:03            puma: cluster worker 0: 1 [app]
nobody              20243               20212               1                   17:39               ?                   00:00:03            puma: cluster worker 1: 1 [app]
nobody              20247               20212               1                   17:39               ?                   00:00:03            puma: cluster worker 2: 1 [app]
nobody              20251               20212               1                   17:39               ?                   00:00:03            puma: cluster worker 3: 1 [app]
```

Number of pid reported by Docker gets relatively high though since now each worker will have multiple Celluloid threads also running.
```
$ docker stats --no-stream server_api_1
CONTAINER           CPU %               MEM USAGE / LIMIT       MEM %               NET I/O               BLOCK I/O           PIDS
server_api_1        3.05%               253.7 MiB / 3.858 GiB   6.42%               1.379 MB / 2.368 MB   0 B / 0 B           246
```

Added this to 1.1.0 milestone as the relevant issue was added to 1.1.0 milestone.


fixes #1223 