### PR TITLE
One step master --remote login

### DIFF
--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -69,13 +69,14 @@ module Kontena::Cli::Master
       if self.remote?
         # no local browser? tell user to launch an external one
         display_remote_message(server, auth_params)
-        update_server_to_config(server)
-        exit 1
+        auth_code = prompt.ask("Enter code displayed in browser:")
+        use_authorization_code(server, auth_code)
       else
         # local web flow
         web_flow(server, auth_params)
-        display_login_info(only: :master) unless (running_silent? || self.no_login_info?)
       end
+
+      display_login_info(only: :master) unless (running_silent? || self.no_login_info?)
     end
 
     def next_default_name
@@ -170,9 +171,6 @@ module Kontena::Cli::Master
       else
         puts "Visit this URL in a browser:"
         puts "#{url}"
-        puts
-        puts "Then complete the authentication by using:"
-        puts "kontena master login --code <CODE FROM BROWSER> #{server.url}"
       end
     end
 

--- a/docs/using-kontena/authentication.md
+++ b/docs/using-kontena/authentication.md
@@ -216,11 +216,7 @@ or
 $ kontena master join --remote <https://master_url> <invite_code>
 ```
 
-The CLI will output a link that the user can open in a browser on any other computer. After the flow is completed the browser will display an authorization code, which the user can use to complete the authentication from the CLI:
-
-```
-$ kontena master login --code <authorization_code> <https://master_url>
-```
+The CLI will output a link that the user can open in a browser on any other computer and a prompt that asks for the authorization code that will be displayed in the browser once the authentication flow is completed on the browser.
 
 It is also possible to use an access token created using another computer and complete the authentication without using a browser at all by using the `--code` parameter:
 

--- a/server/app/views/static/code.html
+++ b/server/app/views/static/code.html
@@ -4,10 +4,10 @@
   </head>
   <body>
     <p>
-    Enter this command to complete authentication:
+      Authorization code:
     </p>
-    <div style='background: black; color: white; font-family: "Lucida Console", Monaco, monospace; padding: 10px 10px 10px 10px;'>
-      kontena master login --code <script>document.write(window.location.hash.split('code=')[1].split('&')[0]);</script> <script>document.write(window.location.origin);</script>
+    <div style='background: black; color: white; font-family: "Lucida Console", Monaco, monospace; padding: 10px 10px 10px 10px; font-size: 24pt'>
+      <script>document.write(window.location.hash.split('code=')[1].split('&')[0]);</script>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Instead of running `kontena master login --remote` and `kontena master login --code`, the remote option now asks for the code displayed in the browser.

![image](https://cloud.githubusercontent.com/assets/224971/22424714/73a7f5ce-e700-11e6-9423-6763cb3b8aa7.png)

Fixes #1665