### PR TITLE
Run e2e specs with docker-compose inside docker-compose with CoreOS inside Vagrant

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,1 +1,2 @@
 .env
+.vagrant

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -24,5 +24,3 @@ RUN bundle install
 
 # XXX: bundler does not install executables from path: ... gems?
 RUN ln -s /kontena/cli/bin/kontena /usr/local/bin/kontena
-
-ADD . /kontena

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -1,0 +1,28 @@
+FROM alpine:3.5
+MAINTAINER Kontena, Inc. <info@kontena.io>
+
+ARG DOCKER_COMPOSE_VERSION=1.11.1
+
+RUN apk update && apk --update add \
+    tzdata ruby ruby-irb ruby-bigdecimal \
+    ruby-io-console ruby-json ca-certificates libssl1.0 openssl libstdc++ \
+    ruby-dev build-base openssl-dev \
+    git curl py-pip
+
+RUN gem install --no-ri --no-rdoc bundler rake
+RUN pip install docker-compose==$DOCKER_COMPOSE_VERSION
+
+ADD test/Gemfile test/Gemfile.lock /kontena/test/
+ADD cli/Gemfile cli/Gemfile.lock cli/kontena-cli.gemspec /kontena/cli/
+
+# required for the gemspec
+ADD cli/lib/kontena/cli/version.rb /kontena/cli/lib/kontena/cli/version.rb
+ADD cli/VERSION /kontena/cli/VERSION
+
+WORKDIR /kontena/test
+RUN bundle install
+
+# XXX: bundler does not install executables from path: ... gems?
+RUN ln -s /kontena/cli/bin/kontena /usr/local/bin/kontena
+
+ADD . /kontena

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -13,7 +13,7 @@ RUN gem install --no-ri --no-rdoc bundler rake
 RUN pip install docker-compose==$DOCKER_COMPOSE_VERSION
 
 ADD test/Gemfile test/Gemfile.lock /kontena/test/
-ADD cli/Gemfile cli/Gemfile.lock cli/kontena-cli.gemspec /kontena/cli/
+ADD cli/Gemfile cli/kontena-cli.gemspec /kontena/cli/
 
 # required for the gemspec
 ADD cli/lib/kontena/cli/version.rb /kontena/cli/lib/kontena/cli/version.rb

--- a/test/README.md
+++ b/test/README.md
@@ -57,20 +57,20 @@ Setup:
 test $ vagrant up
 test $ vagrant ssh
 core@localhost $ cd ~/kontena/test
-core@localhost ~/kontena/test $ docker-compose run test rake compose:setup
+core@localhost ~/kontena/test $ docker-compose run --rm test rake compose:setup
 ```
 
 Specs:
 
 ```
 test $ vagrant ssh
-core@localhost ~/kontena/test $ docker-compose run test rake
+core@localhost ~/kontena/test $ docker-compose run --rm test rake
 ```
 
 Teardown:
 
 ```
 test $ vagrant ssh
-core@localhost ~/kontena/test $ docker-compose run test rake compose:teardown
+core@localhost ~/kontena/test $ docker-compose run --rm test rake compose:teardown
 test $ vagrant destroy
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -56,21 +56,19 @@ Setup:
 ```
 test $ vagrant up
 test $ vagrant ssh
-core@localhost $ cd ~/kontena/test
-core@localhost ~/kontena/test $ docker-compose run --rm test rake compose:setup
+core@localhost $ cd /kontena/test
+core@localhost /kontena/test $ docker-compose run --rm test rake compose:setup
 ```
 
 Specs:
 
 ```
-test $ vagrant ssh
-core@localhost ~/kontena/test $ docker-compose run --rm test rake
+core@localhost /kontena/test $ docker-compose run --rm test rspec
 ```
 
 Teardown:
 
 ```
-test $ vagrant ssh
-core@localhost ~/kontena/test $ docker-compose run --rm test rake compose:teardown
+core@localhost /kontena/test $ docker-compose run --rm test rake compose:teardown
 test $ vagrant destroy
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -63,7 +63,13 @@ core@localhost /kontena/test $ docker-compose run --rm test rake compose:setup
 Specs:
 
 ```
-core@localhost /kontena/test $ docker-compose run --rm test rspec
+core@localhost /kontena/test $ docker-compose run --rm test rake
+```
+
+or
+
+```
+core@localhost /kontena/test $ docker-compose run --rm test rspec spec/
 ```
 
 Teardown:
@@ -71,4 +77,10 @@ Teardown:
 ```
 core@localhost /kontena/test $ docker-compose run --rm test rake compose:teardown
 test $ vagrant destroy
+```
+
+Oneliner:
+
+```
+vagrant up && vagrant ssh -c 'cd /kontena/test && docker-compose up test'
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -15,7 +15,6 @@ or
 $ bundle exec rspec spec/
 ```
 
-
 ## Local test environment using Docker Compose
 
 This environment is built from sources.
@@ -46,4 +45,32 @@ Teardown:
 
 ```
 $ rake vagrant:teardown
+```
+
+## Vagrant test environment using Docker Compose
+
+This environment is built from sources with CoreOS running in Virtualbox.
+
+Setup:
+
+```
+test $ vagrant up
+test $ vagrant ssh
+core@localhost $ cd ~/kontena/test
+core@localhost ~/kontena/test $ docker-compose run test rake compose:setup
+```
+
+Specs:
+
+```
+test $ vagrant ssh
+core@localhost ~/kontena/test $ docker-compose run test rake
+```
+
+Teardown:
+
+```
+test $ vagrant ssh
+core@localhost ~/kontena/test $ docker-compose run test rake compose:teardown
+test $ vagrant destroy
 ```

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -69,7 +69,7 @@ namespace :compose do
   task :teardown_grid do
     sh "docker-compose stop agent"
     sh "docker-compose rm --force agent"
-    sh "kontena node rm --force moby"
+    sh "kontena node rm --force $HOSTNAME"
     sh "kontena grid rm --force e2e"
   end
 end

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -69,8 +69,12 @@ namespace :compose do
 
   task :teardown_grid do
     sh "docker-compose stop agent"
+    # Workaround https://github.com/docker/compose/issues/4548
+    #   The agent service must be stopped before using docker-compose run
+    # Workaround https://github.com/docker/compose/issues/4550
+    #   Strip trailing CR from the docker-compose run output
+    sh "kontena node rm --force $(docker-compose run --rm agent hostname | tr -d $'\r')"
     sh "docker-compose rm --force agent"
-    sh "kontena node rm --force $HOSTNAME"
     sh "kontena grid rm --force e2e"
   end
 end

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -64,6 +64,7 @@ namespace :compose do
   task :teardown_master do
     sh "docker-compose stop api mongodb"
     sh "docker-compose rm --force api mongodb"
+    sh "kontena master remove --force compose-e2e"
   end
 
   task :teardown_grid do

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -5,7 +5,7 @@ $coreos_channel = "stable"
 $image_version = "current"
 
 $vm_memory = 1024
-$vm_cpus = 1
+$vm_cpus = 2
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -42,7 +42,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.network :private_network, ip: "172.17.8.100"
-  config.vm.synced_folder "..", "/home/core/kontena", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp']
+  config.vm.synced_folder "..", "/kontena", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp']
 
   config.vm.provision :shell, :path => 'vagrant-provision.sh'
 end

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,0 +1,48 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$coreos_channel = "stable"
+$image_version = "current"
+
+$vm_memory = 1024
+$vm_cpus = 1
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "coreos-%s" % $coreos_channel
+  if $image_version != "current"
+      config.vm.box_version = $image_version
+  end
+  config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant.json" % [$coreos_channel, $image_version]
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  config.vm.provider :virtualbox do |v|
+    v.gui = false
+
+    v.memory = $vm_memory
+    v.cpus = $vm_cpus
+
+    # On VirtualBox, we don't have guest additions or a functional vboxsf
+    # in CoreOS, so tell Vagrant that so it can be smarter.
+    v.check_guest_additions = false
+    v.functional_vboxsf     = false
+  end
+
+  config.vm.network :private_network, ip: "172.17.8.100"
+  config.vm.synced_folder "..", "/home/core/kontena", id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp']
+
+  config.vm.provision :shell, :path => 'vagrant-provision.sh'
+end

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ..:/kontena
       - ./.kontena_client.json:/root/.kontena_client.json
+    command: rake compose:setup spec compose:teardown
 
   api:
     build:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ..:/kontena
+      - ./.kontena_client.json:/root/.kontena_client.json
 
   api:
     build:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '2'
 
 services:
+  test:
+    build:
+      context: ..
+      dockerfile: test/Dockerfile.test
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   api:
     build:
       context: ../server

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: ..
       dockerfile: test/Dockerfile.test
+    network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ..:/kontena

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: test/Dockerfile.test
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ..:/kontena
 
   api:
     build:

--- a/test/vagrant-provision.sh
+++ b/test/vagrant-provision.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -uex
+
+## docker-compose
+DOCKER_COMPOSE_VERSION=1.11.1
+
+[ -d /opt/bin ] || sudo install -d /opt/bin
+
+[ -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION ] || sudo install -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION
+[ -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin ] || sudo install -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin
+[ -e /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin/docker-compose ] || (
+  curl -o /tmp/docker-compose -sL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m`
+  sudo install -m 755 -t /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin /tmp/docker-compose
+)
+
+sudo ln -sf /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin/docker-compose /opt/bin/docker-compose
+
+## setup
+cd ~/kontena/test
+
+docker-compose build test && docker-compose run test rake compose:setup

--- a/test/vagrant-provision.sh
+++ b/test/vagrant-provision.sh
@@ -15,8 +15,3 @@ DOCKER_COMPOSE_VERSION=1.11.1
 )
 
 sudo ln -sf /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin/docker-compose /opt/bin/docker-compose
-
-## setup
-cd ~/kontena/test
-
-docker-compose build test && docker-compose run test rake compose:setup


### PR DESCRIPTION
Enough levels of nesting yet? This allows you to develop e2e tests while running the agent and services in an actual CoreOS environment.

```
test $ vagrant up
test $ vagrant ssh
core@localhost $ cd ~/kontena/test
core@localhost ~/kontena/test $ docker-compose run --rm test rake compose:setup
...
core@localhost ~/kontena/test $ docker-compose run --rm test rake
/usr/bin/ruby -I/usr/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib:/usr/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.3/lib /usr/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.3/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
..............................

Finished in 9 minutes 42 seconds (files took 0.28375 seconds to load)
30 examples, 0 failures
```

Also fixes  #1879