### PR TITLE
Improve agent RPC request error handling

### DIFF
--- a/agent/lib/kontena/helpers/rpc_helper.rb
+++ b/agent/lib/kontena/helpers/rpc_helper.rb
@@ -6,6 +6,20 @@ module Kontena
       def rpc_client
         Celluloid::Actor[:rpc_client]
       end
+
+      # @param method [String]
+      # @param params [Array]
+      # @raise [Kontena::RpcClient::Error]
+      # @return [Object]
+      def rpc_request(method, params)
+        response, error = rpc_client.request_with_error(method, params)
+
+        if error
+          raise error
+        else
+          return response
+        end
+      end
     end
   end
 end

--- a/agent/lib/kontena/rpc_client.rb
+++ b/agent/lib/kontena/rpc_client.rb
@@ -66,6 +66,23 @@ module Kontena
       end
     end
 
+    # Async request wrapper.
+    #
+    # Logs a warning and returns nil on errors.
+    # Use Kontena::Helpers::RpcError.rpc_request to get a raised error instead.
+    #
+    # @return [Object, nil]
+    def request(method, params, **opts)
+      result, error = request_with_error(method, params, **opts)
+
+      if error
+        warn "RPC request #{method} failed: #{error}"
+        return nil
+      else
+        return result
+      end
+    end
+
     # Called from Kontena::WebsocketClient in the EM thread
     def handle_response(response)
       type, msgid, error, result = response

--- a/agent/lib/kontena/rpc_client.rb
+++ b/agent/lib/kontena/rpc_client.rb
@@ -8,6 +8,8 @@ module Kontena
     include Kontena::Logging
     include Kontena::Helpers::WaitHelper
 
+    REQUEST_ID_RANGE = 1..2**31
+
     class Error < StandardError
       attr_reader :code
 
@@ -90,10 +92,13 @@ module Kontena
 
     # @return [Fixnum]
     def request_id
-      id = -1
-      until id != -1 && !@requests[id]
-        id = rand(2_147_483_647)
+      id = rand(REQUEST_ID_RANGE)
+
+      while @requests.has_key?(id)
+        sleep 0.001
+        id = rand(REQUEST_ID_RANGE)
       end
+
       id
     end
   end

--- a/agent/lib/kontena/rpc_client.rb
+++ b/agent/lib/kontena/rpc_client.rb
@@ -47,13 +47,13 @@ module Kontena
       id = request_id
       @requests[id] = nil
 
-      if !wait_until("websocket client is connected", timeout: timeout, interval: 0.01) { @client.connected? }
+      if !wait_until("websocket client is connected", timeout: timeout, interval: 0.1) { @client.connected? }
         return nil, TimeoutError.new(500, 'WebsocketClient is not connected')
       end
 
       @client.send_request(id, method, params)
 
-      if !wait_until("request #{id} has response", timeout: timeout, interval: 0.01) { @requests[id] }
+      if !wait_until("request #{method} has response wth id=#{id}", timeout: timeout, interval: 0.01) { @requests[id] }
         return nil, TimeoutError.new(500, 'Request timed out')
       end
 

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -44,10 +44,7 @@ module Kontena::Workers
       exclusive {
         request = rpc_client.future.request("/node_service_pods/list", [node.id])
         response = request.value
-        unless response['service_pods'].is_a?(Array)
-          warn "failed to get list of service pods from master: #{response['error']}"
-          return
-        end
+        raise "Invalid response" unless response['service_pods'].is_a?(Array)
 
         service_pods = response['service_pods']
         current_ids = service_pods.map { |p| p['id'] }

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -42,9 +42,9 @@ module Kontena::Workers
 
     def populate_workers_from_master
       exclusive {
-        request = rpc_client.future.request("/node_service_pods/list", [node.id])
-        response = request.value
-        raise "Invalid response" unless response['service_pods'].is_a?(Array)
+        response = rpc_client.request("/node_service_pods/list", [node.id])
+
+        raise "Invalid response: #{response}" unless response['service_pods'].is_a?(Array)
 
         service_pods = response['service_pods']
         current_ids = service_pods.map { |p| p['id'] }

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -42,7 +42,7 @@ module Kontena::Workers
 
     def populate_workers_from_master
       exclusive {
-        response = rpc_client.request("/node_service_pods/list", [node.id])
+        response = rpc_request("/node_service_pods/list", [node.id])
 
         # sanity-check
         unless response['service_pods'].is_a?(Array)

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -35,12 +35,9 @@ module Kontena::Workers::Volumes
 
     def populate_volumes_from_master
       exclusive {
-        request = rpc_client.future.request("/node_volumes/list", [node.id])
-        response = request.value
-        unless response['volumes'].is_a?(Array)
-          warn "failed to get list of volumes from master: #{response['error']}"
-          return
-        end
+        response = rpc_client.request("/node_volumes/list", [node.id])
+
+        fail "Invalid response: #{response}" unless response['volumes'].is_a?(Array)
         debug "got volumes from master: #{response}"
 
         volumes = response['volumes'].map{ |v| Kontena::Models::Volume.new(v) }

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -35,7 +35,7 @@ module Kontena::Workers::Volumes
 
     def populate_volumes_from_master
       exclusive {
-        response = rpc_client.request("/node_volumes/list", [node.id])
+        response = rpc_request("/node_volumes/list", [node.id])
 
         # sanity-check
         unless response['volumes'].is_a?(Array)

--- a/agent/spec/lib/kontena/rpc_client_spec.rb
+++ b/agent/spec/lib/kontena/rpc_client_spec.rb
@@ -67,6 +67,7 @@ describe Kontena::RpcClient, :celluloid => true do
     it "returns nil and logs a warning on errors" do
       expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) # do nothing..
 
+      expect(subject.wrapped_object).to receive(:warn).with(/timeout after waiting/)
       expect(subject.wrapped_object).to receive(:warn).with("RPC request /test failed: Request timed out")
       expect(subject.request("/test", ["foo"], timeout: 0.01)).to be_nil
     end
@@ -75,7 +76,7 @@ describe Kontena::RpcClient, :celluloid => true do
   context "for a very small random pool with conflicts" do
     let(:size) { 5 }
     let(:count) { size ** 2 }
-    
+
     before do
       stub_const("Kontena::RpcClient::REQUEST_ID_RANGE", 1..size)
 

--- a/agent/spec/lib/kontena/rpc_client_spec.rb
+++ b/agent/spec/lib/kontena/rpc_client_spec.rb
@@ -1,11 +1,11 @@
+describe Kontena::RpcClient, :celluloid => true do
 
-describe Kontena::RpcClient do
-
-  let(:ws_client) { double(:ws_client) }
+  let(:ws_client) { instance_double(Kontena::WebsocketClient) }
   let(:subject) { described_class.new(ws_client) }
 
-  before(:each) { Celluloid.boot }
-  after(:each) { Celluloid.shutdown }
+  before do
+    allow(ws_client).to receive(:connected?).and_return(true)
+  end
 
   describe '#request_id' do
     it 'returns random integer' do
@@ -20,6 +20,34 @@ describe Kontena::RpcClient do
         i += 1
       end
       subject.request_id
+    end
+  end
+
+  describe '#request_with_error' do
+    it "returns the response" do
+      expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) do |id, method, params|
+        Celluloid.after(0.0) {
+          subject.async.handle_response([1, id, nil, "foobar"])
+        }
+      end
+
+      expect(subject.request_with_error("/test", ["foo"], timeout: 1.0)).to eq ["foobar", nil]
+    end
+
+    it "returns any error" do
+      expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) do |id, method, params|
+        Celluloid.after(0.0) {
+          subject.async.handle_response([1, id, {'code' => 500, 'message' => "test error"}, nil])
+        }
+      end
+
+      expect(subject.request_with_error("/test", ["foo"], timeout: 1.0)).to eq [nil, Kontena::RpcClient::Error.new(500, "test error")]
+    end
+
+    it "returns a timeout error" do
+      expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) # do nothing..
+
+      expect(subject.request_with_error("/test", ["foo"], timeout: 0.01)).to match [nil, Kontena::RpcClient::TimeoutError]
     end
   end
 end

--- a/agent/spec/lib/kontena/rpc_client_spec.rb
+++ b/agent/spec/lib/kontena/rpc_client_spec.rb
@@ -66,7 +66,7 @@ describe Kontena::RpcClient, :celluloid => true do
     it "returns nil and logs a warning on errors" do
       expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) # do nothing..
 
-      expect(subject.wrapped_object).to receive(:warn).with("RPC request /test failed: Kontena::RpcClient::TimeoutError")
+      expect(subject.wrapped_object).to receive(:warn).with("RPC request /test failed: Request timed out")
       expect(subject.request("/test", ["foo"], timeout: 0.01)).to be_nil
     end
   end

--- a/agent/spec/lib/kontena/workers/service_pod_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_manager_spec.rb
@@ -24,23 +24,25 @@ describe Kontena::Workers::ServicePodManager do
     end
 
     it 'calls terminate_workers' do
-      allow(rpc_client).to receive(:request).with('/node_service_pods/list', [node.id]).and_return(
+      allow(rpc_client).to receive(:request_with_error).with('/node_service_pods/list', [node.id]).and_return([
         {
           'service_pods' => [
             { 'id' => 'a/1', 'instance_number' => 1}
           ]
-        }
-      )
+        },
+        nil
+      ])
       expect(subject.wrapped_object).to receive(:terminate_workers).with(['a/1'])
       subject.populate_workers_from_master
     end
 
     it 'does not call terminate_workers if master returns something weird' do
-      allow(rpc_client).to receive(:request).with('/node_service_pods/list', [node.id]).and_return(
+      allow(rpc_client).to receive(:request_with_error).with('/node_service_pods/list', [node.id]).and_return([
         {
           'service_pods' => 'lolwtf'
-        }
-      )
+        },
+        nil
+      ])
       expect(subject.wrapped_object).to receive(:error).with(/Invalid response from master/)
       expect(subject.wrapped_object).not_to receive(:terminate_workers)
       expect(subject.wrapped_object).not_to receive(:ensure_service_worker)
@@ -49,7 +51,10 @@ describe Kontena::Workers::ServicePodManager do
     end
 
     it 'does not call terminate_workers if RPC fails' do
-      allow(rpc_client).to receive(:request).with('/node_service_pods/list', [node.id]).and_raise(Kontena::RpcClient::Error.new(500, "random failure"))
+      allow(rpc_client).to receive(:request_with_error).with('/node_service_pods/list', [node.id]).and_return([
+        nil,
+        Kontena::RpcClient::Error.new(500, "random failure")
+      ])
       expect(subject.wrapped_object).to receive(:warn).with(/failed to get list of service pods from master/)
       expect(subject.wrapped_object).not_to receive(:terminate_workers)
       expect(subject.wrapped_object).not_to receive(:ensure_service_worker)
@@ -58,14 +63,15 @@ describe Kontena::Workers::ServicePodManager do
     end
 
     it 'calls ensure_service_worker for each service pod' do
-      allow(rpc_client).to receive(:request).with('/node_service_pods/list', [node.id]).and_return(
+      allow(rpc_client).to receive(:request_with_error).with('/node_service_pods/list', [node.id]).and_return([
         {
           'service_pods' => [
             { 'id' => 'a/1', 'instance_number' => 1},
             { 'id' => 'b/2', 'instance_number' => 2}
           ]
-        }
-      )
+        },
+        nil
+      ])
       expect(subject.wrapped_object).to receive(:ensure_service_worker) do |s|
         expect(s.id).to eq('a/1')
       end

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -28,28 +28,23 @@ describe Kontena::Workers::Volumes::VolumeManager do
 
   describe '#populate_volumes_from_master' do
     it 'fails with a warning if no proper response from master' do
-      expect(subject.wrapped_object).to receive(:warn)
       expect(rpc_client).to receive(:request).with('/node_volumes/list', [node.id]).and_return(
-        rpc_future(
-          {
-            'volumes' => 'foo'
-          }
-        )
+        {
+          'volumes' => 'foo'
+        }
       )
-      subject.populate_volumes_from_master
+      expect{subject.populate_volumes_from_master}.to raise_error(/Invalid response/)
     end
 
     it 'calls terminate and ensure with volumes from master' do
       expect(subject.wrapped_object).to receive(:terminate_volumes).with(['123', '456'])
       expect(rpc_client).to receive(:request).with('/node_volumes/list', [node.id]).and_return(
-        rpc_future(
-          {
-            'volumes' => [
-              {'name' => 'foo', 'volume_instance_id' => '123'},
-              {'name' => 'bar', 'volume_instance_id' => '456'}
-            ]
-          }
-        )
+        {
+          'volumes' => [
+            {'name' => 'foo', 'volume_instance_id' => '123'},
+            {'name' => 'bar', 'volume_instance_id' => '456'}
+          ]
+        }
       )
       expect(subject.wrapped_object).to receive(:ensure_volume).twice
       subject.populate_volumes_from_master

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -28,25 +28,27 @@ describe Kontena::Workers::Volumes::VolumeManager do
 
   describe '#populate_volumes_from_master' do
     it 'fails with a warning if no proper response from master' do
-      expect(rpc_client).to receive(:request).with('/node_volumes/list', [node.id]).and_return(
+      expect(rpc_client).to receive(:request_with_error).with('/node_volumes/list', [node.id]).and_return([
         {
           'volumes' => 'foo'
-        }
-      )
+        },
+        nil
+      ])
       expect(subject.wrapped_object).to receive(:error).with(/Invalid response from master/)
       expect{subject.populate_volumes_from_master}.not_to raise_error
     end
 
     it 'calls terminate and ensure with volumes from master' do
       expect(subject.wrapped_object).to receive(:terminate_volumes).with(['123', '456'])
-      expect(rpc_client).to receive(:request).with('/node_volumes/list', [node.id]).and_return(
+      expect(rpc_client).to receive(:request_with_error).with('/node_volumes/list', [node.id]).and_return([
         {
           'volumes' => [
             {'name' => 'foo', 'volume_instance_id' => '123'},
             {'name' => 'bar', 'volume_instance_id' => '456'}
           ]
-        }
-      )
+        },
+        nil
+      ])
       expect(subject.wrapped_object).to receive(:ensure_volume).twice
       subject.populate_volumes_from_master
     end

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -33,7 +33,8 @@ describe Kontena::Workers::Volumes::VolumeManager do
           'volumes' => 'foo'
         }
       )
-      expect{subject.populate_volumes_from_master}.to raise_error(/Invalid response/)
+      expect(subject.wrapped_object).to receive(:error).with(/Invalid response from master/)
+      expect{subject.populate_volumes_from_master}.not_to raise_error
     end
 
     it 'calls terminate and ensure with volumes from master' do

--- a/agent/spec/support/rpc_client_mocks.rb
+++ b/agent/spec/support/rpc_client_mocks.rb
@@ -1,7 +1,7 @@
 module RpcClientMocks
 
   def self.included(base)
-    base.let(:rpc_client) { double(:rpc_client) }
+    base.let(:rpc_client) { instance_double(Kontena::RpcClient) }
   end
 
   def mock_rpc_client

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -9,8 +9,9 @@ module Rpc
     # @return [Array<Hash>]
     def list(id)
       node = @grid.host_nodes.find_by(node_id: id)
-      return { error: 'Node not found' } unless node
-      return { error: 'Migration not done' } unless migration_done?
+      raise 'Node not found' unless node
+      raise 'Migration not done' unless migration_done?
+
       service_pods = node.grid_service_instances.includes(:grid_service).map { |i|
         ServicePodSerializer.new(i).to_hash if i.grid_service
       }.compact
@@ -22,20 +23,18 @@ module Rpc
     # @param [Hash] pod
     def set_state(id, pod)
       node = @grid.host_nodes.find_by(node_id: id)
-      return { error: 'Node not found' } unless node
+      raise 'Node not found' unless node
 
       service_instance = node.grid_service_instances.find_by(
         grid_service_id: pod['service_id'], instance_number: pod['instance_number']
       )
-      if service_instance
-        service_instance.set(
-          state: pod['state'],
-          rev: pod['rev']
-        )
-        {}
-      else
-        { error: 'Instance not found' }
-      end
+      raise 'Instance not found' unless service_instance
+
+      service_instance.set(
+        state: pod['state'],
+        rev: pod['rev']
+      )
+      {}
     end
 
     # @return [Boolean]

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -16,8 +16,6 @@ module Rpc
       }.compact
 
       { service_pods: service_pods }
-    rescue
-      { error: 'Internal server error' }
     end
 
     # @param [String] id

--- a/server/app/services/rpc/node_volume_handler.rb
+++ b/server/app/services/rpc/node_volume_handler.rb
@@ -11,24 +11,20 @@ module Rpc
     # @return [Array<Hash>]
     def list(id)
       node = @grid.host_nodes.find_by(node_id: id)
-      return { error: 'Node not found' } unless node
+      raise "Node not found" unless node
 
       volumes = node.volume_instances.map { |v|
         VolumeSerializer.new(v).to_hash
       }.compact
 
       { volumes: volumes }
-    rescue => exc
-      error "Error listing volumes for agent RPC: #{exc.message}"
-      error exc.backtrace.join("\n") if exc.backtrace
-      { error: 'Internal server error' }
     end
 
     # @param [String] id
     # @param [Hash] volume
     def set_state(id, data)
       node = @grid.host_nodes.find_by(node_id: id)
-      return { error: 'Node not found' } unless node
+      raise "Node not found" unless node
 
       volume_instance = node.volume_instances.find_by(id: data['volume_instance_id'])
       unless volume_instance
@@ -38,16 +34,12 @@ module Rpc
           if volume
             volume_instance = VolumeInstance.create!(host_node: node, volume: volume, name: data['name'])
           else
-            warn "Could not find volume with id: #{volume_id}"
+            raise "Could not find volume with id: #{volume_id}"
           end
         end
       end
 
-      if volume_instance
-        { }
-      else
-        { error: 'Instance not found' }
-      end
+      { }
     end
   end
 end

--- a/server/spec/services/rpc/node_service_pod_handler_spec.rb
+++ b/server/spec/services/rpc/node_service_pod_handler_spec.rb
@@ -10,15 +10,14 @@ describe Rpc::NodeServicePodHandler do
       allow(subject).to receive(:migration_done?).and_return(true)
     end
 
-    it 'returns hash with error if id does not exist' do
-      list = subject.list('foo')
-      expect(list[:error]).not_to be_nil
+    it 'fails if node does not exist' do
+      expect{subject.list('foo')}.to raise_error RuntimeError, 'Node not found'
     end
 
-    it 'returns hash with error if migration is not done' do
-      allow(subject).to receive(:migration_done?).and_return(false)
-      list = subject.list('foo')
-      expect(list[:error]).not_to be_nil
+    it 'fails if migration is not done' do
+      expect(subject).to receive(:migration_done?).and_return(false)
+
+      expect{subject.list(node.node_id)}.to raise_error RuntimeError, 'Migration not done'
     end
 
     it 'returns hash with service pods' do
@@ -62,13 +61,13 @@ describe Rpc::NodeServicePodHandler do
       expect(service_instance.state).to eq(data['state'])
     end
 
-    it 'returns nil if node not found' do
-      expect(subject.set_state('notvalid', data)).to eq({ error: 'Node not found'})
+    it 'fails if node not found' do
+      expect{subject.set_state('notvalid', data)}.to raise_error 'Node not found'
     end
 
-    it 'returns nil if service instance not found' do
+    it 'fail if service instance not found' do
       data['instance_number'] = 3
-      expect(subject.set_state(node.node_id, data)).to eq({ error: 'Instance not found' })
+      expect{subject.set_state(node.node_id, data)}.to raise_error 'Instance not found'
     end
   end
 

--- a/server/spec/services/rpc/node_volume_handler_spec.rb
+++ b/server/spec/services/rpc/node_volume_handler_spec.rb
@@ -7,9 +7,8 @@ describe Rpc::NodeVolumeHandler, celluloid: true do
 
   describe '#list' do
 
-    it 'returns hash with error if id does not exist' do
-      list = subject.list('foo')
-      expect(list[:error]).not_to be_nil
+    it 'fails if host node does not exist' do
+      expect{subject.list('foo')}.to raise_error 'Node not found'
     end
 
     it 'returns hash with volume instances' do
@@ -56,7 +55,7 @@ describe Rpc::NodeVolumeHandler, celluloid: true do
     it 'does not save volume instance if volume not found' do
       data['volume_id'] = 'foo'
       expect {
-        subject.set_state(node.node_id, data)
+        expect{subject.set_state(node.node_id, data)}.to raise_error 'Could not find volume with id: foo'
       }.not_to change {VolumeInstance.count}
     end
 


### PR DESCRIPTION
* Fix the agent RPC client actor to not crash on RPC errors, avoiding unexpected caller task terminations (#2063)

  * Sync requests use `RpcHelper#rpc_request -> RpcClient#request_with_error`, which returns an exception that gets raised locally within the calling actor

  * Any `rpc_client.async.request(...)` errors are now logged as warnings

  * RPC requests now use the `WaitHelper` and log pending requests at the DEBUG level

* Change the server RPC handlers to raise errors instead of returning succesful `{error: ...}` responses

  * Agents can use normal RPC semantics to handle the errors

  * The agent manager actors now rescue all RPC errors (including timeouts), log a warning, and retry later as part of their normal refresh loop

  * Keep some of the response validation as a sanity check to guard against accidential termination of containers/volumes