### PR TITLE
Fix Vault write and update commands

### DIFF
--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -1,6 +1,7 @@
 module Kontena::Cli::Vault
   class UpdateCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
     parameter 'NAME', 'Secret name'
     parameter '[VALUE]', 'Secret value'
@@ -13,10 +14,14 @@ module Kontena::Cli::Vault
       require_current_grid
 
       token = require_token
-      value ||= STDIN.read.chomp
+      secret = value
+      if secret.to_s == ''
+        secret = STDIN.read.chomp
+      end      
+      exit_with_error('No value provided') if secret.to_s == ''
       data = {
         name: name,
-        value: value,
+        value: secret,
         upsert: upsert?
       }
       vspinner "Updating #{name.colorize(:cyan)} value in the vault " do

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Vault
       token = require_token
       secret = value
       if secret.to_s == ''
-        secret = STDIN.read
+        secret = STDIN.read.chomp
       end
       exit_with_error('No value provided') if secret.to_s == ''
       data = {

--- a/cli/spec/kontena/cli/vault/update_spec.rb
+++ b/cli/spec/kontena/cli/vault/update_spec.rb
@@ -1,0 +1,54 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/vault/update_command'
+
+describe Kontena::Cli::Vault::UpdateCommand do
+
+  include RequirementsHelper
+  include ClientHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:client) do
+    double
+  end
+
+  let(:token) do
+    'token'
+  end
+
+
+  describe '#execute' do
+    before(:each) do
+      allow(subject).to receive(:client).with(token).and_return(client)
+      allow(subject).to receive(:current_grid).and_return('test-grid')
+    end
+
+    it 'returns error if value not provided' do
+      allow(STDIN).to receive(:read).once.and_return('')
+      expect(subject).to receive(:exit_with_error).with('No value provided').and_call_original
+      subject.run(['mysql_password'])
+    end
+
+    it 'sends update request' do
+      expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: false})
+      subject.run(['mysql_password', 'secret'])
+    end
+
+    context 'when value not given' do
+      it 'reads value from STDIN' do
+        expect(STDIN).to receive(:read).once.and_return('very-secret')
+        expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'very-secret', upsert: false})
+        subject.run(['mysql_password'])
+      end
+    end
+
+    context 'when giving --upsert flag' do
+      it 'sets upsert true' do
+        expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: true})
+        subject.run(['-u', 'mysql_password', 'secret'])
+      end
+    end
+  end
+end

--- a/cli/spec/kontena/cli/vault/write_spec.rb
+++ b/cli/spec/kontena/cli/vault/write_spec.rb
@@ -1,0 +1,47 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/vault/write_command'
+
+describe Kontena::Cli::Vault::WriteCommand do
+
+  include RequirementsHelper
+  include ClientHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:client) do
+    double
+  end
+
+  let(:token) do
+    'token'
+  end
+
+
+  describe '#execute' do
+    before(:each) do
+      allow(subject).to receive(:client).with(token).and_return(client)
+      allow(subject).to receive(:current_grid).and_return('test-grid')
+    end
+
+    it 'returns error if value not provided' do
+      allow(STDIN).to receive(:read).once.and_return('')
+      expect(subject).to receive(:exit_with_error).with('No value provided').and_call_original
+      subject.run(['mysql_password'])
+    end
+
+    it 'sends create request' do
+      expect(client).to receive(:post).with('grids/test-grid/secrets', { name: 'mysql_password', value: 'secret'})
+      subject.run(['mysql_password', 'secret'])
+    end
+
+    context 'when value not given' do
+      it 'reads value from STDIN' do
+        expect(STDIN).to receive(:read).once.and_return('very-secret')
+        expect(client).to receive(:post).with('grids/test-grid/secrets', { name: 'mysql_password', value: 'very-secret'})
+        subject.run(['mysql_password'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes `kontena vault update` command and unifies logic with `kontena vault write` command. Also added unit tests for both commands.

Fixes #2000 