### PR TITLE
Fix ubuntu packages to also support docker-{ce,ee}, fix docker-engine dependencies

### DIFF
--- a/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
@@ -2,7 +2,7 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>> 1.8), docker-engine (<< 1.13), resolvconf
+Depends: docker-engine (>> 1.8) | docker-ce | docker-ee, resolvconf
 Provides: kontena-weave, kontena-etcd
 Conflicts: kontena-weave, kontena-etcd
 Replaces: kontena-weave, kontena-etcd

--- a/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
@@ -2,7 +2,7 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>> 1.8) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.10) | docker-ce | docker-ee, resolvconf
 Provides: kontena-weave, kontena-etcd
 Conflicts: kontena-weave, kontena-etcd
 Replaces: kontena-weave, kontena-etcd

--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.9) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
 Description: Kontena Agent

--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.9) | docker.io (>= 1.11), resolvconf
+Depends: docker-engine (>= 1.9) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
 Description: Kontena Agent

--- a/server/packaging/ubuntu/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>> 1.8) | docker-ce | docker-ee
+Depends: docker-engine (>= 1.10) | docker-ce | docker-ee
 Description: Kontena Server

--- a/server/packaging/ubuntu/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>> 1.8), docker-engine (<< 1.13)
+Depends: docker-engine (>> 1.8) | docker-ce | docker-ee
 Description: Kontena Server

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.9) | docker.io (>= 1.11), resolvconf
+Depends: docker-engine (>= 1.9) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
 Description: Kontena Server

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.9) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
 Description: Kontena Server


### PR DESCRIPTION
Fixes #1947 

* Add `.. | docker-ce | docker-ee` alternatives to the Ubuntu trusty and xenial package `Depends: ...`

* Remove the Ubuntu trusty package restriction on newer `docker-engine` 1.13 versions

    This is too hard to express together with alternative packages.

* Bump the minimum `docker-engine` dependency to version 1.10

    The agent uses Docker API 1.122, which is provided by Docker 1.10 and newer.
