### PR TITLE
Prompt echo can be disabled

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
@@ -50,10 +50,16 @@ module Kontena::Cli::Stacks
         prompt.yes?(question_text, default: option.default == false ? false : true)
       end
 
-      def ask
-        prompt.ask(question_text, default: option.default, echo: option.handler.options[:echo].nil? ? true : option.handler.options[:echo])
+      def echo?
+        return true if option.handler.nil?
+        return true if option.handler.options.nil?
+        return true if option.handler.options[:echo].nil?
+        option.handler.options[:echo]
       end
 
+      def ask
+        prompt.ask(question_text, default: option.default, echo: echo?)
+      end
 
       def resolve
         return nil if option.skip?

--- a/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
@@ -51,7 +51,7 @@ module Kontena::Cli::Stacks
       end
 
       def ask
-        prompt.ask(question_text, default: option.default)
+        prompt.ask(question_text, default: option.default, echo: option.handler.options[:echo].nil? ? true : option.handler.options[:echo])
       end
 
 

--- a/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/prompt_resolver.rb
@@ -1,3 +1,6 @@
+require 'kontena/cli/stacks/yaml/opto'
+require 'kontena/cli/common'
+
 module Kontena::Cli::Stacks
   module YAML
     class Prompt < ::Opto::Resolver

--- a/cli/spec/kontena/cli/stacks/yaml/opto/prompt_resolver_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/opto/prompt_resolver_spec.rb
@@ -1,0 +1,27 @@
+require 'opto'
+require 'kontena_cli'
+require 'kontena/cli/stacks/yaml/opto'
+
+describe Kontena::Cli::Stacks::YAML::Prompt do
+
+  describe 'echoing' do
+    let(:option_without_echo) { Opto::Option.new(type: 'string', name: 'foo', from: 'prompt', echo: false) }
+    let(:option_with_echo) { Opto::Option.new(type: 'string', name: 'foo', from: 'prompt') }
+    let(:prompt) { double(:prompt) }
+
+    before(:each) do
+      allow(Kontena).to receive(:prompt).and_return(prompt)
+    end
+
+    it 'turns echo off when variable has "echo: false"' do
+      expect(prompt).to receive(:ask).with(/Enter/, hash_including(echo: false))
+      option_without_echo.value
+    end
+
+    it 'keeps echo on when variable does not have "echo: false"' do
+      expect(prompt).to receive(:ask).with(/Enter/, hash_not_including(echo: false))
+      option_with_echo.value
+    end
+  end
+end
+

--- a/docs/references/kontena-yml-variables.md
+++ b/docs/references/kontena-yml-variables.md
@@ -280,6 +280,7 @@ With this configuration you can set the storage zone by setting the environment 
   strip: false        # remove leading/trailing whitespace,
   chomp: false        # remove trailing linefeed
   capitalize: false   # convert to Capital case.
+  echo: true          # when false, prompt will not echo keypresses, useful for password inputs
 
 ```
 
@@ -460,7 +461,7 @@ Ask a link target from the user. List of service links can be filtered by image 
 
 ```
 from:
-  service_link: 
+  service_link:
   	hint: Choose a loadbalancer
   	image: kontena/lb
   	name: loadbalancer


### PR DESCRIPTION
Fixes #1794

```yaml
stack: kke/wutwut
version: 0.0.1-pre1
variables:
  pass:
    type: string
    echo: false
    from:
      prompt: Enter secret password

  if_foo:
    only_if:
      pass: "foo"
    type: string
    from:
      prompt: you win a prize
```

