### PR TITLE
Prettier initializer method for commands

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Stacks
   module YAML
     class Opto::Resolvers::ServiceInstances < Opto::Resolver
       def resolve
-        read_command = Kontena::Cli::Stacks::ShowCommand.new([self.stack])
+        read_command = Kontena::Cli::Stacks::ShowCommand.new([])
         stack = read_command.fetch_stack(self.stack)
         service = stack['services'].find { |s| s['name'] == hint }
         if service

--- a/cli/spec/kontena/command_spec.rb
+++ b/cli/spec/kontena/command_spec.rb
@@ -1,10 +1,9 @@
 require_relative '../spec_helper'
 require 'kontena/command'
 
-describe Kontena do
+describe Kontena::Command do
   let(:subject) do
-    class TestCommand < Kontena::Command
-
+    Class.new(Kontena::Command) do
       callback_matcher 'test', 'foo'
 
       parameter 'PARAM', 'Single param'
@@ -19,12 +18,6 @@ describe Kontena do
         plist_list.size
       end
     end
-
-    TestCommand
-  end
-
-  after(:each) do
-    Object.send(:remove_const, :TestCommand) if Object.const_defined?(:TestCommand)
   end
 
   describe '#new' do

--- a/cli/spec/kontena/command_spec.rb
+++ b/cli/spec/kontena/command_spec.rb
@@ -1,0 +1,55 @@
+require_relative '../spec_helper'
+require 'kontena/command'
+
+describe Kontena do
+  let(:subject) do
+    class TestCommand < Kontena::Command
+
+      callback_matcher 'test', 'foo'
+
+      parameter 'PARAM', 'Single param'
+      parameter '[PLIST] ...', 'A number of params'
+      option '--flag', :flag, 'Flag'
+      option '--foo', 'FOO', 'Option'
+
+      def execute
+      end
+
+      def plist_size
+        plist_list.size
+      end
+    end
+
+    TestCommand
+  end
+
+  after(:each) do
+    Object.send(:remove_const, :TestCommand) if Object.const_defined?(:TestCommand)
+  end
+
+  describe '#new' do
+    it 'works with the classic .new syntax' do
+      cmd = subject.new(['hello'])
+      expect(cmd.flag?).to be_nil
+      expect(cmd.param).to be_nil
+      expect(cmd.plist_list).to be_empty
+    end
+
+    it 'works with a more mutations like syntax' do
+      cmd = subject.new(flag: true, foo: 'bar', param: 'param', plist_list: ['foo', 'bar'])
+      expect(cmd.plist_size).to eq 2
+      expect(cmd.flag?).to be_truthy
+      expect(cmd.foo).to eq 'bar'
+      expect(cmd.param).to eq 'param'
+      expect(cmd.plist_list.first).to eq 'foo'
+      expect(cmd.plist_list.last).to eq 'bar'
+    end
+
+    it 'multi value param can be set without _list' do
+      cmd = subject.new(flag: true, foo: 'bar', param: 'param', plist: ['foo', 'bar'])
+      expect(cmd.plist_list.first).to eq 'foo'
+      expect(cmd.plist_list.last).to eq 'bar'
+    end
+  end
+end
+


### PR DESCRIPTION
Instead of:

```ruby
>> cmd = Kontena::Cli::Nodes::ListCommand.new('kontena') # (.new takes the command name for using in help output, not arguments.)
>> cmd.run(['--all'])
```

or more specifically:

```ruby
# def get_nodes(all = false)
#  nodes = client.get("foofoo")['nodes']
#   unless all
#     nodes.reject! { |n| !n['connected']}
#   end
#   nodes
# end

>>> cmd = Kontena::Cli::Nodes::ListCommand.new('kontena')
>>> cmd.get_nodes(false)
```

You can now do:

```ruby
# def get_nodes
#   nodes = client.get("foofoo")['nodes']
#   unless all?
#     nodes.reject! { |n| !n['connected']}
#   end
#   nodes
# end

>> cmd = Kontena::Cli::Nodes::ListCommand.new(all: true)
>> nodes = cmd.get_nodes
```

Because something like this does not make sense:

```ruby
class FooCommand
  attr_accessor :name

  def initialize(name)
    @name = name
  end

  def execute
    do_foo(name)
  end

  # code smell: method does nothing with the host object
  def do_foo(name)
    foo = Foo.find(name)
    foo.do_foo
  end
end
```

Instance methods should use instance variables:

```ruby
class FooCommand
  attr_accessor :name

  def initialize(name)
    @name = name
  end

  def execute
    do_foo
  end

  def do_foo
    foo = Foo.find(name)
    foo.do_foo
  end
end
```
