### PR TITLE
Fix Ubuntu xenial packaging to support dpkg-reconfigure

### DIFF
--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/config
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/config
@@ -4,6 +4,13 @@ set -e
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
+if [ -e /etc/kontena-agent.env ]; then
+  . /etc/kontena-agent.env
+
+  db_set kontena-agent/server_uri "${KONTENA_URI:-}"
+  db_set kontena-agent/grid_token "${KONTENA_TOKEN:-}"
+fi
+
 db_input high kontena-agent/server_uri || true
 db_input high kontena-agent/grid_token || true
 db_go || true

--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/postinst
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/postinst
@@ -7,11 +7,11 @@ set -e
 # Fetching configuration from debconf
 db_get kontena-agent/server_uri
 URI="KONTENA_URI=${RET}"
-sed -i -r "s#\#KONTENA_URI=.*#${URI}#" /etc/kontena-agent.env
+sed -i -r "s#\#?KONTENA_URI=.*#${URI}#" /etc/kontena-agent.env
 
 db_get kontena-agent/grid_token
 TOKEN="KONTENA_TOKEN=${RET}"
-sed -i -r "s#\#KONTENA_TOKEN=.*#${TOKEN}#" /etc/kontena-agent.env
+sed -i -r "s#\#?KONTENA_TOKEN=.*#${TOKEN}#" /etc/kontena-agent.env
 
 # reduce permissions on config File
 chmod 0600 /etc/kontena-agent.env

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/config
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/config
@@ -4,5 +4,11 @@ set -e
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
+if [ -e /etc/kontena-server.env ]; then
+  . /etc/kontena-server.env
+
+  db_set kontena-server/initial_admin_code "${INITIAL_ADMIN_CODE:-}"
+fi
+
 db_input high kontena-server/initial_admin_code || true
 db_go || true

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/config
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/config
@@ -8,7 +8,7 @@ if [ -e /etc/kontena-server.env ]; then
   . /etc/kontena-server.env
 
   db_set kontena-server/initial_admin_code "${INITIAL_ADMIN_CODE:-}"
+else
+  db_input high kontena-server/initial_admin_code || true
+  db_go || true
 fi
-
-db_input high kontena-server/initial_admin_code || true
-db_go || true

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/postinst
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/postinst
@@ -12,7 +12,7 @@ sed -i -r "s#\#VAULT_IV=.*#VAULT_IV=${VAULT_IV}#" /etc/kontena-server.env
 
 # Fetching configuration from debconf
 db_get kontena-server/initial_admin_code
-sed -i -r "s#\#INITIAL_ADMIN_CODE=.*#INITIAL_ADMIN_CODE=${RET}#" /etc/kontena-server.env
+sed -i -r "s#\#?INITIAL_ADMIN_CODE=.*#INITIAL_ADMIN_CODE=${RET}#" /etc/kontena-server.env
 
 # reduce permissions on config file
 chmod 0600 /etc/kontena-server.env


### PR DESCRIPTION
Fixes #1750

This reads any existing `/etc/kontena-*.env` configuration during the package `config` step, and uses that to set the debconf values that will be shown in the `dpkg-reconfigure` prompt.

The `postinst` step can then also replace any existing `KONTENA_FOO=...` values.

This means that `dpkg-reconfigure kontena-agent` can be used to e.g. fix the `KONTENA_URI` and reload the service.

This complexity also introduces new failure modes for the the maintscripts. For example, invalid syntax in the `/etc/kontena-agent.env` file will break any package operations, like:

```
/var/lib/dpkg/info/kontena-agent.config: 11: /etc/kontena-agent.env: nope: not found
```

However, the error messages seem reasonable, and those cases would also break the systemd units, so perhaps it's robust enough?