### PR TITLE
Copy-paste server WaitHelper changes back to agent

### DIFF
--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -1,45 +1,59 @@
-require_relative '../logging'
+module Kontena::Helpers::WaitHelper
+  include Kontena::Logging
 
-module Kontena
-  module Helpers
-    module WaitHelper
-      include Kontena::Logging
+  WAIT_TIMEOUT = 300
+  WAIT_INTERVAL = 0.5
 
+  def _wait_now
+    Time.now.to_f
+  end
 
-      ##
-      # Wait until given block returns truthy value
-      #
-      # @param timeout [Fixnum] How long to wait
-      # @param interval [Fixnum] At what interval is the block yielded
-      # @param [String] Message for debugging
-      # @param [Block] Block to yield
-      # @return [Object] Last return value of the block
-      def wait(timeout: 300, interval: 0.5, message: nil, &block)
-        wait_until = Time.now.to_f + timeout
-        loop do
-          raise ArgumentError, 'no block given' unless block_given?
-          value = yield
-          return value if value || Time.now.to_f > wait_until
-          debug message if message
-          sleep interval
-        end
-      end
+  # Wait until given block returns truthy value, returning nil on timeout.
+  #
+  # For a zero timeout, only yields exactly once.
+  #
+  # @param timeout [Fixnum] How long to wait
+  # @param interval [Fixnum] At what interval is the block yielded
+  # @param message [String] Message for debugging
+  # @param block [Block] Block to yield
+  # @return [Object] Return value from block, or nil
+  def wait_until(message = nil, timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, &block)
+    raise ArgumentError, 'no block given' unless block_given?
 
-      ##
-      # Wait until given block returns truthy value
-      #
-      # @param timeout [Fixnum] How long to wait
-      # @param interval [Fixnum] At what interval is the block yielded
-      # @param [String] Message for debugging
-      # @param [Block] Block to yield
-      # @return [Object] Last return value of the block
-      # @raise [Timeout::Error] If block does not return truthy value within given timeout
-      def wait!(timeout: 300, interval: 0.5, message: nil, &block)
-        unless wait(timeout: timeout, interval: interval, message: message, &block)
-          raise Timeout::Error, "Timeout while: #{message}"
-        end
-        true
-      end
+    wait_start = _wait_now
+    wait_until = wait_start + timeout
+
+    value = nil
+
+    loop do
+      break if value = yield
+      break if _wait_now >= wait_until
+
+      debug "waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start + interval, timeout, message || '???']
+      sleep interval
+    end
+
+    if value
+      debug "waited %.1fs until: %s yielded %s" % [_wait_now - wait_start, message || '???', value]
+    else
+      debug "timeout after waiting %.1fs until: %s" % [_wait_now - wait_start, message || '???']
+    end
+
+    value
+  end
+
+  # Wait until given block returns truthy value, raising on timeout
+  #
+  # @return [Object] Last return value of the block
+  # @raise [Timeout::Error] If block does not return truthy value within given timeout
+  def wait_until!(message = nil, timeout: WAIT_TIMEOUT, **opts, &block)
+    if value = wait_until(message, timeout: timeout, **opts, &block)
+      return value
+    else
+      raise Timeout::Error, "Timeout after waiting %.1fs until: %s" % [timeout, message || '???']
     end
   end
+
+  # Also allow WaitHelper.wait_until(...) to be called as a module method
+  extend self
 end

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -13,13 +13,13 @@ module Kontena
       end
 
       def wait_weave_running?
-        wait!(timeout: 300, message: 'waiting for weave running') {
+        wait_until!("weave running", timeout: 300) {
           network_adapter.running?
         }
       end
 
       def wait_network_ready?
-        wait!(timeout: 300, message: 'waiting for all network components running') {
+        wait_until!("network ready", timeout: 300) {
           network_adapter.network_ready?
         }
       end

--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -40,7 +40,7 @@ module Kontena::Launchers
     # @param [Node] node
     def start(node)
       create_container(@image_name, node)
-      wait(message: "IPAM running") { running? }
+      wait_until("IPAM running") { running? }
       Celluloid::Notifications.publish('ipam:start', node)
     end
 

--- a/agent/lib/kontena/logging.rb
+++ b/agent/lib/kontena/logging.rb
@@ -25,7 +25,7 @@ module Kontena
     # Send a debug message
     # @param [String] string
     def debug(string)
-      logger.debug(self.class.name.gsub('Kontena::', '')) { string }
+      logger.debug(self.class.name) { string }
     end
 
     # Send a info message

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -218,7 +218,7 @@ module Kontena::NetworkAdapters
     end
 
     def start(node)
-      wait { images_exist? && !starting? }
+      wait_until("weave is ready to start") { images_exist? && !starting? }
 
       @starting = true
 
@@ -238,7 +238,7 @@ module Kontena::NetworkAdapters
         exec_params += ['--trusted-subnets', trusted_subnets.join(',')] if trusted_subnets
         @executor_pool.execute(exec_params)
         weave = Docker::Container.get('weave') rescue nil
-        wait(timeout: 10, interval: 1, message: 'waiting for weave to start') {
+        wait_until("weave started", timeout: 10, interval: 1) {
           weave && weave.running?
         }
 

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -22,7 +22,7 @@ module Kontena::Workers
     end
 
     def start
-      wait!(interval: 0.1, message: 'waiting for node info') { self.node }
+      wait_until!("have node info", interval: 0.1) { self.node }
       populate_workers_from_docker
       loop do
         populate_workers_from_master

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -1,4 +1,3 @@
-
 describe Kontena::Helpers::WaitHelper do
 
   let(:klass) {
@@ -9,65 +8,79 @@ describe Kontena::Helpers::WaitHelper do
     klass.new
   }
 
-  describe 'wait' do
-    let :time_now do
-      Time.now
-    end
+  # fake clock
+  before do
+    @time_elapsed = 0.0
 
+    allow(subject).to receive(:_wait_now) { @time_elapsed }
+    allow(subject).to receive(:sleep) { |dt| @time_elapsed += dt }
+  end
+
+  describe 'wait' do
     it 'returns true immediately' do
       expect(subject).not_to receive(:sleep)
-      value = subject.wait { true }
+
+      value = subject.wait_until { true }
+
       expect(value).to be_truthy
     end
 
     it 'sleeps between retries and logs debug' do
-      expect(Time).to receive(:now).and_return(time_now).once
-      expect(Time).to receive(:now).and_return(time_now + 0.5).once
-      expect(subject).to receive(:sleep).once
-      expect(subject).to receive(:debug).with('foo')
-      expect(subject).to_not receive(:sleep)
+      expect(subject).to receive(:debug).with('waiting 0.5s of 2.0s until: something that is true the second time')
+      expect(subject).to receive(:debug).with('waited 0.5s until: something that is true the second time yielded true')
 
       @loop = 0
-      value = subject.wait(timeout: 2, message: 'foo') { (@loop += 1) > 1 }
+      value = subject.wait_until("something that is true the second time", timeout: 2) { (@loop += 1) > 1 }
 
       expect(value).to be_truthy
+      expect(@loop).to eq 2
+      expect(@time_elapsed).to eq(0.5)
     end
 
     it 'sleeps between retries before timing out' do
-      expect(Time).to receive(:now).and_return(time_now).once
-      expect(Time).to receive(:now).and_return(time_now + 0.5).once
-      expect(subject).to receive(:sleep).once
-      expect(Time).to receive(:now).and_return(time_now + 1.0).once
-      expect(subject).to receive(:sleep).once
-      expect(Time).to receive(:now).and_return(time_now + 1.5).once
-      expect(subject).to receive(:sleep).once
-      expect(Time).to receive(:now).and_return(time_now + 2.001).once
-      expect(subject).to_not receive(:sleep)
-
-      value = subject.wait(timeout: 2) { false }
+      value = subject.wait_until(timeout: 2) { false }
 
       expect(value).to be_falsey
+      expect(@time_elapsed).to eq(2.0)
     end
 
     it 'raises if no block given' do
       expect {
-        subject.wait
+        subject.wait_until
       }.to raise_error(ArgumentError)
+    end
+
+    context "with a zero timeout" do
+      it "yields once returning true" do
+        @count = 0
+        expect(subject.wait_until(timeout: 0.0) { @count += 1; true }).to eq true
+        expect(@count).to eq 1
+        expect(@time_elapsed).to eq(0.0)
+
+      end
+
+      it "yields once returning false" do
+        @count = 0
+        expect(subject.wait_until(timeout: 0.0) { @count += 1; false }).to eq false
+        expect(@count).to eq 1
+        expect(@time_elapsed).to eq(0.0)
+      end
     end
   end
 
   describe '#wait!' do
-    it 'return true when wait gives true' do
-      expect(subject).to receive(:wait).and_return(true)
-      value = subject.wait! { true }
-      expect(value).to be_truthy
+    it 'returns value from wait' do
+      retval = double()
+
+      value = subject.wait_until! { retval }
+
+      expect(value).to be retval
     end
 
-    it 'raises when wait return false' do
-      expect(subject).to receive(:wait).and_return(false)
+    it 'raises when wait times out' do
       expect {
-        subject.wait!(message: 'foo') { false }
-      }.to raise_error(Timeout::Error, "Timeout while: foo")
+        subject.wait_until!("something that is never true") { false }
+      }.to raise_error(Timeout::Error, "Timeout after waiting 300.0s until: something that is never true")
     end
   end
 end


### PR DESCRIPTION
Update the agent to use the same `WaitHelper#wait_until` implementation as the server now uses.

Removes the `self.class.name.gsub` transformation for the `Kontena::Logging#debug` case, because it breaks on the anonymous test `Class.new { ... }`:

```
  2) Kontena::Helpers::WaitHelper wait returns true immediately
     Failure/Error: value = subject.wait_until { true }
     NoMethodError:
       undefined method `gsub' for nil:NilClass
     # ./lib/kontena/logging.rb:28:in `debug'
     # ./lib/kontena/helpers/wait_helper.rb:37:in `wait_until'
     # ./spec/lib/kontena/helpers/wait_helper_spec.rb:23:in `block (3 levels) in <top (required)>'

```