### PR TITLE
Inform user that input from STDIN is expected when doing vault write without value as param

### DIFF
--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -29,8 +29,10 @@ module Kontena::Cli::Master::Config
         self.format = 'yaml'
         path = File.join(Kontena.root, 'lib/kontena/presets', "#{self.preset}.yml")
         File.read(path)
+      elsif !$stdin.tty? && !$stdin.closed?
+        $stdin.read
       else
-        STDIN.read
+        exit_with_error "Missing input"
       end
     end
 

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -23,7 +23,13 @@ module Kontena::Cli::Vault
     end
 
     def input
-      path ? File.read(path) : STDIN.read
+      if path
+        File.read(path)
+      elsif !$stdin.tty? && $stdin.closed?
+        $stdin.read
+      else
+        exit_with_error "Missing input"
+      end
     end
 
     def execute


### PR DESCRIPTION
Fixes #1375

From:

```
$ kontena vault write foo
<nothing until you ctrl-c or ctrl-d>
```

To:

```
$ kontena vault write foo
Enter a value for foo, press ctrl-d when finished:
```

