### PR TITLE
Require --force or confirmation when upgrading to a different stack

### DIFF
--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -15,6 +15,8 @@ module Kontena::Cli::Stacks
 
     option '--[no-]deploy', :flag, 'Trigger deploy after upgrade', default: true
 
+    option '--force', :flag, 'Force upgrade'
+
     requires_current_master
     requires_current_master_token
 
@@ -24,6 +26,10 @@ module Kontena::Cli::Stacks
       end
 
       stack = stack_from_yaml(filename, name: name, values: values, defaults: master_data['variables'])
+
+      unless force? || master_data['stack'] == stack['stack']
+        confirm "Going to replace stack #{Kontena.pastel.cyan(master_data['stack'])} on master with #{Kontena.pastel.cyan(stack['stack'])} from #{Kontena.pastel.yellow(filename)}. Are you sure?"
+      end
 
       spinner "Upgrading stack #{pastel.cyan(name)}" do |spin|
         update_stack(stack) || spin.fail!

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -28,7 +28,7 @@ module Kontena::Cli::Stacks
       stack = stack_from_yaml(filename, name: name, values: values, defaults: master_data['variables'])
 
       unless force? || master_data['stack'] == stack['stack']
-        confirm "Going to replace stack #{Kontena.pastel.cyan(master_data['stack'])} on master with #{Kontena.pastel.cyan(stack['stack'])} from #{Kontena.pastel.yellow(filename)}. Are you sure?"
+        confirm "Replacing stack #{Kontena.pastel.cyan(master_data['stack'])} on master with #{Kontena.pastel.cyan(stack['stack'])} from #{Kontena.pastel.yellow(filename)}. Are you sure?"
       end
 
       spinner "Upgrading stack #{pastel.cyan(name)}" do |spin|

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -13,6 +13,15 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
     let(:stack) do
       {
         'name' => 'stack-a',
+        'stack' => 'foo/stack-a',
+        'services' => []
+      }
+    end
+
+    let(:stack_with_different_stack_name) do
+      {
+        'name' => 'stack-a',
+        'stack' => 'foo/stack-z',
         'services' => []
       }
     end
@@ -24,6 +33,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
     let(:stack_response) do
       {
         'name' => 'stack-a',
+        'stack' => 'foo/stack-a',
         'services' => [],
         'variables' => defaults
       }
@@ -63,6 +73,14 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
         'stacks/test-grid/stack-b', anything
       )
       subject.run(['stack-b',  './path/to/kontena.yml'])
+    end
+
+    it 'requires confirmation when master stack is different than input stack' do
+      expect(client).to receive(:get).with('stacks/test-grid/stack-b').and_return(stack_response)
+      allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
+      allow(subject).to receive(:stack_from_yaml).with('./path/to/kontena.yml', name: 'stack-b', values: nil, defaults: defaults).and_return(stack_with_different_stack_name)
+      expect(subject).to receive(:confirm).and_call_original
+      expect{subject.run(['stack-b',  './path/to/kontena.yml'])}.to exit_with_error
     end
 
     it 'triggers deploy by default' do

--- a/test/spec/features/stack/upgrade_spec.rb
+++ b/test/spec/features/stack/upgrade_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'stack upgrade' do
+  context 'from file' do
+    before(:each) do
+      with_fixture_dir("stack/upgrade") do
+        k = run 'kontena stack install version1.yml'
+        expect(k.code).to eq(0)
+      end
+    end
+
+    after(:each) do
+      run 'kontena stack rm --force redis'
+    end
+
+    it 'upgrades a stack' do
+      k = run 'kontena service show redis/redis'
+      expect(k.code).to eq(0)
+      expect(k.out).to match /image: redis:3.0.7-alpine/
+
+      with_fixture_dir("stack/upgrade") do
+        k = run 'kontena stack upgrade redis version2.yml'
+        expect(k.code).to eq(0), k.out
+      end
+
+      k = run 'kontena service show redis/redis'
+      expect(k.code).to eq(0)
+      expect(k.out).to match /image: redis:3.2.8-alpine/
+    end
+
+    it 'prompts if the stack is different' do
+      with_fixture_dir("stack/upgrade") do
+        k = kommando 'kontena stack upgrade redis different.yml'
+        k.out.on /Are you sure/ do
+          k.in << "n\r"
+        end
+        k.run
+        expect(k.code).to eq(1)
+        expect(k.out).to match /Replacing stack.*Are you sure\?.*Aborted command/m
+      end
+    end
+  end
+end

--- a/test/spec/fixtures/stack/upgrade/different.yml
+++ b/test/spec/fixtures/stack/upgrade/different.yml
@@ -1,0 +1,5 @@
+stack: test/notredis
+version: 3.2.100
+services:
+  redis:
+    image: redis:3.2.100-windowsservercore

--- a/test/spec/fixtures/stack/upgrade/version1.yml
+++ b/test/spec/fixtures/stack/upgrade/version1.yml
@@ -1,0 +1,5 @@
+stack: test/redis
+version: 3.0.7
+services:
+  redis:
+    image: redis:3.0.7-alpine

--- a/test/spec/fixtures/stack/upgrade/version2.yml
+++ b/test/spec/fixtures/stack/upgrade/version2.yml
@@ -1,0 +1,5 @@
+stack: test/redis
+version: 3.2.8
+services:
+  redis:
+    image: redis:3.2.8-alpine


### PR DESCRIPTION
Fixes #1938

Require confirmation or `--force` when user/stackname is different on master than in the source you are trying to upgrade from.
