### PR TITLE
Never filter out a node that already has the service instance

### DIFF
--- a/server/app/services/scheduler/filter/memory.rb
+++ b/server/app/services/scheduler/filter/memory.rb
@@ -35,6 +35,7 @@ module Scheduler
       # @param [GridService] service
       # @param [Integer] instance_number
       def reject_candidate?(candidate, memory, service, instance_number)
+        return false if candidate.containers.service_instance(service, instance_number).first
         return true if candidate.mem_total.to_i < memory
 
         node_stat = candidate.host_node_stats.last
@@ -43,10 +44,6 @@ module Scheduler
         all_used = node_stat.memory['total'] - node_stat.memory['free']
         mem_used = all_used - (node_stat.memory['cached'] + node_stat.memory['buffers'])
         mem_free = node_stat.memory['total'] - mem_used
-
-        if instance = candidate.containers.service_instance(service, instance_number).first
-          mem_free += memory
-        end
 
         return true if mem_free < memory
 

--- a/server/spec/services/scheduler/filter/memory_spec.rb
+++ b/server/spec/services/scheduler/filter/memory_spec.rb
@@ -99,5 +99,25 @@ describe Scheduler::Filter::Memory do
       )
       expect(reject).to be_falsey
     end
+
+    it 'accepts candidate if it is a replacement and stats are missing' do
+      candidate.host_node_stats.create!(
+        memory: {
+          'total' => 0,
+          'free' => 0,
+          'cached' => 0,
+          'buffers' => 0
+        }
+      )
+      service_instance = test_service.containers.create!(
+        name: 'test-service-1',
+        host_node: candidate,
+        instance_number: 1
+      )
+      reject = subject.reject_candidate?(
+        candidate, 500.megabytes, test_service, 1
+      )
+      expect(reject).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
Currently memory filter checks always available memory based on calculations and filters nodes out based on that. This works fine until service (for some reason) does not get memory usage metrics. This PR makes this logic a bit more sane, it does not filter a node out because of memory usage if the service already has given instance scheduled there.

Fixes #1809