### PR TITLE
Updating development.md guide to include step to delete master nodes from local cli config file

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,4 +96,10 @@ docker ps -aq -f name=weave | xargs docker rm -f
 dontena cloud master rm
 ```
 
+You may also want to remove the cli config file to prevent previous state from causing issues:
+
+```bash
+rm $HOME/.kontena_client.json 
+```
+
 and start from the beginning.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,12 +94,7 @@ docker-compose down
 docker ps -aq -f name=kontena- | xargs docker rm -f
 docker ps -aq -f name=weave | xargs docker rm -f
 dontena cloud master rm
-```
-
-You may also want to remove the cli config file to prevent previous state from causing issues:
-
-```bash
-rm $HOME/.kontena_client.json 
+dontena master rm
 ```
 
 and start from the beginning.


### PR DESCRIPTION
Small fix to developer setup documentation.  

At the end of document, when describing how to clean up the local dev environment, I added some notes and script explaining how the ```.kontena_client.json``` file may need to be cleaned up as well to prevent issues with previous CLI state being maintained.