### PR TITLE
Allow to clear deploy options

### DIFF
--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -49,13 +49,16 @@ module Kontena::Cli::Stacks
       data['log_opts'] = options['log_opt'] if options['log_opt'] && !options['log_opt'].empty?
       deploy_opts = options['deploy'] || {}
       data['strategy'] = deploy_opts['strategy'] if deploy_opts['strategy']
-      deploy = {}
-      deploy['wait_for_port'] = deploy_opts['wait_for_port'] if deploy_opts.has_key?('wait_for_port')
-      deploy['min_health'] = deploy_opts['min_health'] if deploy_opts.has_key?('min_health')
-      deploy['interval'] = parse_relative_time(deploy_opts['interval']) if deploy_opts.has_key?('interval')
-      unless deploy.empty?
-        data['deploy_opts'] = deploy
-      end
+      deploy = {
+        'wait_for_port' => deploy_opts['wait_for_port'],
+        'min_health' => deploy_opts['min_health']
+      }
+      if deploy_opts.has_key?('interval')
+        deploy['interval'] = parse_relative_time(deploy_opts['interval'])
+      else
+        deploy['interval'] = nil
+      end      
+      data['deploy_opts'] = deploy
       data['hooks'] = options['hooks'] || {}
       data['secrets'] = options['secrets'] if options['secrets']
       data['build'] = parse_build_options(options) if options['build']

--- a/cli/spec/kontena/cli/stacks/service_generator_spec.rb
+++ b/cli/spec/kontena/cli/stacks/service_generator_spec.rb
@@ -335,12 +335,16 @@ describe Kontena::Cli::Stacks::ServiceGenerator do
         expect(result['deploy_opts']['interval']).to eq(60)
       end
 
-      it 'does not return deploy_opts if no deploy options are defined' do
+      it 'returns nil values if no deploy options are defined' do
         data = {
           'image' => 'foo/bar:latest'
         }
         result = subject.send(:parse_data, data)
-        expect(result['deploy_opts']).to be_nil
+        expect(result['deploy_opts']).to eq({
+          'interval' => nil,
+          'min_health' => nil,
+          'wait_for_port' => nil
+          })
       end
     end
 
@@ -381,5 +385,5 @@ describe Kontena::Cli::Stacks::ServiceGenerator do
         expect(result['secrets']).to be_nil
       end
     end
-  end  
+  end
 end

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -157,9 +157,9 @@ module GridServices
           end
           hash :deploy_opts do
             optional do
-              integer :wait_for_port
-              float :min_health
-              integer :interval
+              integer :wait_for_port, nils: true
+              float :min_health, nils: true
+              integer :interval, nils: true
             end
           end
           array :volumes do

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -60,6 +60,30 @@ describe GridServices::Update do
       }.to change{ redis_service.reload.affinity }.to(['az==b1'])
     end
 
+    it 'updates wait_for_port' do
+      described_class.new(
+          grid_service: redis_service,
+          deploy_opts: {
+            wait_for_port: 6379
+          }
+      ).run
+      redis_service.reload
+      expect(redis_service.deploy_opts.wait_for_port).to eq(6379)
+    end
+
+    it 'allows to delete wait_for_port' do
+      redis_service.deploy_opts.wait_for_port = 6379
+      redis_service.save
+      described_class.new(
+          grid_service: redis_service,
+          deploy_opts: {
+            wait_for_port: nil
+          }
+      ).run
+      redis_service.reload
+      expect(redis_service.deploy_opts.wait_for_port).to be_nil
+    end
+
     it 'updates health check' do
       described_class.new(
           grid_service: redis_service,


### PR DESCRIPTION
When user has defined deploy options in a stack file to service, it is impossible to clear those options afterwards. With this PR CLI sends always deploy options to master and master will update those values correctly to grid service's deploy options.