### PR TITLE
Add configurable stop timeout for services

### DIFF
--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -221,7 +221,7 @@ module Docker
     #
     # @return [Integer]
     def stop_grace_period
-      (self.labels['io.kontena.container.stop_grace_period'] || 10).to_i
+      (self.labels['io.kontena.container.stop_grace_period'] || 10).to_i
     end
 
     private

--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -216,6 +216,14 @@ module Docker
       self.overlay_cidr.split('/')[1] if self.overlay_cidr
     end
 
+    # How long to wait when attempting to stop a container if it doesn’t handle
+    # SIGTERM (or whatever stop signal has been specified with stop_signal), before sending SIGKILL
+    #
+    # @return [Integer]
+    def stop_grace_period
+      self.labels['io.kontena.container.stop_grace_period'] ? self.labels['io.kontena.container.stop_grace_period'].to_i : 10
+    end
+
     private
 
     # @return [Hash]

--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -221,7 +221,7 @@ module Docker
     #
     # @return [Integer]
     def stop_grace_period
-      self.labels['io.kontena.container.stop_grace_period'] ? self.labels['io.kontena.container.stop_grace_period'].to_i : 10
+      (self.labels['io.kontena.container.stop_grace_period'] || 10).to_i
     end
 
     private

--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -41,7 +41,8 @@ module Kontena
                   :secrets,
                   :networks,
                   :wait_for_port,
-                  :volume_specs
+                  :volume_specs,
+                  :stop_grace_period
 
       # @param [Hash] attrs
       def initialize(attrs = {})
@@ -82,6 +83,7 @@ module Kontena
         @secrets = attrs['secrets'] || []
         @networks = attrs['networks'] || []
         @wait_for_port = attrs['wait_for_port']
+        @stop_grace_period = attrs['stop_grace_period']
       end
 
       # @return [Boolean]
@@ -181,6 +183,7 @@ module Kontena
         labels['io.kontena.container.service_revision'] = self.service_revision.to_s
         labels['io.kontena.service.instance_number'] = self.instance_number.to_s
         labels['io.kontena.service.exposed'] = '1' if self.exposed
+        labels['io.kontena.container.stop_grace_period'] = self.stop_grace_period.to_s
         docker_opts['Labels'] = labels
         docker_opts['HostConfig'] = self.service_host_config
         #docker_opts['NetworkingConfig'] = build_networks unless self.networks.empty?

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -153,7 +153,7 @@ module Kontena
 
       # @param [Docker::Container] container
       def cleanup_container(container)
-        container.stop('timeout' => 10)
+        container.stop('timeout' => container.stop_grace_period)
         container.wait
         container.delete(v: true)
       end

--- a/agent/lib/kontena/service_pods/restarter.rb
+++ b/agent/lib/kontena/service_pods/restarter.rb
@@ -22,7 +22,7 @@ module Kontena
         service_container = get_container(self.service_id, self.instance_number)
         if service_container.running?
           info "restarting service: #{service_container.name_for_humans}"
-          service_container.restart!('timeout' => 10)
+          service_container.restart!('timeout' => service_container.stop_grace_period)
           log_service_pod_event(
             self.service_id, self.instance_number,
             "service:restart_instance", "service #{service_container.name_for_humans} instance restarted successfully"

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -26,7 +26,7 @@ module Kontena
             self.service_id, self.instance_number,
             "service:start_instance", "starting service instance #{service_container.name_for_humans}"
           )
-          service_container.restart('timeout' => service_container.stop_grace_period)
+          service_container.restart!('timeout' => service_container.stop_grace_period)
           
         end
 

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -27,7 +27,10 @@ module Kontena
             "service:start_instance", "starting service instance #{service_container.name_for_humans}"
           )
           service_container.restart!('timeout' => service_container.stop_grace_period)
-          
+          log_service_pod_event(
+            self.service_id, self.instance_number,		
+            "service:start_instance", "service instance #{service_container.name_for_humans} started successfully"		
+          )
         end
 
         Celluloid::Notifications.publish('service_pod:start', service_container)

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -26,11 +26,8 @@ module Kontena
             self.service_id, self.instance_number,
             "service:start_instance", "starting service instance #{service_container.name_for_humans}"
           )
-          service_container.restart!('timeout' => 10)
-          log_service_pod_event(
-            self.service_id, self.instance_number,
-            "service:start_instance", "service instance #{service_container.name_for_humans} started successfully"
-          )
+          service_container.restart('timeout' => service_container.stop_grace_period)
+          
         end
 
         Celluloid::Notifications.publish('service_pod:start', service_container)

--- a/agent/lib/kontena/service_pods/stopper.rb
+++ b/agent/lib/kontena/service_pods/stopper.rb
@@ -22,7 +22,7 @@ module Kontena
         service_container = get_container(self.service_id, self.instance_number)
         if service_container.running?
           info "stopping service: #{service_container.name_for_humans}"
-
+          service_container.stop!('timeout' => service_container.stop_grace_period)
           log_service_pod_event(
             self.service_id, self.instance_number,
             "service:stop_instance", "stopping service instance #{service_container.name_for_humans}"

--- a/agent/lib/kontena/service_pods/stopper.rb
+++ b/agent/lib/kontena/service_pods/stopper.rb
@@ -22,10 +22,14 @@ module Kontena
         service_container = get_container(self.service_id, self.instance_number)
         if service_container.running?
           info "stopping service: #{service_container.name_for_humans}"
-          service_container.stop!('timeout' => service_container.stop_grace_period)
           log_service_pod_event(
             self.service_id, self.instance_number,
             "service:stop_instance", "stopping service instance #{service_container.name_for_humans}"
+          )
+          service_container.stop!('timeout' => service_container.stop_grace_period)
+          log_service_pod_event(
+            self.service_id, self.instance_number,
+            "service:stop_instance", "service instance #{service_container.name_for_humans} stopped succesfully"
           )
         else
           log_service_pod_event(

--- a/agent/lib/kontena/service_pods/stopper.rb
+++ b/agent/lib/kontena/service_pods/stopper.rb
@@ -27,11 +27,6 @@ module Kontena
             self.service_id, self.instance_number,
             "service:stop_instance", "stopping service instance #{service_container.name_for_humans}"
           )
-          service_container.stop!('timeout' => 10)
-          log_service_pod_event(
-            self.service_id, self.instance_number,
-            "service:stop_instance", "service instance #{service_container.name_for_humans} stopped successfully"
-          )
         else
           log_service_pod_event(
             self.service_id, self.instance_number,

--- a/agent/lib/kontena/service_pods/terminator.rb
+++ b/agent/lib/kontena/service_pods/terminator.rb
@@ -27,8 +27,7 @@ module Kontena
             self.service_id, self.instance_number,
             "service:remove_instance", "removing service instance #{service_container.name_for_humans}"
           )
-
-          service_container.stop('timeout' => 10)
+          service_container.stop('timeout' => service_container.stop_grace_period)
           service_container.wait
           service_container.delete(v: true)
 

--- a/agent/spec/lib/kontena/service_pods/restarter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/restarter_spec.rb
@@ -7,7 +7,7 @@ describe Kontena::ServicePods::Restarter do
   describe '#perform' do
 
     let(:container) do
-      double(:container, :running? => true, :name_for_humans => 'foo/bar-1')
+      double(:container, :running? => true, :name_for_humans => 'foo/bar-1', :stop_grace_period => 10)
     end
 
     before(:each) do

--- a/agent/spec/lib/kontena/service_pods/starter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/starter_spec.rb
@@ -21,11 +21,13 @@ describe Kontena::ServicePods::Starter do
     end
 
     it 'restarts container if not running' do
+      expect(container).to receive(:stop_grace_period).and_return(10)
       expect(container).to receive(:restart!).with({'timeout' => 10})
       subject.perform
     end
 
     it 'fails if container restart fails' do
+      expect(container).to receive(:stop_grace_period).and_return(10)
       expect(container).to receive(:restart!).with({'timeout' => 10}).and_raise(Docker::Error::ServerError, "failed")
       expect{subject.perform}.to raise_error(Docker::Error::ServerError)
     end

--- a/agent/spec/lib/kontena/service_pods/stopper_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/stopper_spec.rb
@@ -22,7 +22,7 @@ describe Kontena::ServicePods::Stopper do
 
     it 'stops container with a configured timeout' do
       expect(container).to receive(:stop_grace_period).and_return(20)
-      expect(container).to receive(:stop).with({'timeout' => 20})
+      expect(container).to receive(:stop!).with({'timeout' => 20})
       subject.perform
     end
 

--- a/agent/spec/lib/kontena/service_pods/stopper_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/stopper_spec.rb
@@ -7,7 +7,7 @@ describe Kontena::ServicePods::Stopper do
   describe '#perform' do
 
     let(:container) do
-      double(:container, :running? => true, :name_for_humans => 'foo/bar-1')
+      double(:container, :running? => true, :name_for_humans => 'foo/bar-1', :stop_grace_period => 10)
     end
 
     before(:each) do
@@ -17,6 +17,12 @@ describe Kontena::ServicePods::Stopper do
     it 'does nothing if container is not running' do
       allow(container).to receive(:running?).and_return(false)
       expect(container).not_to receive(:stop!)
+      subject.perform
+    end
+
+    it 'stops container with a configured timeout' do
+      expect(container).to receive(:stop_grace_period).and_return(20)
+      expect(container).to receive(:stop).with({'timeout' => 20})
       subject.perform
     end
 

--- a/agent/spec/lib/kontena/service_pods/terminator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/terminator_spec.rb
@@ -6,11 +6,11 @@ describe Kontena::ServicePods::Terminator do
 
   describe '#perform' do
     it 'terminates service instance' do
-      service_container = double(:service, :load_balanced? => false, :name => 'foo.bar-1', :name_for_humans => 'foo/bar-1')
+      service_container = double(:service, :load_balanced? => false, :name => 'foo.bar-1', :name_for_humans => 'foo/bar-1', :stop_grace_period => 15)
       allow(subject).to receive(:get_container).with(service_id, 1).and_return(service_container)
       allow(subject).to receive(:get_container).with(service_id, 1, 'volume')
 
-      expect(service_container).to receive(:stop).with({'timeout' => 10})
+      expect(service_container).to receive(:stop).with({'timeout' => 15})
       expect(service_container).to receive(:wait)
       expect(service_container).to receive(:delete).with({v: true})
       subject.perform

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -41,6 +41,7 @@ module Kontena::Cli::Services
     option "--health-check-initial-delay", "DELAY", "Initial delay for health check"
     option "--health-check-port", "PORT", "Port for health check"
     option "--health-check-protocol", "PROTOCOL", "Protocol of health check"
+    option "--stop-timeout", "STOP_TIMEOUT", "Timeout (duration) to stop a container"
 
     def execute
       require_api_url
@@ -87,6 +88,7 @@ module Kontena::Cli::Services
       health_check = parse_health_check
       data[:health_check] = health_check unless health_check.empty?
       data[:pid] = pid if pid
+      data[:stop_grace_period] = stop_timeout if stop_timeout
       data
     end
   end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -52,6 +52,7 @@ module Kontena
           puts "  stateful: #{service['stateful'] == true ? 'yes' : 'no' }"
           puts "  scaling: #{service['instances'] }"
           puts "  strategy: #{service['strategy']}"
+          puts "  stop_grace_period: #{service['stop_grace_period']}s"
           puts "  deploy_opts:"
           if service['deploy_opts']['min_health']
             puts "    min_health: #{service['deploy_opts']['min_health']}"

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -38,6 +38,7 @@ module Kontena::Cli::Services
     option "--health-check-initial-delay", "DELAY", "Initial for HTTP health check"
     option "--health-check-port", "PORT", "Port for HTTP health check"
     option "--health-check-protocol", "PROTOCOL", "Protocol of health check"
+    option "--stop-timeout", "STOP_TIMEOUT", "Timeout (duration) to stop a container"
 
     def execute
       require_api_url
@@ -78,6 +79,7 @@ module Kontena::Cli::Services
       health_check = parse_health_check
       data[:health_check] = health_check unless health_check.empty?
       data[:pid] = pid if pid
+      data[:stop_grace_period] = stop_timeout if stop_timeout
       data
     end
   end

--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -63,6 +63,7 @@ module Kontena::Cli::Stacks
       data['secrets'] = options['secrets'] if options['secrets']
       data['build'] = parse_build_options(options) if options['build']
       data['health_check'] = parse_health_check(options)
+      data['stop_grace_period'] = options['stop_grace_period'] if options['stop_grace_period']
       data
     end
 

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -74,7 +74,8 @@ module Kontena::Cli::Stacks::YAML
           'timeout' => optional('integer'),
           'interval' => optional('integer'),
           'initial_delay' => optional('integer')
-        })
+        }),
+        'stop_grace_period' => optional(/(\d+(?:\.\d+)?)([hms])/)
       }
     end
 

--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -324,6 +324,16 @@ A reference to a file that contains environment variables.
 env_file: production.env
 ```
 
+#### stop_grace_period
+
+Specify how long to wait when attempting to stop a container if it doesn’t handle SIGTERM (or whatever stop signal has been specified with stop_signal), before sending SIGKILL. Specified as a duration:
+```
+stop_grace_period: 1s
+stop_grace_period: 1m30s
+stop_grace_period: 1m12.3s
+stop_grace_period: 1h1m12.3s
+```
+
 #### extends
 
 Extend another service, in the current file, another file or a stack in the stacks registry, optionally overriding configuration. You can, for example, extend `docker-compose.yml` services and introduce only Kontena-specific fields in `kontena.yml`.

--- a/server/app/helpers/duration.rb
+++ b/server/app/helpers/duration.rb
@@ -1,0 +1,24 @@
+module Duration
+
+  PATTERN = /(\d+(?:\.\d+)?)([hms])/
+
+  UNITS_IN_S = {
+    'h' => 60 * 60,
+    'm' => 60,
+    's' => 1
+  }
+
+  # Calculates duration strings into seconds.
+  # Supports format:
+  # xhymzs
+  # The value given before unit can be also a floating point number
+  #
+  # @param [String] duration string
+  # @return [Float] seconds
+  def parse_duration(duration)
+    duration.scan(PATTERN).map{ |n, unit|
+      n.to_f * UNITS_IN_S[unit]
+    }.reduce(:+).to_f
+  end
+
+end

--- a/server/app/helpers/duration.rb
+++ b/server/app/helpers/duration.rb
@@ -16,7 +16,9 @@ module Duration
   # @param [String] duration string
   # @return [Float] seconds
   def parse_duration(duration)
-    duration.scan(PATTERN).map{ |n, unit|
+    elements = duration.scan(PATTERN)
+    raise ArgumentError, "Duration pattern did not match anything" if elements.empty?
+    elements.map{ |n, unit|
       n.to_f * UNITS_IN_S[unit]
     }.reduce(:+).to_f
   end

--- a/server/app/helpers/duration.rb
+++ b/server/app/helpers/duration.rb
@@ -1,7 +1,12 @@
 module Duration
 
-  PATTERN = /(\d+(?:\.\d+)?)([hms])/
-
+  # Need to do scanning and validation with different regexes
+  # Wasn't able to figure out proper pattern that would both validate and capture things properly
+  # The anchored pattern only returns the last matching group but validates things properly :/
+  SCAN_PATTERN = /(\d+(?:\.\d+)?)([hms])/
+  VALIDATION_PATTERN = /\A(?:(\d+(?:\.\d+)?)([hms]))*\z/
+  
+  # Map supported units into secs
   UNITS_IN_S = {
     'h' => 60 * 60,
     'm' => 60,
@@ -16,10 +21,14 @@ module Duration
   # @param [String] duration string
   # @return [Float] seconds
   def parse_duration(duration)
-    elements = duration.scan(PATTERN)
-    raise ArgumentError, "Duration pattern did not match anything" if elements.empty?
+    raise ArgumentError, "Given duration does not match expected pattern" unless duration =~VALIDATION_PATTERN
+    elements = duration.scan(SCAN_PATTERN)
     elements.map{ |n, unit|
-      n.to_f * UNITS_IN_S[unit]
+      if UNITS_IN_S[unit]
+        n.to_f * UNITS_IN_S[unit]
+      else
+        raise ArgumentError, "Unknown unit: #{unit}"
+      end
     }.reduce(:+).to_f
   end
 

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -37,6 +37,7 @@ class GridService
   field :revision, type: Fixnum, default: 1
   field :stack_revision, type: Fixnum
   field :strategy, type: String, default: 'ha'
+  field :stop_grace_period, type: Fixnum, default: 10
 
   belongs_to :grid
   belongs_to :image

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -261,6 +261,7 @@ module GridServices
               integer :initial_delay, default: 10
             end
           end
+          string :stop_grace_period, matches: Duration::PATTERN
         end
       end
     end

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -261,7 +261,7 @@ module GridServices
               integer :initial_delay, default: 10
             end
           end
-          string :stop_grace_period, matches: Duration::PATTERN
+          string :stop_grace_period, matches: Duration::VALIDATION_PATTERN
         end
       end
     end

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -3,6 +3,7 @@ require_relative 'common'
 module GridServices
   class Create < Mutations::Command
     include Common
+    include Duration
 
     common_validations
 
@@ -42,6 +43,7 @@ module GridServices
       attributes = self.inputs.clone
       attributes[:image_name] = attributes.delete(:image)
       attributes[:container_count] = attributes.delete(:instances) if attributes[:instances]
+      attributes[:stop_grace_period] = parse_duration(attributes.delete(:stop_grace_period)) if attributes[:stop_grace_period]
 
       attributes.delete(:links)
       if self.links

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -4,6 +4,7 @@ module GridServices
   class Update < Mutations::Command
     include Common
     include Logging
+    include Duration
 
     common_validations
 
@@ -80,6 +81,7 @@ module GridServices
       attributes[:deploy_opts] = self.deploy_opts if self.deploy_opts
       attributes[:health_check] = self.health_check if self.health_check
       attributes[:volumes_from] = self.volumes_from if self.volumes_from
+      attributes[:stop_grace_period] = parse_duration(self.stop_grace_period) if self.stop_grace_period
 
       if self.links
         attributes[:grid_service_links] = build_grid_service_links(

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -44,6 +44,7 @@ module Rpc
         log_opts: service.log_opts,
         pid: service.pid,
         wait_for_port: service.deploy_opts.wait_for_port,
+        stop_grace_period: service.stop_grace_period,
         env: build_env,
         secrets: build_secrets,
         labels: build_labels,

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -64,3 +64,4 @@ if grid_service.health_check && grid_service.health_check.protocol
 	end
 	json.health_status grid_service.health_status
 end
+json.stop_grace_period grid_service.stop_grace_period

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -521,6 +521,7 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
   		"stateful": true,
   		"replicas": 3,
   		"cmd": "--replset kontena --smallfiles",
+		"stop_grace_period": "1m23s",
   		"health_check": {
   			"protocol": "tcp",
   			"port": 27017
@@ -815,6 +816,7 @@ log_driver | Log driver (string)
 log_opts | Log driver options (object)
 hooks | Commands to be executed when service instance is deployed
 instance_counts | Stats about how many instances this service currently has
+stop_grace_period | How long to wait when attempting to stop a container if it doesn’t handle SIGTERM (or whatever stop signal has been specified with the image), before sending SIGKILL.
 
 ### Deploy Opt attributes
 

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -81,17 +81,19 @@ describe '/v1/services' do
     }
   end
 
-  describe 'GET /:id' do
-    it 'returns stackless service json' do
-      get "/v1/services/terminal-a/null/redis", nil, request_headers
-      expect(response.status).to eq(200), response.body
-      expect(json_response.keys.sort).to eq(%w(
+  EXPECTED_FIELDS = %w(
         id created_at updated_at stack image affinity name stateful user
         instances cmd entrypoint ports env memory memory_swap cpu_shares
         volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
         strategy deploy_opts pid instance_counts net dns hooks secrets revision
-        stack_revision
-      ).sort)
+        stack_revision stop_grace_period
+      ).sort
+
+  describe 'GET /:id' do
+    it 'returns stackless service json' do
+      get "/v1/services/terminal-a/null/redis", nil, request_headers
+      expect(response.status).to eq(200), response.body
+      expect(json_response.keys.sort).to eq(EXPECTED_FIELDS)
       expect(json_response['id']).to eq('terminal-a/null/redis')
       expect(json_response['image']).to eq(redis_service.image_name)
       expect(json_response['dns']).to eq('redis.terminal-a.kontena.local')
@@ -100,13 +102,7 @@ describe '/v1/services' do
     it 'returns stack service json' do
       get "/v1/services/terminal-a/teststack/redis", nil, request_headers
       expect(response.status).to eq(200), response.body
-      expect(json_response.keys.sort).to eq(%w(
-        id created_at updated_at stack image affinity name stateful user
-        instances cmd entrypoint ports env memory memory_swap cpu_shares
-        volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
-        strategy deploy_opts pid instance_counts net dns hooks secrets revision
-        stack_revision
-      ).sort)
+      expect(json_response.keys.sort).to eq(EXPECTED_FIELDS)
       expect(json_response['id']).to eq('terminal-a/teststack/redis')
       expect(json_response['stack']['name']).to eq('teststack')
       expect(json_response['image']).to eq(stack_redis_service.image_name)
@@ -116,13 +112,7 @@ describe '/v1/services' do
     it 'returns stack service json with volumes' do
       get "/v1/services/terminal-a/null/redis-2", nil, request_headers
       expect(response.status).to eq(200), response.body
-      expect(json_response.keys.sort).to eq(%w(
-        id created_at updated_at stack image affinity name stateful user
-        instances cmd entrypoint ports env memory memory_swap cpu_shares
-        volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
-        strategy deploy_opts pid instance_counts net dns hooks secrets revision
-        stack_revision
-      ).sort)
+      expect(json_response.keys.sort).to eq(EXPECTED_FIELDS)
       expect(json_response['volumes']).to eq(['volume:/data'])
     end
 

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -150,6 +150,14 @@ describe '/v1/services' do
       expect(json_response['health_status']).to be_nil
       expect(json_response['health_check']).to be_nil
     end
+
+    it 'returns stop_grace_period' do
+      redis_service.stop_grace_period = 37
+      redis_service.save
+      get "/v1/services/#{redis_service.to_path}", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['stop_grace_period']).to eq(37)
+    end
   end
 
   describe 'PUT /:id' do

--- a/server/spec/helpers/duration_spec.rb
+++ b/server/spec/helpers/duration_spec.rb
@@ -1,0 +1,35 @@
+describe Duration do
+  class Subject
+    include Duration
+  end
+
+  let(:subject) do
+    subject = Subject.new
+    subject.extend(Duration)
+  end
+
+  it 'parses hours, minutes and seconds' do
+    expect(subject.parse_duration('2h1m23s')).to eq(7283)
+  end
+
+  it 'parses minutes and seconds' do
+    expect(subject.parse_duration('1m23s')).to eq(83)
+  end
+
+  it 'parses minutes and decimal seconds' do
+    expect(subject.parse_duration('1m23.5s')).to eq(83.5)
+  end
+
+  it 'parses seconds' do
+    expect(subject.parse_duration('93s')).to eq(93)
+  end
+
+  it 'parses unknown units to zero' do
+    expect(subject.parse_duration('1m93x')).to eq(60)
+  end
+
+  it 'parses unknown format to zero' do
+    expect(subject.parse_duration('foo')).to eq(0)
+  end
+
+end

--- a/server/spec/helpers/duration_spec.rb
+++ b/server/spec/helpers/duration_spec.rb
@@ -29,7 +29,9 @@ describe Duration do
   end
 
   it 'parses unknown format to zero' do
-    expect(subject.parse_duration('foo')).to eq(0)
+    expect {
+      subject.parse_duration('foo')
+    }.to raise_error(ArgumentError)
   end
 
 end

--- a/server/spec/helpers/duration_spec.rb
+++ b/server/spec/helpers/duration_spec.rb
@@ -24,13 +24,21 @@ describe Duration do
     expect(subject.parse_duration('93s')).to eq(93)
   end
 
-  it 'parses unknown units to zero' do
-    expect(subject.parse_duration('1m93x')).to eq(60)
+  it 'fails with unknown units' do
+    expect {
+      subject.parse_duration('1m93x')
+    }.to raise_error(ArgumentError)
   end
 
-  it 'parses unknown format to zero' do
+  it 'fails with completely unknown format' do
     expect {
       subject.parse_duration('foo')
+    }.to raise_error(ArgumentError)
+  end
+
+  it 'fails with partially unknown format' do
+    expect {
+      puts subject.parse_duration('1m foo')
     }.to raise_error(ArgumentError)
   end
 

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -392,6 +392,17 @@ describe GridServices::Create do
       expect(outcome.result.stop_grace_period).to eq(10)
     end
 
+    it 'fails to save with unknown grace_period' do
+      outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          stop_grace_period: 'foo'
+      ).run
+      expect(outcome).not_to be_success
+    end
+
     context 'volumes' do
       let(:volume) do
         Volume.create!(grid: grid, name: 'foo', scope: 'node')

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -381,6 +381,16 @@ describe GridServices::Create do
       expect(outcome).to_not be_success
       expect(outcome.errors.message).to eq 'env' => [ "Env[0] isn't in the right format" ]
     end
+    
+    it 'saves stop_grace_period with default if not given' do
+      outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false
+      ).run
+      expect(outcome.result.stop_grace_period).to eq(10)
+    end
 
     context 'volumes' do
       let(:volume) do

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -59,6 +59,17 @@ describe GridServices::Update do
       }.to change{ redis_service.reload.affinity }.to(['az==b1'])
     end
 
+    it 'updates stop_grace_period' do
+      redis_service.stop_grace_period = 15
+      redis_service.save
+      expect {
+        described_class.new(
+            grid_service: redis_service,
+            stop_grace_period: '1m23s'
+        ).run
+      }.to change{ redis_service.reload.stop_grace_period }.to(83)
+    end
+
     context 'deploy_opts' do
       it 'updates wait_for_port' do
         described_class.new(

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -18,7 +18,8 @@ describe Rpc::ServicePodSerializer do
       container_count: 2,
       env: ['FOO=bar'],
       networks: [grid.networks.first],
-      service_volumes: [ServiceVolume.new(volume: volume, path:'/data'), ServiceVolume.new(volume: ext_vol, path: '/foo')]
+      service_volumes: [ServiceVolume.new(volume: volume, path:'/data'), ServiceVolume.new(volume: ext_vol, path: '/foo')],
+      stop_grace_period: 20
     )
   end
   let(:service_instance) do
@@ -136,6 +137,10 @@ describe Rpc::ServicePodSerializer do
 
     it 'includes default network' do
       expect(subject.to_hash).to include(:networks => [{name: 'kontena', subnet: '10.81.0.0/16', multicast: true, internal: false}])
+    end
+
+    it 'includes default network' do
+      expect(subject.to_hash).to include(:stop_grace_period => 20)
     end
 
     describe '[:env]' do

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -139,7 +139,7 @@ describe Rpc::ServicePodSerializer do
       expect(subject.to_hash).to include(:networks => [{name: 'kontena', subnet: '10.81.0.0/16', multicast: true, internal: false}])
     end
 
-    it 'includes default network' do
+    it 'stop_grace_period' do
       expect(subject.to_hash).to include(:stop_grace_period => 20)
     end
 

--- a/test/spec/features/service/update_spec.rb
+++ b/test/spec/features/service/update_spec.rb
@@ -24,4 +24,13 @@ describe 'service update' do
       expect(k.out.match(/port: 8080/)).not_to be_truthy
     end
   end
+
+  context 'stop_grace_period' do
+    it 'allows update stop-timeout' do
+      k = run "kontena service update --stop-timeout 1m23s test-1"
+      expect(k.code).to eq(0)
+      k = run "kontena service show test-1"
+      expect(k.out.match(/stop_grace_period: 83s/)).to be_truthy
+    end
+  end
 end

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 
 describe 'stack install' do
+  
+  after(:each) do
+    run 'kontena stack rm --force simple'
+  end
 
   context 'from file' do
-    after(:each) do
-      run 'kontena stack rm --force simple'
-    end
 
     it 'installs a stack' do
       with_fixture_dir("stack/simple") do
@@ -50,6 +51,17 @@ describe 'stack install' do
         expect(k.code).to eq(1)
         expect(k.out).to match /services:\s*a:\s*links: Linked service 'nope' does not exist/m
       end
+    end
+  end
+
+  context 'For a stack with stop_grace_period' do
+    it 'creates stack service with stop_grace_period' do
+      with_fixture_dir("stack/simple") do
+        run 'kontena stack install stop-period.yml'
+      end
+      k = run 'kontena service show simple/redis'
+      expect(k.code).to eq(0)
+      expect(k.out.match(/stop_grace_period: 23s/)).to be_truthy
     end
   end
 end

--- a/test/spec/fixtures/stack/simple/stop-period.yml
+++ b/test/spec/fixtures/stack/simple/stop-period.yml
@@ -1,0 +1,6 @@
+stack: test/simple
+version: 0.1.0
+services:
+  redis:
+    image: redis:3-alpine
+    stop_grace_period: 23s


### PR DESCRIPTION
Agent used hard coded 10sec timeout in every container stop request. 10sec might not be enough for all services so this PR adds support for configurable timeout for services.
```
stack: test/redis-timeout
version: 0.1.0
services:
  redis:
    image: redis:3-alpine
    stop_grace_period: 20s
```

The term `stop_grace_period` is used in Docker compose so it's used also on this so things are extensible.

There's still a default 10s timeout used if no other is specified in services.

On plain service commands there's an option on this also:
```
--stop-timeout STOP_TIMEOUT   Timeout (duration) to stop a container
```
I used `stop-timeout` as that's used in Docker CLI.

fixes #1334

### TODO

- [x] API docs
- [x] docs
