### PR TITLE
Do not start health check if no protocol specified

### DIFF
--- a/server/app/models/grid_service_health_check.rb
+++ b/server/app/models/grid_service_health_check.rb
@@ -10,4 +10,11 @@ class GridServiceHealthCheck
 
   embedded_in :grid_service
 
+  def is_valid?()
+    return false if protocol.nil?
+    return false if protocol.empty?
+    return false if port.nil?
+    true
+  end
+
 end

--- a/server/app/models/grid_service_health_check.rb
+++ b/server/app/models/grid_service_health_check.rb
@@ -10,7 +10,7 @@ class GridServiceHealthCheck
 
   embedded_in :grid_service
 
-  def is_valid?()
+  def is_valid?
     return false if protocol.nil?
     return false if protocol.empty?
     return false if port.nil?

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -131,7 +131,7 @@ module Docker
         labels['io.kontena.load_balancer.internal_port'] = internal_port
         labels['io.kontena.load_balancer.mode'] = mode
       end
-      if grid_service.health_check && grid_service.health_check.protocol
+      if grid_service.health_check && grid_service.health_check.is_valid?
         labels['io.kontena.health_check.uri'] = grid_service.health_check.uri
         labels['io.kontena.health_check.protocol'] = grid_service.health_check.protocol
         labels['io.kontena.health_check.interval'] = grid_service.health_check.interval.to_s

--- a/server/app/services/docker/service_creator.rb
+++ b/server/app/services/docker/service_creator.rb
@@ -131,7 +131,7 @@ module Docker
         labels['io.kontena.load_balancer.internal_port'] = internal_port
         labels['io.kontena.load_balancer.mode'] = mode
       end
-      if grid_service.health_check
+      if grid_service.health_check && grid_service.health_check.protocol
         labels['io.kontena.health_check.uri'] = grid_service.health_check.uri
         labels['io.kontena.health_check.protocol'] = grid_service.health_check.protocol
         labels['io.kontena.health_check.interval'] = grid_service.health_check.interval.to_s

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -53,7 +53,7 @@ end
 json.hooks grid_service.hooks.as_json(only: [:name, :type, :cmd, :oneshot])
 json.revision grid_service.revision
 json.stack_revision grid_service.stack_revision
-if grid_service.health_check
+if grid_service.health_check && grid_service.health_check.protocol
 	json.health_check do
 		json.protocol grid_service.health_check.protocol
 		json.uri grid_service.health_check.uri

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -118,6 +118,15 @@ describe '/v1/services' do
       expect(json_response['health_status']['total']).to eq(1)
       expect(json_response['health_status']['healthy']).to eq(1)
     end
+
+    it 'returns no health check or status if protocol nil' do
+      redis_service.health_check = GridServiceHealthCheck.new(port: 5000)
+      redis_service.save
+      get "/v1/services/#{redis_service.to_path}", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['health_status']).to be_nil
+      expect(json_response['health_check']).to be_nil
+    end
   end
 
   describe 'PUT /:id' do

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -110,7 +110,7 @@ describe '/v1/services' do
     end
 
     it 'returns health status' do
-      redis_service.health_check = GridServiceHealthCheck.new(port: 5000)
+      redis_service.health_check = GridServiceHealthCheck.new(port: 5000, protocol: 'tcp')
       redis_service.save
       container = redis_service.containers.create!(name: 'redis-1', container_id: 'aaa', health_status: 'healthy')
       get "/v1/services/#{redis_service.to_path}", nil, request_headers

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -166,6 +166,16 @@ describe Docker::ServiceCreator do
         expect(labels).to include('io.kontena.health_check.timeout' => '10')
         expect(labels).to include('io.kontena.health_check.initial_delay' => '10')
       end
+
+      it 'includes no health check labels if protocol nil' do
+        service.health_check = GridServiceHealthCheck.new(uri: '/', port: 80)
+        expect(labels).not_to include('io.kontena.health_check.protocol' => 'http')
+        expect(labels).not_to include('io.kontena.health_check.uri' => '/')
+        expect(labels).not_to include('io.kontena.health_check.port' => '80')
+        expect(labels).not_to include('io.kontena.health_check.interval' => '60')
+        expect(labels).not_to include('io.kontena.health_check.timeout' => '10')
+        expect(labels).not_to include('io.kontena.health_check.initial_delay' => '10')
+      end
     end
   end
 end


### PR DESCRIPTION
Due to #1837 server added health check labels with nil protocol and port for every service. With those agent started the health check defaulting to use tcp and port 0. As this naturally doesn't provide healthy statuses, master was on constant re-scheduling loop for every single service.

Fixed by adding health check labels only if valid protocol is set.