### PR TITLE
Avoid leaking auth codes to cloud in referer header 

### DIFF
--- a/cli/lib/kontena/cli/localhost_web_server.rb
+++ b/cli/lib/kontena/cli/localhost_web_server.rb
@@ -17,7 +17,7 @@ module Kontena
     attr_accessor :server, :success_response, :error_response, :port
 
     DEFAULT_ERROR_MESSAGE   = "Bad request"
-    SUCCESS_URL             = "http://cloud.kontena.io/terminal-success"
+    SUCCESS_URL             = "https://cloud.kontena.io/terminal-success"
 
     # Get new server instance
     #
@@ -73,6 +73,7 @@ module Kontena
           socket.print [
             'HTTP/1.1 301 Found',
             "Location: #{SUCCESS_URL}",
+            "Referrer-Policy: no-referrer"
             "Connection: close",
             ''
           ].join("\r\n")

--- a/cli/lib/kontena/cli/localhost_web_server.rb
+++ b/cli/lib/kontena/cli/localhost_web_server.rb
@@ -71,7 +71,7 @@ module Kontena
           ].join("\r\n")
         else
           socket.print [
-            'HTTP/1.1 301 Found',
+            'HTTP/1.1 302 Found',
             "Location: #{SUCCESS_URL}",
             "Referrer-Policy: no-referrer",
             "Connection: close",

--- a/cli/lib/kontena/cli/localhost_web_server.rb
+++ b/cli/lib/kontena/cli/localhost_web_server.rb
@@ -73,7 +73,7 @@ module Kontena
           socket.print [
             'HTTP/1.1 301 Found',
             "Location: #{SUCCESS_URL}",
-            "Referrer-Policy: no-referrer"
+            "Referrer-Policy: no-referrer",
             "Connection: close",
             ''
           ].join("\r\n")

--- a/cli/lib/kontena/cli/localhost_web_server.rb
+++ b/cli/lib/kontena/cli/localhost_web_server.rb
@@ -17,8 +17,8 @@ module Kontena
     attr_accessor :server, :success_response, :error_response, :port
 
     DEFAULT_ERROR_MESSAGE   = "Bad request"
-    SUCCESS_URL             = "https://cloud.kontena.io/terminal-success"
-      
+    SUCCESS_URL             = "http://cloud.kontena.io/terminal-success"
+
     # Get new server instance
     #
     # @param [String] success_response Returned for successful callback


### PR DESCRIPTION
As realized by @SpComb - the CLI authentication mechanism can leak the auth code in referrer header when doing the final redirect to https://cloud.kontena.io/terminal-success during the oauth dance.

This PR adds `Referrer-Policy: no-referrer` header to the request which should eliminate the referrer on most browsers.
