### PR TITLE
Fix grid update specs for --log-forwarder fluentd

### DIFF
--- a/test/spec/features/grid/update_spec.rb
+++ b/test/spec/features/grid/update_spec.rb
@@ -1,13 +1,13 @@
 describe 'update grid' do
   it 'validates log opts' do
     k = run "kontena grid update --log-opt server=foo e2e"
-    expect(k.code).not_to eq(0)
-    expect(k.out).to match /Need to specify --log-driver when using --log-opt/
+    expect(k.code).not_to eq(0), k.out
+    expect(k.out).to match /Need to specify --log-forwarder when using --log-opt/
   end
 
   it 'updates log shipping' do
-    k = run "kontena grid update --log-forwarder fluentd --log-opt server=foo e2e"
-    expect(k.code).to eq(0)
+    k = run "kontena grid update --log-forwarder fluentd --log-opt fluentd-address=foo e2e"
+    expect(k.code).to eq(0), k.out
     k = run "kontena grid show e2e"
     expect(k.out).to match /fluentd/
   end


### PR DESCRIPTION
```
Failures:

  1) update grid validates log opts
     Failure/Error: expect(k.out).to match /Need to specify --log-driver when using --log-opt/
     
       expected " [\e[31merror\e[0m] Need to specify --log-forwarder when using --log-opt\r\n" to match /Need to specify --log-driver when using --log-opt/
       Diff:
       @@ -1,2 +1,2 @@
       -/Need to specify --log-driver when using --log-opt/
       + [error] Need to specify --log-forwarder when using --log-opt
       
     # ./spec/features/grid/update_spec.rb:5:in `block (2 levels) in <top (required)>'

  2) update grid updates log shipping
     Failure/Error: expect(k.code).to eq(0), k.out
        [error] {"logs"=>"fluentd-address option must be given"}
     # ./spec/features/grid/update_spec.rb:10:in `block (2 levels) in <top (required)>'
```