### PR TITLE
Fix server v1.1: allow wait with zero timeout

### DIFF
--- a/server/app/helpers/wait_helper.rb
+++ b/server/app/helpers/wait_helper.rb
@@ -8,7 +8,9 @@ module WaitHelper
     Time.now.to_f
   end
 
-  # Wait until given block returns truthy value, returning nil on timeout
+  # Wait until given block returns truthy value, returning nil on timeout.
+  #
+  # For a zero timeout, only yields exactly once.
   #
   # @param timeout [Fixnum] How long to wait
   # @param interval [Fixnum] At what interval is the block yielded
@@ -20,18 +22,17 @@ module WaitHelper
 
     wait_until = _wait_now + timeout
 
+    value = nil
+    
     loop do
-      return nil if _wait_now > wait_until
+      break if value = yield
+      break if _wait_now >= wait_until
 
-      value = yield
-
-      if value
-        return value
-      else
-        debug "wait... #{message}" if message
-        sleep interval
-      end
+      debug "wait... #{message}" if message
+      sleep interval
     end
+
+    value
   end
 
   # Wait until given block returns truthy value, raising on timeout

--- a/server/spec/helpers/wait_helper_spec.rb
+++ b/server/spec/helpers/wait_helper_spec.rb
@@ -25,7 +25,6 @@ describe WaitHelper do
       expect(subject).to receive(:_wait_now).and_return(time_now + 0.5).once
       expect(subject).to receive(:sleep).once
       expect(subject).to receive(:debug).with('wait... foo')
-      expect(subject).to receive(:_wait_now).and_return(time_now + 1.5).once
       expect(subject).to_not receive(:sleep)
 
       @loop = 0
@@ -54,6 +53,21 @@ describe WaitHelper do
       expect {
         subject.wait_until
       }.to raise_error(ArgumentError)
+    end
+
+    context "with a zero timeout" do
+      it "yields once returning true" do
+        @count = 0
+        expect(subject.wait_until(timeout: 0.0) { @count += 1; true }).to eq true
+        expect(@count).to eq 1
+
+      end
+
+      it "yields once returning false" do
+        @count = 0
+        expect(subject.wait_until(timeout: 0.0) { @count += 1; false }).to eq false
+        expect(@count).to eq 1
+      end
     end
   end
 


### PR DESCRIPTION
The new server `WaitHelper#wait_until` had an edge case when called with a zero timeout. This happens when removing a service with zero containers, which uses a timeout proportional to the number of containers. Without the fix, this will immediately fail with a timeout, even if the wait condition is true. This breaks removal of a service that has failed to deploy.

The previous `Timeout::timeout(0)` would not impose any timeout on the block. The new `WaitHelper.wait_until(timeout: 0) { ... }` will always yield the block exactly once, and fail with a timeout if the block is not immediately true.

This is sufficient to fix the `GridServiceRemoveWorker` case:

```ruby
      wait_instance_removal(grid_service, grid_service.containers.scoped.count * 30)

  def wait_instance_removal(grid_service, timeout)
    wait_until!(timeout: timeout) { grid_service.reload.containers.scoped.count == 0 }
  end
```