### PR TITLE
Upgrade to tty-prompt 0.11 with improved windows support

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "excon", "~> 0.49.0"
-  spec.add_runtime_dependency "tty-prompt", "~> 0.11"
+  spec.add_runtime_dependency "tty-prompt", "~> 0.11.0"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "excon", "~> 0.49.0"
-  spec.add_runtime_dependency "tty-prompt", "~> 0.10"
+  spec.add_runtime_dependency "tty-prompt", "~> 0.11"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -41,7 +41,7 @@ module Kontena
   end
 
   def self.simple_terminal?
-    on_windows? || ENV['KONTENA_SIMPLE_TERM'] || !$stdout.tty?
+    ENV['KONTENA_SIMPLE_TERM'] || !$stdout.tty?
   end
 
   def self.pastel


### PR DESCRIPTION
The new tty-prompt has better support for windows.

Fixes #1841 
