### PR TITLE
Fix v1.1/server timeout interrupts

### DIFF
--- a/server/app/helpers/wait_helper.rb
+++ b/server/app/helpers/wait_helper.rb
@@ -46,6 +46,6 @@ module WaitHelper
     end
   end
 
-  # Also allow WaitHelper.wait(...) to be called as a module method
+  # Also allow WaitHelper.wait_until(...) to be called as a module method
   extend self
 end

--- a/server/app/helpers/wait_helper.rb
+++ b/server/app/helpers/wait_helper.rb
@@ -1,0 +1,51 @@
+module WaitHelper
+  include Logging
+
+  WAIT_TIMEOUT = 300
+  WAIT_INTERVAL = 0.5
+
+  def _wait_now
+    Time.now.to_f
+  end
+
+  # Wait until given block returns truthy value, returning nil on timeout
+  #
+  # @param timeout [Fixnum] How long to wait
+  # @param interval [Fixnum] At what interval is the block yielded
+  # @param message [String] Message for debugging
+  # @param block [Block] Block to yield
+  # @return [Object] Return value from block, or nil
+  def wait(timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, message: nil, &block)
+    raise ArgumentError, 'no block given' unless block_given?
+
+    wait_until = _wait_now + timeout
+
+    loop do
+      return nil if _wait_now > wait_until
+
+      value = yield
+
+      if value
+        return value
+      else
+        debug "wait... #{message}"
+        sleep interval
+      end
+    end
+  end
+
+  # Wait until given block returns truthy value, raising on timeout
+  #
+  # @return [Object] Last return value of the block
+  # @raise [Timeout::Error] If block does not return truthy value within given timeout
+  def wait!(**opts, &block)
+    if value = wait(**opts, &block)
+      return value
+    else
+      raise Timeout::Error
+    end
+  end
+
+  # Also allow WaitHelper.wait(...) to be called as a module method
+  extend self
+end

--- a/server/app/helpers/wait_helper.rb
+++ b/server/app/helpers/wait_helper.rb
@@ -15,7 +15,7 @@ module WaitHelper
   # @param message [String] Message for debugging
   # @param block [Block] Block to yield
   # @return [Object] Return value from block, or nil
-  def wait(timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, message: nil, &block)
+  def wait_until(timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, message: nil, &block)
     raise ArgumentError, 'no block given' unless block_given?
 
     wait_until = _wait_now + timeout
@@ -28,7 +28,7 @@ module WaitHelper
       if value
         return value
       else
-        debug "wait... #{message}" if message
+        debug "wait... #{message}"
         sleep interval
       end
     end
@@ -38,8 +38,8 @@ module WaitHelper
   #
   # @return [Object] Last return value of the block
   # @raise [Timeout::Error] If block does not return truthy value within given timeout
-  def wait!(**opts, &block)
-    if value = wait(**opts, &block)
+  def wait_until!(**opts, &block)
+    if value = wait_until(**opts, &block)
       return value
     else
       raise Timeout::Error

--- a/server/app/helpers/wait_helper.rb
+++ b/server/app/helpers/wait_helper.rb
@@ -28,7 +28,7 @@ module WaitHelper
       if value
         return value
       else
-        debug "wait... #{message}"
+        debug "wait... #{message}" if message
         sleep interval
       end
     end

--- a/server/app/jobs/grid_service_remove_worker.rb
+++ b/server/app/jobs/grid_service_remove_worker.rb
@@ -1,6 +1,7 @@
 class GridServiceRemoveWorker
   include Celluloid
   include Logging
+  include WaitHelper
 
   def perform(grid_service_id)
     grid_service = GridService.find_by(id: grid_service_id)
@@ -30,9 +31,7 @@ class GridServiceRemoveWorker
   # @param [GridService] grid_service
   # @param [Integer] timeout
   def wait_instance_removal(grid_service, timeout)
-    Timeout::timeout(timeout) do
-      sleep 1 until grid_service.reload.containers.scoped.count == 0
-    end
+    wait!(timeout: timeout) { grid_service.reload.containers.scoped.count == 0 }
   end
 
   # @param [HostNode] node

--- a/server/app/jobs/grid_service_remove_worker.rb
+++ b/server/app/jobs/grid_service_remove_worker.rb
@@ -31,7 +31,7 @@ class GridServiceRemoveWorker
   # @param [GridService] grid_service
   # @param [Integer] timeout
   def wait_instance_removal(grid_service, timeout)
-    wait!(timeout: timeout) { grid_service.reload.containers.scoped.count == 0 }
+    wait_until!(timeout: timeout) { grid_service.reload.containers.scoped.count == 0 }
   end
 
   # @param [HostNode] node

--- a/server/app/jobs/stack_remove_worker.rb
+++ b/server/app/jobs/stack_remove_worker.rb
@@ -4,6 +4,7 @@ class StackRemoveWorker
   include Celluloid
   include Logging
   include Stacks::SortHelper
+  include WaitHelper
 
   def perform(stack_id)
     stack = Stack.find_by(id: stack_id)
@@ -24,11 +25,7 @@ class StackRemoveWorker
     services.each do |service|
       outcome = GridServices::Delete.run(grid_service: service)
       if outcome.success?
-        begin
-          Timeout::timeout(600) do
-            sleep 1 until GridService.find_by(id: service.id).nil?
-          end
-        rescue Timeout::Error
+        unless wait(timeout: 600) { GridService.find_by(id: service.id).nil? }
           error "Removing of #{service.to_path} timed out"
         end
       else

--- a/server/app/jobs/stack_remove_worker.rb
+++ b/server/app/jobs/stack_remove_worker.rb
@@ -25,7 +25,7 @@ class StackRemoveWorker
     services.each do |service|
       outcome = GridServices::Delete.run(grid_service: service)
       if outcome.success?
-        unless wait(timeout: 600) { GridService.find_by(id: service.id).nil? }
+        unless wait_until(timeout: 600) { GridService.find_by(id: service.id).nil? }
           error "Removing of #{service.to_path} timed out"
         end
       else

--- a/server/app/models/distributed_lock.rb
+++ b/server/app/models/distributed_lock.rb
@@ -15,7 +15,7 @@ class DistributedLock
     lock_id = nil
     begin
       if timeout.to_f > 0.0
-        lock_id = WaitHelper.wait(timeout: timeout) { self.obtain_lock(name) }
+        lock_id = WaitHelper.wait(timeout: timeout, interval: 0.05) { self.obtain_lock(name) }
       else
         lock_id = self.obtain_lock(name)
       end

--- a/server/app/models/distributed_lock.rb
+++ b/server/app/models/distributed_lock.rb
@@ -1,3 +1,5 @@
+require_relative '../helpers/wait_helper'
+
 class DistributedLock
   include Mongoid::Document
 
@@ -13,17 +15,16 @@ class DistributedLock
     lock_id = nil
     begin
       if timeout.to_f > 0.0
-        Timeout.timeout(timeout) do
-          sleep 0.01 until lock_id = self.obtain_lock(name)
-        end
+        lock_id = WaitHelper.wait(timeout: timeout) { self.obtain_lock(name) }
       else
         lock_id = self.obtain_lock(name)
       end
+
       if lock_id
         return yield
+      else
+        return false
       end
-    rescue Timeout::Error
-      return false
     ensure
       self.release_lock(name, lock_id) if lock_id
     end

--- a/server/app/models/distributed_lock.rb
+++ b/server/app/models/distributed_lock.rb
@@ -15,7 +15,7 @@ class DistributedLock
     lock_id = nil
     begin
       if timeout.to_f > 0.0
-        lock_id = WaitHelper.wait(timeout: timeout, interval: 0.05) { self.obtain_lock(name) }
+        lock_id = WaitHelper.wait_until(timeout: timeout, interval: 0.05) { self.obtain_lock(name) }
       else
         lock_id = self.obtain_lock(name)
       end

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -33,7 +33,7 @@ class GridServiceInstanceDeployer
   # @param [String] deploy_rev
   def wait_for_service_to_start(node, instance_number, deploy_rev)
     # node/agent has 5 minutes to do it's job
-    wait!(timeout: 30) {
+    wait!(timeout: 300) {
       next false unless self.deployed_service_container_exists?(instance_number, deploy_rev)
 
       if self.wait_for_port?

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -33,12 +33,14 @@ class GridServiceInstanceDeployer
   # @param [String] deploy_rev
   def wait_for_service_to_start(node, instance_number, deploy_rev)
     # node/agent has 5 minutes to do it's job
-    wait!(timeout: 300) { self.deployed_service_container_exists?(instance_number, deploy_rev) }
-
-    if self.wait_for_port?
-      container = self.find_service_instance_container(instance_number, deploy_rev)
-      wait!(timeout: 300) { port_responding?(container, self.wait_for_port) }
-    end
+    wait!(timeout: 300) {
+      self.deployed_service_container_exists?(instance_number, deploy_rev)
+      
+      if self.wait_for_port?
+        container = self.find_service_instance_container(instance_number, deploy_rev)
+        port_responding?(container, self.wait_for_port)
+      end
+    }
   end
 
   # @param [HostNode] node

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -33,12 +33,17 @@ class GridServiceInstanceDeployer
   # @param [String] deploy_rev
   def wait_for_service_to_start(node, instance_number, deploy_rev)
     # node/agent has 5 minutes to do it's job
-    wait!(timeout: 300) {
-      self.deployed_service_container_exists?(instance_number, deploy_rev)
-      
-      if self.wait_for_port?
-        container = self.find_service_instance_container(instance_number, deploy_rev)
-        port_responding?(container, self.wait_for_port)
+    wait!(timeout: 30) {
+      if !self.deployed_service_container_exists?(instance_number, deploy_rev)
+        false
+      elsif self.wait_for_port?
+        if container = self.find_service_instance_container(instance_number, deploy_rev)
+          port_responding?(container, self.wait_for_port)
+        else
+          false
+        end
+      else
+        true
       end
     }
   end

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -1,5 +1,6 @@
 class GridServiceInstanceDeployer
   include Logging
+  include WaitHelper
 
   attr_reader :grid_service
 
@@ -32,12 +33,11 @@ class GridServiceInstanceDeployer
   # @param [String] deploy_rev
   def wait_for_service_to_start(node, instance_number, deploy_rev)
     # node/agent has 5 minutes to do it's job
-    Timeout.timeout(300) do
-      sleep 0.5 until self.deployed_service_container_exists?(instance_number, deploy_rev)
-      if self.wait_for_port?
-        container = self.find_service_instance_container(instance_number, deploy_rev)
-        sleep 0.5 until port_responding?(container, self.wait_for_port)
-      end
+    wait!(timeout: 300) { self.deployed_service_container_exists?(instance_number, deploy_rev) }
+
+    if self.wait_for_port?
+      container = self.find_service_instance_container(instance_number, deploy_rev)
+      wait!(timeout: 300) { port_responding?(container, self.wait_for_port) }
     end
   end
 

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -34,14 +34,12 @@ class GridServiceInstanceDeployer
   def wait_for_service_to_start(node, instance_number, deploy_rev)
     # node/agent has 5 minutes to do it's job
     wait!(timeout: 30) {
-      if !self.deployed_service_container_exists?(instance_number, deploy_rev)
-        false
-      elsif self.wait_for_port?
-        if container = self.find_service_instance_container(instance_number, deploy_rev)
-          port_responding?(container, self.wait_for_port)
-        else
-          false
-        end
+      next false unless self.deployed_service_container_exists?(instance_number, deploy_rev)
+
+      if self.wait_for_port?
+        next false unless container = self.find_service_instance_container(instance_number, deploy_rev)
+
+        port_responding?(container, self.wait_for_port)
       else
         true
       end

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -33,7 +33,7 @@ class GridServiceInstanceDeployer
   # @param [String] deploy_rev
   def wait_for_service_to_start(node, instance_number, deploy_rev)
     # node/agent has 5 minutes to do it's job
-    wait!(timeout: 300) {
+    wait_until!(timeout: 300) {
       next false unless self.deployed_service_container_exists?(instance_number, deploy_rev)
 
       if self.wait_for_port?

--- a/server/spec/helpers/wait_helper_spec.rb
+++ b/server/spec/helpers/wait_helper_spec.rb
@@ -16,7 +16,7 @@ describe WaitHelper do
 
     it 'returns true immediately' do
       expect(subject).not_to receive(:sleep)
-      value = subject.wait { true }
+      value = subject.wait_until { true }
       expect(value).to be_truthy
     end
 
@@ -29,7 +29,7 @@ describe WaitHelper do
       expect(subject).to_not receive(:sleep)
 
       @loop = 0
-      value = subject.wait(timeout: 2, message: 'foo') { (@loop += 1) > 1 }
+      value = subject.wait_until(timeout: 2, message: 'foo') { (@loop += 1) > 1 }
 
       expect(value).to be_truthy
     end
@@ -45,14 +45,14 @@ describe WaitHelper do
       expect(subject).to receive(:_wait_now).and_return(time_now + 2.001).once
       expect(subject).to_not receive(:sleep)
 
-      value = subject.wait(timeout: 2) { false }
+      value = subject.wait_until(timeout: 2) { false }
 
       expect(value).to be_falsey
     end
 
     it 'raises if no block given' do
       expect {
-        subject.wait
+        subject.wait_until
       }.to raise_error(ArgumentError)
     end
   end
@@ -62,16 +62,16 @@ describe WaitHelper do
       retval = double()
 
       expect(subject).to_not receive(:sleep)
-      value = subject.wait! { retval }
+      value = subject.wait_until! { retval }
 
       expect(value).to be retval
     end
 
     it 'raises when wait return false' do
-      expect(subject).to receive(:wait).and_return(nil)
+      expect(subject).to receive(:wait_until).and_return(nil)
 
       expect {
-        subject.wait!(message: 'foo') { true }
+        subject.wait_until!(message: 'foo') { false }
       }.to raise_error(Timeout::Error)
     end
   end

--- a/server/spec/helpers/wait_helper_spec.rb
+++ b/server/spec/helpers/wait_helper_spec.rb
@@ -1,0 +1,78 @@
+
+describe WaitHelper do
+
+  let(:klass) {
+    Class.new { include WaitHelper }
+  }
+
+  let(:subject) {
+    klass.new
+  }
+
+  describe 'wait' do
+    let :time_now do
+      Time.now.to_f
+    end
+
+    it 'returns true immediately' do
+      expect(subject).not_to receive(:sleep)
+      value = subject.wait { true }
+      expect(value).to be_truthy
+    end
+
+    it 'sleeps between retries and logs debug' do
+      expect(subject).to receive(:_wait_now).and_return(time_now).once
+      expect(subject).to receive(:_wait_now).and_return(time_now + 0.5).once
+      expect(subject).to receive(:sleep).once
+      expect(subject).to receive(:debug).with('wait... foo')
+      expect(subject).to receive(:_wait_now).and_return(time_now + 1.5).once
+      expect(subject).to_not receive(:sleep)
+
+      @loop = 0
+      value = subject.wait(timeout: 2, message: 'foo') { (@loop += 1) > 1 }
+
+      expect(value).to be_truthy
+    end
+
+    it 'sleeps between retries before timing out' do
+      expect(subject).to receive(:_wait_now).and_return(time_now).once
+      expect(subject).to receive(:_wait_now).and_return(time_now + 0.5).once
+      expect(subject).to receive(:sleep).once
+      expect(subject).to receive(:_wait_now).and_return(time_now + 1.0).once
+      expect(subject).to receive(:sleep).once
+      expect(subject).to receive(:_wait_now).and_return(time_now + 1.5).once
+      expect(subject).to receive(:sleep).once
+      expect(subject).to receive(:_wait_now).and_return(time_now + 2.001).once
+      expect(subject).to_not receive(:sleep)
+
+      value = subject.wait(timeout: 2) { false }
+
+      expect(value).to be_falsey
+    end
+
+    it 'raises if no block given' do
+      expect {
+        subject.wait
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#wait!' do
+    it 'return value from wait' do
+      retval = double()
+
+      expect(subject).to_not receive(:sleep)
+      value = subject.wait! { retval }
+
+      expect(value).to be retval
+    end
+
+    it 'raises when wait return false' do
+      expect(subject).to receive(:wait).and_return(nil)
+
+      expect {
+        subject.wait!(message: 'foo') { true }
+      }.to raise_error(Timeout::Error)
+    end
+  end
+end

--- a/server/spec/jobs/leader_elector_job_spec.rb
+++ b/server/spec/jobs/leader_elector_job_spec.rb
@@ -11,9 +11,7 @@ describe LeaderElectorJob do
     it 'elects only one candidate' do
       candidate1 = LeaderElectorJob.new
       candidate2 = LeaderElectorJob.new
-      Timeout.timeout(5) do
-        sleep 0.1 until candidate1.leader? || candidate2.leader?
-      end
+      WaitHelper.wait!(timeout: 5) { candidate1.leader? || candidate2.leader? }
       expect(candidate1.leader? != candidate2.leader?).to be_truthy
     end
   end

--- a/server/spec/jobs/leader_elector_job_spec.rb
+++ b/server/spec/jobs/leader_elector_job_spec.rb
@@ -11,7 +11,7 @@ describe LeaderElectorJob do
     it 'elects only one candidate' do
       candidate1 = LeaderElectorJob.new
       candidate2 = LeaderElectorJob.new
-      WaitHelper.wait!(timeout: 5) { candidate1.leader? || candidate2.leader? }
+      WaitHelper.wait_until!(timeout: 5) { candidate1.leader? || candidate2.leader? }
       expect(candidate1.leader? != candidate2.leader?).to be_truthy
     end
   end

--- a/server/spec/models/distributed_lock_spec.rb
+++ b/server/spec/models/distributed_lock_spec.rb
@@ -25,11 +25,11 @@ describe DistributedLock do
     it 'returns false if getting lock timeouts' do
       threads = []
       threads << Thread.new {
-        described_class.with_lock('foo1') { sleep 0.1 }
+        expect(described_class.with_lock('foo1') { sleep 0.1; "thread A got lock" }).to eq("thread A got lock")
       }
       threads << Thread.new {
         sleep 0.01
-        expect(described_class.with_lock('foo1', 0.01) { true }).to eq(false)
+        expect(described_class.with_lock('foo1', 0.01) { "thread B got lock" }).to eq(false)
       }
       threads.each(&:join)
     end

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -98,9 +98,7 @@ describe GridServiceDeployer do
       allow(subject).to receive(:deploy_service_instance)
       deploy = Thread.new { subject.deploy }
       MongoPubsub.publish(channel, {'event' => 'ping'})
-      Timeout::timeout(5) do
-        sleep 0.05 until events.size > 0
-      end
+      WaitHelper.wait!(timeout: 5) { events.size > 0 }
       expect(events.size).to eq(1)
       deploy.kill
     end
@@ -115,9 +113,7 @@ describe GridServiceDeployer do
       subject.deploy
       sleep 0.01
       MongoPubsub.publish(channel, {'event' => 'ping'})
-      Timeout::timeout(1) do
-        sleep 0.05 until events.size == 0
-      end
+      WaitHelper.wait!(timeout: 1) { events.size == 0 }
     end
   end
 end

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -98,7 +98,7 @@ describe GridServiceDeployer do
       allow(subject).to receive(:deploy_service_instance)
       deploy = Thread.new { subject.deploy }
       MongoPubsub.publish(channel, {'event' => 'ping'})
-      WaitHelper.wait!(timeout: 5) { events.size > 0 }
+      WaitHelper.wait_until!(timeout: 5) { events.size > 0 }
       expect(events.size).to eq(1)
       deploy.kill
     end
@@ -113,7 +113,7 @@ describe GridServiceDeployer do
       subject.deploy
       sleep 0.01
       MongoPubsub.publish(channel, {'event' => 'ping'})
-      WaitHelper.wait!(timeout: 1) { events.size == 0 }
+      WaitHelper.wait_until!(timeout: 1) { events.size == 0 }
     end
   end
 end

--- a/server/spec/services/mongo_pubsub_spec.rb
+++ b/server/spec/services/mongo_pubsub_spec.rb
@@ -23,9 +23,8 @@ describe MongoPubsub do
       described_class.publish('channel1', channel1_msg)
       described_class.publish('channel2', channel2_msg)
 
-      Timeout::timeout(5) do
-        sleep 0.01 until messages.size == 2
-      end
+      WaitHelper.wait!(timeout: 5) { messages.size == 2 }
+
       subs.each(&:terminate)
     end
 

--- a/server/spec/services/mongo_pubsub_spec.rb
+++ b/server/spec/services/mongo_pubsub_spec.rb
@@ -23,7 +23,7 @@ describe MongoPubsub do
       described_class.publish('channel1', channel1_msg)
       described_class.publish('channel2', channel2_msg)
 
-      WaitHelper.wait!(timeout: 5) { messages.size == 2 }
+      WaitHelper.wait_until!(timeout: 5) { messages.size == 2 }
 
       subs.each(&:terminate)
     end


### PR DESCRIPTION
Backport of #1987 for 1.1, see #1986

Changes:
* The `GridServiceInstanceDeployer#wait_for_service_to_start` now does two separate 300-second waits: for the service container to deploy, and for the container to start responding to the port.