### PR TITLE
Stringify non-string values when setting string type stack variable values

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
   spec.add_runtime_dependency "hash_validator", "~> 0.7.0"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
-  spec.add_runtime_dependency "opto", "1.8.3"
+  spec.add_runtime_dependency "opto", "1.8.4"
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "safe_yaml", "~> 1.0"
   spec.add_runtime_dependency "liquid", "~> 4.0.0"


### PR DESCRIPTION
Fixes #1875 by upgrading opto to 1.8.4 which includes https://github.com/kontena/opto/pull/26
