### PR TITLE
Change node->containers removal to use callback

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -26,7 +26,7 @@ gem 'rack-attack'
 group :development, :test do
   gem 'dotenv'
   gem 'rspec', '~> 3.1.0', require: false
-  gem 'mongoid-rspec', '~> 2.1.0', require: false
+  gem 'mongoid-rspec', '~> 2.2.0', require: false
   gem 'rack-test', require: false
   gem 'rerun', require: false
   gem 'simplecov', require: false

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       tzinfo (>= 0.3.37)
     mongoid-enum (0.3.0)
       mongoid (~> 4.0)
-    mongoid-rspec (2.1.0)
+    mongoid-rspec (2.2.0)
       mongoid (~> 4.0.0)
       rake
       rspec (~> 3.1)
@@ -153,7 +153,7 @@ DEPENDENCIES
   jsonpath
   mongoid (~> 4.0.0)
   mongoid-enum
-  mongoid-rspec (~> 2.1.0)
+  mongoid-rspec (~> 2.2.0)
   msgpack
   mutations
   puma
@@ -172,4 +172,4 @@ DEPENDENCIES
   websocket-driver (~> 0.6.2)
 
 BUNDLED WITH
-   1.12.5
+   1.14.3

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -29,7 +29,7 @@ class HostNode
   attr_accessor :schedule_counter
 
   belongs_to :grid
-  has_many :containers, dependent: :destroy
+  has_many :containers
   has_many :host_node_stats
   has_and_belongs_to_many :images
 
@@ -41,6 +41,10 @@ class HostNode
   index({ grid_id: 1, node_number: 1 }, { unique: true, sparse: true })
 
   scope :connected, -> { where(connected: true) }
+
+  after_destroy do |node|
+    node.containers.unscoped.delete_all
+  end
 
   def to_path
     "#{self.grid.try(:name)}/#{self.name}"

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -43,7 +43,7 @@ class HostNode
   scope :connected, -> { where(connected: true) }
 
   after_destroy do |node|
-    node.containers.unscoped.delete_all
+    node.containers.unscoped.destroy
   end
 
   def to_path


### PR DESCRIPTION
Mongoid removes dependant models using the `default_scope` only if one is specified. In this case `Container` model has default scope to find only non-volume containers. This caused volume containers to be left behind when a node was removed. For some reason the removal works as was expected during specs, see https://github.com/mongoid-rspec/mongoid-rspec/issues/182.

fixes #1785 