### PR TITLE
Remove unnecessary spec_helper requires in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/_book
 .*.swo
 .*.swp
 .rspec-local
+.DS_Store
+.byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/node_modules
 docs/_book
 .*.swo
 .*.swp
+.rspec-local

--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -8,3 +8,4 @@ log/*.log
 /build/
 /release/
 /vendor/
+.rspec-local

--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -8,4 +8,3 @@ log/*.log
 /build/
 /release/
 /vendor/
-.rspec-local

--- a/agent/spec/lib/docker/container_spec.rb
+++ b/agent/spec/lib/docker/container_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Docker::Container do
 

--- a/agent/spec/lib/kontena/actors/container_coroner_spec.rb
+++ b/agent/spec/lib/kontena/actors/container_coroner_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Actors::ContainerCoroner do
 

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Helpers::WaitHelper do
 

--- a/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
+++ b/agent/spec/lib/kontena/launchers/cadvisor_launcher.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Launchers::Cadvisor do
 

--- a/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
+++ b/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Launchers::Etcd do
 

--- a/agent/spec/lib/kontena/launchers/ipam_launcer_spec.rb
+++ b/agent/spec/lib/kontena/launchers/ipam_launcer_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Launchers::IpamPlugin do
 

--- a/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/configurer_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::LoadBalancers::Configurer do
 

--- a/agent/spec/lib/kontena/load_balancers/registrator_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/registrator_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::LoadBalancers::Registrator do
 

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Models::ServicePod do
 

--- a/agent/spec/lib/kontena/network_adapters/weave_executor_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_executor_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::NetworkAdapters::WeaveExecutor do
 

--- a/agent/spec/lib/kontena/network_adapters/weave_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::NetworkAdapters::Weave do
 

--- a/agent/spec/lib/kontena/rpc/agent_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/agent_api_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Rpc::AgentApi do
 

--- a/agent/spec/lib/kontena/rpc/docker_container_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/docker_container_api_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Rpc::DockerContainerApi do
 

--- a/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Rpc::ServicePodsApi do
 

--- a/agent/spec/lib/kontena/rpc_client_spec.rb
+++ b/agent/spec/lib/kontena/rpc_client_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Kontena::RpcClient do
 

--- a/agent/spec/lib/kontena/rpc_server_spec.rb
+++ b/agent/spec/lib/kontena/rpc_server_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Kontena::RpcServer do
 

--- a/agent/spec/lib/kontena/service_pods/creator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/creator_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::ServicePods::Creator do
 

--- a/agent/spec/lib/kontena/service_pods/restarter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/restarter_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::ServicePods::Restarter do
 

--- a/agent/spec/lib/kontena/service_pods/starter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/starter_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::ServicePods::Starter do
 

--- a/agent/spec/lib/kontena/service_pods/stopper_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/stopper_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::ServicePods::Stopper do
 

--- a/agent/spec/lib/kontena/service_pods/terminator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/terminator_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::ServicePods::Terminator do
 

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Kontena::WebsocketClient do
 

--- a/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::ContainerHealthCheckWorker do
   include RpcClientMocks

--- a/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::ContainerInfoWorker do
   include RpcClientMocks

--- a/agent/spec/lib/kontena/workers/container_log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_log_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::ContainerLogWorker do
 

--- a/agent/spec/lib/kontena/workers/container_starter_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_starter_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::ContainerStarterWorker do
 

--- a/agent/spec/lib/kontena/workers/event_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/event_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::EventWorker do
   include RpcClientMocks

--- a/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::HealthCheckWorker do
   include RpcClientMocks

--- a/agent/spec/lib/kontena/workers/image_cleanup_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/image_cleanup_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::ImageCleanupWorker do
   let(:subject) { described_class.new(false) }

--- a/agent/spec/lib/kontena/workers/image_pull_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/image_pull_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::ImagePullWorker do
 

--- a/agent/spec/lib/kontena/workers/log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/log_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::LogWorker do
   include RpcClientMocks

--- a/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::NodeInfoWorker do
   include RpcClientMocks

--- a/agent/spec/lib/kontena/workers/stats_workers_spec.rb
+++ b/agent/spec/lib/kontena/workers/stats_workers_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 require_relative '../../helpers/fixtures_helpers'
 
 describe Kontena::Workers::StatsWorker do

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Kontena::Workers::WeaveWorker do
 

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -15,3 +15,4 @@ mkmf.log
 .idea
 *.gem
 /vendor/
+/.rspec-local

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -15,4 +15,3 @@ mkmf.log
 .idea
 *.gem
 /vendor/
-/.rspec-local

--- a/cli/.rspec
+++ b/cli/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/cli/spec/kontena/cli/app/build_command_spec.rb
+++ b/cli/spec/kontena/cli/app/build_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/apps/build_command"
 
 describe Kontena::Cli::Apps::BuildCommand do

--- a/cli/spec/kontena/cli/app/build_command_spec.rb
+++ b/cli/spec/kontena/cli/app/build_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/apps/build_command"
 
 describe Kontena::Cli::Apps::BuildCommand do

--- a/cli/spec/kontena/cli/app/common_spec.rb
+++ b/cli/spec/kontena/cli/app/common_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/apps/common"
 
 describe Kontena::Cli::Apps::Common do

--- a/cli/spec/kontena/cli/app/common_spec.rb
+++ b/cli/spec/kontena/cli/app/common_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/apps/common"
 
 describe Kontena::Cli::Apps::Common do

--- a/cli/spec/kontena/cli/app/config_command_spec.rb
+++ b/cli/spec/kontena/cli/app/config_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/apps/config_command"
 require 'ruby_dig'
 

--- a/cli/spec/kontena/cli/app/config_command_spec.rb
+++ b/cli/spec/kontena/cli/app/config_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/apps/config_command"
 require 'ruby_dig'
 

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/apps/deploy_command"
 

--- a/cli/spec/kontena/cli/app/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/app/deploy_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/apps/deploy_command"
 

--- a/cli/spec/kontena/cli/app/docker_helper_spec.rb
+++ b/cli/spec/kontena/cli/app/docker_helper_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/apps/docker_helper"
 
 describe Kontena::Cli::Apps::DockerHelper do

--- a/cli/spec/kontena/cli/app/docker_helper_spec.rb
+++ b/cli/spec/kontena/cli/app/docker_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/apps/docker_helper"
 
 describe Kontena::Cli::Apps::DockerHelper do

--- a/cli/spec/kontena/cli/app/init_command_spec.rb
+++ b/cli/spec/kontena/cli/app/init_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/apps/init_command'
 
 describe Kontena::Cli::Apps::InitCommand do

--- a/cli/spec/kontena/cli/app/init_command_spec.rb
+++ b/cli/spec/kontena/cli/app/init_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/apps/init_command'
 
 describe Kontena::Cli::Apps::InitCommand do

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/apps/logs_command"
 

--- a/cli/spec/kontena/cli/app/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/app/logs_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/apps/logs_command"
 

--- a/cli/spec/kontena/cli/app/scale_spec.rb
+++ b/cli/spec/kontena/cli/app/scale_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/apps/scale_command"
 
 describe Kontena::Cli::Apps::ScaleCommand do

--- a/cli/spec/kontena/cli/app/scale_spec.rb
+++ b/cli/spec/kontena/cli/app/scale_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/apps/scale_command"
 
 describe Kontena::Cli::Apps::ScaleCommand do

--- a/cli/spec/kontena/cli/app/service_generator_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/apps/service_generator"
 
 describe Kontena::Cli::Apps::ServiceGenerator do

--- a/cli/spec/kontena/cli/app/service_generator_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/apps/service_generator"
 
 describe Kontena::Cli::Apps::ServiceGenerator do
@@ -381,5 +381,5 @@ describe Kontena::Cli::Apps::ServiceGenerator do
         expect(result['secrets']).to be_nil
       end
     end
-  end  
+  end
 end

--- a/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/apps/service_generator_v2"
 require 'ruby_dig'
 

--- a/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
+++ b/cli/spec/kontena/cli/app/service_generator_v2_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/apps/service_generator_v2"
 require 'ruby_dig'
 

--- a/cli/spec/kontena/cli/app/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/reader_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/apps/yaml/reader'
 
 describe Kontena::Cli::Apps::YAML::Reader do

--- a/cli/spec/kontena/cli/app/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/reader_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../../spec_helper'
+require 'spec_helper'
 require 'kontena/cli/apps/yaml/reader'
 
 describe Kontena::Cli::Apps::YAML::Reader do

--- a/cli/spec/kontena/cli/app/yaml/service_extender_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/service_extender_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/apps/yaml/service_extender'
 
 describe Kontena::Cli::Apps::YAML::ServiceExtender do

--- a/cli/spec/kontena/cli/app/yaml/service_extender_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/service_extender_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../../spec_helper'
+require 'spec_helper'
 require 'kontena/cli/apps/yaml/service_extender'
 
 describe Kontena::Cli::Apps::YAML::ServiceExtender do

--- a/cli/spec/kontena/cli/app/yaml/validator_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/apps/yaml/validator'
 
 describe Kontena::Cli::Apps::YAML::Validator do

--- a/cli/spec/kontena/cli/app/yaml/validator_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../../spec_helper'
+require 'spec_helper'
 require 'kontena/cli/apps/yaml/validator'
 
 describe Kontena::Cli::Apps::YAML::Validator do

--- a/cli/spec/kontena/cli/app/yaml/validator_v2_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_v2_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../../spec_helper'
+require 'spec_helper'
 require 'kontena/cli/apps/yaml/validator_v2'
 
 describe Kontena::Cli::Apps::YAML::ValidatorV2 do

--- a/cli/spec/kontena/cli/app/yaml/validator_v2_spec.rb
+++ b/cli/spec/kontena/cli/app/yaml/validator_v2_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/apps/yaml/validator_v2'
 
 describe Kontena::Cli::Apps::YAML::ValidatorV2 do

--- a/cli/spec/kontena/cli/cloud/login_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/login_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/cloud/login_command'
 require 'kontena/cli/localhost_web_server'
 require 'launchy'

--- a/cli/spec/kontena/cli/cloud/login_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/login_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/cloud/login_command'
 require 'kontena/cli/localhost_web_server'
 require 'launchy'

--- a/cli/spec/kontena/cli/cloud/logout_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/logout_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/cloud/logout_command'
 
 describe Kontena::Cli::Cloud::LogoutCommand do

--- a/cli/spec/kontena/cli/cloud/logout_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/logout_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/cloud/logout_command'
 
 describe Kontena::Cli::Cloud::LogoutCommand do

--- a/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/cloud/master/add_command'
 
 describe Kontena::Cli::Cloud::Master::AddCommand do

--- a/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/cloud/master/add_command'
 
 describe Kontena::Cli::Cloud::Master::AddCommand do

--- a/cli/spec/kontena/cli/common_spec.rb
+++ b/cli/spec/kontena/cli/common_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/common"
 
 describe Kontena::Cli::Common do

--- a/cli/spec/kontena/cli/common_spec.rb
+++ b/cli/spec/kontena/cli/common_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/common"
 
 describe Kontena::Cli::Common do

--- a/cli/spec/kontena/cli/containers/list_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/list_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/containers/list_command"
 

--- a/cli/spec/kontena/cli/containers/list_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/list_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/containers/list_command"
 

--- a/cli/spec/kontena/cli/containers/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/logs_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/containers/logs_command"
 

--- a/cli/spec/kontena/cli/containers/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/logs_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/grid_options'
 require "kontena/cli/containers/logs_command"
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/grids/trusted_subnet_command"
 require "kontena/cli/grids/trusted_subnets/add_command"
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/grids/trusted_subnet_command"
 require "kontena/cli/grids/trusted_subnets/add_command"
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/grids/trusted_subnet_command"
 require "kontena/cli/grids/trusted_subnets/list_command"
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/grids/trusted_subnet_command"
 require "kontena/cli/grids/trusted_subnets/list_command"
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/grids/trusted_subnet_command"
 require "kontena/cli/grids/trusted_subnets/remove_command"
 

--- a/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/grids/trusted_subnet_command"
 require "kontena/cli/grids/trusted_subnets/remove_command"
 

--- a/cli/spec/kontena/cli/grids/use_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/use_command_spec.rb
@@ -1,5 +1,5 @@
 
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/grids/use_command'
 
 describe Kontena::Cli::Grids::UseCommand do

--- a/cli/spec/kontena/cli/grids/use_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/use_command_spec.rb
@@ -1,5 +1,4 @@
 
-require 'spec_helper'
 require 'kontena/cli/grids/use_command'
 
 describe Kontena::Cli::Grids::UseCommand do

--- a/cli/spec/kontena/cli/helpers/log_helper_spec.rb
+++ b/cli/spec/kontena/cli/helpers/log_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/helpers/log_helper"
 
 describe Kontena::Cli::Helpers::LogHelper do

--- a/cli/spec/kontena/cli/helpers/log_helper_spec.rb
+++ b/cli/spec/kontena/cli/helpers/log_helper_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/helpers/log_helper"
 
 describe Kontena::Cli::Helpers::LogHelper do

--- a/cli/spec/kontena/cli/main_command_spec.rb
+++ b/cli/spec/kontena/cli/main_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../spec_helper"
+require 'spec_helper'
 require "kontena/main_command"
 
 describe Kontena::MainCommand do

--- a/cli/spec/kontena/cli/main_command_spec.rb
+++ b/cli/spec/kontena/cli/main_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/main_command"
 
 describe Kontena::MainCommand do

--- a/cli/spec/kontena/cli/master/current_command_spec.rb
+++ b/cli/spec/kontena/cli/master/current_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/current_command'
 
 describe Kontena::Cli::Master::CurrentCommand do

--- a/cli/spec/kontena/cli/master/current_command_spec.rb
+++ b/cli/spec/kontena/cli/master/current_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/current_command'
 
 describe Kontena::Cli::Master::CurrentCommand do

--- a/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
+++ b/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/master/init_cloud_command"
 
 describe Kontena::Cli::Master::InitCloudCommand do

--- a/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
+++ b/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/master/init_cloud_command"
 
 describe Kontena::Cli::Master::InitCloudCommand do

--- a/cli/spec/kontena/cli/master/login_command_spec.rb
+++ b/cli/spec/kontena/cli/master/login_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/login_command'
 require 'kontena/cli/localhost_web_server'
 require 'launchy'

--- a/cli/spec/kontena/cli/master/login_command_spec.rb
+++ b/cli/spec/kontena/cli/master/login_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/login_command'
 require 'kontena/cli/localhost_web_server'
 require 'launchy'

--- a/cli/spec/kontena/cli/master/logout_command_spec.rb
+++ b/cli/spec/kontena/cli/master/logout_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/logout_command'
 
 describe Kontena::Cli::Master::LogoutCommand do

--- a/cli/spec/kontena/cli/master/logout_command_spec.rb
+++ b/cli/spec/kontena/cli/master/logout_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/logout_command'
 
 describe Kontena::Cli::Master::LogoutCommand do

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/use_command'
 
 describe Kontena::Cli::Master::UseCommand do

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/use_command'
 
 describe Kontena::Cli::Master::UseCommand do

--- a/cli/spec/kontena/cli/master/users/invite_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/invite_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require 'kontena/cli/master/users/invite_command'
 

--- a/cli/spec/kontena/cli/master/users/invite_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/invite_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require 'kontena/cli/master/users/invite_command'
 

--- a/cli/spec/kontena/cli/master/users/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/remove_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require "kontena/cli/master/users/remove_command"
 

--- a/cli/spec/kontena/cli/master/users/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/remove_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require "kontena/cli/master/users/remove_command"
 

--- a/cli/spec/kontena/cli/master/users/roles/add_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/roles/add_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require 'kontena/cli/master/users/roles/add_command'
 

--- a/cli/spec/kontena/cli/master/users/roles/add_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/roles/add_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require 'kontena/cli/master/users/roles/add_command'
 

--- a/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require 'kontena/cli/master/users/roles/remove_command'
 

--- a/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/users/roles/remove_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/master/users_command'
 require 'kontena/cli/master/users/roles/remove_command'
 

--- a/cli/spec/kontena/cli/services/containers_command_spec.rb
+++ b/cli/spec/kontena/cli/services/containers_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/services/containers_command"
 
 describe Kontena::Cli::Services::ContainersCommand do

--- a/cli/spec/kontena/cli/services/containers_command_spec.rb
+++ b/cli/spec/kontena/cli/services/containers_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/services/containers_command"
 
 describe Kontena::Cli::Services::ContainersCommand do

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/services/exec_command'
 
 describe Kontena::Cli::Services::ExecCommand do

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/services/exec_command'
 
 describe Kontena::Cli::Services::ExecCommand do

--- a/cli/spec/kontena/cli/services/link_command_spec.rb
+++ b/cli/spec/kontena/cli/services/link_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/services/link_command"
 
 describe Kontena::Cli::Services::LinkCommand do

--- a/cli/spec/kontena/cli/services/link_command_spec.rb
+++ b/cli/spec/kontena/cli/services/link_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/services/link_command"
 
 describe Kontena::Cli::Services::LinkCommand do

--- a/cli/spec/kontena/cli/services/restart_command_spec.rb
+++ b/cli/spec/kontena/cli/services/restart_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/services/restart_command"
 
 describe Kontena::Cli::Services::RestartCommand do

--- a/cli/spec/kontena/cli/services/restart_command_spec.rb
+++ b/cli/spec/kontena/cli/services/restart_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/services/restart_command"
 
 describe Kontena::Cli::Services::RestartCommand do

--- a/cli/spec/kontena/cli/services/secrets/link_command_spec.rb
+++ b/cli/spec/kontena/cli/services/secrets/link_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/grid_options"
 require "kontena/cli/services/secrets/link_command"
 

--- a/cli/spec/kontena/cli/services/secrets/link_command_spec.rb
+++ b/cli/spec/kontena/cli/services/secrets/link_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/grid_options"
 require "kontena/cli/services/secrets/link_command"
 

--- a/cli/spec/kontena/cli/services/secrets/unlink_command_spec.rb
+++ b/cli/spec/kontena/cli/services/secrets/unlink_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/grid_options"
 require "kontena/cli/services/secrets/unlink_command"
 

--- a/cli/spec/kontena/cli/services/secrets/unlink_command_spec.rb
+++ b/cli/spec/kontena/cli/services/secrets/unlink_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/grid_options"
 require "kontena/cli/services/secrets/unlink_command"
 

--- a/cli/spec/kontena/cli/services/services_helper_spec.rb
+++ b/cli/spec/kontena/cli/services/services_helper_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/services/services_helper"
 
 module Kontena::Cli::Services

--- a/cli/spec/kontena/cli/services/services_helper_spec.rb
+++ b/cli/spec/kontena/cli/services/services_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/services/services_helper"
 
 module Kontena::Cli::Services

--- a/cli/spec/kontena/cli/services/unlink_command_spec.rb
+++ b/cli/spec/kontena/cli/services/unlink_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/services/unlink_command"
 
 describe Kontena::Cli::Services::UnlinkCommand do

--- a/cli/spec/kontena/cli/services/unlink_command_spec.rb
+++ b/cli/spec/kontena/cli/services/unlink_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/services/unlink_command"
 
 describe Kontena::Cli::Services::UnlinkCommand do

--- a/cli/spec/kontena/cli/services/update_command_spec.rb
+++ b/cli/spec/kontena/cli/services/update_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/grid_options"
 require "kontena/cli/services/update_command"
 

--- a/cli/spec/kontena/cli/services/update_command_spec.rb
+++ b/cli/spec/kontena/cli/services/update_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/grid_options"
 require "kontena/cli/services/update_command"
 

--- a/cli/spec/kontena/cli/stacks/build_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/build_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/build_command"
 
 describe Kontena::Cli::Stacks::BuildCommand do

--- a/cli/spec/kontena/cli/stacks/build_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/build_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/build_command"
 
 describe Kontena::Cli::Stacks::BuildCommand do

--- a/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/deploy_command"
 
 describe Kontena::Cli::Stacks::DeployCommand do

--- a/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/deploy_command"
 
 describe Kontena::Cli::Stacks::DeployCommand do

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/install_command"
 
 describe Kontena::Cli::Stacks::InstallCommand do

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/install_command"
 
 describe Kontena::Cli::Stacks::InstallCommand do

--- a/cli/spec/kontena/cli/stacks/list_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/list_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/list_command"
 
 describe Kontena::Cli::Stacks::ListCommand do

--- a/cli/spec/kontena/cli/stacks/list_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/list_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/list_command"
 
 describe Kontena::Cli::Stacks::ListCommand do

--- a/cli/spec/kontena/cli/stacks/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/remove_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/remove_command"
 
 describe Kontena::Cli::Stacks::RemoveCommand do

--- a/cli/spec/kontena/cli/stacks/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/remove_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/remove_command"
 
 describe Kontena::Cli::Stacks::RemoveCommand do

--- a/cli/spec/kontena/cli/stacks/service_generator_spec.rb
+++ b/cli/spec/kontena/cli/stacks/service_generator_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/service_generator"
 
 describe Kontena::Cli::Stacks::ServiceGenerator do

--- a/cli/spec/kontena/cli/stacks/service_generator_spec.rb
+++ b/cli/spec/kontena/cli/stacks/service_generator_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/service_generator"
 
 describe Kontena::Cli::Stacks::ServiceGenerator do

--- a/cli/spec/kontena/cli/stacks/service_generator_v2_spec.rb
+++ b/cli/spec/kontena/cli/stacks/service_generator_v2_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/service_generator_v2"
 require 'ruby_dig'
 

--- a/cli/spec/kontena/cli/stacks/service_generator_v2_spec.rb
+++ b/cli/spec/kontena/cli/stacks/service_generator_v2_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/service_generator_v2"
 require 'ruby_dig'
 

--- a/cli/spec/kontena/cli/stacks/show_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/show_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/show_command"
 
 describe Kontena::Cli::Stacks::ShowCommand do

--- a/cli/spec/kontena/cli/stacks/show_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/show_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/show_command"
 
 describe Kontena::Cli::Stacks::ShowCommand do

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/stacks/upgrade_command"
 
 describe Kontena::Cli::Stacks::UpgradeCommand do

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/stacks/upgrade_command"
 
 describe Kontena::Cli::Stacks::UpgradeCommand do

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/stacks/yaml/reader'
 require 'liquid'
 

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../../spec_helper'
+require 'spec_helper'
 require 'kontena/cli/stacks/yaml/reader'
 require 'liquid'
 

--- a/cli/spec/kontena/cli/stacks/yaml/service_extender_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/service_extender_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/stacks/yaml/service_extender'
 
 describe Kontena::Cli::Stacks::YAML::ServiceExtender do

--- a/cli/spec/kontena/cli/stacks/yaml/service_extender_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/service_extender_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../../spec_helper'
+require 'spec_helper'
 require 'kontena/cli/stacks/yaml/service_extender'
 
 describe Kontena::Cli::Stacks::YAML::ServiceExtender do

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../../../spec_helper'
+require 'spec_helper'
 require 'kontena/cli/stacks/yaml/validator_v3'
 
 describe Kontena::Cli::Stacks::YAML::ValidatorV3 do

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/stacks/yaml/validator_v3'
 
 describe Kontena::Cli::Stacks::YAML::ValidatorV3 do

--- a/cli/spec/kontena/cli/vault/export_spec.rb
+++ b/cli/spec/kontena/cli/vault/export_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/vault/export_command'
 
 describe Kontena::Cli::Vault::ExportCommand do

--- a/cli/spec/kontena/cli/vault/export_spec.rb
+++ b/cli/spec/kontena/cli/vault/export_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/vault/export_command'
 
 describe Kontena::Cli::Vault::ExportCommand do

--- a/cli/spec/kontena/cli/vault/import_spec.rb
+++ b/cli/spec/kontena/cli/vault/import_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/cli/vault/import_command'
 
 

--- a/cli/spec/kontena/cli/vault/import_spec.rb
+++ b/cli/spec/kontena/cli/vault/import_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require 'kontena/cli/vault/import_command'
 
 

--- a/cli/spec/kontena/cli/version_command_spec.rb
+++ b/cli/spec/kontena/cli/version_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/version_command"
 
 describe Kontena::Cli::VersionCommand do

--- a/cli/spec/kontena/cli/version_command_spec.rb
+++ b/cli/spec/kontena/cli/version_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/version_command"
 
 describe Kontena::Cli::VersionCommand do

--- a/cli/spec/kontena/cli/vpn/create_command_spec.rb
+++ b/cli/spec/kontena/cli/vpn/create_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../../spec_helper"
+require 'spec_helper'
 require "kontena/cli/vpn/create_command"
 
 describe Kontena::Cli::Vpn::CreateCommand do

--- a/cli/spec/kontena/cli/vpn/create_command_spec.rb
+++ b/cli/spec/kontena/cli/vpn/create_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require "kontena/cli/vpn/create_command"
 
 describe Kontena::Cli::Vpn::CreateCommand do

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena_cli'
 require 'ostruct'
 

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 require 'kontena_cli'
 require 'ostruct'
 

--- a/cli/spec/kontena/config_spec.rb
+++ b/cli/spec/kontena/config_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 
 # Lots of coverage already in Common spec
 describe Kontena::Cli::Config do

--- a/cli/spec/kontena/config_spec.rb
+++ b/cli/spec/kontena/config_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 # Lots of coverage already in Common spec
 describe Kontena::Cli::Config do

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 require 'kontena_cli'
 require 'kontena/light_prompt'
 

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena_cli'
 require 'kontena/light_prompt'
 

--- a/cli/spec/kontena/main_command_spec.rb
+++ b/cli/spec/kontena/main_command_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 require 'kontena/main_command'
 
 describe Kontena::MainCommand do

--- a/cli/spec/kontena/main_command_spec.rb
+++ b/cli/spec/kontena/main_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena/main_command'
 
 describe Kontena::MainCommand do

--- a/cli/spec/kontena/plugin_manager_spec.rb
+++ b/cli/spec/kontena/plugin_manager_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'kontena_cli'
 
 describe Kontena::PluginManager do

--- a/cli/spec/kontena/plugin_manager_spec.rb
+++ b/cli/spec/kontena/plugin_manager_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../spec_helper'
+require 'spec_helper'
 require 'kontena_cli'
 
 describe Kontena::PluginManager do

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -19,3 +19,4 @@
 /release/
 /vendor/
 /.bundle/
+.rspec-local

--- a/server/.rspec
+++ b/server/.rspec
@@ -1,2 +1,3 @@
 --color
 --format progress
+--require spec_helper

--- a/server/spec/api/oauth2_spec.rb
+++ b/server/spec/api/oauth2_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe 'OAuth2 API' do
   let(:david) { User.create(email: 'david@example.com') }

--- a/server/spec/api/root_spec.rb
+++ b/server/spec/api/root_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe '/' do
   it 'should return success' do

--- a/server/spec/api/v1/containers_spec.rb
+++ b/server/spec/api/v1/containers_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/containers' do
 

--- a/server/spec/api/v1/etcd_spec.rb
+++ b/server/spec/api/v1/etcd_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/etcd/:grid_name/:etcd_path' do
 

--- a/server/spec/api/v1/grid_external_registries_spec.rb
+++ b/server/spec/api/v1/grid_external_registries_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/grids/:name/external_registries' do
 

--- a/server/spec/api/v1/grid_stacks_spec.rb
+++ b/server/spec/api/v1/grid_stacks_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/grids/:grid/stacks', celluloid: true do
 

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/grids', celluloid: true do
   let(:request_headers) do

--- a/server/spec/api/v1/nodes_spec.rb
+++ b/server/spec/api/v1/nodes_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/grids', celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }

--- a/server/spec/api/v1/secrets_spec.rb
+++ b/server/spec/api/v1/secrets_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe 'secrets' do
 

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/services' do
 

--- a/server/spec/api/v1/stack_container_logs_spec.rb
+++ b/server/spec/api/v1/stack_container_logs_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/stacks/:id/container_logs', celluloid: true do
 

--- a/server/spec/api/v1/stacks_spec.rb
+++ b/server/spec/api/v1/stacks_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/stacks', celluloid: true do
 

--- a/server/spec/api/v1/user_spec.rb
+++ b/server/spec/api/v1/user_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/user' do
 

--- a/server/spec/api/v1/users_spec.rb
+++ b/server/spec/api/v1/users_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe '/v1/users' do
 

--- a/server/spec/authorizers/grid_authorizer_spec.rb
+++ b/server/spec/authorizers/grid_authorizer_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridAuthorizer do
 

--- a/server/spec/authorizers/role_authorizer_spec.rb
+++ b/server/spec/authorizers/role_authorizer_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe RoleAuthorizer do
 

--- a/server/spec/authorizers/user_authorizer_spec.rb
+++ b/server/spec/authorizers/user_authorizer_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe UserAuthorizer do
 

--- a/server/spec/jobs/cloud_websocket_connection_job_spec.rb
+++ b/server/spec/jobs/cloud_websocket_connection_job_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe CloudWebsocketConnectJob, celluloid: true do
 

--- a/server/spec/jobs/container_cleanup_job_spec.rb
+++ b/server/spec/jobs/container_cleanup_job_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe ContainerCleanupJob, celluloid: true do
 

--- a/server/spec/jobs/grid_scheduler_worker_spec.rb
+++ b/server/spec/jobs/grid_scheduler_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridSchedulerWorker, celluloid: true do
 

--- a/server/spec/jobs/grid_service_health_monitor_job_spec.rb
+++ b/server/spec/jobs/grid_service_health_monitor_job_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceHealthMonitorJob, celluloid: true do
 

--- a/server/spec/jobs/grid_service_remove_worker.rb
+++ b/server/spec/jobs/grid_service_remove_worker.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceRemoveWorker, celluloid: true do
 

--- a/server/spec/jobs/grid_service_scheduler_worker_spec.rb
+++ b/server/spec/jobs/grid_service_scheduler_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceSchedulerWorker, celluloid: true do
 

--- a/server/spec/jobs/leader_elector_job_spec.rb
+++ b/server/spec/jobs/leader_elector_job_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe LeaderElectorJob, celluloid: true do
   before(:each) { DistributedLock.delete_all }

--- a/server/spec/jobs/node_cleanup_job_spec.rb
+++ b/server/spec/jobs/node_cleanup_job_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe NodeCleanupJob, celluloid: true do
 

--- a/server/spec/jobs/service_balancer_job_spec.rb
+++ b/server/spec/jobs/service_balancer_job_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe ServiceBalancerJob, celluloid: true do
   before(:each) { DistributedLock.delete_all }

--- a/server/spec/jobs/stack_deploy_worker_spec.rb
+++ b/server/spec/jobs/stack_deploy_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe StackDeployWorker, celluloid: true do
 

--- a/server/spec/jobs/stack_remove_worker_spec.rb
+++ b/server/spec/jobs/stack_remove_worker_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe StackRemoveWorker do
   before(:each) do

--- a/server/spec/jobs/telemetry_job_spec.rb
+++ b/server/spec/jobs/telemetry_job_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe TelemetryJob, celluloid: true do
 

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 require_relative '../../app/middlewares/websocket_backend'
 
 describe WebsocketBackend, celluloid: true do

--- a/server/spec/migrations/default_network_spec.rb
+++ b/server/spec/migrations/default_network_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 require_relative '../../db/migrations/16_default_network'
 
 describe DefaultNetwork do

--- a/server/spec/models/access_token_spec.rb
+++ b/server/spec/models/access_token_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe AccessToken do
   it { should be_timestamped_document }

--- a/server/spec/models/audit_log_spec.rb
+++ b/server/spec/models/audit_log_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe AuditLog do
   it { should be_timestamped_document }

--- a/server/spec/models/configuration_spec.rb
+++ b/server/spec/models/configuration_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe Configuration do
 

--- a/server/spec/models/container_log_spec.rb
+++ b/server/spec/models/container_log_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe ContainerLog do
   it { should be_timestamped_document }

--- a/server/spec/models/container_spec.rb
+++ b/server/spec/models/container_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe Container do
   it { should be_timestamped_document }

--- a/server/spec/models/container_stat_spec.rb
+++ b/server/spec/models/container_stat_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe ContainerStat do
   it { should be_timestamped_document }

--- a/server/spec/models/distributed_lock_spec.rb
+++ b/server/spec/models/distributed_lock_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe DistributedLock do
   it { should have_fields(:name, :lock_id, :created_at)}

--- a/server/spec/models/grid_domain_authorization_spec.rb
+++ b/server/spec/models/grid_domain_authorization_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridDomainAuthorization do
   it { should have_fields(:domain).of_type(String)}

--- a/server/spec/models/grid_secret_spec.rb
+++ b/server/spec/models/grid_secret_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridSecret do
   it { should be_timestamped_document }

--- a/server/spec/models/grid_service_deploy_opt_spec.rb
+++ b/server/spec/models/grid_service_deploy_opt_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceDeployOpt do
   it { should be_embedded_in(:grid_service) }

--- a/server/spec/models/grid_service_deploy_spec.rb
+++ b/server/spec/models/grid_service_deploy_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceDeploy do
   it { should be_timestamped_document }

--- a/server/spec/models/grid_service_hook_spec.rb
+++ b/server/spec/models/grid_service_hook_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceHook do
   it { should be_embedded_in(:grid_service) }

--- a/server/spec/models/grid_service_link_spec.rb
+++ b/server/spec/models/grid_service_link_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceLink do
   it { should be_embedded_in(:grid_service) }

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridService do
   it { should be_timestamped_document }

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe Grid do
   it { should be_timestamped_document }

--- a/server/spec/models/grid_stat_spec.rb
+++ b/server/spec/models/grid_stat_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridStat do
   it { should be_timestamped_document }

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe HostNode do
   before(:all) do

--- a/server/spec/models/host_node_stat_spec.rb
+++ b/server/spec/models/host_node_stat_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe HostNodeStat do
   it { should be_timestamped_document }

--- a/server/spec/models/registry_spec.rb
+++ b/server/spec/models/registry_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe Registry do
   it { should be_timestamped_document }

--- a/server/spec/models/role_spec.rb
+++ b/server/spec/models/role_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe Role do
   it { should have_fields(:name, :description)}

--- a/server/spec/models/schema_migration_spec.rb
+++ b/server/spec/models/schema_migration_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe SchemaMigration do
   it { should have_fields(:version).of_type(Integer) }

--- a/server/spec/models/stack_deploy_spec.rb
+++ b/server/spec/models/stack_deploy_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe StackDeploy do
   it { should be_timestamped_document }

--- a/server/spec/models/stack_revision_spec.rb
+++ b/server/spec/models/stack_revision_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe StackRevision do
   it { should be_timestamped_document }

--- a/server/spec/models/stack_spec.rb
+++ b/server/spec/models/stack_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe Stack do
 

--- a/server/spec/models/user_spec.rb
+++ b/server/spec/models/user_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe User do
   it { should be_timestamped_document }

--- a/server/spec/mutations/access_tokens/create_spec.rb
+++ b/server/spec/mutations/access_tokens/create_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe AccessTokens::Create do
 

--- a/server/spec/mutations/audit_logs/create_spec.rb
+++ b/server/spec/mutations/audit_logs/create_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe AuditLogs::Create do
 

--- a/server/spec/mutations/grid_certificates/authorize_domain_spec.rb
+++ b/server/spec/mutations/grid_certificates/authorize_domain_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridCertificates::AuthorizeDomain do
 

--- a/server/spec/mutations/grid_certificates/get_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/get_certificate_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridCertificates::GetCertificate do
 

--- a/server/spec/mutations/grid_secrets/create_spec.rb
+++ b/server/spec/mutations/grid_secrets/create_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridSecrets::Create do
 

--- a/server/spec/mutations/grid_secrets/update_spec.rb
+++ b/server/spec/mutations/grid_secrets/update_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridSecrets::Update do
 

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridServices::Create do
   let(:grid) {

--- a/server/spec/mutations/grid_services/delete_spec.rb
+++ b/server/spec/mutations/grid_services/delete_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridServices::Delete do
   let(:user) { User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/grid_services/deploy_spec.rb
+++ b/server/spec/mutations/grid_services/deploy_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridServices::Deploy, celluloid: true do
   let(:host_node) { HostNode.create(node_id: 'aa')}

--- a/server/spec/mutations/grid_services/restart_spec.rb
+++ b/server/spec/mutations/grid_services/restart_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridServices::Restart, celluloid: true do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/mutations/grid_services/scale_spec.rb
+++ b/server/spec/mutations/grid_services/scale_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridServices::Scale, celluloid: true do
   let(:host_node) { HostNode.create(node_id: 'aa')}

--- a/server/spec/mutations/grid_services/start_spec.rb
+++ b/server/spec/mutations/grid_services/start_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridServices::Start, celluloid: true do
   let(:grid) {

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe GridServices::Update do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/mutations/grids/assign_user_spec.rb
+++ b/server/spec/mutations/grids/assign_user_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Grids::AssignUser do
   let(:current_user) { User.create!(email: 'jane@domain.com') }

--- a/server/spec/mutations/grids/create_spec.rb
+++ b/server/spec/mutations/grids/create_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Grids::Create, celluloid: true do
   let(:user) { User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/grids/delete_spec.rb
+++ b/server/spec/mutations/grids/delete_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Grids::Delete do
   let(:user) { User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/grids/unassign_user_spec.rb
+++ b/server/spec/mutations/grids/unassign_user_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Grids::UnassignUser do
   let(:current_user) { User.create!(email: 'jane@domain.com') }

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Grids::Update, celluloid: true do
   let(:user) { User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/host_nodes/common_spec.rb
+++ b/server/spec/mutations/host_nodes/common_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe HostNodes::Common, celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }

--- a/server/spec/mutations/host_nodes/register_spec.rb
+++ b/server/spec/mutations/host_nodes/register_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe HostNodes::Register do
   let(:grid) { Grid.create!(name: 'test') }

--- a/server/spec/mutations/host_nodes/remove_spec.rb
+++ b/server/spec/mutations/host_nodes/remove_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe HostNodes::Remove, celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe HostNodes::Update, celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }

--- a/server/spec/mutations/registries/create_spec.rb
+++ b/server/spec/mutations/registries/create_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Registries::Create do
   let(:user) { User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/stacks/common_spec.rb
+++ b/server/spec/mutations/stacks/common_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Stacks::Common do
   let(:described_class) {

--- a/server/spec/mutations/stacks/create_spec.rb
+++ b/server/spec/mutations/stacks/create_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Stacks::Create do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/mutations/stacks/delete_spec.rb
+++ b/server/spec/mutations/stacks/delete_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Stacks::Delete, celluloid: true do
   let(:user) { User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/stacks/deploy_spec.rb
+++ b/server/spec/mutations/stacks/deploy_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Stacks::Deploy, celluloid: true do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/mutations/stacks/update_spec.rb
+++ b/server/spec/mutations/stacks/update_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Stacks::Update do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/mutations/users/add_role_spec.rb
+++ b/server/spec/mutations/users/add_role_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Users::AddRole do
   let(:user) {User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/users/invite_spec.rb
+++ b/server/spec/mutations/users/invite_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Users::Invite do
   let(:user) { User.create!(email: 'joe@domain.com')}

--- a/server/spec/mutations/users/remove_role_spec.rb
+++ b/server/spec/mutations/users/remove_role_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Users::RemoveRole do
   let(:user) {User.create!(email: 'joe@domain.com')}

--- a/server/spec/services/agent/node_plugger_spec.rb
+++ b/server/spec/services/agent/node_plugger_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Agent::NodePlugger do
 

--- a/server/spec/services/agent/node_unplugger_spec.rb
+++ b/server/spec/services/agent/node_unplugger_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Agent::NodeUnplugger do
 

--- a/server/spec/services/auth_provider_spec.rb
+++ b/server/spec/services/auth_provider_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe AuthProvider do
 

--- a/server/spec/services/cloud/rpc/server_api_spec.rb
+++ b/server/spec/services/cloud/rpc/server_api_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Cloud::Rpc::ServerApi do
   let(:david) do

--- a/server/spec/services/cloud/rpc_server_spec.rb
+++ b/server/spec/services/cloud/rpc_server_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Cloud::RpcServer do
 

--- a/server/spec/services/docker/image_puller_spec.rb
+++ b/server/spec/services/docker/image_puller_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Docker::ImagePuller do
 

--- a/server/spec/services/docker/service_creator_spec.rb
+++ b/server/spec/services/docker/service_creator_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Docker::ServiceCreator do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/services/docker/service_restarter_spec.rb
+++ b/server/spec/services/docker/service_restarter_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Docker::ServiceRestarter do
 end

--- a/server/spec/services/docker/service_starter_spec.rb
+++ b/server/spec/services/docker/service_starter_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Docker::ServiceStarter do
 

--- a/server/spec/services/docker/service_stopper_spec.rb
+++ b/server/spec/services/docker/service_stopper_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Docker::ServiceStopper do
 

--- a/server/spec/services/docker/service_terminator_spec.rb
+++ b/server/spec/services/docker/service_terminator_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Docker::ServiceTerminator do
 

--- a/server/spec/services/grid_scheduler_spec.rb
+++ b/server/spec/services/grid_scheduler_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridScheduler do
 

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceDeployer do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/services/grid_service_instance_deployer_spec.rb
+++ b/server/spec/services/grid_service_instance_deployer_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceInstanceDeployer do
   let(:grid) { Grid.create!(name: 'test-grid') }

--- a/server/spec/services/grid_service_scheduler_spec.rb
+++ b/server/spec/services/grid_service_scheduler_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe GridServiceScheduler do
 

--- a/server/spec/services/logs_helpers_spec.rb
+++ b/server/spec/services/logs_helpers_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe LogsHelpers do
   class Subject

--- a/server/spec/services/mongo_pubsub_spec.rb
+++ b/server/spec/services/mongo_pubsub_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe MongoPubsub do
 

--- a/server/spec/services/mongodb/migrator_spec.rb
+++ b/server/spec/services/mongodb/migrator_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Mongodb::Migrator do
 

--- a/server/spec/services/rpc/container_handler_spec.rb
+++ b/server/spec/services/rpc/container_handler_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Rpc::ContainerHandler, celluloid: true do
   let(:grid) { Grid.create! }

--- a/server/spec/services/rpc/container_info_mapper_spec.rb
+++ b/server/spec/services/rpc/container_info_mapper_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Rpc::ContainerInfoMapper do
   let(:grid) { Grid.create! }

--- a/server/spec/services/rpc/node_handler_spec.rb
+++ b/server/spec/services/rpc/node_handler_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../spec_helper'
 
 describe Rpc::NodeHandler, celluloid: true do
   let(:grid) { Grid.create! }

--- a/server/spec/services/rpc_client_spec.rb
+++ b/server/spec/services/rpc_client_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe RpcClient, celluloid: true do
   let(:node_id) { SecureRandom.hex(32) }

--- a/server/spec/services/rpc_server_spec.rb
+++ b/server/spec/services/rpc_server_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../spec_helper'
 
 describe RpcServer, celluloid: true do
 

--- a/server/spec/services/scheduler/filter/affinity_spec.rb
+++ b/server/spec/services/scheduler/filter/affinity_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Scheduler::Filter::Affinity do
 

--- a/server/spec/services/scheduler/filter/dependency_spec.rb
+++ b/server/spec/services/scheduler/filter/dependency_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Scheduler::Filter::Dependency do
 

--- a/server/spec/services/scheduler/filter/memory_spec.rb
+++ b/server/spec/services/scheduler/filter/memory_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Scheduler::Filter::Memory do
 

--- a/server/spec/services/scheduler/filter/port_spec.rb
+++ b/server/spec/services/scheduler/filter/port_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Scheduler::Filter::Port do
 

--- a/server/spec/services/scheduler/strategy/daemon_spec.rb
+++ b/server/spec/services/scheduler/strategy/daemon_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Scheduler::Strategy::Daemon do
 

--- a/server/spec/services/scheduler/strategy/high_availability_spec.rb
+++ b/server/spec/services/scheduler/strategy/high_availability_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Scheduler::Strategy::HighAvailability do
 

--- a/server/spec/services/scheduler/strategy/random_spec.rb
+++ b/server/spec/services/scheduler/strategy/random_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../../../spec_helper'
 
 describe Scheduler::Strategy::HighAvailability do
 


### PR DESCRIPTION
Rspec adds spec/ to load path. You don't need any `require_relative "../../../spec_helper"` sorcery, 'require "spec_helper"` works fine.
