### PR TITLE
Improve service stack revision visibility

### DIFF
--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -43,10 +43,13 @@ module Kontena
           service = get_service(token, service_id)
           grid = service['id'].split('/')[0]
           puts "#{service['id']}:"
+          puts "  created: #{service['created_at']}"
+          puts "  updated: #{service['updated_at']}"
           puts "  stack: #{service['stack']['id'] }"
-          puts "  status: #{service['state'] }"
+          puts "  state: #{service['state'] }"
           puts "  image: #{service['image']}"
           puts "  revision: #{service['revision']}"
+          puts "  stack_revision: #{service['stack_revision']}" if service['stack_revision']
           puts "  stateful: #{service['stateful'] == true ? 'yes' : 'no' }"
           puts "  scaling: #{service['instances'] }"
           puts "  strategy: #{service['strategy']}"

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -25,11 +25,12 @@ module Kontena::Cli::Stacks
       stack = fetch_stack(name)
 
       puts "#{stack['name']}:"
+      puts "  created: #{stack['created_at']}"
+      puts "  updated: #{stack['updated_at']}"
       puts "  state: #{stack['state']}"
       puts "  stack: #{stack['stack']}"
       puts "  version: #{stack['version']}"
-      puts "  created_at: #{stack['created_at']}"
-      puts "  updated_at: #{stack['updated_at']}"
+      puts "  revision: #{stack['revision']}"
       puts "  expose: #{stack['expose'] || '-'}"
       puts "  services:"
       stack['services'].each do |service|
@@ -43,14 +44,16 @@ module Kontena::Cli::Stacks
       service = get_service(token, service_id)
       pad = '    '.freeze
       puts "#{pad}#{service['name']}:"
+      puts "#{pad}  created: #{service['created_at']}"
+      puts "#{pad}  updated: #{service['updated_at']}"
       puts "#{pad}  image: #{service['image']}"
-      puts "#{pad}  status: #{service['state'] }"
+      puts "#{pad}  revision: #{service['stack_revision']}"
+      puts "#{pad}  state: #{service['state'] }"
       if service['health_status']
         puts "#{pad}  health_status:"
         puts "#{pad}    healthy: #{service['health_status']['healthy']}"
         puts "#{pad}    total: #{service['health_status']['total']}"
       end
-      puts "#{pad}  revision: #{service['revision']}"
       puts "#{pad}  stateful: #{service['stateful'] == true ? 'yes' : 'no' }"
       puts "#{pad}  scaling: #{service['instances'] }"
       puts "#{pad}  strategy: #{service['strategy']}"
@@ -71,6 +74,15 @@ module Kontena::Cli::Stacks
         end
       end
 
+      if service['secrets'].to_a.size > 0
+        puts "#{pad}  secrets: "
+        service['secrets'].to_a.each do |s|
+          puts "#{pad}    - secret: #{s['secret']}"
+          puts "#{pad}      name: #{s['name']}"
+          puts "#{pad}      type: #{s['type']}"
+        end
+      end
+
       unless service['cmd'].to_s.empty?
         if service['cmd']
           puts "#{pad}  cmd: #{service['cmd'].join(' ')}"
@@ -83,6 +95,20 @@ module Kontena::Cli::Stacks
         puts "#{pad}  ports:"
         service['ports'].to_a.each do |p|
           puts "#{pad}    - #{p['node_port']}:#{p['container_port']}/#{p['protocol']}"
+        end
+      end
+
+      if service['volumes'].to_a.size > 0
+        puts "#{pad}  volumes:"
+        service['volumes'].to_a.each do |v|
+          puts "#{pad}    - #{v}"
+        end
+      end
+
+      if service['volumes_from'].to_a.size > 0
+        puts "#{pad}  volumes_from:"
+        service['volumes_from'].to_a.each do |v|
+          puts "#{pad}    - #{v}"
         end
       end
 

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -33,6 +33,7 @@ class GridService
   field :deploy_requested_at, type: DateTime
   field :deployed_at, type: DateTime
   field :revision, type: Fixnum, default: 1
+  field :stack_revision, type: Fixnum
   field :strategy, type: String, default: 'ha'
 
   belongs_to :grid

--- a/server/app/mutations/stacks/deploy.rb
+++ b/server/app/mutations/stacks/deploy.rb
@@ -52,6 +52,8 @@ module Stacks
         end
         unless outcome.success?
           handle_service_outcome_errors(service[:name], outcome.errors.message, :update)
+        else
+          outcome.result.set(:stack_revision => stack_rev.revision)
         end
       end
     end

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -52,6 +52,7 @@ json.instance_counts do
 end
 json.hooks grid_service.hooks.as_json(only: [:name, :type, :cmd, :oneshot])
 json.revision grid_service.revision
+json.stack_revision grid_service.stack_revision
 if grid_service.health_check
 	json.health_check do
 		json.protocol grid_service.health_check.protocol

--- a/server/app/views/v1/stacks/_stack.json.jbuilder
+++ b/server/app/views/v1/stacks/_stack.json.jbuilder
@@ -1,13 +1,14 @@
+latest_rev = stack.latest_rev || stack.stack_revisions.build
+
 json.id stack.to_path
 json.name stack.name
 json.state stack.state
 json.created_at stack.created_at
-json.updated_at stack.updated_at
-
-latest_rev = stack.latest_rev || stack.stack_revisions.build
+json.updated_at latest_rev.created_at
 json.stack latest_rev.stack_name
 json.registry latest_rev.registry
 json.version latest_rev.version
+json.revision latest_rev.revision
 json.expose latest_rev.expose
 json.source latest_rev.source
 json.variables latest_rev.variables

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -80,6 +80,7 @@ describe '/v1/services' do
         instances cmd entrypoint ports env memory memory_swap cpu_shares
         volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
         strategy deploy_opts pid instance_counts net dns hooks secrets revision
+        stack_revision
       ).sort)
       expect(json_response['id']).to eq('terminal-a/null/redis')
       expect(json_response['image']).to eq(redis_service.image_name)
@@ -94,6 +95,7 @@ describe '/v1/services' do
         instances cmd entrypoint ports env memory memory_swap cpu_shares
         volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
         strategy deploy_opts pid instance_counts net dns hooks secrets revision
+        stack_revision
       ).sort)
       expect(json_response['id']).to eq('terminal-a/teststack/redis')
       expect(json_response['stack']['name']).to eq('teststack')

--- a/server/spec/api/v1/stacks_spec.rb
+++ b/server/spec/api/v1/stacks_spec.rb
@@ -63,7 +63,8 @@ describe '/v1/stacks' do
   end
 
   let(:expected_attributes) do
-    %w(id created_at updated_at name stack version services state expose source variables registry)
+    %w(id created_at updated_at name stack version revision
+    services state expose source variables registry)
   end
 
   describe 'GET /:name' do

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -5,7 +5,8 @@ describe GridService do
   it { should have_fields(:image_name, :name, :user, :entrypoint, :state,
                           :net, :log_driver, :pid).of_type(String) }
   it { should have_fields(:container_count, :memory,
-                          :memory_swap, :cpu_shares).of_type(Fixnum) }
+                          :memory_swap, :cpu_shares,
+                          :revision, :stack_revision).of_type(Fixnum) }
   it { should have_fields(:affinity, :cmd, :ports, :env, :volumes, :volumes_from,
                           :cap_add, :cap_drop, :volumes).of_type(Array) }
   it { should have_fields(:labels, :log_opts).of_type(Hash) }


### PR DESCRIPTION
stack show:
```
$ kontena stack show redis
redis:
  created: 2017-01-30T17:42:09.642Z
  updated: 2017-01-30T17:42:09.645Z
  state: running
  stack: jakolehm/redis
  version: 0.1.0
  revision: 2
  expose: -
  services:
    redis:
      created: 2017-01-30T17:42:09.659Z
      updated: 2017-01-31T06:30:11.353Z
      image: redis:3-alpine
      revision: 2
      state: running
      stateful: yes
      scaling: 1
      strategy: ha
      deploy_opts:
        min_health: 0.8
      dns: redis.redis.test.kontena.local
```

service show:
```
$ kontena service show redis/redis
test/redis/redis:
  created: 2017-01-30T17:42:09.659Z
  updated: 2017-01-31T06:30:11.353Z
  stack: test/redis
  state: running
  image: redis:3-alpine
  revision: 2
  stack_revision: 2
  stateful: yes
  scaling: 1
  strategy: ha
  deploy_opts:
    min_health: 0.8
  dns: redis.redis.test.kontena.local
  net: bridge
  instances:
    redis.redis-1:
      rev: 2017-01-31 06:30:11 UTC
      service_rev: 2
      node: core-01
      dns: redis-1.redis.test.kontena.local
      ip: 10.81.128.93
      public ip: 91.158.130.116
      status: running
      exit code: 0
```