### PR TITLE
Bump opto to 1.8.2 to fix conditional short syntax

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
   spec.add_runtime_dependency "hash_validator", "~> 0.7.0"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
-  spec.add_runtime_dependency "opto", "~> 1.8.0"
+  spec.add_runtime_dependency "opto", "1.8.2"
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "safe_yaml", "~> 1.0"
   spec.add_runtime_dependency "liquid", "~> 4.0.0"


### PR DESCRIPTION
Fixes #1786

```yaml
stack: kke/wutwut
version: 0.0.1-pre1
variables:
  yes_or_no:
    type: boolean
    from: prompt

  if_yes:
    only_if: yes_or_no
    type: string
    from:
      prompt: yes selected

  if_not:
    skip_if: yes_or_no
    type: string
    from:
      prompt: no selected
```

```
$ kontena stack validate opts.yml
> Enable yes_or_no : Yes
> yes selected:                                                                                                                                                                                                                                                                                                                                                                                                                               
$ kontena stack validate opts.yml
> Enable yes_or_no : no
> no selected:
```
