### PR TITLE
The registry url was not stored properly in stack metadata

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -71,7 +71,7 @@ module Kontena::Cli::Stacks
         'expose' => outcome[:expose],
         'version' => outcome[:version],
         'source' => reader.raw_content,
-        'registry' => 'file://',
+        'registry' => outcome[:registry],
         'services' => kontena_services,
         'variables' => outcome[:variables]
       }

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -31,7 +31,7 @@ module Kontena::Cli::Stacks
           @registry = file
         else
           @raw_content = File.read(File.expand_path(file))
-          @registry = "file:///#{File.basename(file)}"
+          @registry = "file://#{File.basename(file)}"
         end
 
         @errors           = []

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -25,13 +25,13 @@ module Kontena::Cli::Stacks
         if from_registry?
           require 'shellwords'
           @raw_content = Kontena::StacksCache.pull(file)
-          @registry    = current_account.name
+          @registry    = current_account.stacks_url
         elsif from_url?
           @raw_content = load_from_url(file)
-          @registry = file
+          @registry = nil
         else
           @raw_content = File.read(File.expand_path(file))
-          @registry = "file://#{File.basename(file)}"
+          @registry = nil
         end
 
         @errors           = []

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Stacks
         if from_registry?
           require 'shellwords'
           @raw_content = Kontena::StacksCache.pull(file)
-          @registry    = file
+          @registry    = current_account.name
         elsif from_url?
           @raw_content = load_from_url(file)
           @registry = file

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Stacks
         if from_registry?
           require 'shellwords'
           @raw_content = Kontena::StacksCache.pull(file)
-          @registry    = Kontena::StacksCache.registry_url(file)
+          @registry    = file
         elsif from_url?
           @raw_content = load_from_url(file)
           @registry = file

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Stacks
         if from_registry?
           require 'shellwords'
           @raw_content = Kontena::StacksCache.pull(file)
-          @registry    = Kontena::StacksCache.registry_url
+          @registry    = Kontena::StacksCache.registry_url(file)
         elsif from_url?
           @raw_content = load_from_url(file)
           @registry = file

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Stacks
       include Kontena::Util
       include Kontena::Cli::Common
 
-      attr_reader :file, :raw_content, :errors, :notifications, :defaults, :values
+      attr_reader :file, :raw_content, :errors, :notifications, :defaults, :values, :registry
 
       def initialize(file, skip_validation: false, skip_variables: false, variables: nil, values: nil, defaults: nil)
         require 'yaml'
@@ -27,11 +27,11 @@ module Kontena::Cli::Stacks
           @raw_content = Kontena::StacksCache.pull(file)
           @registry    = Kontena::StacksCache.registry_url
         elsif from_url?
-          require 'open-uri'
-          stream = open(file)
-          @raw_content = stream.read
+          @raw_content = load_from_url(file)
+          @registry = file
         else
           @raw_content = File.read(File.expand_path(file))
+          @registry = "file:///#{File.basename(file)}"
         end
 
         @errors           = []
@@ -41,6 +41,12 @@ module Kontena::Cli::Stacks
         @variables        = variables
         @values           = values
         @defaults         = defaults
+      end
+
+      def load_from_url(url)
+        require 'open-uri'
+        stream = open(url)
+        stream.read
       end
 
       def internals_interpolated_yaml
@@ -121,7 +127,7 @@ module Kontena::Cli::Stacks
           result[:stack]         = raw_yaml['stack']
           result[:version]       = self.stack_version
           result[:name]          = self.stack_name
-          result[:registry]      = @registry if from_registry?
+          result[:registry]      = registry
           result[:expose]        = fully_interpolated_yaml['expose']
           result[:errors]        = errors unless skip_validation?
           result[:notifications] = notifications

--- a/cli/lib/kontena/stacks_cache.rb
+++ b/cli/lib/kontena/stacks_cache.rb
@@ -2,6 +2,7 @@ require_relative 'stacks_client'
 require_relative 'cli/common'
 require_relative 'cli/stacks/common'
 require 'yaml'
+require 'uri'
 
 module Kontena
   class StacksCache
@@ -94,8 +95,8 @@ module Kontena
         stack
       end
 
-      def registry_url
-        client.api_url
+      def registry_url(stack, version = nil)
+        client.full_uri(stack, version)
       end
 
       def client

--- a/cli/lib/kontena/stacks_client.rb
+++ b/cli/lib/kontena/stacks_client.rb
@@ -7,6 +7,10 @@ module Kontena
     ACCEPT_YAML = { 'Accept' => 'application/yaml' }
     CT_YAML     = { 'Content-Type' => 'application/yaml' }
 
+    def full_uri(stack_name, version = nil)
+      URI.join(api_url, path_to(stack_name, version)).to_s
+    end
+
     def path_to(stack_name, version = nil)
       version ? "/stack/#{stack_name}/version/#{version}" : "/stack/#{stack_name}"
     end

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -408,7 +408,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       expect(stack_double).to receive(:read).and_return(fixture('kontena_v3.yml'))
       instance = described_class.new('foo/foo')
       expect(instance.from_registry?).to be_truthy
-      expect(instance.execute[:registry]).to eq 'https://stacks.kontena.io/stack/foo/foo'
+      expect(instance.execute[:registry]).to eq 'foo/foo'
     end
 
     it 'can read from an url' do

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -398,20 +398,25 @@ describe Kontena::Cli::Stacks::YAML::Reader do
         .with(absolute_yaml_path('kontena_v3.yml'))
         .and_return(fixture('stack-with-liquid.yml'))
       expect(subject.from_file?).to be_truthy
+      expect(subject.execute[:registry]).to eq 'file://kontena_v3.yml'
     end
 
     it 'can read from the registry' do
-      expect(Kontena::StacksCache).to receive(:pull)
-        .with('foo/foo')
-        .and_return(fixture('stack-with-liquid.yml'))
-      expect(Kontena::StacksCache).to receive(:registry_url).and_return('foo')
-      expect(described_class.new('foo/foo').from_registry?).to be_truthy
+      stack_double = double
+      allow_any_instance_of(Kontena::StacksCache::RegistryClientFactory).to receive(:cloud_auth?).and_return(true)
+      expect(Kontena::StacksCache).to receive(:cache).with('foo/foo', nil).and_return(stack_double)
+      expect(stack_double).to receive(:read).and_return(fixture('kontena_v3.yml'))
+      instance = described_class.new('foo/foo')
+      expect(instance.from_registry?).to be_truthy
+      expect(instance.execute[:registry]).to eq 'https://stacks.kontena.io/stack/foo/foo'
     end
 
     it 'can read from an url' do
       stub_request(:get, "http://foo.example.com/foo").to_return(:status => 200, :body => fixture('stack-with-liquid.yml'), :headers => {})
       allow_any_instance_of(described_class).to receive(:load_from_url).and_return(fixture('stack-with-liquid.yml'))
-      expect(described_class.new('http://foo.example.com/foo').from_url?).to be_truthy
+      instance = described_class.new('http://foo.example.com/foo')
+      expect(instance.from_url?).to be_truthy
+      expect(instance.execute[:registry]).to eq 'http://foo.example.com/foo'
     end
   end
 

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -398,7 +398,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
         .with(absolute_yaml_path('kontena_v3.yml'))
         .and_return(fixture('stack-with-liquid.yml'))
       expect(subject.from_file?).to be_truthy
-      expect(subject.execute[:registry]).to eq 'file://kontena_v3.yml'
+      expect(subject.execute[:registry]).to be_nil
     end
 
     it 'can read from the registry' do
@@ -408,7 +408,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       expect(stack_double).to receive(:read).and_return(fixture('kontena_v3.yml'))
       instance = described_class.new('foo/foo')
       expect(instance.from_registry?).to be_truthy
-      expect(instance.execute[:registry]).to eq 'kontena'
+      expect(instance.execute[:registry]).to eq instance.current_account.stacks_url
     end
 
     it 'can read from an url' do
@@ -416,7 +416,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       allow_any_instance_of(described_class).to receive(:load_from_url).and_return(fixture('stack-with-liquid.yml'))
       instance = described_class.new('http://foo.example.com/foo')
       expect(instance.from_url?).to be_truthy
-      expect(instance.execute[:registry]).to eq 'http://foo.example.com/foo'
+      expect(instance.execute[:registry]).to be_nil
     end
   end
 

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -409,7 +409,8 @@ describe Kontena::Cli::Stacks::YAML::Reader do
     end
 
     it 'can read from an url' do
-     stub_request(:get, "http://foo.example.com/foo").to_return(:status => 200, :body => fixture('stack-with-liquid.yml'), :headers => {})
+      stub_request(:get, "http://foo.example.com/foo").to_return(:status => 200, :body => fixture('stack-with-liquid.yml'), :headers => {})
+      allow_any_instance_of(described_class).to receive(:load_from_url).and_return(fixture('stack-with-liquid.yml'))
       expect(described_class.new('http://foo.example.com/foo').from_url?).to be_truthy
     end
   end

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -408,7 +408,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       expect(stack_double).to receive(:read).and_return(fixture('kontena_v3.yml'))
       instance = described_class.new('foo/foo')
       expect(instance.from_registry?).to be_truthy
-      expect(instance.execute[:registry]).to eq 'foo/foo'
+      expect(instance.execute[:registry]).to eq 'kontena'
     end
 
     it 'can read from an url' do

--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -42,7 +42,6 @@ module Stacks
         required do
           string :stack
           string :version
-          string :registry
           string :source
           array :services do
             model :object, class: Hash
@@ -51,6 +50,7 @@ module Stacks
 
         optional do
           string :expose
+          string :registry
           model :variables, class: Hash
         end
       end


### PR DESCRIPTION
Fixes #1844

The "registry" field always contained "file:///" no matter what.

Now it contains the url of the registry in case the stack came from a registry. Otherwise it's nil.
