### PR TITLE
Remove unnecessary vault_keys

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -83,8 +83,7 @@ module Kontena::Cli::Stacks
         'source' => reader.raw_content,
         'registry' => 'file://',
         'services' => kontena_services,
-        'variables' => outcome[:variables],
-        'vault_keys' => outcome[:vault_keys]
+        'variables' => outcome[:variables]
       }
       stack
     end

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -119,7 +119,6 @@ module Kontena::Cli::Stacks
               k == 'GRID' || k == 'STACK' || variables.option(k).to.has_key?(:vault) || variables.option(k).from.has_key?(:vault)
             end
           end
-          result[:vault_keys]    = extract_vault_keys(result[:services])
         end
         result
       end
@@ -382,19 +381,6 @@ module Kontena::Cli::Stacks
             options['build']['args'][k] = v
           end
         end
-      end
-
-      # Goes through an array of service hashes and extracts vault secret key names
-      # @param [Hash] services_array
-      # @return [Array] keys
-      def extract_vault_keys(services)
-        keys = []
-        services.each do |_, data|
-          Array(services['secrets']).each do |secret|
-            keys << secret['secret']
-          end
-        end
-        keys.uniq.compact
       end
 
       # Takes a stack name such as user/foo:1.0.0 and breaks it into components


### PR DESCRIPTION
No point sending the vault_keys, you can always read them from `service['secrets']`

(also they're not stored/returned by master)
