### PR TITLE
Fix v1.1 server sharing of Moped::Session connections between threads

### DIFF
--- a/server/app/boot_jobs.rb
+++ b/server/app/boot_jobs.rb
@@ -3,7 +3,7 @@ require_relative 'services/worker_supervisor'
 require_relative 'services/mongodb/migrator'
 
 unless ENV['RACK_ENV'] == 'test' || ENV['NO_MONGO_PUBSUB']
-  MongoPubsub.start!(PubsubChannel.collection)
+  MongoPubsub.start!(PubsubChannel)
   JobSupervisor.run!
 end
 

--- a/server/app/services/agent/message_handler.rb
+++ b/server/app/services/agent/message_handler.rb
@@ -12,15 +12,17 @@ module Agent
       @stats = []
       @cached_grid = nil
       @cached_container = nil
-      @db_session = ContainerLog.collection.session.with(
-        write: {
-          w: 0, fsync: false, j: false
-        }
-      )
     end
 
     def run
       Thread.new {
+        # this Moped::Session may only be used in the same thread
+        @db_session = ContainerLog.collection.session.with(
+          write: {
+            w: 0, fsync: false, j: false
+          }
+        )
+
         i = 0
         loop do
           begin

--- a/server/app/services/agent/message_handler.rb
+++ b/server/app/services/agent/message_handler.rb
@@ -14,14 +14,17 @@ module Agent
       @cached_container = nil
     end
 
+    def init!
+      @db_session = ContainerLog.collection.session.with(
+        write: {
+          w: 0, fsync: false, j: false
+        }
+      )
+    end
+
     def run
       Thread.new {
-        # this Moped::Session may only be used in the same thread
-        @db_session = ContainerLog.collection.session.with(
-          write: {
-            w: 0, fsync: false, j: false
-          }
-        )
+        self.init! # the Moped::Session must be initialized within the thread
 
         i = 0
         loop do

--- a/server/app/services/mongo_pubsub.rb
+++ b/server/app/services/mongo_pubsub.rb
@@ -65,9 +65,10 @@ class MongoPubsub
 
   attr_accessor :collection, :subscriptions
 
-  # @param [Moped::Collection]
-  def initialize(collection)
-    @collection = collection
+  # @param [Mongoid::Document] model
+  def initialize(model)
+    # The collection session is local to this Actor's thread
+    @collection = model.collection
     @subscriptions = []
     async.tail!
   end
@@ -120,8 +121,9 @@ class MongoPubsub
     @supervisor.actors.first.unsubscribe(subscription)
   end
 
-  def self.start!(collection)
-    @supervisor = self.supervise(collection)
+  # @param [Mongoid::Document] model
+  def self.start!(model)
+    @supervisor = self.supervise(model)
   end
 
   def self.clear!

--- a/server/spec/services/agent/message_handler_spec.rb
+++ b/server/spec/services/agent/message_handler_spec.rb
@@ -8,6 +8,10 @@ describe Agent::MessageHandler do
   let(:subject) { described_class.new(queue) }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
 
+  before do
+    subject.init!
+  end
+
   describe '#run' do
     it 'performs', :performance => true do
       container = grid.containers.create!(container_id: SecureRandom.hex(16))

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -60,7 +60,7 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
-    MongoPubsub.start!(PubsubChannel.collection)
+    MongoPubsub.start!(PubsubChannel)
     sleep 0.1 until Mongoid.default_session.collection_names.include?(PubsubChannel.collection.name)
     Mongoid::Tasks::Database.create_indexes if ENV["CI"]
   end


### PR DESCRIPTION
Fixes #1964 for 1.1.5

Backport of #1965 fixes for  + the v1.1 specific `Agent::MessageHandler` fixes.

This does not include the `Moped::Session` thread tracing/checking in #1965.