### PR TITLE
Read stack name from ./kontena.yml unless given in stack commands

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -7,6 +7,28 @@ module Kontena::Cli::Stacks
   module Common
     include Kontena::Cli::Services::ServicesHelper
 
+    module StackNameParamWithKontenaYmlFallback
+      def self.included(where)
+        where.class_eval do
+          parameter "[NAME]", "Stack name (default: read from kontena.yml)" do |name|
+            name == '.' ? nil : name
+          end
+
+          def default_name
+            if File.exist?('kontena.yml') && File.readable?('kontena.yml')
+              name = ::YAML.safe_load(File.read('kontena.yml'))['stack'].split('/').last
+              ENV["DEBUG"] && STDERR.puts("Using stack name #{pastel.cyan(name)} from #{pastel.yellow('kontena.yml')}")
+              name
+            else
+              exit_with_error 'Stack name required'
+            end
+          rescue
+            exit_with_error 'Stack name required'
+          end
+        end
+      end
+    end
+
     module StackNameParam
       attr_accessor :stack_version
 

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -1,3 +1,6 @@
+require 'kontena/cli/common'
+require 'kontena/cli/stacks/common'
+require 'kontena/cli/grid_options'
 require_relative 'stacks_helper'
 
 module Kontena::Cli::Stacks
@@ -8,7 +11,7 @@ module Kontena::Cli::Stacks
 
     banner "Deploys all services of a stack that has been installed in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    include Common::StackNameParamWithKontenaYmlFallback
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -1,3 +1,5 @@
+require 'kontena/cli/common'
+require 'kontena/cli/grid_options'
 require_relative 'common'
 
 module Kontena::Cli::Stacks

--- a/cli/lib/kontena/cli/stacks/logs_command.rb
+++ b/cli/lib/kontena/cli/stacks/logs_command.rb
@@ -1,12 +1,18 @@
+require 'kontena/cli/common'
+require 'kontena/cli/stacks/common'
+require 'kontena/cli/grid_options'
+require 'kontena/cli/helpers/log_helper'
+
 module Kontena::Cli::Stacks
   class LogsCommand < Kontena::Command
+
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 
     banner "Shows logs from services in a stack"
 
-    parameter "NAME", "Stack name"
+    include Common::StackNameParamWithKontenaYmlFallback
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/monitor_command.rb
+++ b/cli/lib/kontena/cli/stacks/monitor_command.rb
@@ -1,4 +1,6 @@
-require_relative 'common'
+require 'kontena/cli/common'
+require 'kontena/cli/stacks/common'
+require 'kontena/cli/grid_options'
 
 module Kontena::Cli::Stacks
   class MonitorCommand < Kontena::Command
@@ -8,7 +10,8 @@ module Kontena::Cli::Stacks
 
     banner "Monitor services in a stack"
 
-    parameter "NAME", "Stack name"
+    include Common::StackNameParamWithKontenaYmlFallback
+
     parameter "[SERVICES] ...", "Stack services to monitor", attribute_name: 'selected_services'
 
     requires_current_master

--- a/cli/lib/kontena/cli/stacks/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/remove_command.rb
@@ -1,4 +1,6 @@
-require_relative 'common'
+require 'kontena/cli/common'
+require 'kontena/cli/stacks/common'
+require 'kontena/cli/grid_options'
 
 module Kontena::Cli::Stacks
   class RemoveCommand < Kontena::Command
@@ -8,7 +10,8 @@ module Kontena::Cli::Stacks
 
     banner "Removes a stack in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    include Common::StackNameParamWithKontenaYmlFallback
+
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     requires_current_master

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -1,4 +1,6 @@
-require_relative 'common'
+require 'kontena/cli/common'
+require 'kontena/cli/stacks/common'
+require 'kontena/cli/grid_options'
 
 module Kontena::Cli::Stacks
   class ShowCommand < Kontena::Command
@@ -8,7 +10,7 @@ module Kontena::Cli::Stacks
 
     banner "Show information and status of a stack in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    include Common::StackNameParamWithKontenaYmlFallback
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -1,4 +1,6 @@
-require_relative 'common'
+require 'kontena/cli/common'
+require 'kontena/cli/stacks/common'
+require 'kontena/cli/grid_options'
 
 module Kontena::Cli::Stacks
   class UpgradeCommand < Kontena::Command
@@ -8,9 +10,9 @@ module Kontena::Cli::Stacks
 
     banner "Upgrades a stack in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
-
+    include Common::StackNameParamWithKontenaYmlFallback
     include Common::StackFileOrNameParam
+
     include Common::StackValuesFromOption
 
     option '--[no-]deploy', :flag, 'Trigger deploy after upgrade', default: true

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -32,7 +32,7 @@ describe Kontena::Cli::Stacks::InstallCommand do
       expect(client).to receive(:post).with(
         'grids/test-grid/stacks', stack
       )
-      subject.run([])
+      subject.run(['--no-deploy'])
     end
 
     it 'allows to override stack name' do
@@ -44,7 +44,7 @@ describe Kontena::Cli::Stacks::InstallCommand do
       expect(client).to receive(:post).with(
         'grids/test-grid/stacks', stack
       )
-      subject.run(['--name', 'stack-b'])
+      subject.run(['--no-deploy', '--name', 'stack-b'])
     end
 
     it 'accepts a stack name as filename' do
@@ -53,7 +53,7 @@ describe Kontena::Cli::Stacks::InstallCommand do
       expect(client).to receive(:post).with(
         'grids/test-grid/stacks', stack
       )
-      subject.run(['user/stack:1.0.0'])
+      subject.run(['--no-deploy', 'user/stack:1.0.0'])
     end
   end
 end

--- a/cli/spec/kontena/cli/stacks/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/logs_command_spec.rb
@@ -1,0 +1,21 @@
+require "kontena/cli/stacks/logs_command"
+
+describe Kontena::Cli::Stacks::LogsCommand do
+  include ClientHelpers
+  include RequirementsHelper
+
+  expect_to_require_current_master
+  expect_to_require_current_master_token
+
+  describe '#execute' do
+    it 'when stack name not provided, reads it from kontena.yml in current dir' do
+      expect(subject).to receive(:default_name).and_call_original
+      allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:readable?).and_return(true)
+      expect(File).to receive(:read).with('kontena.yml').and_return("stack: foo/bar")
+      expect(client).to receive(:get).and_return('logs' => [{'data' => 'foobar'}])
+      expect{subject.run([])}.to output(/foobar/).to_stdout
+    end
+  end
+end
+


### PR DESCRIPTION
The stack name in all stack commands is now optional in case you are in a directory that has `kontena.yml`, in which case the stack name is read from it.

Fixes #1920

However, there are several stack commands that have multiple parameters and that brings a problem.

for example:
```
$ kontena stack monitor [STACK_NAME] [SERVICE_NAMES..]
```

Now if stack name is optional and left out, the first service name would be used as the stack name.
In this PR, using `.` as stack_name will read it from the kontena.yml.

