### PR TITLE
Change ruby 2.4.0 to 2.4.1 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.1.10
   - 2.2.6
   - 2.3.3
-  - 2.4.0
+  - 2.4.1
 cache: bundler
 cache:
   directories:
@@ -36,9 +36,9 @@ matrix:
       env: TEST_DIR=agent
     - rvm: 2.2.6
       env: TEST_DIR=server
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: TEST_DIR=agent
-    - rvm: 2.4.0
+    - rvm: 2.4.1
       env: TEST_DIR=server
 script: ./build/travis/test.sh
 deploy:


### PR DESCRIPTION
Ruby 2.4.1 has been released. [What's changed](https://medium.com/rubyinside/ruby-2-4-1-released-whats-changed-fa83346c93f3)?

