### PR TITLE
Fix Ubuntu xenial package install to not override prompted debconf values with empty values from the default config file

### DIFF
--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/config
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/config
@@ -8,7 +8,7 @@ if [ -e /etc/kontena-agent.env ]; then
   . /etc/kontena-agent.env
 
   [ -n "$KONTENA_URI" ] && db_set kontena-agent/server_uri "$KONTENA_URI"
-  [ -n "$KONTENA_URI" ] && db_set kontena-agent/grid_token "$KONTENA_TOKEN"
+  [ -n "$KONTENA_TOKEN" ] && db_set kontena-agent/grid_token "$KONTENA_TOKEN"
 fi
 
 db_input high kontena-agent/server_uri || true

--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/config
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/config
@@ -7,8 +7,8 @@ set -e
 if [ -e /etc/kontena-agent.env ]; then
   . /etc/kontena-agent.env
 
-  db_set kontena-agent/server_uri "${KONTENA_URI:-}"
-  db_set kontena-agent/grid_token "${KONTENA_TOKEN:-}"
+  [ -n "$KONTENA_URI" ] && db_set kontena-agent/server_uri "$KONTENA_URI"
+  [ -n "$KONTENA_URI" ] && db_set kontena-agent/grid_token "$KONTENA_TOKEN"
 fi
 
 db_input high kontena-agent/server_uri || true

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/config
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/config
@@ -6,9 +6,12 @@ set -e
 
 if [ -e /etc/kontena-server.env ]; then
   . /etc/kontena-server.env
+fi
 
-  db_set kontena-server/initial_admin_code "${INITIAL_ADMIN_CODE:-}"
+if [ -n "$INITIAL_ADMIN_CODE" ]; then
+  db_set kontena-server/initial_admin_code "$INITIAL_ADMIN_CODE"
 else
+  # do not re-prompt, because we do not support re-configuring the INITIAL_ADMIN_CODE
   db_input high kontena-server/initial_admin_code || true
   db_go || true
 fi


### PR DESCRIPTION
Fixes #1974

Kontena 1.1.2 included support for `dpkg-reconfigure`(#1754), which involves having the package `config` scripts read any existing configuration values from the `/etc/kontena-*.env` conffile, and setting them to debconf. If the `config` script is only run once, this behaves correctly, as debconf will always prompt for the values when run the first time.

However, during normal `apt install`, the config script will be run twice: once during `dpkg-preconfigure` without any `/etc/kontena-*.env` conffiles in place, and then a second time after unpacking the `/etc/kontena-*.env` conffile. The first `config` run would prompt for the values, but the second `config` run would override the prompted values with the empty `KONTENA_*` values from the default `/etc/kontena-*.env` conffile. These empty debconf values would then get used by the `postinst` script and written into the conffile :disappointed: 

This fixes the `kontena-server` and `kontena-agent` `config` maintscripts to skip the debconf set if the config variables read from the default `/etc/kontena-*.env` conffile are empty. This preserves any existing debconf values from earlier prompts.

Testing this properly requires a 1.1.5 pre-release build, installed using `apt install`, ideally directly from the standard bintray source, as this issue does not happen when installing with `dpkg -i`: https://github.com/kontena/kontena/issues/1974#issuecomment-286403674