### PR TITLE
Allow usage of local envs that have been set through to: env

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -252,8 +252,11 @@ module Kontena::Cli::Stacks
               if use_opto
                 opt = variables.option(var)
                 if opt.nil?
-                  raise RuntimeError, "Undeclared variable '#{var}' in #{file}:#{line_num} -- #{row}" if raise_on_unknown
-                  val = nil
+                  if variables.find { |opt| opt.to[:env][var] }
+                    val = env[var]
+                  else
+                    raise RuntimeError, "Undeclared variable '#{var}' in #{file}:#{line_num} -- #{row}" if raise_on_unknown
+                  end
                 else
                   val = opt.value
                 end

--- a/cli/spec/fixtures/stack-with-prompted-variables.yml
+++ b/cli/spec/fixtures/stack-with-prompted-variables.yml
@@ -31,8 +31,12 @@ variables:
       env: test_var
   TEST_ENV_VAR:      # the default from/to is to set/read env of the option name
     type: :string
-  TAG:
+  tag:
     type: string
+    from:
+      env: TAG
+    to:
+      env: TAG
   MYSQL_IMAGE:
     type: string
     empty_is_nil: false

--- a/cli/spec/fixtures/stack-with-variables.yml
+++ b/cli/spec/fixtures/stack-with-variables.yml
@@ -23,8 +23,12 @@ variables:
       env: test_var
   TEST_ENV_VAR:      # the default from/to is to set/read env of the option name
     type: string
-  TAG:
+  tag:
     type: string
+    from:
+      env: TAG
+    to:
+      env: TAG
   MYSQL_IMAGE:
     type: string
     empty_is_nil: false

--- a/docs/references/kontena-yml-variables.md
+++ b/docs/references/kontena-yml-variables.md
@@ -68,7 +68,7 @@ variables:
   this_is_the_name:
 ```
 
-By default, a local environment variable with the same name gets populated with the variables value. You can then use it later in the yaml as: `${this_is_the_name}`.
+You can then use it later in the yaml as: `${this_is_the_name}`.
 
 ```
   environment:
@@ -94,12 +94,11 @@ You can define multiple sources, for example:
 
 ### To
 
-Define what to do with the value. The default behavior is to set it to local environment using the variable name. You can also use another environment variable name or write the value to the Vault on Kontena Master.
+Define what to do with the value.
 
 ```
   to:
-    env: MYSQL_USER # set to local env
-    vault: foo-mysql-user # also send to vault
+    vault: foo-mysql-user # send the value to vault with key name foo-mysql-user
 ```
 
 ### Conditionals
@@ -293,6 +292,32 @@ With this configuration you can set the storage zone by setting the environment 
 ```
 
 Only allow http:// and https:// uris by default.
+
+### `array`
+
+```
+  split: ',', # Use this pattern to split an incoming string into an array
+  join: false, # Set to a pattern such as ',' to output a comma separated string
+  empty_is_nil: false, # When true, an empty array will become nil
+  sort: false, # Sort the array before output
+  uniq: false, # Remove duplicates before output
+  count: false, # Instead of outputting the array, output the array size
+  compact: false # Remove nils before output
+```
+
+Usage example:
+
+```
+arr:
+  type: array
+  join: ","
+  value:
+    - a
+    - b
+    - c
+```
+
+The variable `arr` will have the value `a,b,c`.
 
 ## Resolvers (From:)
 

--- a/docs/references/kontena-yml-variables.md
+++ b/docs/references/kontena-yml-variables.md
@@ -261,25 +261,25 @@ With this configuration you can set the storage zone by setting the environment 
 ### `integer`
 
 ```
-  min: 0 # minimum value, can be negative
-  max: nil # maximum value
+  min: 0             # minimum value, can be negative
+  max: nil           # maximum value
   nil_is_zero: false # null value will be turned into zero
 ```
 
 ### `string`
 
 ```
-  min_length: nil # minimum length
-  max_length: nil # maximum length
-  hexdigest: nil  # hexdigest output. options: md5, sha1, sha256, sha384 or sha512.
+  min_length: nil     # minimum length
+  max_length: nil     # maximum length
+  hexdigest: nil      # hexdigest output. options: md5, sha1, sha256, sha384 or sha512.
   empty_is_nil: true, # if string contains whitespace only, make value null
-  encode_64: false # encode content to base64
-  decode_64: false # decode content from base64
-  upcase: false # convert to UPPERCASE
-  downcase: false # convert to lowercase
-  strip: false # remove leading/trailing whitespace,
-  chomp: false # remove trailing linefeed
-  capitalize: false # convert to Capital case.
+  encode_64: false    # encode content to base64
+  decode_64: false    # decode content from base64
+  upcase: false       # convert to UPPERCASE
+  downcase: false     # convert to lowercase
+  strip: false        # remove leading/trailing whitespace,
+  chomp: false        # remove trailing linefeed
+  capitalize: false   # convert to Capital case.
 
 ```
 
@@ -296,13 +296,13 @@ Only allow http:// and https:// uris by default.
 ### `array`
 
 ```
-  split: ',', # Use this pattern to split an incoming string into an array
-  join: false, # Set to a pattern such as ',' to output a comma separated string
-  empty_is_nil: false, # When true, an empty array will become nil
-  sort: false, # Sort the array before output
-  uniq: false, # Remove duplicates before output
-  count: false, # Instead of outputting the array, output the array size
-  compact: false # Remove nils before output
+  split: ','          # Use this pattern to split an incoming string into an array
+  join: false         # Set to a pattern such as ',' to output a comma separated string
+  empty_is_nil: false # When true, an empty array will become nil
+  sort: false         # Sort the array before output
+  uniq: false         # Remove duplicates before output
+  count: false        # Instead of outputting the array, output the array size
+  compact: false      # Remove nils before output
 ```
 
 Usage example:

--- a/docs/references/kontena-yml-variables.md
+++ b/docs/references/kontena-yml-variables.md
@@ -272,7 +272,7 @@ With this configuration you can set the storage zone by setting the environment 
   min_length: nil     # minimum length
   max_length: nil     # maximum length
   hexdigest: nil      # hexdigest output. options: md5, sha1, sha256, sha384 or sha512.
-  empty_is_nil: true, # if string contains whitespace only, make value null
+  empty_is_nil: true  # if string contains whitespace only, make value null
   encode_64: false    # encode content to base64
   decode_64: false    # decode content from base64
   upcase: false       # convert to UPPERCASE

--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -11,7 +11,7 @@ Each service defined in kontena.yml will create a service with that name within 
 
 Each service is reachable by all other services in the same grid and discoverable by other services in the same stack by using the service name as a DNS hostname. See [networking](#networking) for full details.
 
-You can use environment variables in configuration values with a bash-like `${VARIABLE}` syntax. See [variable substitution](#variable-substitution) for full details.
+You can use variables to set configuration values with a bash-like `${VARIABLE}` syntax. See [variable substitution](#variable-substitution) for full details.
 
 ## Stack configuration reference
 
@@ -30,7 +30,7 @@ version: 0.1.0
 
 #### variables
 
-Variables to be used to fill in values and to create conditional logic.
+Variables to be used to fill in values and to create conditional logic in the stack file.
 See the complete [variables reference](kontena-yml-variables.md).
 
 ```
@@ -40,8 +40,10 @@ variables:
     from:
       prompt: Enter a root password for MySQL or leave empty to auto generate
       random_string: 16
-    to:
-      env: MYSQL_PASSWORD
+services:
+  mysql:
+    environment:
+      - "MYSQL_PASSWORD=${mysql_root_pw}"
 ```
 
 #### expose


### PR DESCRIPTION
Only variable names were accepted. Now it also accepts env variables that are set by a `to:` setter.

Now this works:

```
variables:
  foo:
    type: string
    from:
      env: BAR
    to:
      env: BAR
services:
  mysql:
    image: $BAR
```

