### PR TITLE
Docs/compose agent to version 2

### DIFF
--- a/docs/getting-started/installing/docker-compose.md
+++ b/docs/getting-started/installing/docker-compose.md
@@ -102,17 +102,19 @@ Now you can start provisioning nodes to your host machines.
 **Step 1:** copy the following `docker-compose.yml` file to each host:
 
 ```yaml
-agent:
-  container_name: kontena-agent
-  image: kontena/agent:latest
-  net: host
-  restart: unless-stopped
-  environment:
-    - KONTENA_URI=ws://<master_ip>/
-    - KONTENA_TOKEN=<grid_token>
-    - KONTENA_PEER_INTERFACE=eth1
-  volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
+version: '2'
+services:
+  agent:
+    container_name: kontena-agent
+    image: kontena/agent:latest
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - KONTENA_URI=ws://<master_ip>/
+      - KONTENA_TOKEN=<grid_token>
+      - KONTENA_PEER_INTERFACE=eth1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 ```
 
 - `KONTENA_URI` is the uri to Kontena Master (use ws:// for a non-tls connection)

--- a/docs/getting-started/installing/docker-compose.md
+++ b/docs/getting-started/installing/docker-compose.md
@@ -50,7 +50,7 @@ services:
   mongodb:
     image: mongo:3.0
     container_name: kontena-server-mongo
-    restart: always
+    restart: unless-stopped
     command: mongod --smallfiles
     volumes:
       - kontena-server-mongo:/data/db

--- a/docs/getting-started/installing/docker-compose.md
+++ b/docs/getting-started/installing/docker-compose.md
@@ -26,7 +26,7 @@ services:
   haproxy:
     image: kontena/haproxy:latest
     container_name: kontena-server-haproxy
-    restart: always
+    restart: unless-stopped
     environment:
       - SSL_CERT=**None**
       - BACKENDS=kontena-server-api:9292
@@ -34,11 +34,11 @@ services:
       - master
     ports:
       - 80:80
-      - 443:443    
+      - 443:443
   master:
     image: kontena/server:latest
     container_name: kontena-server-api
-    restart: always
+    restart: unless-stopped
     environment:
       - RACK_ENV=production
       - MONGODB_URI=mongodb://mongodb:27017/kontena
@@ -106,7 +106,7 @@ agent:
   container_name: kontena-agent
   image: kontena/agent:latest
   net: host
-  restart: always
+  restart: unless-stopped
   environment:
     - KONTENA_URI=ws://<master_ip>/
     - KONTENA_TOKEN=<grid_token>


### PR DESCRIPTION
Agent is defined in old compose format (master is as version 2 couple of lines up) -- also see #1692 
