### PR TITLE
Fixing node_id issue in server node_handler_spec.

### DIFF
--- a/server/spec/services/rpc/node_handler_spec.rb
+++ b/server/spec/services/rpc/node_handler_spec.rb
@@ -3,14 +3,15 @@ require_relative '../../spec_helper'
 describe Rpc::NodeHandler, celluloid: true do
   let(:grid) { Grid.create! }
   let(:subject) { described_class.new(grid) }
-  let(:node) { HostNode.create!(grid: grid, name: 'test-node') }
+  let(:node) { HostNode.create!(node_id: 'a', grid: grid, name: 'test-node') }
 
   describe '#stats' do
     it 'saves host_node_stat item' do
-      node
+      puts 'save:'
+      puts node.node_id
       expect {
         subject.stats({
-          'node_id' => node.node_id,
+          'id' => node.node_id,
           'load' => {'1m' => 0.1, '5m' => 0.2, '15m' => 0.1},
           'memory' => {},
           'filesystems' => [],
@@ -25,7 +26,7 @@ describe Rpc::NodeHandler, celluloid: true do
       node
 
       subject.stats({
-        'node_id' => node.node_id,
+        'id' => node.node_id,
         'load' => {'1m' => 0.1, '5m' => 0.2, '15m' => 0.1},
         'memory' => {},
         'filesystems' => [],
@@ -43,7 +44,7 @@ describe Rpc::NodeHandler, celluloid: true do
       time = '2017-02-28 00:00:00 -0500'
 
       subject.stats({
-        'node_id' => node.node_id,
+        'id' => node.node_id,
         'load' => {'1m' => 0.1, '5m' => 0.2, '15m' => 0.1},
         'memory' => {},
         'filesystems' => [],

--- a/server/spec/services/rpc/node_handler_spec.rb
+++ b/server/spec/services/rpc/node_handler_spec.rb
@@ -7,8 +7,8 @@ describe Rpc::NodeHandler, celluloid: true do
 
   describe '#stats' do
     it 'saves host_node_stat item' do
-      puts 'save:'
-      puts node.node_id
+      node
+      
       expect {
         subject.stats({
           'id' => node.node_id,


### PR DESCRIPTION
Fixing missing `node_id` field for `HostNode` object in `server/spec/services/rpc/node_handler_spec.rb`.