### PR TITLE
Fixing paths for nested sub commands in calls to load_subcommand.

### DIFF
--- a/cli/lib/kontena/cli/grids/user_command.rb
+++ b/cli/lib/kontena/cli/grids/user_command.rb
@@ -2,8 +2,8 @@ module Kontena::Cli::Grids
 
 
   class UserCommand < Kontena::Command
-    subcommand ["list", "ls"], "List grid users", load_subcommand('users/list_command')
-    subcommand "add", "Add user to grid", load_subcommand('users/add_command')
-    subcommand ["remove", "rm"], "Remove user from grid", load_subcommand('users/remove_command')
+    subcommand ["list", "ls"], "List grid users", load_subcommand('grids/users/list_command')
+    subcommand "add", "Add user to grid", load_subcommand('grids/users/add_command')
+    subcommand ["remove", "rm"], "Remove user from grid", load_subcommand('grids/users/remove_command')
   end
 end

--- a/cli/lib/kontena/cli/master/users/role_command.rb
+++ b/cli/lib/kontena/cli/master/users/role_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Master::Users
 
 
   class RoleCommand < Kontena::Command
-    subcommand "add", "Add role to user", load_subcommand('roles/add_command')
-    subcommand ["remove", "rm"], "Remove role from user", load_subcommand('roles/remove_command')
+    subcommand "add", "Add role to user", load_subcommand('master/users/roles/add_command')
+    subcommand ["remove", "rm"], "Remove role from user", load_subcommand('master/users/roles/remove_command')
   end
 end

--- a/cli/lib/kontena/cli/master/users_command.rb
+++ b/cli/lib/kontena/cli/master/users_command.rb
@@ -2,9 +2,9 @@ module Kontena::Cli::Master
 
 
   class UsersCommand < Kontena::Command
-    subcommand "invite", "Invite user to Kontena Master", load_subcommand('users/invite_command')
-    subcommand ["remove", "rm"], "Remove user from Kontena Master", load_subcommand('users/remove_command')
-    subcommand ["list", "ls"], "List users", load_subcommand('users/list_command')
-    subcommand "role", "User role specific commands", load_subcommand('users/role_command')
+    subcommand "invite", "Invite user to Kontena Master", load_subcommand('master/users/invite_command')
+    subcommand ["remove", "rm"], "Remove user from Kontena Master", load_subcommand('master/users/remove_command')
+    subcommand ["list", "ls"], "List users", load_subcommand('master/users/list_command')
+    subcommand "role", "User role specific commands", load_subcommand('master/users/role_command')
   end
 end

--- a/cli/lib/kontena/cli/nodes/label_command.rb
+++ b/cli/lib/kontena/cli/nodes/label_command.rb
@@ -1,8 +1,8 @@
 module Kontena::Cli::Nodes
   class LabelCommand < Kontena::Command
-    subcommand ["list", "ls"], "List node labels", load_subcommand('labels/list_command')
-    subcommand "add", "Add label to node", load_subcommand('labels/add_command')
-    subcommand ["remove", "rm"], "Remove label from node", load_subcommand('labels/remove_command')
+    subcommand ["list", "ls"], "List node labels", load_subcommand('nodes/labels/list_command')
+    subcommand "add", "Add label to node", load_subcommand('nodes/labels/add_command')
+    subcommand ["remove", "rm"], "Remove label from node", load_subcommand('nodes/labels/remove_command')
 
     def execute
     end

--- a/cli/lib/kontena/cli/services/env_command.rb
+++ b/cli/lib/kontena/cli/services/env_command.rb
@@ -2,8 +2,8 @@ module Kontena::Cli::Services
 
 
   class EnvCommand < Kontena::Command
-    subcommand ["list", "ls"], "List service environment variables", load_subcommand('envs/list_command')
-    subcommand "add", "Add environment variable", load_subcommand('envs/add_command')
-    subcommand ["remove", "rm"], "Remove environment variable", load_subcommand('envs/remove_command')
+    subcommand ["list", "ls"], "List service environment variables", load_subcommand('services/envs/list_command')
+    subcommand "add", "Add environment variable", load_subcommand('services/envs/add_command')
+    subcommand ["remove", "rm"], "Remove environment variable", load_subcommand('services/envs/remove_command')
   end
 end

--- a/cli/lib/kontena/cli/services/secret_command.rb
+++ b/cli/lib/kontena/cli/services/secret_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Services
 
 
   class SecretCommand < Kontena::Command
-    subcommand "link", "Link secret from Vault", load_subcommand('secrets/link_command')
-    subcommand "unlink", "Unlink secret from Vault", load_subcommand('secrets/unlink_command')
+    subcommand "link", "Link secret from Vault", load_subcommand('services/secrets/link_command')
+    subcommand "unlink", "Unlink secret from Vault", load_subcommand('services/secrets/unlink_command')
   end
 end

--- a/cli/lib/kontena/cli/stacks/registry_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry_command.rb
@@ -1,17 +1,10 @@
 module Kontena::Cli::Stacks
-
-  require_relative 'registry/push_command'
-  require_relative 'registry/pull_command'
-  require_relative 'registry/search_command'
-  require_relative 'registry/show_command'
-  require_relative 'registry/remove_command'
-
   class RegistryCommand < Kontena::Command
 
-    subcommand "push", "Push a stack into the stacks registry", Registry::PushCommand
-    subcommand "pull", "Pull a stack from the stacks registry", Registry::PullCommand
-    subcommand "search", "Search for stacks in the stacks registry", Registry::SearchCommand
-    subcommand "show", "Show info about a stack in the stacks registry", Registry::ShowCommand
-    subcommand ["remove", "rm"], "Remove a stack (or version) from the stacks registry", Registry::RemoveCommand
+    subcommand "push", "Push a stack into the stacks registry", load_subcommand('stacks/registry/push_command')
+    subcommand "pull", "Pull a stack from the stacks registry", load_subcommand('stacks/registry/pull_command')
+    subcommand "search", "Search for stacks in the stacks registry", load_subcommand('stacks/registry/search_command')
+    subcommand "show", "Show info about a stack in the stacks registry", load_subcommand('stacks/registry/show_command')
+    subcommand ["remove", "rm"], "Remove a stack (or version) from the stacks registry", load_subcommand('stacks/registry/remove_command')
   end
 end


### PR DESCRIPTION
Fixes an issue in [PR 1093](https://github.com/kontena/kontena/pull/1093) where paths are incorrect for some nested sub commands.