### PR TITLE
Better error message when vault key nil/empty in vault resolver

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/opto/vault_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/vault_resolver.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Stacks
   module YAML
     class Opto::Resolvers::Vault < Opto::Resolver
       def resolve
-        raise RuntimeError, "Missing / empty vault secret name" if hint.to_s.empty?
+        raise RuntimeError, "Missing or empty vault secret name" if hint.to_s.empty?
         require 'shellwords'
         Kontena.run("vault read --return #{hint.shellescape}", returning: :result)
       end

--- a/cli/lib/kontena/cli/stacks/yaml/opto/vault_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/vault_resolver.rb
@@ -2,6 +2,7 @@ module Kontena::Cli::Stacks
   module YAML
     class Opto::Resolvers::Vault < Opto::Resolver
       def resolve
+        raise RuntimeError, "Missing / empty vault secret name" if hint.to_s.empty?
         require 'shellwords'
         Kontena.run("vault read --return #{hint.shellescape}", returning: :result)
       end


### PR DESCRIPTION
When variable definition has something like:

```yaml
variables:
  foo:
    from:
      vault: $EMPTY_STRING
```

Before: `Resolver 'vault' for 'secret' : undefined method "shellescape" for nil:NilClass`

After: `Resolver 'vault' for 'secret' : Missing or empty vault secret name`

