### PR TITLE
Make --force more predictable in master rm

### DIFF
--- a/cli/lib/kontena/cli/master/remove_command.rb
+++ b/cli/lib/kontena/cli/master/remove_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Master
 
     banner "Note: This command only removes the master from your local configuration file"
 
-    option '--force', :flag, "Don't ask questions"
+    option '--force', :flag, "Don't ask for confirmation"
 
     def run_interactive
       selections = prompt.multi_select("Select masters to remove from configuration file:") do |menu|
@@ -22,19 +22,14 @@ module Kontena::Cli::Master
     end
 
     def delete_servers(servers)
-      case servers.size
-      when 0
-        abort "Master not found in configuration"
-      when 1
-        config.servers.delete(config.servers.delete(servers.first))
-        puts "Removed Master '#{servers.first.name}'"
-      else
-        unless self.force?
-          abort("Aborted") unless prompt.yes?("Remove #{servers.size} masters from configuration?")
-        end
-        config.servers.delete_if {|s| servers.include?(s) }
-        puts "Removed #{servers.size} masters from configuration"
+      abort "Master not found in configuration" if servers.empty?
+
+      unless self.force?
+        abort("Aborted") unless prompt.yes?("Remove #{servers.size} master#{"s" if servers.size > 1} from configuration?")
       end
+
+      config.servers.delete_if {|s| servers.include?(s) }
+
       unless config.find_server(config.current_server)
         puts
         puts "Current master was removed, to select a new current master use:"
@@ -43,6 +38,7 @@ module Kontena::Cli::Master
         puts "  " + pastel.green.on_black("  kontena master login <master_url>  ")
         config.current_server = nil
       end
+
       config.write
     end
 

--- a/cli/lib/kontena/cli/master/remove_command.rb
+++ b/cli/lib/kontena/cli/master/remove_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Master
 
     banner "Note: This command only removes the master from your local configuration file"
 
-    option '--force', :flag, "Don't ask for confirmation"
+    option '--force', :flag, "Don't ask for confirmation", attribute_name: :forced
 
     def run_interactive
       selections = prompt.multi_select("Select masters to remove from configuration file:") do |menu|
@@ -24,8 +24,9 @@ module Kontena::Cli::Master
     def delete_servers(servers)
       abort "Master not found in configuration" if servers.empty?
 
-      unless self.force?
-        abort("Aborted") unless prompt.yes?("Remove #{servers.size} master#{"s" if servers.size > 1} from configuration?")
+      unless forced?
+        puts "Removing #{servers.size} master#{"s" if servers.size > 1} from configuration"
+        confirm
       end
 
       config.servers.delete_if {|s| servers.include?(s) }


### PR DESCRIPTION
Previously it only asked for confirmation when more than one server was going to be removed and that was only possible through the interactive selector anyway.

Fixes #1693