### PR TITLE
Switch cli docker image to root user

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -8,14 +8,8 @@ RUN apk update && \
   apk --update add ruby ruby-json ruby-bigdecimal ruby-io-console \
   ca-certificates libssl1.0 openssl libstdc++ && \
   gem install kontena-cli --no-rdoc --no-ri -v ${CLI_VERSION} && \
-  adduser kontena -D -h /home/kontena -s /bin/sh && \
-  echo "gem: --user-install" > /home/kontena/.gemrc && \
-  chown -R kontena.kontena /home/kontena && \
-  chmod +sx /usr/local/bin/docker
+  chmod +x /usr/local/bin/docker
 
-ENV PATH=$PATH:/home/kontena/.gem/ruby/2.3.0/bin
-
-VOLUME ["/home/kontena"]
-WORKDIR /home/kontena
-USER kontena
+VOLUME ["/root"]
+WORKDIR /root
 ENTRYPOINT ["/usr/bin/kontena"]


### PR DESCRIPTION
Reason for switching: drone ci (and probably other systems) expect root user.. if we have non-root user it will fail in mysterious ways and user does not really have a clue why it happens.

Related: #1672 