### PR TITLE
Fix server stack create links errors

### DIFF
--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -10,7 +10,7 @@ module Stacks
     # @param [String] type
     def handle_service_outcome_errors(service_name, messages, type)
       messages.each do |key, msg|
-        add_error(:services, :key, "Service #{type} failed for service '#{service_name}': #{msg}")
+        add_error(:services, key.to_sym, "Service #{type} failed for service '#{service_name}': #{msg}")
       end
     end
 

--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -27,7 +27,7 @@ module Stacks
       links = links - internal_links
       internal_links.each do |l|
         unless self.services.any?{|s| s[:name] == l['name']}
-          handle_service_outcome_errors(service[:name], ["Linked service #{l['name']} does not exist"], :create)
+          handle_service_outcome_errors(service[:name], { links: "Linked service '#{l['name']}' does not exist" }, :validate)
         end
       end
       service[:links] = links

--- a/server/app/mutations/stacks/create.rb
+++ b/server/app/mutations/stacks/create.rb
@@ -31,7 +31,7 @@ module Stacks
         service[:grid] = self.grid
         outcome = GridServices::Create.validate(service)
         unless outcome.success?
-          handle_service_outcome_errors(service[:name], outcome.errors.message, :create)
+          handle_service_outcome_errors(service[:name], outcome.errors.message, :validate)
         end
       end
     end

--- a/server/spec/mutations/stacks/create_spec.rb
+++ b/server/spec/mutations/stacks/create_spec.rb
@@ -190,7 +190,7 @@ describe Stacks::Create do
         services: services
       ).run
       expect(outcome.success?).to be(false)
-      expect(outcome.errors.message.keys).to include('services')
+      expect(outcome.errors.message).to eq 'services' => "Service validate failed for service 'api': Link redis/redis points to non-existing stack"
     end
 
     it 'does not create a stack if link within a stack is invalid' do

--- a/server/spec/mutations/stacks/create_spec.rb
+++ b/server/spec/mutations/stacks/create_spec.rb
@@ -215,7 +215,7 @@ describe Stacks::Create do
         services: services
       ).run
       expect(outcome.success?).to be(false)
-      expect(outcome.errors.message.keys).to include('services')
+      expect(outcome.errors.message).to eq 'services' => "Service validate failed for service 'api': Linked service 'redis' does not exist"
     end
 
     it 'does not create stack if any service validation fails' do

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -41,4 +41,14 @@ describe 'stack install' do
       end
     end
   end
+
+  context 'For a stack with a broken link' do
+    it 'Returns an error' do
+      with_fixture_dir("stack/links-broken") do
+        k = run 'kontena stack install kontena.yml'
+        expect(k.code).to eq(1)
+        expect(k.out).to match /Service validate failed for service 'a': Linked service 'nope' does not exist/
+      end
+    end
+  end
 end

--- a/test/spec/fixtures/stack/links-broken/kontena.yml
+++ b/test/spec/fixtures/stack/links-broken/kontena.yml
@@ -1,0 +1,6 @@
+stack: test/links
+services:
+  a:
+    image: redis
+    links:
+      - nope


### PR DESCRIPTION
Fixes #1848

#### `kontena stack install test/links.yaml`
```
 [fail] Creating stack links      
 [error] {"services"=>"Service validate failed for service 'a': Linked service 'nope' does not exist"}
```