### PR TITLE
Stack deploy command spec was sleeping

### DIFF
--- a/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
@@ -4,26 +4,24 @@ require "kontena/cli/stacks/deploy_command"
 describe Kontena::Cli::Stacks::DeployCommand do
 
   include ClientHelpers
+  include RequirementsHelper
+
+  expect_to_require_current_master
+  expect_to_require_current_master_token
+
+  mock_current_master
 
   describe '#execute' do
     before(:each) do
-      allow(subject).to receive(:wait_for_deploy_to_finish).and_return(spy)
-    end
-
-    it 'requires api url' do
-      expect(described_class.requires_current_master?).to be_truthy
-      subject.run(['test-stack'])
-    end
-
-    it 'requires token' do
-      expect(described_class.requires_current_master_token?).to be_truthy
-      subject.run(['test-stack'])
+      allow(subject).to receive(:wait_for_deploy_to_finish).and_return(true)
+      allow(subject).to receive(:wait_for_deployment_to_start).and_return(true)
+      allow(subject).to receive(:wait_for_service_deploy).and_return(true)
     end
 
     it 'sends deploy command to master' do
       expect(client).to receive(:post).with(
         'stacks/test-grid/test-stack/deploy', {}
-      )
+      ).and_return({})
       subject.run(['test-stack'])
     end
   end


### PR DESCRIPTION

```
Top 10 slowest example groups:
  Kontena::Cli::Stacks::DeployCommand
    1.01 seconds average (3.02 seconds / 3 examples) ./spec/kontena/cli/stacks/deploy_command_spec.rb:4
  Kontena::Cli::Stacks::YAML::Reader
    0.01279 seconds average (0.34545 seconds / 27 examples) ./spec/kontena/cli/stacks/yaml/reader_spec.rb:5
  Kontena::Cli::Apps::DeployCommand
```
