### PR TITLE
Send file:// as registry url to allow backwards compatibility with pre v1.1.2 masters

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -38,10 +38,10 @@ module Kontena::Cli::Stacks
           @registry    = current_account.stacks_url
         elsif from_url?
           @raw_content = load_from_url(file)
-          @registry = nil
+          @registry = 'file://'
         else
           @raw_content = File.read(File.expand_path(file))
-          @registry = nil
+          @registry = 'file://'
         end
 
         @errors           = []

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -402,7 +402,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       subject = described_class.new(fixture_path('kontena_v3.yml'))
 
       expect(subject.from_file?).to be_truthy
-      expect(subject.execute[:registry]).to be_nil
+      expect(subject.execute[:registry]).to eq 'file://'
     end
 
     it 'can read from the registry' do
@@ -428,7 +428,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       allow_any_instance_of(described_class).to receive(:load_from_url).and_return(fixture('stack-with-liquid.yml'))
       instance = described_class.new('http://foo.example.com/foo')
       expect(instance.from_url?).to be_truthy
-      expect(instance.execute[:registry]).to be_nil
+      expect(instance.execute[:registry]).to eq 'file://'
     end
   end
 


### PR DESCRIPTION
The "registry" field in stack metadata was mandatory before v1.1.2. 

This PR sends 'file://' as registry url for stacks installed from local files or direct urls like pre v1.1.2 CLI's did.
