### PR TITLE
Fix cleanup command, run cleanup only on upgrade

### DIFF
--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -23,6 +23,10 @@ module Kontena::Cli::Plugins
             spin.fail!
           end
         end
+
+        spinner "Running cleanup" do |spin|
+          Kontena::PluginManager.instance.cleanup_plugin(name)
+        end
       else
         installed = spinner "Installing plugin #{name.colorize(:cyan)}" do |spin|
           begin

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -33,7 +33,6 @@ module Kontena
       )
       plugin_version = version.nil? ? Gem::Requirement.default : Gem::Requirement.new(version)
       without_safe { cmd.install(prefix(plugin_name), plugin_version) }
-      cleanup_plugin(plugin_name)
       cmd.installed_gems
     end
 
@@ -123,7 +122,7 @@ module Kontena
     def cleanup_plugin(plugin_name)
       require 'rubygems/commands/cleanup_command'
       cmd = Gem::Commands::CleanupCommand.new
-      options = ['--norc']
+      options = []
       options += ['-q', '--no-verbose'] unless ENV["DEBUG"]
       cmd.handle_options options
       without_safe { cmd.execute }

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../spec_helper'
 require 'kontena_cli'
+require 'kontena/light_prompt'
 
 describe Kontena do
   context 'prompt' do


### PR DESCRIPTION
Fixes #1781

Cleanup is performed only on plugin upgrade (which will remove leftover dependencies from the earlier version).

Also the cleanup parameters were invalid.
