### PR TITLE
Detect if running a graphical browser is theoretically possible

### DIFF
--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -51,6 +51,14 @@ module Kontena::Cli::Cloud
     end
 
     def web_flow
+      if Kontena.browserless? && !force?
+        STDERR.puts "Your current environment does not seem to support opening a local graphical WWW browser."
+        STDERR.puts
+        STDERR.puts "You can perorm a login on another computer, copy the token and use it with 'kontena cloud login --token <token>'."
+        STDERR.puts "There will be an easier way to log in from a browserless environment soon."
+        exit_with_error 'Unable to launch a web browser'
+      end
+
       require_relative '../localhost_web_server'
       require 'launchy'
 
@@ -85,7 +93,7 @@ module Kontena::Cli::Cloud
 
       server_thread  = Thread.new { Thread.main['response'] = web_server.serve_one }
       browser_thread = Thread.new { Launchy.open(uri.to_s) }
-      
+
       spinner "Waiting for browser authorization response" do
         server_thread.join
       end

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::Master
     option ['-t', '--token'], '[TOKEN]', 'Use a pre-generated access token', environment_variable: 'KONTENA_TOKEN'
     option ['-n', '--name'], '[NAME]', 'Set server name', environment_variable: 'KONTENA_MASTER'
     option ['-c', '--code'], '[CODE]', 'Use authorization code generated during master install'
-    option ['-r', '--remote'], :flag, 'Do not try to open a browser'
+    option ['-r', '--remote'], :flag, 'Do not try to open a browser', default: Kontena.browserless?
     option ['-e', '--expires-in'], '[SECONDS]', 'Request token with expiration of X seconds. Use 0 to never expire', default: 7200
     option ['-v', '--verbose'], :flag, 'Increase output verbosity'
     option ['-f', '--force'], :flag, 'Force reauthentication'

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::Master
     option ['-t', '--token'], '[TOKEN]', 'Use a pre-generated access token', environment_variable: 'KONTENA_TOKEN'
     option ['-n', '--name'], '[NAME]', 'Set server name', environment_variable: 'KONTENA_MASTER'
     option ['-c', '--code'], '[CODE]', 'Use authorization code generated during master install'
-    option ['-r', '--remote'], :flag, 'Do not try to open a browser', default: Kontena.browserless?
+    option ['-r', '--[no-]remote'], :flag, 'Login using a browser on another device', default: Kontena.browserless?
     option ['-e', '--expires-in'], '[SECONDS]', 'Request token with expiration of X seconds. Use 0 to never expire', default: 7200
     option ['-v', '--verbose'], :flag, 'Increase output verbosity'
     option ['-f', '--force'], :flag, 'Force reauthentication'

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -36,6 +36,10 @@ module Kontena
     ENV['OS'] == 'Windows_NT' && RUBY_PLATFORM !~ /cygwin/
   end
 
+  def self.browserless?
+    RUBY_PLATFORM =~ /linux|(?:free|net|open|net)bsd|solaris|aix|hpux/ && ENV['DISPLAY'].to_s.empty?
+  end
+
   def self.simple_terminal?
     ENV['KONTENA_SIMPLE_TERM'] || !$stdout.tty?
   end

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -37,7 +37,7 @@ module Kontena
   end
 
   def self.browserless?
-    RUBY_PLATFORM =~ /linux|(?:free|net|open|net)bsd|solaris|aix|hpux/ && ENV['DISPLAY'].to_s.empty?
+    !!(RUBY_PLATFORM =~ /linux|(?:free|net|open)bsd|solaris|aix|hpux/ && ENV['DISPLAY'].to_s.empty?)
   end
 
   def self.simple_terminal?

--- a/cli/spec/kontena/cli/cloud/login_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/login_command_spec.rb
@@ -17,6 +17,7 @@ describe Kontena::Cli::Cloud::LoginCommand do
   before(:each) do
     allow(subject).to receive(:config).and_return(config)
     allow(Kontena::Client).to receive(:new).and_return(client)
+    allow(Kontena).to receive(:browserless?).and_return(false)
   end
 
   it 'should give error if trying to use --code and --force' do

--- a/cli/spec/kontena/cli/master/login_command_spec.rb
+++ b/cli/spec/kontena/cli/master/login_command_spec.rb
@@ -14,6 +14,10 @@ describe Kontena::Cli::Master::LoginCommand do
 
   let(:client) { double(:client) }
 
+  before(:each) do
+    allow(Kontena).to receive(:browserless?).and_return(false)
+  end
+
   it 'should exit with error if --code and --token both given' do
     expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
     subject.run(%w(--code abcd --token defg))

--- a/cli/spec/kontena/cli/master/login_command_spec.rb
+++ b/cli/spec/kontena/cli/master/login_command_spec.rb
@@ -7,16 +7,13 @@ require 'ostruct'
 describe Kontena::Cli::Master::LoginCommand do
 
   include ClientHelpers
+  RUBY_PLATFORM = 'linux'
 
   let(:subject) do
     described_class.new(File.basename($0))
   end
 
   let(:client) { double(:client) }
-
-  before(:each) do
-    allow(Kontena).to receive(:browserless?).and_return(false)
-  end
 
   it 'should exit with error if --code and --token both given' do
     expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
@@ -236,7 +233,7 @@ describe Kontena::Cli::Master::LoginCommand do
     it 'goes to web flow when the existing token does not work' do
       expect(client).to receive(:authentication_ok?).and_return(false)
       expect(subject).to receive(:web_flow).and_return(true)
-      subject.run(%w(fooserver))
+      subject.run(%w(--no-remote fooserver))
     end
   end
 
@@ -269,7 +266,7 @@ describe Kontena::Cli::Master::LoginCommand do
       end.and_return({})
       expect(Launchy).to receive(:open).with('http://authprovider.example.com/authplz').and_return(true)
       expect(client).to receive(:exchange_code).with('abcd1234').and_return('access_token' => 'defg456', 'server' => { 'name' => 'foobar' }, 'user' => { 'name' => 'testuser' })
-      subject.run(%w(--skip-grid-auto-select http://foobar.example.com))
+      subject.run(%w(--no-remote --skip-grid-auto-select http://foobar.example.com))
       expect(subject.config.servers.size).to eq 1
       server = subject.config.servers.first
       expect(server.url).to eq 'http://foobar.example.com'

--- a/cli/spec/kontena/cli/master/login_command_spec.rb
+++ b/cli/spec/kontena/cli/master/login_command_spec.rb
@@ -7,7 +7,6 @@ require 'ostruct'
 describe Kontena::Cli::Master::LoginCommand do
 
   include ClientHelpers
-  RUBY_PLATFORM = 'linux'
 
   let(:subject) do
     described_class.new(File.basename($0))
@@ -328,6 +327,7 @@ describe Kontena::Cli::Master::LoginCommand do
       allow(File).to receive(:readable?).and_return(true)
       allow(Kontena::Client).to receive(:new).and_return(client)
       allow(Kontena::LocalhostWebServer).to receive(:new).and_return(webserver)
+      allow(Kontena).to receive(:browserless?).and_return(false)
       allow(webserver).to receive(:port).and_return(12345)
       allow(webserver).to receive(:serve_one).and_return(
         { 'code' => 'abcd1234' }
@@ -341,7 +341,7 @@ describe Kontena::Cli::Master::LoginCommand do
       allow(client).to receive(:exchange_code).with('abcd1234').and_return('access_token' => 'defg456', 'server' => { 'name' => 'foobar' }, 'user' => { 'name' => 'testuser' })
       subject.config.current_master = 'fooserver'
       subject.config.current_master
-      subject.run(%w(--skip-grid-auto-select http://foobar.example.com))
+      subject.run(%w(--no-remote --skip-grid-auto-select http://foobar.example.com))
       expect(subject.config.current_master.name).to eq 'foobar'
     end
   end


### PR DESCRIPTION
If OS is linux/bsd/aix/hpux/solaris and env `$DISPLAY` is empty, assume there's no way to run a local graphical web browser.

