### PR TITLE
Remove grid token from Grid and HostNode JSON

### DIFF
--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -102,6 +102,10 @@ module Kontena::Cli::Grids
       grids['grids'].find {|grid| grid['name'] == name }
     end
 
+    def get_grid_token(name)
+      client.get("grids/#{name}/token")
+    end
+
     def to_gigabytes(amount)
       return 0.0 if amount.nil?
       (amount.to_f / 1024 / 1024 / 1024).to_f.round(2)

--- a/cli/lib/kontena/cli/grids/env_command.rb
+++ b/cli/lib/kontena/cli/grids/env_command.rb
@@ -16,8 +16,8 @@ module Kontena::Cli::Grids
       if name_or_current.nil?
         exit_with_error "No grid selected. Use: kontena grid env <name>, or select a grid with: kontena grid use <name>"
       else
-        grid = find_grid_by_name(name_or_current)
-        exit_with_error("Grid not found") unless grid
+        token = get_grid_token(name_or_current)
+        exit_with_error("Grid not found") unless token
 
         grid_uri = self.current_master['url'].sub('http', 'ws')
 
@@ -25,7 +25,7 @@ module Kontena::Cli::Grids
         prefix = export? ? 'export ' : ''
 
         puts "#{prefix}KONTENA_URI=#{grid_uri}"
-        puts "#{prefix}KONTENA_TOKEN=#{grid['token']}"
+        puts "#{prefix}KONTENA_TOKEN=#{token['token']}"
       end
     end
   end

--- a/cli/lib/kontena/cli/grids/show_command.rb
+++ b/cli/lib/kontena/cli/grids/show_command.rb
@@ -12,12 +12,13 @@ module Kontena::Cli::Grids
     def execute
       require_api_url
 
-      grid = find_grid_by_name(name)
-      exit_with_error("Grid not found") unless grid
-
       if self.token?
-        puts grid['token']
+        token = client.get("grids/#{name}/token")
+        exit_with_error("Grid not found") unless token
+        puts token['token']
       else
+        grid = find_grid_by_name(name)
+        exit_with_error("Grid not found") unless grid
         print_grid(grid)
       end
     end

--- a/cli/lib/kontena/cli/grids/show_command.rb
+++ b/cli/lib/kontena/cli/grids/show_command.rb
@@ -13,7 +13,7 @@ module Kontena::Cli::Grids
       require_api_url
 
       if self.token?
-        token = client.get("grids/#{name}/token")
+        token = get_grid_token(name)
         exit_with_error("Grid not found") unless token
         puts token['token']
       else

--- a/cli/spec/kontena/cli/grids/show_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/show_command_spec.rb
@@ -1,0 +1,50 @@
+
+require_relative "../../../spec_helper"
+require 'kontena/cli/grids/show_command'
+
+describe Kontena::Cli::Grids::ShowCommand do
+
+  include ClientHelpers
+
+  let(:server) do
+    Kontena::Cli::Config::Server.new(url: 'https://localhost', token: 'abcd1234')
+  end
+
+  let(:grids_response) do
+    { 'grids' => [
+      {
+        'id' => 'test-grid',
+        'name' => 'test-grid'
+      }
+    ]}
+  end
+
+  describe "#execute" do
+
+    it 'request grids endpoint' do
+      expect(client).to receive(:get).with('grids').and_return(grids_response)
+      allow(subject).to receive(:print_grid)
+      subject.run(['test-grid'])
+    end
+
+    it 'outputs grid information' do
+      allow(client).to receive(:get).with('grids').and_return(grids_response)
+      expect(subject).to receive(:print_grid).with(grids_response['grids'].first)
+      subject.run(['test-grid'])
+    end
+
+    context 'with token option' do
+      it 'request token endpoint' do
+        expect(client).to receive(:get).with('grids/test-grid/token').and_return({'token' => 'xxxyyyzzz'})
+        subject.run(['--token', 'test-grid'])
+      end
+
+      it 'outputs token' do
+        allow(client).to receive(:get).with('grids/test-grid/token').and_return({'token' => 'xxxyyyzzz'})
+        expect{
+          subject.run(['--token', 'test-grid'])
+        }.to output(/xxxyyyzzz/).to_stdout
+      end
+    end
+  end
+end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -104,6 +104,11 @@ module V1
             render('grids/show')
           end
 
+          r.on 'token' do
+            halt_request(403, {error: 'Forbidden'}) unless current_user.can_update?(@grid)
+            render('grids/token')
+          end
+
           r.on 'container_logs' do
             scope = @grid.container_logs
 

--- a/server/app/views/v1/grids/_grid.json.jbuilder
+++ b/server/app/views/v1/grids/_grid.json.jbuilder
@@ -1,6 +1,5 @@
 json.id grid.to_path
 json.name grid.name
-json.token grid.token
 json.initial_size grid.initial_size
 json.stats do
   json.statsd grid.stats['statsd']

--- a/server/app/views/v1/grids/token.json.jbuilder
+++ b/server/app/views/v1/grids/token.json.jbuilder
@@ -1,0 +1,2 @@
+json.id @grid.to_path
+json.token @grid.token

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -32,7 +32,6 @@ json.grid do
     json.id grid.to_path
     json.name grid.name
     json.initial_size grid.initial_size
-    json.token grid.token
     json.stats do
       json.statsd grid.stats['statsd']
     end

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -154,6 +154,29 @@ describe '/v1/grids', celluloid: true do
       expect(json_response['trusted_subnets']).to eq([])
     end
 
+    describe '/token' do
+      context 'when user is not master_admin or grid_admin' do
+        it 'returns error' do
+          grid = david.grids.first
+          get "/v1/grids/#{grid.to_path}/token", nil, request_headers
+          expect(response.status).to eq(403)
+        end
+      end
+
+      context 'when allowed to fetch token' do
+        before(:each) do
+          david.roles << Role.create(name: 'master_admin', description: 'Master admin')
+        end
+
+        it 'returns token' do
+          grid = david.grids.first
+          get "/v1/grids/#{grid.to_path}/token", nil, request_headers
+          expect(response.status).to eq(200)
+          expect(json_response['token']).to eq(grid.token)
+        end
+      end
+    end
+
     describe '/services' do
       it 'returns grid services' do
         grid = david.grids.first


### PR DESCRIPTION
This PR will remove grid token from Grid and HostNode JSON responses. Instead there will be new `/v1/grids/:grid/token` endpoint from where token can be requested (only for users with `master_admin` and `grid_admin` role). This way grid token is not leaked among other grid information.