### PR TITLE
Don't count volume containers into totals in aggregation

### DIFF
--- a/server/app/models/container.rb
+++ b/server/app/models/container.rb
@@ -133,7 +133,7 @@ class Container
   # @param [Hash] match
   # @return [Array<Hash>]
   def self.counts_for_grid_services(grid_id, match = {})
-    match = { :grid_id => grid_id}.merge(match)
+    match = { :grid_id => grid_id, :container_type => 'container'}.merge(match)
     self.collection.aggregate([
       { :$match => match },
       { :$group => { _id: "$grid_service_id", total: {:$sum => 1} } }

--- a/server/spec/models/container_spec.rb
+++ b/server/spec/models/container_spec.rb
@@ -186,4 +186,42 @@ describe Container do
       expect(container.name).to eq("redis-2")
     end
   end
+
+  describe 'counts_for_grid_services' do
+    let(:redis) do
+      GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8')
+    end
+    let(:nginx) do
+      GridService.create!(grid: grid, name: 'nginx', image_name: 'nginx')
+    end
+
+    it 'returns correct count per service' do
+      (1..3).each do |i|
+        redis.containers.create!(
+          grid: grid,
+          name: "redis-#{i}",
+          instance_number: i,
+          container_type: 'container'
+        )
+        redis.containers.create!(
+          grid: grid,
+          name: "redis-#{i}-volumes",
+          instance_number: i,
+          container_type: 'volume'
+        )
+      end
+      (1..3).each do |i|
+        nginx.containers.create!(
+          grid: grid,
+          name: "nginx-#{i}",
+          instance_number: i,
+          container_type: 'container'
+        )
+      end
+      expect(described_class.counts_for_grid_services(grid.id)).to include(
+        {'_id' => redis.id, 'total' => 3},
+        {'_id' => nginx.id, 'total' => 3}
+      )
+    end
+  end
 end


### PR DESCRIPTION
`Container.counts_for_grid_services(@grid.id)` counts the containers per service using Mongo aggregation. The `Container` model has a default scope for `container_type: 'container'` but the aggregation uses direct collection to run the aggregation which by-passes the default scope. This resulted into erroneous totals as also volume containers were counted for stateful services.

This PR fixes this by using the same `container_type: 'container'`  in aggregation match.