### PR TITLE
Fix service volume update

### DIFF
--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -18,7 +18,6 @@ module GridServices
       if self.links
         validate_links(self.grid_service.grid, self.grid_service.stack, self.links)
       end
-
       if self.strategy && !self.strategies[self.strategy]
         add_error(:strategy, :invalid_strategy, 'Strategy not supported')
       end
@@ -27,6 +26,12 @@ module GridServices
       end
       if self.secrets
         validate_secrets_exist(self.grid_service.grid, self.secrets)
+      end
+      if self.volumes && self.grid_service.stateful?
+        changed_volumes = self.volumes.select { |v| !self.grid_service.volumes.include?(v) }
+        if changed_volumes.any? { |v| !v.include?(':') }
+          add_error(:volumes, :invalid, 'Adding a non-named volume is not supported to a stateful service')
+        end
       end
     end
 
@@ -53,6 +58,7 @@ module GridServices
       attributes[:devices] = self.devices if self.devices
       attributes[:deploy_opts] = self.deploy_opts if self.deploy_opts
       attributes[:health_check] = self.health_check if self.health_check
+      attributes[:volumes] = self.volumes if self.volumes
 
       if self.links
         attributes[:grid_service_links] = build_grid_service_links(

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -93,6 +93,82 @@ describe GridServices::Update do
       ).run
       expect(outcome.success?).to be(true)
     end
+
+    context 'volumes' do
+      context 'stateless service' do
+        it 'allows to add non-named volume' do
+          outcome = described_class.new(
+            grid_service: redis_service,
+            volumes: ['/foo']
+          ).run
+          expect(outcome.success?).to be_truthy
+          expect(outcome.result.volumes).to eq(['/foo'])
+        end
+
+        it 'allows to add named volume' do
+          outcome = described_class.new(
+            grid_service: redis_service,
+            volumes: ['foo:/foo']
+          ).run
+          expect(outcome.success?).to be_truthy
+          expect(outcome.result.volumes).to eq(['foo:/foo'])
+        end
+
+        it 'allows to add bind mounted volume' do
+          outcome = described_class.new(
+            grid_service: redis_service,
+            volumes: ['/foo:/foo']
+          ).run
+          expect(outcome.success?).to be_truthy
+          expect(outcome.result.volumes).to eq(['/foo:/foo'])
+        end
+      end
+
+      context 'stateful service' do
+        let(:stateful_service) do
+          GridService.create(
+            grid: grid, name: 'redis', image_name: 'redis:2.8', stateful: true,
+            volumes: ['/data']
+          )
+        end
+
+        it 'does not allow to add non-named volume' do
+          outcome = described_class.new(
+            grid_service: stateful_service,
+            volumes: ['/data', '/foo']
+          ).run
+          expect(outcome.success?).to be_falsey
+        end
+
+        it 'allows to add named volume' do
+          outcome = described_class.new(
+            grid_service: stateful_service,
+            volumes: ['/data', 'foo:/foo']
+          ).run
+          expect(outcome.success?).to be_truthy
+          expect(outcome.result.volumes).to eq(['/data', 'foo:/foo'])
+        end
+
+        it 'allows to add bind mounted volume' do
+          outcome = described_class.new(
+            grid_service: stateful_service,
+            volumes: ['/data', '/foo:/foo']
+          ).run
+          expect(outcome.success?).to be_truthy
+          expect(outcome.result.volumes).to eq(['/data', '/foo:/foo'])
+        end
+
+        it 'allows to remove a volume' do
+          outcome = described_class.new(
+            grid_service: stateful_service,
+            volumes: []
+          ).run
+          expect(outcome.success?).to be_truthy
+          expect(outcome.result.volumes).to eq([])
+        end
+      end
+    end
+
   end
 
   describe '#build_grid_service_hooks' do

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -169,6 +169,35 @@ describe GridServices::Update do
       end
     end
 
+    context 'volumes_from' do
+      context 'stateless service' do
+        it 'allows to update volumes_from' do
+          outcome = described_class.new(
+            grid_service: redis_service,
+            volumes_from: ['data-1']
+          ).run
+          expect(outcome.success?).to be_truthy
+          expect(outcome.result.volumes_from).to eq(['data-1'])
+        end
+      end
+
+      context 'stateful service' do
+        let(:stateful_service) do
+          GridService.create(
+            grid: grid, name: 'redis', image_name: 'redis:2.8', stateful: true,
+            volumes: ['/data']
+          )
+        end
+
+        it 'does not allow to update volumes_from' do
+          outcome = described_class.new(
+            grid_service: stateful_service,
+            volumes_from: ['data-1']
+          ).run
+          expect(outcome.success?).to be_falsey
+        end
+      end
+    end
   end
 
   describe '#build_grid_service_hooks' do


### PR DESCRIPTION
Allow to update service volume definitions, except when service is stateful and added volume is not a bind-mounted or a named volume.