### PR TITLE
Simple menus were not enabled on windows by default

### DIFF
--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -41,7 +41,7 @@ module Kontena
   end
 
   def self.simple_terminal?
-    ENV['KONTENA_SIMPLE_TERM'] || !$stdout.tty?
+    on_windows? || ENV['KONTENA_SIMPLE_TERM'] || !$stdout.tty?
   end
 
   def self.pastel

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -4,8 +4,7 @@ require 'kontena_cli'
 describe Kontena do
   context 'prompt' do
     it 'uses light prompt on windows' do
-      allow(ENV).to receive(:[]).and_call_original
-      expect(ENV).to receive(:[]).with('OS').and_return('Windows_NT')
+      allow(ENV).to receive(:[]).with('OS').and_return('Windows_NT')
       expect(Kontena.prompt).to be_kind_of(Kontena::LightPrompt)
     end
   end

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -5,6 +5,7 @@ describe Kontena do
   context 'prompt' do
     it 'uses light prompt on windows' do
       expect(ENV).to receive(:[]).with('OS').and_return('Windows_NT')
+      allow(ENV).to receive(:[]).with(anything).and_call_original
       expect(Kontena.prompt).to be_kind_of(Kontena::LightPrompt)
     end
   end

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -2,27 +2,35 @@ require_relative '../spec_helper'
 require 'kontena_cli'
 
 describe Kontena do
-  let(:subject) { described_class }
+  context 'prompt' do
+    it 'uses light prompt on windows' do
+      expect(ENV).to receive(:[]).with('OS').and_return('Windows_NT')
+      expect(Kontena.prompt).to be_kind_of(Kontena::LightPrompt)
+    end
+  end
 
   describe '#run' do
-    let(:whoami) { double(:whoami_command) }
+    let(:whoami) { double(:whoami) }
 
     before(:each) do
-      expect(Kontena::MainCommand).to receive(:new).and_call_original
       expect(Kontena::Cli::WhoamiCommand).to receive(:new).and_return(whoami)
       expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
     end
 
     it 'accepts a command line as string' do
-      subject.run('whoami --bash-completion-path')
+
+      Kontena.run('whoami --bash-completion-path')
     end
 
     it 'accepts a command line as a list of parameters' do
-      subject.run('whoami', '--bash-completion-path')
+      Kontena.run('whoami', '--bash-completion-path')
     end
 
     it 'accepts a command line as an array' do
-      subject.run(['whoami', '--bash-completion-path'])
+      Kontena.run(['whoami', '--bash-completion-path'])
     end
   end
 end
+
+
+

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -4,8 +4,8 @@ require 'kontena_cli'
 describe Kontena do
   context 'prompt' do
     it 'uses light prompt on windows' do
+      allow(ENV).to receive(:[]).and_call_original
       expect(ENV).to receive(:[]).with('OS').and_return('Windows_NT')
-      allow(ENV).to receive(:[]).with(anything).and_call_original
       expect(Kontena.prompt).to be_kind_of(Kontena::LightPrompt)
     end
   end

--- a/cli/spec/kontena/main_command_spec.rb
+++ b/cli/spec/kontena/main_command_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../spec_helper'
+require 'kontena/main_command'
+
+describe Kontena::MainCommand do
+  let(:subject) { described_class.new('kontena') }
+
+  describe '--version' do
+    it 'outputs the version number and exits' do
+      expect do
+        expect{subject.run(['--version'])}.to output(/kontena-cli #{Kontena::Cli::VERSION}/).to_stdout
+      end.to raise_error(SystemExit) do |exc|
+        expect(exc.status).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1783

The "simple menus" were not used on Windows by default as  was intended. Only when you set env KONTENA_SIMPLE_TERM.

This PR makes windows choose the simple terminal always.
