### PR TITLE
Stop container health check also on kill event

### DIFF
--- a/agent/lib/kontena/workers/health_check_worker.rb
+++ b/agent/lib/kontena/workers/health_check_worker.rb
@@ -11,7 +11,7 @@ module Kontena::Workers
     finalizer :terminate_workers
 
     START_EVENTS = ['start']
-    STOP_EVENTS = ['die']
+    STOP_EVENTS = ['die', 'kill']
     ETCD_PREFIX = '/kontena/log_worker/containers'
 
     ##

--- a/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
@@ -62,6 +62,12 @@ describe Kontena::Workers::HealthCheckWorker do
   end
 
   describe '#on_container_event' do
+    it 'stops check on kill' do
+      expect(subject.wrapped_object).to receive(:stop_container_check).once.with('foo')
+      subject.on_container_event('topic', double(:event, id: 'foo', status: 'kill'))
+      sleep 0.01
+    end
+
     it 'stops check on die' do
       expect(subject.wrapped_object).to receive(:stop_container_check).once.with('foo')
       subject.on_container_event('topic', double(:event, id: 'foo', status: 'die'))


### PR DESCRIPTION
When container is stopped (`docker stop <container>`), Docker will send container event with status `kill`. Currently agent will stop container health check worker only with `die` event.