### PR TITLE
Bump opto to 1.8.3. to stop repeating prompts

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
   spec.add_runtime_dependency "hash_validator", "~> 0.7.0"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
-  spec.add_runtime_dependency "opto", "1.8.2"
+  spec.add_runtime_dependency "opto", "1.8.3"
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "safe_yaml", "~> 1.0"
   spec.add_runtime_dependency "liquid", "~> 4.0.0"


### PR DESCRIPTION
With this yaml:

```yaml
stack: kke/wutwut
version: 0.0.1-pre1
variables:
  pass:
    type: string
    from:
      prompt: pass1
  pass2:
    type: string
    from:
      prompt: pass2
```

before this PR:

```
$ kontena stack validate opts.yml
> pass1 :
> Enter pass2 : a
> pass1 : # asks again
> pass1 : # and again
```

after this PR:

```
$ kontena stack validate opts.yml
> pass1 :
> Enter pass2 : a
[error] Variable validation failed: {"pass"=>{:presence=>"Required value missing"}}
```

