### PR TITLE
Fluentd log shipping

### DIFF
--- a/agent/Gemfile
+++ b/agent/Gemfile
@@ -9,6 +9,7 @@ gem 'celluloid', '~> 0.17.3'
 gem 'etcd'
 gem 'statsd-ruby'
 gem 'vmstat'
+gem 'fluent-logger', '~>0.6.2'
 
 group :development, :test do
   gem 'rake', require: false

--- a/agent/Gemfile.lock
+++ b/agent/Gemfile.lock
@@ -92,8 +92,8 @@ DEPENDENCIES
   etcd
   eventmachine (~> 1.2.3)
   faye-websocket (~> 0.10.7)
-  msgpack (~> 1.0.3)
   fluent-logger (~> 0.6.2)
+  msgpack (~> 1.0.3)
   rake
   rspec
   simplecov
@@ -102,4 +102,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/agent/Gemfile.lock
+++ b/agent/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
     faye-websocket (0.10.7)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
+    fluent-logger (0.6.2)
+      msgpack (>= 0.5.6, < 2)
     hitimes (1.2.3)
     i18n (0.7.0)
     json (1.8.3)
@@ -91,6 +93,7 @@ DEPENDENCIES
   eventmachine (~> 1.2.3)
   faye-websocket (~> 0.10.7)
   msgpack (~> 1.0.3)
+  fluent-logger (~> 0.6.2)
   rake
   rspec
   simplecov

--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -118,6 +118,14 @@ module Docker
       self.labels['io.kontena.service.instance_number'].to_i
     end
 
+    def service_name
+      self.labels['io.kontena.service.name'].to_s
+    end
+
+    def stack_name
+      self.labels['io.kontena.stack.name'].to_s
+    end
+
     # @return [Hash]
     def env_hash
       if @env_hash.nil?

--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -119,11 +119,11 @@ module Docker
     end
 
     def service_name
-      self.labels['io.kontena.service.name'].to_s
+      (self.labels['io.kontena.service.name'] || self.name).to_s
     end
 
     def stack_name
-      self.labels['io.kontena.stack.name'].to_s
+      (self.labels['io.kontena.stack.name'] || 'system').to_s
     end
 
     # @return [Hash]

--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -37,6 +37,7 @@ require_relative 'kontena/workers/image_cleanup_worker'
 require_relative 'kontena/workers/image_pull_worker'
 require_relative 'kontena/workers/health_check_worker'
 require_relative 'kontena/workers/container_starter_worker'
+require_relative 'kontena/workers/fluentd_worker'
 
 require_relative 'kontena/actors/container_coroner'
 

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -129,6 +129,10 @@ module Kontena
         type: Kontena::Workers::ContainerStarterWorker,
         as: :container_starter_worker
       )
+      @supervisor.supervise(
+        type: Kontena::Workers::FluentdWorker,
+        as: :fluentd_worker
+      )
     end
 
     def supervise_lb

--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -63,13 +63,16 @@ module Kontena::Workers
           event: EVENT_NAME,
           data: {
               id: id,
+              service: @container.service_name,
+              stack: @container.stack_name,
+              instance: @container.instance_number,
               time: time.utc.xmlschema,
               type: stream,
               data: data
           }
       }
       @queue << msg
-      publish_log(msg)
+      publish_log(msg.dig('data', 'data'))
     end
 
     def publish_log(log)

--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -60,7 +60,7 @@ module Kontena::Workers
       data = match[2]
       msg = {
         id: id,
-        service: @container.service_name,
+        service: @container.service_name || @container.name,
         stack: @container.stack_name,
         instance: @container.instance_number,
         time: time.utc.xmlschema,

--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -4,7 +4,6 @@ module Kontena::Workers
     include Kontena::Logging
 
     CHUNK_REGEX = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\s(.*)$/
-    EVENT_NAME = 'container:log'
 
     # @param [Docker::Container] container
     # @param [Queue] queue
@@ -60,7 +59,7 @@ module Kontena::Workers
       time = DateTime.parse(match[1])
       data = match[2]
       msg = {
-          event: EVENT_NAME,
+          event: 'container:log',
           data: {
               id: id,
               service: @container.service_name,
@@ -76,7 +75,7 @@ module Kontena::Workers
     end
 
     def publish_log(log)
-      Celluloid::Notifications.publish(EVENT_NAME, log)
+      Celluloid::Notifications.publish('container:log', log)
     end
   end
 end

--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -59,19 +59,16 @@ module Kontena::Workers
       time = DateTime.parse(match[1])
       data = match[2]
       msg = {
-          event: 'container:log',
-          data: {
-              id: id,
-              service: @container.service_name,
-              stack: @container.stack_name,
-              instance: @container.instance_number,
-              time: time.utc.xmlschema,
-              type: stream,
-              data: data
-          }
+        id: id,
+        service: @container.service_name,
+        stack: @container.stack_name,
+        instance: @container.instance_number,
+        time: time.utc.xmlschema,
+        type: stream,
+        data: data
       }
       @queue << msg
-      publish_log(msg.dig('data', 'data'))
+      publish_log(msg)
     end
 
     def publish_log(log)

--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -76,7 +76,7 @@ module Kontena::Workers
     end
 
     def publish_log(log)
-      Celluloid:: Notifications.publish(EVENT_NAME, log)
+      Celluloid::Notifications.publish(EVENT_NAME, log)
     end
   end
 end

--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -60,7 +60,7 @@ module Kontena::Workers
       data = match[2]
       msg = {
         id: id,
-        service: @container.service_name || @container.name,
+        service: @container.service_name,
         stack: @container.stack_name,
         instance: @container.instance_number,
         time: time.utc.xmlschema,

--- a/agent/lib/kontena/workers/fluentd_worker.rb
+++ b/agent/lib/kontena/workers/fluentd_worker.rb
@@ -32,7 +32,8 @@ module Kontena::Workers
         @fluentd = Fluent::Logger::FluentLogger
           .new("#{node_name}.#{info.dig('grid' 'name')}",
               :host => host,
-              :port => port || 24224)
+              :port => port || 24224,
+              :logger => Kontena::Logging.logger)
         @forwarding = true
       else
         info "stopping fluentd log streaming"

--- a/agent/lib/kontena/workers/fluentd_worker.rb
+++ b/agent/lib/kontena/workers/fluentd_worker.rb
@@ -24,16 +24,15 @@ module Kontena::Workers
     # @param [Hash] info
     def on_node_info(topic, info)
       node_name = info['name']
-      driver = info.dig('grid', 'logs', 'driver')
+      driver = info.dig('grid', 'logs', 'forwarder')
       if driver == 'fluentd'
         fluentd_address = info.dig('grid', 'logs', 'opts', 'fluentd-address')
         info "starting fluentd log streaming to #{fluentd_address}"
         host, port = fluentd_address.split(':')
         @fluentd = Fluent::Logger::FluentLogger
-          .new("#{node_name}.#{info.dig('grid' 'name')}",
+          .new("#{node_name}.#{info.dig('grid', 'name')}",
               :host => host,
-              :port => port || 24224,
-              :logger => Kontena::Logging.logger)
+              :port => port || 24224)
         @forwarding = true
       elsif @forwarding
         info "stopping fluentd log streaming"

--- a/agent/lib/kontena/workers/fluentd_worker.rb
+++ b/agent/lib/kontena/workers/fluentd_worker.rb
@@ -35,7 +35,7 @@ module Kontena::Workers
               :port => port || 24224,
               :logger => Kontena::Logging.logger)
         @forwarding = true
-      else
+      elsif @forwarding
         info "stopping fluentd log streaming"
         @fluentd.close if @fluentd
         @forwarding = false
@@ -44,13 +44,10 @@ module Kontena::Workers
     end
 
     def on_log_event(topic, log)
-      # TODO Get more tags
-      # maybe stack.service.instance
-      #puts "forwarding: #{@forwarding}, fluentd: #{@fluentd}"
       if @forwarding && @fluentd
         tag = [log[:stack], log[:service], log[:instance]].join('.')
         record = {
-          event: log[:data], # the actual log event
+          log: log[:data], # the actual log event
           source: log[:type] # stdout/stderr
         }
         @fluentd.post(tag, record)

--- a/agent/lib/kontena/workers/fluentd_worker.rb
+++ b/agent/lib/kontena/workers/fluentd_worker.rb
@@ -17,7 +17,7 @@ module Kontena::Workers
       @forwarding = false
       info 'initialized'
       subscribe('agent:node_info', :on_node_info)
-      subscribe(Kontena::Workers::ContainerLogWorker::EVENT_NAME, :on_log_event)
+      subscribe('container:log', :on_log_event)
     end
 
     # @param [String] topic

--- a/agent/lib/kontena/workers/fluentd_worker.rb
+++ b/agent/lib/kontena/workers/fluentd_worker.rb
@@ -1,0 +1,51 @@
+require 'fluent-logger'
+
+module Kontena::Workers
+  class FluentdWorker
+    include Celluloid
+    include Celluloid::Notifications
+    include Kontena::Logging
+
+    attr_reader :fluentd, :node_name, :queue
+
+    ##
+    # @param [Queue] queue
+    # @param [Boolean] autostart
+    def initialize(autostart = true)
+      @fluentd = nil
+      @queue = []
+      @forwarding = false
+      info 'initialized'
+      subscribe('agent:node_info', :on_node_info)
+      subscribe(Kontena::Workers::ContainerLogWorker::EVENT_NAME, :on_log_event)
+    end
+
+    # @param [String] topic
+    # @param [Hash] info
+    def on_node_info(topic, info)
+      node_name = info['name']
+      driver = info.dig('grid', 'logs', 'driver')
+      if driver == 'fluentd'
+        fluentd_address = info.dig('grid', 'logs', 'opts', 'fluentd-address')
+        puts "starting fluentd log streaming to #{fluentd_address}"
+        host, port = fluentd_address.split(':')
+        @fluentd = Fluent::Logger::FluentLogger
+          .new("#{node_name}.#{info.dig('grid' 'name')}",
+              :host => host,
+              :port => port || 24224)
+        @forwarding = true
+      else
+        info "stopping fluentd log streaming"
+        @fluentd.close if @fluentd
+        @forwarding = false
+        @fluentd = nil
+      end
+    end
+
+    def on_log_event(topic, log)
+      # TODO Get more tags
+      # maybe stack.service.instance
+      @fluentd.post(nil, log) if @forwarding && @fluentd
+    end
+  end
+end

--- a/agent/spec/lib/kontena/workers/container_log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_log_worker_spec.rb
@@ -33,5 +33,23 @@ describe Kontena::Workers::ContainerLogWorker do
         subject.on_message('id', 'stdout', '2016-02-29T07:26:07.798612937Z log message')
       }.to change{ queue.length }.by(1)
     end
+
+    it 'publishes log event' do
+      expect(container).to receive(:service_name).and_return('a-service')
+      expect(container).to receive(:stack_name).and_return('stack')
+      expect(container).to receive(:instance_number).and_return(1)
+      log = '2016-02-29T07:26:07.798612937Z log message'
+      expected_log = {
+        id: 'id',
+        service: 'a-service',
+        stack: 'stack',
+        instance: 1,
+        type: 'stdout',
+        data: 'log message',
+        time: '2016-02-29T07:26:07+00:00'
+      }
+      expect(subject.wrapped_object).to receive(:publish_log).with(expected_log)
+      subject.on_message('id', 'stdout', log)
+    end
   end
 end

--- a/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../../../spec_helper'
+
+describe Kontena::Workers::FluentdWorker do
+
+  let(:subject) { described_class.new(false) }
+
+
+
+  before(:each) do
+    Celluloid.boot
+  end
+
+  after(:each) { Celluloid.shutdown }
+
+  describe '#on_node_info' do
+
+    let(:info) do
+      {
+        'grid' => {
+          'logs' => {
+            'driver' => 'fluentd',
+            'opts' => {
+              'fluentd-address' => 'foo:12345'
+            }
+          }
+        }
+      }
+    end
+    it 'creates fluentd logger and starts forwarding' do
+      subject.on_node_info('agent:node_info', info)
+      expect(subject.wrapped_object.instance_variable_get('@fluentd')).not_to be_nil
+      expect(subject.wrapped_object.instance_variable_get('@forwarding')).to be_truthy
+    end
+
+    it 'removes fluentd logger and stops forwarding' do
+      subject.on_node_info('agent:node_info', info)
+      info['grid']['logs'] = { 'driver' => 'none'}
+      expect_any_instance_of(Fluent::Logger::FluentLogger).to receive(:close)
+      subject.on_node_info('agent:node_info', info)
+      expect(subject.wrapped_object.instance_variable_get('@fluentd')).to be_nil
+      expect(subject.wrapped_object.instance_variable_get('@forwarding')).to be_falsey
+    end
+  end
+
+end

--- a/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
@@ -16,7 +16,7 @@ describe Kontena::Workers::FluentdWorker do
       {
         'grid' => {
           'logs' => {
-            'driver' => 'fluentd',
+            'forwarder' => 'fluentd',
             'opts' => {
               'fluentd-address' => 'foo:12345'
             }

--- a/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
@@ -56,7 +56,7 @@ describe Kontena::Workers::FluentdWorker do
       fluentd = instance_double(Fluent::Logger::FluentLogger)
       subject.wrapped_object.instance_variable_set('@fluentd', fluentd)
       subject.wrapped_object.instance_variable_set('@forwarding', true)
-      expect(fluentd).to receive(:post).with('web.nginx.1', {event: 'foo bar', source: 'stdout'})
+      expect(fluentd).to receive(:post).with('web.nginx.1', {log: 'foo bar', source: 'stdout'})
       subject.on_log_event('container:log', log_event)
     end
 

--- a/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/fluentd_worker_spec.rb
@@ -4,8 +4,6 @@ describe Kontena::Workers::FluentdWorker do
 
   let(:subject) { described_class.new(false) }
 
-
-
   before(:each) do
     Celluloid.boot
   end
@@ -39,6 +37,42 @@ describe Kontena::Workers::FluentdWorker do
       subject.on_node_info('agent:node_info', info)
       expect(subject.wrapped_object.instance_variable_get('@fluentd')).to be_nil
       expect(subject.wrapped_object.instance_variable_get('@forwarding')).to be_falsey
+    end
+  end
+
+  describe '#on_log_event' do
+    let(:log_event) do
+      {
+        id: 1234567890,
+        service: 'nginx',
+        stack: 'web',
+        instance: 1,
+        time: Time.now.utc.xmlschema,
+        type: 'stdout',
+        data: 'foo bar'
+      }
+    end
+    it 'sends proper event to fluentd' do
+      fluentd = instance_double(Fluent::Logger::FluentLogger)
+      subject.wrapped_object.instance_variable_set('@fluentd', fluentd)
+      subject.wrapped_object.instance_variable_set('@forwarding', true)
+      expect(fluentd).to receive(:post).with('web.nginx.1', {event: 'foo bar', source: 'stdout'})
+      subject.on_log_event('container:log', log_event)
+    end
+
+    it 'does not post event if not forwarding' do
+      fluentd = instance_double(Fluent::Logger::FluentLogger)
+      subject.wrapped_object.instance_variable_set('@fluentd', fluentd)
+      subject.wrapped_object.instance_variable_set('@forwarding', false)
+      expect(fluentd).not_to receive(:post)
+      subject.on_log_event('container:log', log_event)
+    end
+
+    it 'does not post event if no fluentd configured' do
+      subject.wrapped_object.instance_variable_set('@fluentd', nil)
+      subject.wrapped_object.instance_variable_set('@forwarding', true)
+      expect_any_instance_of(Fluent::Logger::FluentLogger).not_to receive(:post)
+      subject.on_log_event('container:log', log_event)
     end
   end
 

--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -43,7 +43,7 @@ module Kontena::Cli::Grids
       end
       if logs = grid.dig('logs')
         puts "logs:"
-        puts "  driver: #{logs['driver']}"
+        puts "  forwarder: #{logs['forwarder']}"
         logs['opts'].each do |k,v|
           puts "  #{k}: #{v}"
         end

--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -41,6 +41,13 @@ module Kontena::Cli::Grids
         puts "  exports:"
         puts "    statsd: #{statsd['server']}:#{statsd['port']}"
       end
+      if logs = grid.dig('logs')
+        puts "logs:"
+        puts "  driver: #{logs['driver']}"
+        logs['opts'].each do |k,v|
+          puts "  #{k}: #{v}"
+        end
+      end
     end
 
     def grids

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Grids
     parameter "NAME", "Grid name"
     option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
     option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
-    option "--log-driver", "LOG_DRIVER", "Set grid wide log driver"
+    option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder"
     option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
 
     def execute
@@ -26,9 +26,9 @@ module Kontena::Cli::Grids
         }
       end
 
-      if log_driver
+      if log_forwarder
         payload[:logs] = {
-          driver: log_driver,
+          forwarder: log_forwarder,
           opts: parse_log_opts
         }
       end
@@ -40,8 +40,8 @@ module Kontena::Cli::Grids
     end
 
     def validate_log_opts
-      if !log_opt_list.empty? && log_driver.nil?
-        raise Kontena::Errors::StandardError.new(1, "Need to specify --log-driver when using --log-opt")
+      if !log_opt_list.empty? && log_forwarder.nil?
+        raise Kontena::Errors::StandardError.new(1, "Need to specify --log-forwarder when using --log-opt")
       end
     end
 

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -8,10 +8,13 @@ module Kontena::Cli::Grids
     parameter "NAME", "Grid name"
     option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
     option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
+    option "--log-driver", "LOG_DRIVER", "Set grid wide log driver"
+    option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
 
     def execute
       require_api_url
       token = require_token
+      validate_log_opts
       payload = {}
       if statsd_server
         server, port = statsd_server.split(':')
@@ -22,10 +25,32 @@ module Kontena::Cli::Grids
           }
         }
       end
+
+      if log_driver
+        payload[:logs] = {
+          driver: log_driver,
+          opts: parse_log_opts
+        }
+      end
+
       if default_affinity_list
         payload[:default_affinity] = default_affinity_list
       end
       client(token).put("grids/#{name}", payload)
+    end
+
+    def validate_log_opts
+      if !log_opt_list.empty? && log_driver.nil?
+        raise "Need to specify --log-driver when using --log-opt"
+      end
+    end
+
+    def parse_log_opts
+      opts = {}
+      log_opt_list.each do |opt|
+        opts.merge!(Hash[*opt.split('=')])
+      end
+      opts
     end
   end
 end

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -41,14 +41,15 @@ module Kontena::Cli::Grids
 
     def validate_log_opts
       if !log_opt_list.empty? && log_driver.nil?
-        raise "Need to specify --log-driver when using --log-opt"
+        raise Kontena::Errors::StandardError.new(1, "Need to specify --log-driver when using --log-opt")
       end
     end
 
     def parse_log_opts
       opts = {}
       log_opt_list.each do |opt|
-        opts.merge!(Hash[*opt.split('=')])
+        key, value = opt.split('=')
+        opts[key.to_sym] = value
       end
       opts
     end

--- a/cli/spec/kontena/cli/grids/update_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/update_command_spec.rb
@@ -1,6 +1,6 @@
 
 require_relative "../../../spec_helper"
-require 'kontena/cli/grids/use_command'
+require 'kontena/cli/grids/update_command'
 
 describe Kontena::Cli::Grids::UpdateCommand do
 
@@ -32,14 +32,14 @@ describe Kontena::Cli::Grids::UpdateCommand do
         expect(client).to receive(:put).with(
           'grids/test', hash_including({
             logs: {
-              driver: 'fluentd',
+              forwarder: 'fluentd',
               opts: {
                 foo: 'bar'
               }
             }
           })
         )
-        subject.run(['--log-driver', 'fluentd', '--log-opt', 'foo=bar', 'test'])
+        subject.run(['--log-forwarder', 'fluentd', '--log-opt', 'foo=bar', 'test'])
       end
     end
   end

--- a/cli/spec/kontena/cli/grids/update_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/update_command_spec.rb
@@ -31,10 +31,10 @@ describe Kontena::Cli::Grids::UpdateCommand do
       it 'should send valid options to server' do
         expect(client).to receive(:put).with(
           'grids/test', hash_including({
-            'logs': {
-              'driver': 'fluentd',
-              'opts': {
-                'foo': 'bar'
+            logs: {
+              driver: 'fluentd',
+              opts: {
+                foo: 'bar'
               }
             }
           })

--- a/cli/spec/kontena/cli/grids/update_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/update_command_spec.rb
@@ -1,0 +1,46 @@
+
+require_relative "../../../spec_helper"
+require 'kontena/cli/grids/use_command'
+
+describe Kontena::Cli::Grids::UpdateCommand do
+
+  include ClientHelpers
+
+  let(:client) do
+    Kontena::Client.new('https://foo', {access_token: 'abcd1234'})
+  end
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:server) do
+    Kontena::Cli::Config::Server.new(url: 'https://localhost', token: 'abcd1234')
+  end
+
+  describe "#update" do
+
+    context 'log options' do
+      it 'should fail if no driver specified' do
+        expect {
+          subject.run(['--log-opt', 'foo=bar', 'test'])
+        }.to exit_with_error
+
+      end
+
+      it 'should send valid options to server' do
+        expect(client).to receive(:put).with(
+          'grids/test', hash_including({
+            'logs': {
+              'driver': 'fluentd',
+              'opts': {
+                'foo': 'bar'
+              }
+            }
+          })
+        )
+        subject.run(['--log-driver', 'fluentd', '--log-opt', 'foo=bar', 'test'])
+      end
+    end
+  end
+end

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -43,6 +43,7 @@
 * [Etcd](using-kontena/etcd.md)
 * [Applications](using-kontena/applications.md)
 * [Telemetry](using-kontena/telemetry.md)
+* [Logs](using-kontena/logs.md)
 
 ### Core Concepts
 

--- a/docs/using-kontena/grids.md
+++ b/docs/using-kontena/grids.md
@@ -61,7 +61,7 @@ See the [Statistics](stats.md#exporting-stats) documentation for further details
 
 ### Logging options
 
-The `kontena grid update --log-driver some-driver --log-opt xyz=foo` options configures each host node to send container logs to a remote log collection service.
+The `kontena grid update --log-forwarder fluentd --log-opt fluentd-server=xyz:22445` options configures each host node to send container logs to a remote log collection service.
 
 See the [Logs](logs.md) documentation for further details.
 

--- a/docs/using-kontena/grids.md
+++ b/docs/using-kontena/grids.md
@@ -59,6 +59,13 @@ The `kontena grid update --statsd-server HOST:PORT` option configures each host 
 
 See the [Statistics](stats.md#exporting-stats) documentation for further details.
 
+### Logging options
+
+The `kontena grid update --log-driver some-driver --log-opt xyz=foo` options configures each host node to send container logs to a remote log collection service.
+
+See the [Logs](logs.md) documentation for further details.
+
+
 ## Initial Nodes
 
 Each grid is created with an initial size, where the first `initial_size` nodes to join the grid will become ***initial*** nodes.

--- a/docs/using-kontena/logs.md
+++ b/docs/using-kontena/logs.md
@@ -18,13 +18,13 @@ The logs are stored in a capacity-bounded MongoDB collection, which limits the d
 
 Often there is a need to further process the logs and gather some relevant statistics and insight what is happening in your services. To ship the logs to some other system there are three different alternatives outlined in below chapters.
 
-### Enable fluentd shipping
+### Enable fluentd forwarding
 
-Kontena supports fluentd log shipping that can be configured on each grid. When fluentd shipping is enabled, all container logs are automatically sent to fluentd for further processing **in addition** of storing them in Kontena Master.
+Kontena supports fluentd log shipping that can be configured on each grid. When fluentd forwarding is enabled, all container logs are automatically sent to fluentd for further processing **in addition** of storing them in Kontena Master.
 
 You can enable fluentd forwarding using:
 ```
-kontena grid update --log-driver fluentd --log-opt fluentd-address=server:port my-grid
+kontena grid update --log-forwarder fluentd --log-opt fluentd-address=server:port my-grid
 ```
 
 Each event sent to fluentd is tagged with following notation:
@@ -33,7 +33,7 @@ Each event sent to fluentd is tagged with following notation:
 The record itself is a hash with following semantics:
 ```
 {
-  event: <log data>,
+  log: <log data>,
   type: stdout / stderr
 }
 ```

--- a/docs/using-kontena/logs.md
+++ b/docs/using-kontena/logs.md
@@ -24,11 +24,14 @@ Kontena supports fluentd log shipping that can be configured on each grid. When 
 
 You can enable fluentd forwarding using:
 ```
-kontena grid update --log-forwarder fluentd --log-opt fluentd-address=server:port my-grid
+kontena grid update --log-forwarder fluentd --log-opt fluentd-address=server[:port] my-grid
 ```
 
 Each event sent to fluentd is tagged with following notation:
-`grid.stack.service.instance`
+`node.grid.stack.service.instance`
+
+Kontena "system" containers (kontena-agent, ipam-plugin, weave, etc.) will be tagged like:
+`node.grid.system.service`
 
 The record itself is a hash with following semantics:
 ```
@@ -39,7 +42,7 @@ The record itself is a hash with following semantics:
 ```
 
 To disable log forwarding, use:
-`kontena grid update --log-driver none my-grid`
+`kontena grid update --log-forwarder none my-grid`
 
 ### Enable container log shipping with Docker.
 
@@ -55,7 +58,7 @@ This is recommended for environments where lots of logs are being generated to a
 
 As logs are stored in Kontena Masters database, there is a single point of collection available. The Master database is MongoDB where the logs are stored in capped collection.
 
-To gather logs from master database directly, you need to run the collector somewhere that has access to the master database. Usually the database is not exposes to outside world from the master node, so natural place is to run it alongside with the master.
+To gather logs from master database directly, you need to run the collector somewhere that has access to the master database. Usually the database is not exposed to outside world from the master node, so natural place is to run it alongside with the master.
 
 For example, with fluentd you could use following configuration to get the logs shipped to AWS S3:
 ```

--- a/docs/using-kontena/logs.md
+++ b/docs/using-kontena/logs.md
@@ -12,7 +12,7 @@ There are various methods to access this log information.
 - `kontena service logs xyz` for individual service logs
 - `kontena stack logs xyz` for stacks service logs
 
-The logs are stored in capped collection which ensures that old events gets automatically removed and do not consume disk space on master database.
+The logs are stored in a capacity-bounded MongoDB collection, which limits the disk space consumed on the master by automatically removing old logs.
 
 ## Sending logs for further processing
 
@@ -24,7 +24,7 @@ Kontena supports fluentd log shipping that can be configured on each grid. When 
 
 You can enable fluentd forwarding using:
 ```
-kontena grid update --log-driver fluentd --log_opt fluentd-address=server:port my-grid
+kontena grid update --log-driver fluentd --log-opt fluentd-address=server:port my-grid
 ```
 
 Each event sent to fluentd is tagged with following notation:

--- a/docs/using-kontena/logs.md
+++ b/docs/using-kontena/logs.md
@@ -1,0 +1,92 @@
+---
+title: Logs
+---
+
+# Logs
+
+Kontena streams all logs of the services deployed and stores them in Kontena Master for easy access.
+
+There are various methods to access this log information.
+
+- `kontena grid logs` for grid wide logs (all services and Kontena internal components)
+- `kontena service logs xyz` for individual service logs
+- `kontena stack logs xyz` for stacks service logs
+
+The logs are stored in capped collection which ensures that old events gets automatically removed and do not consume disk space on master database.
+
+## Sending logs for further processing
+
+Often there is a need to further process the logs and gather some relevant statistics and insight what is happening in your services. To ship the logs to some other system there are three different alternatives outlined in below chapters.
+
+### Enable fluentd shipping
+
+Kontena supports fluentd log shipping that can be configured on each grid. When fluentd shipping is enabled, all container logs are automatically sent to fluentd for further processing **in addition** of storing them in Kontena Master.
+
+You can enable fluentd forwarding using:
+```
+kontena grid update --log-driver fluentd --log_opt fluentd-address=server:port my-grid
+```
+
+Each event sent to fluentd is tagged with following notation:
+`grid.stack.service.instance`
+
+The record itself is a hash with following semantics:
+```
+{
+  event: <log data>,
+  type: stdout / stderr
+}
+```
+
+To disable log forwarding, use:
+`kontena grid update --log-driver none my-grid`
+
+### Enable container log shipping with Docker.
+
+You can of course use Docker log-driver options when defining services in your stacks. See [log options](../references/kontena-yml.md#logging) for details. Also check Docker log [documentation](https://docs.docker.com/engine/admin/logging/overview/#/supported-logging-drivers) for details on supported drivers and their options.
+
+Or you can define the log drivers on Docker engine level and thus every container will use same log configuration if not otherwise configured.
+
+**Note:** By configuring log forwarding directly on docker or container level makes Kontena not to be able to grab the logs, so they are **not** available on Kontena master.
+
+This is recommended for environments where lots of logs are being generated to avoid Kontena master becoming the bottleneck due to log storing.
+
+### Gather logs from Kontena Master DB
+
+As logs are stored in Kontena Masters database, there is a single point of collection available. The Master database is MongoDB where the logs are stored in capped collection.
+
+To gather logs from master database directly, you need to run the collector somewhere that has access to the master database. Usually the database is not exposes to outside world from the master node, so natural place is to run it alongside with the master.
+
+For example, with fluentd you could use following configuration to get the logs shipped to AWS S3:
+```
+<source>
+  type mongo_tail
+  url "#{ENV['MONGODB_URL']}"
+  collection container_logs
+  tag_key name
+  time_key created_at
+  id_store_collection container_logs_tail
+</source>
+
+<match **>
+  @type s3
+
+  aws_key_id "#{ENV['S3_ACCESS_KEY']}"
+  aws_sec_key "#{ENV['S3_SECRET_KEY']}"
+  s3_bucket "#{ENV['S3_BUCKET']}"
+  s3_region "#{ENV['S3_REGION']}"
+  buffer_type memory
+  buffer_chunk_limit 256m
+  buffer_queue_limit 128
+  path logs/
+
+  format json
+  include_time_key true
+  include_tag_key true
+
+  s3_object_key_format %{path}/ts=%{time_slice}/%{index}_json.%{file_extension}
+  time_slice_format %Y%m%d-%H
+  time_slice_wait 30m
+  utc
+</match>
+```

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -14,7 +14,6 @@ class Grid
   field :trusted_subnets, type: Array, default: []
   field :stats, type: Hash, default: {}
   field :default_affinity, type: Array, default: []
-  field :logs, type: Hash, default: {}
   field :subnet, type: String, default: SUBNET
   field :supernet, type: String, default: SUPERNET
 
@@ -31,6 +30,7 @@ class Grid
   has_many :grid_domain_authorizations, dependent: :delete
   has_many :networks, dependent: :delete
   has_and_belongs_to_many :users
+  embeds_one :grid_logs_opts, class_name: 'GridLogsOpts'
 
   index({ name: 1 }, { unique: true })
   index({ token: 1 }, { unique: true })

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -14,6 +14,7 @@ class Grid
   field :trusted_subnets, type: Array, default: []
   field :stats, type: Hash, default: {}
   field :default_affinity, type: Array, default: []
+  field :logs, type: Hash, default: {}
   field :subnet, type: String, default: SUBNET
   field :supernet, type: String, default: SUPERNET
 

--- a/server/app/models/grid_log_opts.rb
+++ b/server/app/models/grid_log_opts.rb
@@ -1,0 +1,8 @@
+class GridLogsOpts
+  include Mongoid::Document
+
+  field :driver, type: String
+  field :opts, type: Hash, default: {}
+
+  embedded_in :grid
+end

--- a/server/app/models/grid_log_opts.rb
+++ b/server/app/models/grid_log_opts.rb
@@ -1,7 +1,7 @@
 class GridLogsOpts
   include Mongoid::Document
 
-  field :driver, type: String
+  field :forwarder, type: String
   field :opts, type: Hash, default: {}
 
   embedded_in :grid

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -23,6 +23,12 @@ module Grids
       array :default_affinity do
         string
       end
+      hash :logs do
+        required do
+          string :driver, matches: /^(fluentd)$/ # Only fluentd now supported
+          model :opts, class: Hash
+        end
+      end
     end
 
     def validate
@@ -48,6 +54,9 @@ module Grids
       end
       if self.default_affinity
         attributes[:default_affinity] = self.default_affinity
+      end
+      if self.logs
+        attributes[:logs] = self.logs
       end
       grid.update_attributes(attributes)
       if grid.errors.size > 0

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -97,10 +97,6 @@ module Grids
     def validate_fluentd_opts(opts)
       address = opts['fluentd-address']
       add_error(:logs, :forwarder, 'fluentd-address option must be given') unless address
-      if address
-        host, port = address.split(':')
-        add_error(:logs, :forwarder, 'fluentd-address must be given in format address:port') unless host && port
-      end
     end
   end
 end

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -60,9 +60,9 @@ module Grids
 
       if self.logs
         if self.logs[:driver] == 'none'
-          attributes[:logs] = {}
+          self.grid.grid_logs_opts = nil
         else
-          attributes[:logs] = self.logs
+          self.grid.grid_logs_opts = GridLogsOpts.new(driver: self.logs[:driver], opts: self.logs[:opts])
         end
       end
       grid.update_attributes(attributes)

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -25,7 +25,9 @@ module Grids
       end
       hash :logs do
         required do
-          string :driver, matches: /^(fluentd)$/ # Only fluentd now supported
+          string :driver, matches: /^(fluentd|none)$/ # Only fluentd now supported, none removes log shipping
+        end
+        optional do
           model :opts, class: Hash
         end
       end
@@ -55,8 +57,13 @@ module Grids
       if self.default_affinity
         attributes[:default_affinity] = self.default_affinity
       end
+
       if self.logs
-        attributes[:logs] = self.logs
+        if self.logs[:driver] == 'none'
+          attributes[:logs] = {}
+        else
+          attributes[:logs] = self.logs
+        end
       end
       grid.update_attributes(attributes)
       if grid.errors.size > 0

--- a/server/app/views/v1/grids/_grid.json.jbuilder
+++ b/server/app/views/v1/grids/_grid.json.jbuilder
@@ -13,3 +13,7 @@ json.container_count grid.containers.count
 json.user_count grid.users.count
 json.subnet grid.subnet
 json.supernet grid.supernet
+json.logs do
+  json.driver grid.logs['driver']
+  json.opts grid.logs['opts']
+end

--- a/server/app/views/v1/grids/_grid.json.jbuilder
+++ b/server/app/views/v1/grids/_grid.json.jbuilder
@@ -13,7 +13,9 @@ json.container_count grid.containers.count
 json.user_count grid.users.count
 json.subnet grid.subnet
 json.supernet grid.supernet
-json.logs do
-  json.driver grid.logs['driver']
-  json.opts grid.logs['opts']
+if grid.grid_logs_opts
+  json.logs do
+    json.driver grid.grid_logs_opts.driver
+    json.opts grid.grid_logs_opts.opts
+  end
 end

--- a/server/app/views/v1/grids/_grid.json.jbuilder
+++ b/server/app/views/v1/grids/_grid.json.jbuilder
@@ -15,7 +15,7 @@ json.subnet grid.subnet
 json.supernet grid.supernet
 if grid.grid_logs_opts
   json.logs do
-    json.driver grid.grid_logs_opts.driver
+    json.forwarder grid.grid_logs_opts.forwarder
     json.opts grid.grid_logs_opts.opts
   end
 end

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -36,9 +36,11 @@ json.grid do
     json.stats do
       json.statsd grid.stats['statsd']
     end
-    json.logs do
-      json.driver grid.logs['driver']
-      json.opts grid.logs['opts']
+    if grid.grid_logs_opts
+      json.logs do
+        json.driver grid.grid_logs_opts.driver
+        json.opts grid.grid_logs_opts.opts
+      end
     end
     json.trusted_subnets grid.trusted_subnets
     json.subnet grid.subnet

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -38,7 +38,7 @@ json.grid do
     end
     if grid.grid_logs_opts
       json.logs do
-        json.driver grid.grid_logs_opts.driver
+        json.forwarder grid.grid_logs_opts.forwarder
         json.opts grid.grid_logs_opts.opts
       end
     end

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -36,6 +36,10 @@ json.grid do
     json.stats do
       json.statsd grid.stats['statsd']
     end
+    json.logs do
+      json.driver grid.logs['driver']
+      json.opts grid.logs['opts']
+    end
     json.trusted_subnets grid.trusted_subnets
     json.subnet grid.subnet
     json.supernet grid.supernet

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -441,9 +441,9 @@ describe '/v1/grids', celluloid: true do
       }
       put "/v1/grids/#{grid.to_path}", data.to_json, request_headers
       expect(response.status).to eq(200)
-      logs = grid.reload.logs
-      expect(logs['driver']).to eq('fluentd')
-      expect(logs['opts']['server']).to eq(server)
+      logs = grid.reload.grid_logs_opts
+      expect(logs.driver).to eq('fluentd')
+      expect(logs.opts['server']).to eq(server)
       expect(json_response['logs']['driver']).to eq('fluentd')
       expect(json_response['logs']['opts']['server']).to eq(server)
     end

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -426,6 +426,28 @@ describe '/v1/grids', celluloid: true do
       expect(statsd['port']).to eq(port)
     end
 
+    it 'updates logs' do
+      grid = david.grids.first
+      server = '192.168.89.12'
+      port = 8125
+      data = {
+        logs: {
+          driver: 'fluentd',
+          opts: {
+            server: server,
+            port: port
+          }
+        }
+      }
+      put "/v1/grids/#{grid.to_path}", data.to_json, request_headers
+      expect(response.status).to eq(200)
+      logs = grid.reload.logs
+      expect(logs['driver']).to eq('fluentd')
+      expect(logs['opts']['server']).to eq(server)
+      expect(json_response['logs']['driver']).to eq('fluentd')
+      expect(json_response['logs']['opts']['server']).to eq(server)
+    end
+
     it 'updates trusted_subnets' do
       grid = david.grids.first
       data = {

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -428,14 +428,11 @@ describe '/v1/grids', celluloid: true do
 
     it 'updates logs' do
       grid = david.grids.first
-      server = '192.168.89.12'
-      port = 8125
       data = {
         logs: {
           forwarder: 'fluentd',
           opts: {
-            server: server,
-            port: port
+            'fluentd-address': '192.168.89.12:22445'
           }
         }
       }
@@ -443,9 +440,9 @@ describe '/v1/grids', celluloid: true do
       expect(response.status).to eq(200)
       logs = grid.reload.grid_logs_opts
       expect(logs.forwarder).to eq('fluentd')
-      expect(logs.opts['server']).to eq(server)
+      expect(logs.opts['fluentd-address']).to eq('192.168.89.12:22445')
       expect(json_response['logs']['forwarder']).to eq('fluentd')
-      expect(json_response['logs']['opts']['server']).to eq(server)
+      expect(json_response['logs']['opts']['fluentd-address']).to eq('192.168.89.12:22445')
     end
 
     it 'disables logs' do

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -432,7 +432,7 @@ describe '/v1/grids', celluloid: true do
       port = 8125
       data = {
         logs: {
-          driver: 'fluentd',
+          forwarder: 'fluentd',
           opts: {
             server: server,
             port: port
@@ -442,10 +442,22 @@ describe '/v1/grids', celluloid: true do
       put "/v1/grids/#{grid.to_path}", data.to_json, request_headers
       expect(response.status).to eq(200)
       logs = grid.reload.grid_logs_opts
-      expect(logs.driver).to eq('fluentd')
+      expect(logs.forwarder).to eq('fluentd')
       expect(logs.opts['server']).to eq(server)
-      expect(json_response['logs']['driver']).to eq('fluentd')
+      expect(json_response['logs']['forwarder']).to eq('fluentd')
       expect(json_response['logs']['opts']['server']).to eq(server)
+    end
+
+    it 'disables logs' do
+      grid = david.grids.first
+      data = {
+        logs: {
+          forwarder: 'none'
+        }
+      }
+      put "/v1/grids/#{grid.to_path}", data.to_json, request_headers
+      expect(response.status).to eq(200)
+      expect(grid.reload.grid_logs_opts).to be_nil
     end
 
     it 'updates trusted_subnets' do

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -3,7 +3,7 @@ describe Grid do
   it { should be_timestamped_document }
   it { should have_fields(:name, :token) }
   it { should have_fields(:initial_size).of_type(Integer) }
-  it { should have_fields(:stats, :logs).of_type(Hash) }
+  it { should have_fields(:stats).of_type(Hash) }
   it { should have_fields(:trusted_subnets, :default_affinity).of_type(Array) }
 
   it { should have_and_belong_to_many(:users) }
@@ -16,6 +16,8 @@ describe Grid do
   it { should have_many(:container_stats) }
   it { should have_many(:audit_logs) }
   it { should have_many(:registries) }
+
+  it { should embed_one(:grid_logs_opts) }
 
   it { should have_index_for(token: 1).with_options(unique: true) }
 

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -3,7 +3,7 @@ describe Grid do
   it { should be_timestamped_document }
   it { should have_fields(:name, :token) }
   it { should have_fields(:initial_size).of_type(Integer) }
-  it { should have_fields(:stats).of_type(Hash) }
+  it { should have_fields(:stats, :logs).of_type(Hash) }
   it { should have_fields(:trusted_subnets, :default_affinity).of_type(Array) }
 
   it { should have_and_belong_to_many(:users) }

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -27,5 +27,29 @@ describe Grids::Update, celluloid: true do
       outcome = described_class.new(user: user, grid: grid, stats: 'foo').run
       expect(outcome.success?).to be_falsey
     end
+
+    it 'updates log settings' do
+      logs = {
+        driver: 'fluentd',
+        opts: {
+          fluentd_address: '192.168.0.42:24224'
+        }
+      }
+      described_class.new(user: user, grid: grid, logs: logs).run
+      expect(grid.reload.logs['driver']).to eq('fluentd')
+      expect(grid.reload.logs['opts']['fluentd_address']).to eq('192.168.0.42:24224')
+    end
+
+    it 'fails update log settings with unsupported driver' do
+      logs = {
+        driver: 'foobar',
+        opts: {
+          fluentd_address: '192.168.0.42:24224'
+        }
+      }
+      outcome = described_class.new(user: user, grid: grid, logs: logs).run
+      expect(outcome.success?).to be_falsey
+      expect(grid.reload.logs).to eq({})
+    end
   end
 end

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -30,36 +30,46 @@ describe Grids::Update, celluloid: true do
 
     it 'updates log settings' do
       logs = {
-        driver: 'fluentd',
+        forwarder: 'fluentd',
         opts: {
-          fluentd_address: '192.168.0.42:24224'
+          'fluentd-address': '192.168.0.42:24224'
         }
       }
       described_class.new(user: user, grid: grid, logs: logs).run
       grid.reload
-      expect(grid.grid_logs_opts.driver).to eq('fluentd')
-      expect(grid.grid_logs_opts.opts['fluentd_address']).to eq('192.168.0.42:24224')
+      expect(grid.grid_logs_opts.forwarder).to eq('fluentd')
+      expect(grid.grid_logs_opts.opts['fluentd-address']).to eq('192.168.0.42:24224')
     end
 
     it 'removes log settings' do
       logs = {
-        driver: 'fluentd',
+        forwarder: 'fluentd',
         opts: {
-          fluentd_address: '192.168.0.42:24224'
+          'fluentd-address': '192.168.0.42:24224'
         }
       }
       grid.grid_logs_opts = GridLogsOpts.new(**logs)
-      outcome = described_class.new(user: user, grid: grid, logs: { driver: 'none'}).run
+      outcome = described_class.new(user: user, grid: grid, logs: { forwarder: 'none'}).run
       expect(outcome.success?).to be_truthy, outcome.errors
       expect(grid.reload.grid_logs_opts).to be_nil
     end
 
-    it 'fails update log settings with unsupported driver' do
+    it 'fails to update log settings with unsupported driver' do
       logs = {
-        driver: 'foobar',
+        forwarder: 'foobar',
         opts: {
-          fluentd_address: '192.168.0.42:24224'
+          'fluentd-address': '192.168.0.42:24224'
         }
+      }
+      outcome = described_class.new(user: user, grid: grid, logs: logs).run
+      expect(outcome.success?).to be_falsey
+      expect(grid.reload.grid_logs_opts).to be_nil
+    end
+
+    it 'fails to update fluentd forwarding with no address given' do
+      logs = {
+        forwarder: 'foobar',
+        opts: { }
       }
       outcome = described_class.new(user: user, grid: grid, logs: logs).run
       expect(outcome.success?).to be_falsey

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -40,6 +40,19 @@ describe Grids::Update, celluloid: true do
       expect(grid.reload.logs['opts']['fluentd_address']).to eq('192.168.0.42:24224')
     end
 
+    it 'removes log settings' do
+      logs = {
+        driver: 'fluentd',
+        opts: {
+          fluentd_address: '192.168.0.42:24224'
+        }
+      }
+      grid.update_attributes({:logs => logs})
+      outcome = described_class.new(user: user, grid: grid, logs: { driver: 'none'}).run
+      expect(outcome.success?).to be_truthy, outcome.errors
+      expect(grid.reload.logs).to eq({})
+    end
+
     it 'fails update log settings with unsupported driver' do
       logs = {
         driver: 'foobar',

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -36,8 +36,9 @@ describe Grids::Update, celluloid: true do
         }
       }
       described_class.new(user: user, grid: grid, logs: logs).run
-      expect(grid.reload.logs['driver']).to eq('fluentd')
-      expect(grid.reload.logs['opts']['fluentd_address']).to eq('192.168.0.42:24224')
+      grid.reload
+      expect(grid.grid_logs_opts.driver).to eq('fluentd')
+      expect(grid.grid_logs_opts.opts['fluentd_address']).to eq('192.168.0.42:24224')
     end
 
     it 'removes log settings' do
@@ -47,10 +48,10 @@ describe Grids::Update, celluloid: true do
           fluentd_address: '192.168.0.42:24224'
         }
       }
-      grid.update_attributes({:logs => logs})
+      grid.grid_logs_opts = GridLogsOpts.new(**logs)
       outcome = described_class.new(user: user, grid: grid, logs: { driver: 'none'}).run
       expect(outcome.success?).to be_truthy, outcome.errors
-      expect(grid.reload.logs).to eq({})
+      expect(grid.reload.grid_logs_opts).to be_nil
     end
 
     it 'fails update log settings with unsupported driver' do
@@ -62,7 +63,7 @@ describe Grids::Update, celluloid: true do
       }
       outcome = described_class.new(user: user, grid: grid, logs: logs).run
       expect(outcome.success?).to be_falsey
-      expect(grid.reload.logs).to eq({})
+      expect(grid.reload.grid_logs_opts).to be_nil
     end
   end
 end

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - mongodb
 
   agent:
-    container_name: e2e-kontena-agent
+    container_name: kontena-agent
     build:
       context: ../agent
       dockerfile: Dockerfile

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - mongodb
 
   agent:
-    container_name: kontena-agent
+    container_name: e2e-kontena-agent
     build:
       context: ../agent
       dockerfile: Dockerfile

--- a/test/spec/features/grid/update_spec.rb
+++ b/test/spec/features/grid/update_spec.rb
@@ -6,7 +6,7 @@ describe 'update grid' do
   end
 
   it 'updates log shipping' do
-    k = run "kontena grid update --log-driver fluentd --log-opt server=foo e2e"
+    k = run "kontena grid update --log-forwarder fluentd --log-opt server=foo e2e"
     expect(k.code).to eq(0)
     k = run "kontena grid show e2e"
     expect(k.out).to match /fluentd/

--- a/test/spec/features/grid/update_spec.rb
+++ b/test/spec/features/grid/update_spec.rb
@@ -1,0 +1,14 @@
+describe 'update grid' do
+  it 'validates log opts' do
+    k = run "kontena grid update --log-opt server=foo e2e"
+    expect(k.code).not_to eq(0)
+    expect(k.out).to match /Need to specify --log-driver when using --log-opt/
+  end
+
+  it 'updates log shipping' do
+    k = run "kontena grid update --log-driver fluentd --log-opt server=foo e2e"
+    expect(k.code).to eq(0)
+    k = run "kontena grid show e2e"
+    expect(k.out).to match /fluentd/
+  end
+end


### PR DESCRIPTION
Added support for direct log shipping using fluentd.

Can be enabled from cli using:
`kontena grid update --log-driver fluentd --log-opt fluentd-address=localhost:24224 test`

Can be disabled using:
`kontena grid update --log-driver none test`

Still few todos:

- [x] add proper tagging based on service, stack, instance, node etc., https://github.com/kontena/kontena/pull/1860/commits/9451655ad1719aaebf779aba27ffc5ca20d8ab0e
- [x] try to direct fluentd logger logs to standard logger, https://github.com/kontena/kontena/pull/1860/commits/f814868759744afc7d79ff8507768d95a73d79e4
- [x] docs, https://github.com/kontena/kontena/pull/1860/commits/84016882ea240252a874b1c4a6dd9efd5d217d94
- [x] check if there are other relevant options to support, IMO no
- [x] should we validate fluentd opts on the server mutation


fixes #1719 