### PR TITLE
Fix Agent state_in_sync for stopped containers

### DIFF
--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -107,7 +107,7 @@ module Kontena::Workers
       return false if !service_pod.terminated? && service_container.nil?
 
       return true if service_pod.running? && service_container.running?
-      return true if service_pod.stopped? && service_container.stopped?
+      return true if service_pod.stopped? && !service_container.running?
 
       false
     end

--- a/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
@@ -68,6 +68,28 @@ describe Kontena::Workers::ServicePodWorker do
     end
   end
 
+  describe '#state_in_sync' do
+    let(:container) { instance_double(Docker::Container) }
+
+    context "for a stopped service pod" do
+      let(:service_pod) do
+        Kontena::Models::ServicePod.new(
+          'id' => 'foo/2',
+          'instance_number' => 2,
+          'updated_at' => Time.now.to_s,
+          'deploy_rev' => Time.now.to_s,
+          'desired_state' => 'stopped',
+        )
+      end
+
+      it "returns true for a stopped container" do
+        expect(container).to receive(:running?).and_return(false)
+
+        expect(subject.state_in_sync?(service_pod, container)).to be_truthy
+      end
+    end
+  end
+
   describe '#current_state' do
     it 'returns missing if container is not found' do
       allow(subject.wrapped_object).to receive(:get_container).and_return(nil)


### PR DESCRIPTION
```
kontena-agent | E, [2017-03-27T10:49:11.979170 #1] ERROR -- : Actor crashed!
kontena-agent | NoMethodError: undefined method `stopped?' for #<Docker::Container:0x00562dcb43ed70>
kontena-agent | Did you mean?  stop!
kontena-agent | 	/app/lib/kontena/workers/service_pod_worker.rb:110:in `state_in_sync?'
kontena-agent | 	/app/lib/kontena/workers/service_pod_worker.rb:57:in `block in ensure_desired_state'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:97:in `exclusive'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid.rb:421:in `exclusive'
kontena-agent | 	/app/lib/kontena/workers/service_pod_worker.rb:37:in `ensure_desired_state'
kontena-agent | 	/app/lib/kontena/workers/service_pod_worker.rb:28:in `update'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/call/async.rb:7:in `dispatch'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
kontena-agent | 	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```