### PR TITLE
Bump ipam to 0.2.2

### DIFF
--- a/agent/lib/kontena/launchers/ipam_plugin.rb
+++ b/agent/lib/kontena/launchers/ipam_plugin.rb
@@ -11,7 +11,7 @@ module Kontena::Launchers
 
     IPAM_SERVICE_NAME = 'kontena-ipam-plugin'.freeze
 
-    IPAM_VERSION = ENV['IPAM_VERSION'] || '0.2.1'
+    IPAM_VERSION = ENV['IPAM_VERSION'] || '0.2.2'
     IPAM_IMAGE = ENV['IPAM_IMAGE'] || 'kontena/ipam-plugin'
 
     def initialize(autostart = true)

--- a/agent/lib/kontena/network_adapters/ipam_client.rb
+++ b/agent/lib/kontena/network_adapters/ipam_client.rb
@@ -73,12 +73,7 @@ module Kontena::NetworkAdapters
       debug "response: #{response.status}/#{response.body}"
       JSON.parse(response.body)
     rescue Excon::Errors::HTTPStatusError => error
-      if error.response.status == 409
-        # IPAM return 409 in case the address still responds to ping, case zombies
-        warn error.response.body
-      else
-        handle_error_response(error)
-      end
+      handle_error_response(error)
     end
 
     def release_pool(network)

--- a/agent/lib/kontena/network_adapters/ipam_client.rb
+++ b/agent/lib/kontena/network_adapters/ipam_client.rb
@@ -73,7 +73,12 @@ module Kontena::NetworkAdapters
       debug "response: #{response.status}/#{response.body}"
       JSON.parse(response.body)
     rescue Excon::Errors::HTTPStatusError => error
-      handle_error_response(error)
+      if error.response.status == 409
+        # IPAM return 409 in case the address still responds to ping, case zombies
+        warn error.response.body
+      else
+        handle_error_response(error)
+      end
     end
 
     def release_pool(network)

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -352,6 +352,9 @@ module Kontena::NetworkAdapters
       info "Remove container=#{container_id} from network=#{overlay_network} at cidr=#{overlay_cidr}"
 
       @ipam_client.release_address(overlay_network, overlay_cidr)
+    rescue IpamError => error
+      # Cleanup will take care of these later on
+      warn "Failed to release container=#{container_id} from network=#{overlay_network} at cidr=#{overlay_cidr}: #{error}"
     end
 
     private

--- a/agent/spec/lib/kontena/network_adapters/ipam_client_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/ipam_client_spec.rb
@@ -98,8 +98,16 @@ describe Kontena::NetworkAdapters::IpamClient do
 
     it 'handles error' do
       expect(connection).to receive(:post)
-        .and_raise(Excon::Errors::HTTPStatusError.new('error'))
+        .and_raise(Excon::Errors::HTTPStatusError.new('error', double(:request), double(:response, :status => 400)))
       expect(subject).to receive(:handle_error_response)
+      subject.release_address('kontena', '10.81.128.100')
+    end
+
+    it 'handles 409 zombie error' do
+      expect(connection).to receive(:post)
+        .and_raise(Excon::Errors::HTTPStatusError.new('error', double(:request), double(:response, :status => 409, :body => 'foo')))
+      expect(subject).not_to receive(:handle_error_response)
+      expect(subject).to receive(:warn).with('foo')
       subject.release_address('kontena', '10.81.128.100')
     end
   end

--- a/agent/spec/lib/kontena/network_adapters/ipam_client_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/ipam_client_spec.rb
@@ -102,14 +102,6 @@ describe Kontena::NetworkAdapters::IpamClient do
       expect(subject).to receive(:handle_error_response)
       subject.release_address('kontena', '10.81.128.100')
     end
-
-    it 'handles 409 zombie error' do
-      expect(connection).to receive(:post)
-        .and_raise(Excon::Errors::HTTPStatusError.new('error', double(:request), double(:response, :status => 409, :body => 'foo')))
-      expect(subject).not_to receive(:handle_error_response)
-      expect(subject).to receive(:warn).with('foo')
-      subject.release_address('kontena', '10.81.128.100')
-    end
   end
 
   describe '#release_pool' do


### PR DESCRIPTION
Ipam 0.2.2 introduced mitigation to zombie netns issues by not actually releasing addresses that still respond to ping. This PR bumps agent to take ipam 0.2.2 into use.