### PR TITLE
cli stack service_link resolver: fix default index when optional

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
@@ -32,8 +32,11 @@ module Kontena::Cli::Stacks::YAML::Opto::Resolvers
     # @return [Integer]
     def default_index(services)
       index = services.index {|s| service_link(s) == option.default }
-      if index
-        index.to_i + 1
+
+      if index && !option.required?
+        index + 2
+      elsif index
+        index + 1
       else
         0
       end

--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
@@ -34,11 +34,11 @@ module Kontena::Cli::Stacks::YAML::Opto::Resolvers
       index = services.index {|s| service_link(s) == option.default }
 
       if index && !option.required?
-        index + 2
+        index + 2 # extra offset for the initial <none> option
       elsif index
-        index + 1
+        index + 1 # menu index starts from 1
       else
-        0
+        0 # XXX: this just explodes?
       end
     end
 

--- a/cli/spec/kontena/cli/stacks/yaml/opto/service_link_resolver_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/opto/service_link_resolver_spec.rb
@@ -24,31 +24,54 @@ describe Kontena::Cli::Stacks::YAML::Opto::Resolvers::ServiceLink do
     end
   end
 
-  describe '#default_index' do
+  context "For a required option with a default value" do
     let(:option) do
-      ::Opto::Option.new(default: 'foo/bar')
+      ::Opto::Option.new(type: 'string', name: 'link', default: 'foo/bar')
     end
     let(:subject) do
       described_class.new({'prompt' => 'foo'}, option)
     end
 
-    it 'returns matching index' do
-      services = [
-        {'id' => 'test/foo/foo'},
-        {'id' => 'test/foo/bar'},
-        {'id' => 'test/asd/asd'}
-      ]
-      index = subject.default_index(services)
-      expect(index).to eq(2)
+    describe '#default_index' do
+      it 'returns matching index' do
+        services = [
+          {'id' => 'test/foo/foo'},
+          {'id' => 'test/foo/bar'},
+          {'id' => 'test/asd/asd'}
+        ]
+        index = subject.default_index(services)
+        expect(index).to eq(2)
+      end
+
+      it 'returns 0 if no matches' do
+        services = [
+          {'id' => 'test/foo/foo'},
+          {'id' => 'test/asd/asd'}
+        ]
+        index = subject.default_index(services)
+        expect(index).to eq(0)
+      end
+    end
+  end
+
+  context "For an optional option with a default value" do
+    let(:option) do
+      ::Opto::Option.new(type: 'string', name: 'link', default: 'foo/bar', required: false)
+    end
+    let(:subject) do
+      described_class.new({'prompt' => 'foo'}, option)
     end
 
-    it 'returns 0 if no matches' do
-      services = [
-        {'id' => 'test/foo/foo'},
-        {'id' => 'test/asd/asd'}
-      ]
-      index = subject.default_index(services)
-      expect(index).to eq(0)
+    describe '#default_index' do
+      it 'returns matching index' do
+        services = [
+          {'id' => 'test/foo/foo'},
+          {'id' => 'test/foo/bar'},
+          {'id' => 'test/asd/asd'}
+        ]
+        index = subject.default_index(services)
+        expect(index).to eq(3)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes  #1888

The `from: service_link` resolver used the wrong `menu.default` index if the variable was optional. It did not take into the extra `<none>` option at `index=1` into account.