### PR TITLE
Only warn about server/cli version mismatch when minor version differs by 2+

### DIFF
--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -491,7 +491,13 @@ module Kontena
       return nil if $VERSION_WARNING_ADDED
       return nil unless server_version.to_s =~ /^\d+\.\d+\.\d+/
 
-      unless server_version[/^(\d+\.\d+)/, 1] == Kontena::Cli::VERSION[/^(\d+\.\d+)/, 1] # Just compare x.y
+      server_major, server_minor, _ = server_version.split('.')
+      cli_major,    cli_minor,    _ = Kontena::Cli::VERSION.split('.')
+
+      # 1.0.0 <--> 0.16.0 warns
+      # 1.4.0 <--> 1.6.0  warns
+      # 1.4.0 <--> 1.5.0  does not
+      if server_major != cli_major || (server_minor.to_i - cli_minor.to_i).abs >= 2
         add_version_warning(server_version)
         $VERSION_WARNING_ADDED = true
       end

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -308,7 +308,7 @@ describe Kontena::Client do
       end
 
       it 'warns the user once if server version differs enough from master version' do
-        bumped_version = cli_version.split('.')[0] + '.' + (cli_version.split('.')[1].to_i + 1).to_s + '.0' # 1.5.4 --> 1.6.0
+        bumped_version = cli_version.split('.')[0] + '.' + (cli_version.split('.')[1].to_i + 2).to_s + '.0' # 1.5.4 --> 1.7.0
         expect(response).to receive(:headers).at_least(:once).and_return({'X-Kontena-Version' => bumped_version})
         expect(subject).to receive(:check_version_and_warn).at_least(:once).and_call_original
         expect(subject).to receive(:add_version_warning).with(bumped_version).once.and_return(true)


### PR DESCRIPTION
Super annoying.

Now it only warns if:
- trying to talk with 0.x or 2.x servers using 1.x cli
- trying to talk with 1.6 server using 1.4 cli. 

1.2 CLI does not warn when talking to 1.3 or 1.1 server.
