### PR TITLE
Use the master url to build the redirect uri in init-cloud

### DIFF
--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Cloud::Master
 
     def register(name, url = nil, provider = nil, redirect_uri = nil, version = nil, owner = nil)
       attributes = {}
-      attributes['name']         = name 
+      attributes['name']         = name
       attributes['url']          = url if url
       attributes['provider']     = provider if provider
       attributes['redirect-uri'] = redirect_uri if redirect_uri
@@ -107,7 +107,7 @@ module Kontena::Cli::Cloud::Master
         end
       else
         response = spinner "Registering current Kontena Master '#{current_master.name}' #{" as '#{new_name}' " unless new_name == current_master.name}to Kontena Cloud" do
-          register(new_name, current_master.url, self.provider, nil, self.version)
+          register(new_name, current_master.url, self.provider, current_master.url.gsub(/\/$/, '') + "/cb", self.version)
         end
       end
 

--- a/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
@@ -64,7 +64,7 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
     let(:success_response) {
         {
           'data' => {
-            'attributes' => { 
+            'attributes' => {
               'client-id' => '123',
               'client-secret' => '345',
               'provider' => 'foo',
@@ -90,7 +90,7 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
         expect(url).to eq current_master.url
         expect(provider).to eq 'provider'
         expect(version).to eq '10.10.10'
-        expect(redirect_uri).to be_nil
+        expect(redirect_uri).to eq (current_master.url + "/cb")
       end.and_return(success_response)
 
       subject.provider = 'provider'


### PR DESCRIPTION
Currently it leaves it to the master to register its own redirect-uri based on the `server.root_url` config.

This PR makes the CLI pass the redirect-uri when registering the master to kontena cloud.

Fixes #1697