### PR TITLE
cli: kontena service exec

### DIFF
--- a/agent/lib/kontena/rpc/docker_container_api.rb
+++ b/agent/lib/kontena/rpc/docker_container_api.rb
@@ -105,7 +105,7 @@ module Kontena
       # @param [String] id
       # @param [String] cmd
       # @param [Hash] opts
-      # @return [Array]
+      # @return [Array<(Array<String>, Array<String>, Integer)>] stdout, stderr, exit_status
       def exec(id, cmd, opts = {})
         container = Docker::Container.get(id)
         container.exec(cmd, opts)

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -92,12 +92,12 @@ module Kontena
 
       def warning(msg)
         warning = pastel.yellow('warn')
-        STDERR.puts " [#{warning}] #{msg}"
+        $stderr.puts " [#{warning}] #{msg}"
       end
 
       def exit_with_error(msg, code = 1)
         error = pastel.red('error')
-        STDERR.puts " [#{error}] #{msg}"
+        $stderr.puts " [#{error}] #{msg}"
         exit code
       end
 

--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -19,6 +19,7 @@ require_relative 'services/secret_command'
 
 require_relative 'services/link_command'
 require_relative 'services/unlink_command'
+require_relative 'services/exec_command'
 
 class Kontena::Cli::ServiceCommand < Kontena::Command
 
@@ -44,6 +45,7 @@ class Kontena::Cli::ServiceCommand < Kontena::Command
 
   subcommand "link", "Link service to another service", Kontena::Cli::Services::LinkCommand
   subcommand "unlink", "Unlink service from another service", Kontena::Cli::Services::UnlinkCommand
+  subcommand "exec", "Execute commands in service containers", Kontena::Cli::Services::ExecCommand
 
   def execute
   end

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -12,8 +12,9 @@ module Kontena::Cli::Services
     option ["-i", "--instance"], "INSTANCE", "Exec on given numbered instance, default first running" do |value| Integer(value) end
     option ["-a", "--all"], :flag, "Exec on all running instances"
     option ["--shell"], :flag, "Execute as a shell command"
-    option ["--[no-]spinner"], :flag, "Execute with interactive output", attribute_name: :with_spinner, default: nil
     option ["--skip"], :flag, "Skip failed instances when executing --all"
+    option ["--silent"], :flag, "Do not show exec status"
+    option ["--verbose"], :flag, "Show exec status"
 
     requires_current_master
     requires_current_grid
@@ -28,7 +29,7 @@ module Kontena::Cli::Services
 
       stdout = stderr = exit_status = nil
 
-      if with_spinner? || (@with_spinner.nil? && all?)
+      if !silent? && (verbose? || all?)
         spinner "Executing command on #{container['name']}" do
           stdout, stderr, exit_status = client.post("containers/#{container['id']}/exec", {cmd: cmd})
 

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -35,6 +35,7 @@ module Kontena::Cli::Services
 
     def execute
       service_containers = client.get("services/#{parse_service_id(name)}/containers")['containers']
+      service_containers.sort_by! { |container| container['instance_number'] }
       running_containers = service_containers.select{|container| container['status'] == 'running' }
 
       if running_containers.empty?

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -12,7 +12,7 @@ module Kontena::Cli::Services
     option ["-i", "--instance"], "INSTANCE", "Exec on given numbered instance, default first running" do |value| Integer(value) end
     option ["-a", "--all"], :flag, "Exec on all running instances"
     option ["--shell"], :flag, "Execute as a shell command"
-    option ["--[no-]spinner"], :flag, "Execute with interactive output", attribute_name: :with_spinner, default: true
+    option ["--[no-]spinner"], :flag, "Execute with interactive output", attribute_name: :with_spinner, default: nil
 
     requires_current_master
     requires_current_grid
@@ -27,7 +27,7 @@ module Kontena::Cli::Services
 
       stdout = stderr = exit_status = nil
 
-      if with_spinner?
+      if with_spinner? || (@with_spinner.nil? && all?)
         spinner "Executing command on #{container['name']}" do
           stdout, stderr, exit_status = client.post("containers/#{container['id']}/exec", {cmd: cmd})
 

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -26,8 +26,9 @@ module Kontena::Cli::Services
 
       stdout, stderr, exit_status = client.post("containers/#{container['id']}/exec", {cmd: cmd})
 
-      $stdout.puts stdout unless stdout.empty?
-      $stderr.puts stderr unless stderr.empty?
+      stdout.each do |chunk| $stdout.write chunk end
+      stderr.each do |chunk| $stderr.write chunk end
+
       exit exit_status if exit_status != 0
 
       return true

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -26,9 +26,11 @@ module Kontena::Cli::Services
 
       stdout, stderr, exit_status = client.post("containers/#{container['id']}/exec", {cmd: cmd})
 
-      STDOUT.puts stdout unless stdout.empty?
-      STDERR.puts stderr unless stderr.empty?
+      $stdout.puts stdout unless stdout.empty?
+      $stderr.puts stderr unless stderr.empty?
       exit exit_status if exit_status != 0
+
+      return true
     end
 
     def execute

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -29,7 +29,7 @@ module Kontena::Cli::Services
       running_containers = service_containers.select{|container| container['status'] == 'running' }
 
       if running_containers.empty?
-        exit_with_error "Service #{name} does not have any running container instances"
+        exit_with_error "Service #{name} does not have any running containers"
       end
 
       if all?

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -11,13 +11,20 @@ module Kontena::Cli::Services
 
     option ["-i", "--instance"], "INSTANCE", "Exec on given numbered instance, default first running" do |value| Integer(value) end
     option ["-a", "--all"], :flag, "Exec on all running instances"
+    option ["--shell"], :flag, "Execute as a shell command"
 
     requires_current_master
     requires_current_grid
 
     # Exits if exec returns with non-zero
     def exec_container(container)
-      stdout, stderr, exit_status = client.post("containers/#{container['id']}/exec", {cmd: cmd_list})
+      if shell?
+        cmd = ['sh', '-c', cmd_list.join(' ')]
+      else
+        cmd = cmd_list
+      end
+
+      stdout, stderr, exit_status = client.post("containers/#{container['id']}/exec", {cmd: cmd})
 
       STDOUT.puts stdout unless stdout.empty?
       STDERR.puts stderr unless stderr.empty?

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -1,0 +1,52 @@
+require_relative 'services_helper'
+
+module Kontena::Cli::Services
+  class ExecCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include ServicesHelper
+
+    parameter "NAME", "Service name"
+    parameter "CMD ...", "Command"
+
+    option ["-i", "--instance"], "INSTANCE", "Exec on given numbered instance, default first running" do |value| Integer(value) end
+    option ["-a", "--all"], :flag, "Exec on all running instances"
+
+    requires_current_master
+    requires_current_grid
+
+    # Exits if exec returns with non-zero
+    def exec_container(container)
+      stdout, stderr, exit_status = client.post("containers/#{container['id']}/exec", {cmd: cmd_list})
+
+      STDOUT.puts stdout unless stdout.empty?
+      STDERR.puts stderr unless stderr.empty?
+      exit exit_status if exit_status != 0
+    end
+
+    def execute
+      service_containers = client.get("services/#{parse_service_id(name)}/containers")['containers']
+      running_containers = service_containers.select{|container| container['state']['running']}
+
+      if running_containers.empty?
+        exit_with_error "Service #{name} does not have any running container instances"
+      end
+
+      if all?
+        running_containers.each do |container|
+          exec_container(container)
+        end
+      elsif instance
+        if !(container = service_containers.find{|container| container['instance_number'] == instance})
+          exit_with_error "Service #{name} does not have container instance #{instance}"
+        elsif !container['state']['running']
+          exit_with_error "Service #{name} container instance #{instance} is not running, it is #{container['status']}"
+        else
+          exec_container(container)
+        end
+      else
+        exec_container(running_containers.first)
+      end
+    end
+  end
+end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -2,12 +2,6 @@ describe Kontena::Cli::Services::ExecCommand do
   include ClientHelpers
   include OutputHelpers
 
-  subject do
-    subject = described_class.new('.')
-    subject.with_spinner = false
-    subject
-  end
-
   let :exec_ok do
     [
       ["ok\n"],
@@ -113,14 +107,14 @@ describe Kontena::Cli::Services::ExecCommand do
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(exec_ok)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-3/exec', { cmd: ['test'] }).and_return(exec_ok)
 
-      expect{subject.run(['--all', 'test-service', 'test'])}.to output_lines ["ok", "ok", "ok"]
+      expect{subject.run(['--silent', '--all', 'test-service', 'test'])}.to output_lines ["ok", "ok", "ok"]
     end
 
     it "Stops if the first container fails" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_fail)
 
-      expect{subject.run(['--all', 'test-service', 'test'])}.to output("error\n").to_stderr.and raise_error(SystemExit)
+      expect{subject.run(['--silent', '--all', 'test-service', 'test'])}.to output("error\n").to_stderr.and raise_error(SystemExit)
     end
 
     it "Stops if the second container fails" do
@@ -128,7 +122,7 @@ describe Kontena::Cli::Services::ExecCommand do
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(exec_fail)
 
-      expect{subject.run(['--all', 'test-service', 'test'])}.to output("ok\n").to_stdout.and output("error\n").to_stderr.and raise_error(SystemExit)
+      expect{subject.run(['--silent', '--all', 'test-service', 'test'])}.to output("ok\n").to_stdout.and output("error\n").to_stderr.and raise_error(SystemExit)
     end
 
     it "Keeps going if the second container fails when using --skip" do
@@ -137,7 +131,7 @@ describe Kontena::Cli::Services::ExecCommand do
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(exec_fail)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-3/exec', { cmd: ['test'] }).and_return(exec_ok)
 
-      expect{subject.run(['--all', '--skip', 'test-service', 'test'])}.to output("ok\nok\n").to_stdout.and output("error\n").to_stderr.and raise_error(SystemExit)
+      expect{subject.run(['--silent', '--all', '--skip', 'test-service', 'test'])}.to output("ok\nok\n").to_stdout.and output("error\n").to_stderr.and raise_error(SystemExit)
     end
   end
 end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -34,4 +34,41 @@ describe Kontena::Cli::Services::ExecCommand do
       ]
     end
   end
+
+  context "For a service with multiple running instances" do
+    let :service_containers do
+      { 'containers' => [
+        {
+          'id' => 'test-grid/host/test-service.container-1',
+          'name' => 'test-service.container-1',
+          'instance_number' => 1,
+          'status' => 'running',
+        },
+        {
+          'id' => 'test-grid/host/test-service.container-2',
+          'name' => 'test-service.container-2',
+          'instance_number' => 2,
+          'status' => 'running',
+        },
+      ] }
+    end
+
+    it "Executes on the first running container by default" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+
+      expect{subject.run(['test-service', 'test'])}.to return_and_output true, [
+        'stdout',
+      ]
+    end
+
+    it "Executes on the first running container, even if they are ordered differently" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return({'containers' => service_containers['containers'].reverse })
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+
+      expect{subject.run(['test-service', 'test'])}.to return_and_output true, [
+        'stdout',
+      ]
+    end
+  end
 end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -70,5 +70,43 @@ describe Kontena::Cli::Services::ExecCommand do
         'stdout',
       ]
     end
+
+    it "Executes on the first running container if given" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+
+      expect{subject.run(['--instance=1', 'test-service', 'test'])}.to return_and_output true, [
+        'stdout',
+      ]
+    end
+
+    it "Executes on the second running container if given" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(container_exec)
+
+      expect{subject.run(['--instance=2', 'test-service', 'test'])}.to return_and_output true, [
+        'stdout',
+      ]
+    end
+
+    it "Errors on the third container if given" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+
+      expect{subject.run(['--instance=3', 'test-service', 'test'])}.to exit_with_error [
+        " [error] Service test-service does not have container instance 3",
+      ]
+    end
+
+    it "Executes on each running container" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(container_exec)
+
+      expect{subject.run(['--all', 'test-service', 'test'])}.to return_and_output a_truthy_value, [
+        'stdout',
+        'stdout',
+      ]
+    end
+
   end
 end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -57,44 +57,34 @@ describe Kontena::Cli::Services::ExecCommand do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
 
-      expect{subject.run(['test-service', 'test'])}.to return_and_output true, [
-        'stdout',
-      ]
+      expect{subject.run(['test-service', 'test'])}.to output_lines ["stdout"]
     end
 
     it "Executes on the first running container, even if they are ordered differently" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return({'containers' => service_containers['containers'].reverse })
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
 
-      expect{subject.run(['test-service', 'test'])}.to return_and_output true, [
-        'stdout',
-      ]
+      expect{subject.run(['test-service', 'test'])}.to output_lines ["stdout"]
     end
 
     it "Executes on the first running container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
 
-      expect{subject.run(['--instance=1', 'test-service', 'test'])}.to return_and_output true, [
-        'stdout',
-      ]
+      expect{subject.run(['--instance=1', 'test-service', 'test'])}.to output_lines ["stdout"]
     end
 
     it "Executes on the second running container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(container_exec)
 
-      expect{subject.run(['--instance=2', 'test-service', 'test'])}.to return_and_output true, [
-        'stdout',
-      ]
+      expect{subject.run(['--instance=2', 'test-service', 'test'])}.to output_lines ["stdout"]
     end
 
     it "Errors on the third container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
 
-      expect{subject.run(['--instance=3', 'test-service', 'test'])}.to exit_with_error [
-        " [error] Service test-service does not have container instance 3",
-      ]
+      expect{subject.run(['--instance=3', 'test-service', 'test'])}.to output(/Service test-service does not have container instance 3/).to_stderr.and raise_error(SystemExit)
     end
 
     it "Executes on each running container" do
@@ -102,11 +92,7 @@ describe Kontena::Cli::Services::ExecCommand do
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
       expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(container_exec)
 
-      expect{subject.run(['--all', 'test-service', 'test'])}.to return_and_output a_truthy_value, [
-        'stdout',
-        'stdout',
-      ]
+      expect{subject.run(['--all', 'test-service', 'test'])}.to output_lines ["stdout", "stdout"]
     end
-
   end
 end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -8,11 +8,19 @@ describe Kontena::Cli::Services::ExecCommand do
     subject
   end
 
-  let :container_exec do
+  let :exec_ok do
     [
-      ["stdout\n"],
-      ["stderr\n"],
+      ["ok\n"],
+      [],
       0, # exit
+    ]
+  end
+
+  let :exec_fail do
+    [
+      [],
+      ["error\n"],
+      1, # exit
     ]
   end
 
@@ -33,10 +41,10 @@ describe Kontena::Cli::Services::ExecCommand do
     end
 
     it "Executes on the running container by default" do
-      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
 
       expect{subject.run(['test-service', 'test'])}.to return_and_output true, [
-        'stdout',
+        'ok',
       ]
     end
   end
@@ -56,49 +64,80 @@ describe Kontena::Cli::Services::ExecCommand do
           'instance_number' => 2,
           'status' => 'running',
         },
+        {
+          'id' => 'test-grid/host/test-service.container-3',
+          'name' => 'test-service.container-3',
+          'instance_number' => 3,
+          'status' => 'running',
+        },
       ] }
     end
 
     it "Executes on the first running container by default" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
 
-      expect{subject.run(['test-service', 'test'])}.to output_lines ["stdout"]
+      expect{subject.run(['test-service', 'test'])}.to output_lines ["ok"]
     end
 
     it "Executes on the first running container, even if they are ordered differently" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return({'containers' => service_containers['containers'].reverse })
-      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
 
-      expect{subject.run(['test-service', 'test'])}.to output_lines ["stdout"]
+      expect{subject.run(['test-service', 'test'])}.to output_lines ["ok"]
     end
 
     it "Executes on the first running container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
 
-      expect{subject.run(['--instance=1', 'test-service', 'test'])}.to output_lines ["stdout"]
+      expect{subject.run(['--instance=1', 'test-service', 'test'])}.to output_lines ["ok"]
     end
 
     it "Executes on the second running container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(container_exec)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(exec_ok)
 
-      expect{subject.run(['--instance=2', 'test-service', 'test'])}.to output_lines ["stdout"]
+      expect{subject.run(['--instance=2', 'test-service', 'test'])}.to output_lines ["ok"]
     end
 
-    it "Errors on the third container if given" do
+    it "Errors on a nonexistant container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
 
-      expect{subject.run(['--instance=3', 'test-service', 'test'])}.to output(/Service test-service does not have container instance 3/).to_stderr.and raise_error(SystemExit)
+      expect{subject.run(['--instance=4', 'test-service', 'test'])}.to output(/Service test-service does not have container instance 4/).to_stderr.and raise_error(SystemExit)
     end
 
     it "Executes on each running container" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
-      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(container_exec)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(exec_ok)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-3/exec', { cmd: ['test'] }).and_return(exec_ok)
 
-      expect{subject.run(['--all', 'test-service', 'test'])}.to output_lines ["stdout", "stdout"]
+      expect{subject.run(['--all', 'test-service', 'test'])}.to output_lines ["ok", "ok", "ok"]
+    end
+
+    it "Stops if the first container fails" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_fail)
+
+      expect{subject.run(['--all', 'test-service', 'test'])}.to output("error\n").to_stderr.and raise_error(SystemExit)
+    end
+
+    it "Stops if the second container fails" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(exec_fail)
+
+      expect{subject.run(['--all', 'test-service', 'test'])}.to output("ok\n").to_stdout.and output("error\n").to_stderr.and raise_error(SystemExit)
+    end
+
+    it "Keeps going if the second container fails when using --skip" do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(exec_ok)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-2/exec', { cmd: ['test'] }).and_return(exec_fail)
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-3/exec', { cmd: ['test'] }).and_return(exec_ok)
+
+      expect{subject.run(['--all', '--skip', 'test-service', 'test'])}.to output("ok\nok\n").to_stdout.and output("error\n").to_stderr.and raise_error(SystemExit)
     end
   end
 end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -4,8 +4,8 @@ describe Kontena::Cli::Services::ExecCommand do
 
   let :container_exec do
     [
-      "stdout",
-      "stderr",
+      ["stdout\n"],
+      ["stderr\n"],
       0, # exit
     ]
   end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -1,0 +1,37 @@
+describe Kontena::Cli::Services::ExecCommand do
+  include ClientHelpers
+  include OutputHelpers
+
+  let :container_exec do
+    [
+      "stdout",
+      "stderr",
+      0, # exit
+    ]
+  end
+
+  context "For a service with one running instance" do
+    let :service_containers do
+      { 'containers' => [
+        {
+          'id' => 'test-grid/host/test-service.container-1',
+          'name' => 'test-service.container-1',
+          'instance_number' => 1,
+          'status' => 'running',
+        },
+      ] }
+    end
+
+    before do
+      expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
+    end
+
+    it "Executes on the running container by default" do
+      expect(client).to receive(:post).with('containers/test-grid/host/test-service.container-1/exec', { cmd: ['test'] }).and_return(container_exec)
+
+      expect{subject.run(['test-service', 'test'])}.to return_and_output true, [
+        'stdout',
+      ]
+    end
+  end
+end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -2,6 +2,12 @@ describe Kontena::Cli::Services::ExecCommand do
   include ClientHelpers
   include OutputHelpers
 
+  subject do
+    subject = described_class.new('.')
+    subject.with_spinner = false
+    subject
+  end
+
   let :container_exec do
     [
       ["stdout\n"],

--- a/cli/spec/support/client_helpers.rb
+++ b/cli/spec/support/client_helpers.rb
@@ -13,12 +13,16 @@ module ClientHelpers
       '1234567'
     end
 
+    base.let(:current_grid) do
+      'test-grid'
+    end
+
     base.let(:settings) do
       {'current_server' => 'alias',
        'current_account' => 'kontena',
        'servers' => [
            {'name' => 'some_master', 'url' => 'some_master'},
-           {'name' => 'alias', 'url' => 'someurl', 'token' => token, 'account' => 'master'}
+           {'name' => 'alias', 'url' => 'someurl', 'token' => token, 'account' => 'master', 'grid' => current_grid},
        ]
       }
     end
@@ -26,7 +30,7 @@ module ClientHelpers
     base.before(:each) do
       RSpec::Mocks.space.proxy_for(File).reset
       allow(subject).to receive(:client).and_return(client)
-      allow(subject).to receive(:current_grid).and_return('test-grid')
+      allow(subject).to receive(:current_grid).and_return(current_grid)
       allow(File).to receive(:exist?).with(File.join(Dir.home, '.kontena/certs/.pem')).and_return(false)
       allow(File).to receive(:exist?).with(File.join(Dir.home, '.kontena_client.json')).and_return(true)
       allow(File).to receive(:readable?).with(File.join(Dir.home, '.kontena_client.json')).and_return(true)

--- a/cli/spec/support/output_helpers.rb
+++ b/cli/spec/support/output_helpers.rb
@@ -50,37 +50,25 @@ module OutputHelpers
     end
   end
 
-  matcher :exit_with_error do |*lines|
+  matcher :output_lines do |lines|
     supports_block_expectations
 
     match do |block|
-      stderr = lines.flatten.join("\n") + "\n"
-
-      @exit = nil
-
-      wrapper = proc {
-        begin
-          block.call
-        rescue SystemExit => exc
-          @exit = exc
-        end
-      }
+      stdout = lines.flatten.join("\n") + "\n"
 
       begin
-        expect{wrapper.call}.to output(stderr).to_stderr
+        expect{@return = block.call}.to output(stdout).to_stdout
       rescue Exception => error
         @error = error
 
         return false
       else
-        return @exit != nil
+        return true
       end
     end
 
     failure_message do |block|
-      return @error if @error
-      return "did not exit" unless @exit
+      return @error
     end
   end
-
 end

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -141,14 +141,6 @@ module V1
               halt_request(422, { error: outcome.errors.message })
             end
           end
-
-          # POST /v1/services/:grid_name/:stack_name/:service_name/exec
-          r.on 'exec' do
-            data = parse_json_body
-            container = @grid_service.containers.where(name: "#{@grid_service.name}-#{data['instance']}")
-            halt_request(404) unless container
-            Docker::ContainerExecutor.new(container).exec_in_container(data['cmd'])
-          end
         end
 
         # PUT /v1/services/:grid_name/:stack_name/:service_name


### PR DESCRIPTION
Fixes #1563

This adds a new `kontena service exec SERVICE CMD...` command to complement `kontena container exec NODE/CONTAINER`.

The `kontena container` commands are difficult to use with the unpredictable node name prefix, and the changing container naming schemas in Kontena 0.16 -> 1.0 -> #1494.

This PR also removes the undocumented and broken `POST /v1/services/:grid_name/:stack_name/:service_name/exec` API.

## Examples

For a `redis` service with four instances:

```
NAME                                                         INSTANCES  STATEFUL STATE      EXPOSED PORTS                                     
⊝ redis                                                      4 / 4      no       running                                                      
```

#### `kontena service exec redis hostname`
```
redis-1.development.kontena.local
```

#### `kontena service exec --instance=3 redis hostname`
```
redis-3.development.kontena.local
```

#### `kontena service exec --all redis hostname`
```
 [done] Executing command on null-redis-1     
redis-1.development.kontena.local
 [done] Executing command on null-redis-2     
redis-2.development.kontena.local
 [done] Executing command on null-redis-3     
redis-3.development.kontena.local
 [done] Executing command on null-redis-4     
redis-4.development.kontena.local
```

#### `kontena service exec --silent --all redis hostname`
```
redis-1.development.kontena.local
redis-2.development.kontena.local
redis-3.development.kontena.local
redis-4.development.kontena.local
```

### Exit code

The exit code is propagated by the `kontena-cli`:

#### `kontena service exec redis ls /nonexist || echo fail`

```
ls: 
cannot access /nonexist: No such file or directory
fail
```

#### `kontena service exec --all --shell redis '[ $KONTENA_SERVICE_INSTANCE_NUMBER != 5 ]' && echo yay`
```
 [done] Executing command on null-redis-1     
 [done] Executing command on null-redis-2     
 [done] Executing command on null-redis-3     
 [done] Executing command on null-redis-4     
yay
```

#### `kontena service exec --all --shell redis '[ $KONTENA_SERVICE_INSTANCE_NUMBER != 2 ]' && echo yay`
```
 [done] Executing command on null-redis-1     
 [fail] Executing command on null-redis-2     
```

#### `kontena service exec --all --skip --shell redis '[ $KONTENA_SERVICE_INSTANCE_NUMBER != 2 ]' && echo yay`
```
 [done] Executing command on null-redis-1     
 [fail] Executing command on null-redis-2     
 [done] Executing command on null-redis-3     
 [done] Executing command on null-redis-4     
```

### Only running containers

#### `kontena service exec --instance=2 redis hostname`
```
 [error] Service redis container null-redis-2 is not running, it is paused
```

####  `kontena service exec --all redis hostname`
```
 [done] Executing command on null-redis-1     
redis-1.development.kontena.local
 [warn] Service redis container null-redis-2 is paused, skipping
 [done] Executing command on null-redis-3     
redis-3.development.kontena.local
 [done] Executing command on null-redis-4     
redis-4.development.kontena.local
```

#### `kontena service stop redis && kontena service exec redis hostname`
```
 [error] Service redis does not have any running containers
```

### Optional shell command

This does not execute the command using a shell by default, unlike `kontena container exec`

####  `kontena service exec redis touch 'foo bar' && kontena service exec redis ls -l`
```
total 12
-rw-r--r--. 1 redis redis 76 Jan 26 14:51 dump.rdb
-rw-r--r--. 1 root  root   0 Jan 26 14:55 foo bar
```

#### `kontena service exec --shell redis 'touch foo bar' && kontena service exec redis ls -l`
```
-rw-r--r--. 1 root  root   0 Jan 26 15:04 bar
-rw-r--r--. 1 redis redis 76 Jan 26 14:51 dump.rdb
-rw-r--r--. 1 root  root   0 Jan 26 15:04 foo
```

#### `kontena service exec --shell redis 'for name in *; do echo "have file: $name"; done'`
```
have file: bar
have file: dump.rdb
have file: foo
```