### PR TITLE
Confirm dies with error without --force when piping

### DIFF
--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -247,6 +247,7 @@ module Kontena
         if self.respond_to?(:force?) && self.force?
           return
         end
+        exit_with_error 'Command requires --force' unless $stdout.tty?
         puts message if message
         puts "Destructive command. To proceed, type \"#{name}\" or re-run this command with --force option."
 
@@ -257,6 +258,7 @@ module Kontena
         if self.respond_to?(:force?) && self.force?
           return
         end
+        exit_with_error 'Command requires --force' unless $stdout.tty?
         prompt.yes?(message) || error('Aborted command.')
       end
 

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -247,7 +247,7 @@ module Kontena
         if self.respond_to?(:force?) && self.force?
           return
         end
-        exit_with_error 'Command requires --force' unless $stdout.tty?
+        exit_with_error 'Command requires --force' unless $stdout.tty? && $stdin.tty?
         puts message if message
         puts "Destructive command. To proceed, type \"#{name}\" or re-run this command with --force option."
 
@@ -258,7 +258,7 @@ module Kontena
         if self.respond_to?(:force?) && self.force?
           return
         end
-        exit_with_error 'Command requires --force' unless $stdout.tty?
+        exit_with_error 'Command requires --force' unless $stdout.tty? && $stdin.tty?
         prompt.yes?(message) || error('Aborted command.')
       end
 

--- a/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
@@ -115,7 +115,6 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
 
       subject.register_current
     end
-
   end
 end
 

--- a/cli/spec/kontena/cli/common_spec.rb
+++ b/cli/spec/kontena/cli/common_spec.rb
@@ -128,35 +128,42 @@ describe Kontena::Cli::Common do
     end
   end
 
-  describe '#confirm_command' do
-    it 'returns true if input matches' do
-      allow(subject).to receive(:ask).and_return('name-to-confirm')
-
-      expect(subject.confirm_command('name-to-confirm')).to be_truthy
-      expect{subject.confirm_command('name-to-confirm')}.to_not raise_error
+  context 'confirm' do
+    before(:each) do
+      expect($stdout).to receive(:tty?).at_least(:once).and_return(true)
+      expect($stdin).to receive(:tty?).at_least(:once).and_return(true)
     end
 
-    it 'raises error unless input matches' do
-      expect(subject).to receive(:ask).and_return('wrong-name')
-      expect(subject).to receive(:error).with(/did not match/)
+    describe '#confirm_command' do
+      it 'returns true if input matches' do
+        allow(subject).to receive(:ask).and_return('name-to-confirm')
 
-      subject.confirm_command('name-to-confirm')
+        expect(subject.confirm_command('name-to-confirm')).to be_truthy
+        expect{subject.confirm_command('name-to-confirm')}.to_not raise_error
+      end
+
+      it 'raises error unless input matches' do
+        expect(subject).to receive(:ask).and_return('wrong-name')
+        expect(subject).to receive(:error).with(/did not match/)
+
+        subject.confirm_command('name-to-confirm')
+      end
     end
-  end
 
-  describe '#confirm' do
-    it 'returns true if confirmed' do
-      allow(subject.prompt).to receive(:yes?).and_return(true)
+    describe '#confirm' do
+      it 'returns true if confirmed' do
+        allow(subject.prompt).to receive(:yes?).and_return(true)
 
-      expect(subject.confirm).to be_truthy
-      expect{subject.confirm}.to_not raise_error
-    end
+        expect(subject.confirm).to be_truthy
+        expect{subject.confirm}.to_not raise_error
+      end
 
-    it 'raises error unless confirmed' do
-      expect(subject.prompt).to receive(:yes?).and_return(false)
-      expect(subject).to receive(:error).with(/Aborted/)
+      it 'raises error unless confirmed' do
+        expect(subject.prompt).to receive(:yes?).and_return(false)
+        expect(subject).to receive(:error).with(/Aborted/)
 
-      subject.confirm
+        subject.confirm
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1650

Piping to command:

```
$ echo "foo" | kontena stack rm foo
```

Before:
```
Destructive command. To proceed, type "foo" or re-run this command with --force option.
> Enter 'foo' to confirm:   [error] Inappropriate ioctl for device
```

After:
```
[error] Command requires --force
```

Piping from command:
```
$ kontena stack rm foo | grep 'foo'
```

Before:
```
# nothing, waits for you to enter 'foo' in the dark.
```
After:
```
[error] Command requires --force
```

