### PR TITLE
Test: Skip compose build, bind-mount /app instead

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -31,6 +31,18 @@ Teardown:
 $ rake compose:teardown
 ```
 
+The `agent` and `server` sources are bind-mounted into the Docker containers, and restarting the containers is sufficient for re-running tests after code changes:
+
+```
+$ docker-compose restart api agent
+```
+
+However, if you update the `agent` or `server` build (`Dockerfile`, `Gemfile`) files, then you must also rebuild the Docker images:
+
+```
+$ rake compose:build
+```
+
 ## Local test environment using Vagrant
 
 This environment uses official images. Version can be defined via `VERSION` environment variable (default: edge).
@@ -78,6 +90,9 @@ Teardown:
 core@localhost /kontena/test $ docker-compose run --rm test rake compose:teardown
 test $ vagrant destroy
 ```
+
+The `cli` and `test` sources are bind-mounted into the `test` container, and any changes to the cli or test specs will have immediate effect on the next `docker-compose run`.
+As for the `rake compose` in general, you can either restart or may need to `rake compose:build` the `server` and `agent` containers on changes.
 
 Oneliner:
 

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -40,12 +40,20 @@ namespace :vagrant  do
 end
 
 namespace :compose do
+  task :build => [:build_master, :build_agent]
+  task :build_master do
+    sh "docker-compose build api"
+  end
+  task :build_agent do
+    sh "docker-compose build agent"
+  end
+
   desc "setup compose"
   task :setup => [:setup_master, :setup_grid]
 
   desc "setup vagrant master"
   task :setup_master do
-    sh "docker-compose up --build -d api"
+    sh "docker-compose up -d api"
     sleep 20
     sh "kontena master login --code initialadmincode --name compose-e2e http://localhost:9292"
   end
@@ -53,7 +61,7 @@ namespace :compose do
   desc "setup vagrant grid"
   task :setup_grid do
     sh "kontena grid create --token e2etoken e2e"
-    sh "docker-compose up --build -d agent"
+    sh "docker-compose up -d agent"
     sleep 30
     sh "kontena node ls"
   end

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     build:
       context: ../server
       dockerfile: Dockerfile
+    volumes:
+      - ../server:/app
     ports:
       - 9292:9292
     environment:
@@ -39,6 +41,7 @@ services:
     network_mode: "host"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ../agent:/app
     depends_on:
       - api
 


### PR DESCRIPTION
Override the `/app` code included in the `agent` and `api` images with a `-v ../asdf:/app` bind-mount. This makes repeated `rake compose:setup` commands much faster, which makes developing tests much more convenient, whereby `docker-compose restart ...` is enough to re-run tests after code changes. 

Downside is that you need to explicitly run `rake compose:build` if you change any of the `Dockerfile`/`Gemfile`s.

```
core@localhost /kontena/test $ docker-compose run --rm test rake compose:setup   
docker-compose up -d api
Creating test_mongodb_1
Creating test_api_1
kontena master login --code initialadmincode --name compose-e2e http://localhost:9292

 [done] Retrieving a list of available grids     

Kontena Master compose-e2e doesn't have any grids yet. Create one now using 'kontena grid create' command

kontena grid create --token e2etoken e2e
 [warn] Option --initial-size=1 is only recommended for test/dev usage
 [done] Creating e2e grid      
 [done] Switching scope to e2e grid      
docker-compose up -d agent
test_mongodb_1 is up-to-date
test_api_1 is up-to-date
Creating kontena-agent
kontena node ls
  Name                                                                   Version    Status     Initial    Labels
⊛ localhost                                                              1.1.1      online     1 / 1      -
core@localhost /kontena/test $ docker-compose run --rm test rspec spec/features/stack/list_spec.rb 
..

Finished in 6.79 seconds (files took 0.19151 seconds to load)
2 examples, 0 failures

core@localhost /kontena/test $ edit /kontena/server/...
core@localhost /kontena/test $ git diff | cat
diff --git a/server/app/routes/v1/grids/grid_stacks.rb b/server/app/routes/v1/grids/grid_stacks.rb
index 91817b5..4c4c447 100644
--- a/server/app/routes/v1/grids/grid_stacks.rb
+++ b/server/app/routes/v1/grids/grid_stacks.rb
@@ -25,6 +25,7 @@ V1::GridsApi.route('grid_stacks') do |r|
   r.get do
     r.is do
       @stacks = @grid.stacks.where(:name.ne => Stack::NULL_STACK).includes(:grid_services)
+      fail "testing"
       render('stacks/index')
     end
   end
core@localhost /kontena/test $ docker-compose restart api
Restarting test_api_1 ... done
core@localhost /kontena/test $ docker-compose run --rm test rspec spec/features/stack/list_spec.rb 
FF

Failures:

  1) stack list returns an empty list
     Failure/Error: expect(k.code).to eq(0)
     
       expected: 0
            got: 1
     
       (compared using ==)
     # ./spec/features/stack/list_spec.rb:6:in `block (2 levels) in <top (required)>'

  2) stack list returns an installed stack
     Failure/Error: expect(k.code).to eq(0)
     
       expected: 0
            got: 1
     
       (compared using ==)
     # ./spec/features/stack/list_spec.rb:15:in `block (2 levels) in <top (required)>'

Finished in 4.56 seconds (files took 0.17667 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./spec/features/stack/list_spec.rb:4 # stack list returns an empty list
rspec ./spec/features/stack/list_spec.rb:10 # stack list returns an installed stack

```