### PR TITLE
Fix server stack remove service reverse-dependency sorting on links

### DIFF
--- a/server/app/mutations/stacks/sort_helper.rb
+++ b/server/app/mutations/stacks/sort_helper.rb
@@ -21,7 +21,7 @@ module Stacks
     # @return [Array<Hash>]
     def __links_for_service(service)
       if service.is_a?(GridService)
-        service.grid_service_links.map{ |l| { name: l.grid_service.name } }
+        service.grid_service_links.map{ |l| { name: l.linked_grid_service.name } }
       else
         service[:links] || []
       end

--- a/server/spec/jobs/stack_remove_worker_spec.rb
+++ b/server/spec/jobs/stack_remove_worker_spec.rb
@@ -1,6 +1,14 @@
 require_relative '../spec_helper'
 
 describe StackRemoveWorker do
+  before(:each) do
+    Celluloid.boot
+  end
+
+  after(:each) do
+    Celluloid.shutdown
+  end
+
   let :grid do
     Grid.create(name: 'test')
   end

--- a/server/spec/jobs/stack_remove_worker_spec.rb
+++ b/server/spec/jobs/stack_remove_worker_spec.rb
@@ -1,0 +1,84 @@
+require_relative '../spec_helper'
+
+describe StackRemoveWorker do
+  let :grid do
+    Grid.create(name: 'test')
+  end
+
+  let :default_stack do
+    grid.stacks.find_by(name: Stack::NULL_STACK)
+  end
+
+  let :lb_service do
+    GridService.create(grid: grid, stack: default_stack, name: 'lb', image_name: 'kontena/lb:latest')
+  end
+
+  let :stack do
+    lb_service
+
+    Stacks::Create.run!(
+      grid: grid,
+      name: 'stack',
+      stack: 'foo/bar',
+      version: '0.1.0',
+      registry: 'file://',
+      source: '...',
+      services: [
+        {name: 'redis', image: 'redis:2.8', stateful: true, links: [
+          { name: "null/lb", alias: 'lb' },
+        ] },
+      ],
+    )
+  end
+
+  let :redis_service do
+    stack.grid_services.first
+  end
+
+  let :outcome_success do
+    double(success?: true)
+  end
+
+  before do
+    expect(redis_service.grid_service_links.map {|l| l.linked_grid_service.name}).to eq ['lb']
+  end
+
+  context "For a stack with linked services" do
+    let :foo_service do
+      GridServices::Create.run!(
+        grid: grid,
+        stateful: false,
+        name: 'foo',
+        image: 'foo:latest',
+        stack: stack,
+        links: [
+          { name: 'redis', alias: 'redis' }
+        ]
+      )
+    end
+
+    let :bar_service do
+      GridServices::Create.run!(
+        grid: grid,
+        stateful: false,
+        name: 'bar',
+        image: 'bar:latest',
+        stack: stack,
+        links: [
+          { name: 'redis', alias: 'redis' }
+        ]
+      )
+    end
+
+    describe '#sort_services' do
+      it "Sorts the services in reverse-dependency order" do
+        # assume stable sort
+        expect(subject.sort_services([redis_service, foo_service, bar_service]).reverse).to eq [bar_service, foo_service, redis_service]
+      end
+
+      it "Sorts the services in reverse-dependency order when the linked-to service is after the linking service" do
+        expect(subject.sort_services([foo_service, redis_service, bar_service]).reverse).to eq [bar_service, foo_service, redis_service]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1836

#1358 used `Stacks::SortHelper.sort_services` to sort stack services into reverse-dependency order for removal, to avoid `GridServices::Delete` errors when removing a service that still has links to it. The implementation of `Stacks::SortHelper.sort_services` was broken, and used the `GridServiceLink.grid_service` instead of the `GridServiceLink.linked_grid_service`, causing it to consider each service as only linking to itself:

```
a=foo links=[{:name=>"foo"}]
b=bar links=[{:name=>"bar"}]
a=redis links=[{:name=>"redis"}]
b=foo links=[{:name=>"foo"}]
.a=redis links=[{:name=>"redis"}]
b=bar links=[{:name=>"bar"}]
a=foo links=[{:name=>"foo"}]
b=redis links=[{:name=>"redis"}]
```

This means that it effectively only sorted on the number of links. This worked for the simple case of services in a stack linking to one service, where that the linked-to service would thus have fewer links (zero). However, if that service then also linked to e.g. an lb service outside of the stack, the services could get sorted into the wrong order.