### PR TITLE
Fix link resolver to fail gracefully when no matching services.

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
@@ -12,6 +12,7 @@ module Kontena::Cli::Stacks
         services = client.get("grids/#{current_grid}/services")['services']
         services = filter_by_image(services, image_filter) if image_filter
         services = filter_by_name(services, name_filter) if name_filter
+        raise "No service matched the given filter(s)" if services.size == 0
         prompt.select(message) do |menu|
           menu.choice "<none>", nil unless option.required?
           services.each do |s|

--- a/cli/spec/kontena/cli/stacks/yaml/opto/service_link_resolver_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/opto/service_link_resolver_spec.rb
@@ -1,0 +1,21 @@
+# Commented untill we know how to refactor the modules to be more easily tested
+# require_relative '../../../../../spec_helper'
+# require 'kontena/cli/stacks/yaml/opto/service_link_resolver'
+#
+# describe Kontena::Cli::Stacks::YAML::Opto::Resolvers::ServiceLink do
+#   it 'works?' do
+#     prompt = double(:prompt)
+#     menu = double(:menu)
+#     allow(subject).to receive(:prompt).and_return(prompt)
+#     expect(prompt).to receive(:select).and_yield(menu)
+#     expect(subject).to receive(:get_services).and_return(
+#       [
+#         {'name' => 'lb', 'stack' => {'name' => 'null'}},
+#         {'name' => 'lb', 'stack' => {'name' => 'foo'}}
+#       ]
+#     )
+#     expect(menu).to receive(:choice).with('lb', 'null/lb')
+#     expect(menu).to receive(:choice).with('foo/lb', 'foo/lb')
+#
+#   end
+# end


### PR DESCRIPTION
fixes #1765 

Now it fails more gracefully:
```
$ k stack install --no-deploy ~/code/stacks/link-resolver.yml 
 [error] Resolver 'service_link' for 'lb_link' : No service matched the given filter(s)
         Rerun the command with environment DEBUG=true set to get the full exception
```
