### PR TITLE
Validate volumes before stack gets created or updated

### DIFF
--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -49,6 +49,11 @@ module Stacks
           unless vol
             add_error(:volumes, :not_found, "External volume #{volume_name} not found")
           end
+        else
+          outcome = Volumes::Create.validate(grid: self.grid, **volume.symbolize_keys)
+          unless outcome.success?
+            handle_volume_outcome_errors(volume['name'], outcome.errors)
+          end
         end
       end
     end

--- a/server/spec/mutations/stacks/create_spec.rb
+++ b/server/spec/mutations/stacks/create_spec.rb
@@ -43,8 +43,9 @@ describe Stacks::Create do
         source: '...',
         variables: {foo: 'bar'},
         services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
-        volumes: [{name: 'vol1', scope: 'grid', external: false, driver: 'local'}]
+        volumes: [{name: 'vol1', scope: 'grid', driver: 'local'}]
       ).run
+      expect(outcome.success?).to be_truthy
       expect(outcome.result.stack_revisions.count).to eq(1)
       expect(outcome.result.latest_rev.volumes.count).to eq(1)
     end
@@ -307,7 +308,7 @@ describe Stacks::Create do
             volumes: [{name: 'vol1', scope: 'grid'}]
           ).run
           expect(outcome.success?).to be_falsey
-        }.to change{ Volume.count }.by(0)
+        }.not_to change{ Stack.count }
       end
 
       it 'creates stack with external volumes with name' do
@@ -348,7 +349,7 @@ describe Stacks::Create do
         expect(outcome.success?).to be_truthy
         redis = outcome.result.grid_services.first
         expect(redis.service_volumes.first.volume).to eq(volume)
-      }.to change{ Volume.count }.by(0)
+      }.not_to change{ Volume.count }
     end
 
 
@@ -366,7 +367,7 @@ describe Stacks::Create do
           volumes: [{name: 'vol1', external: {name: 'foo'}}]
         ).run
         expect(outcome.success?).to be_falsey
-      }.to change{ Volume.count }.by(0)
+      }.not_to change{ Volume.count }
     end
   end
 end

--- a/server/spec/mutations/stacks/update_spec.rb
+++ b/server/spec/mutations/stacks/update_spec.rb
@@ -109,7 +109,7 @@ describe Stacks::Update do
       expect {
         outcome = subject.run
         expect(outcome.success?).to be_falsey
-      }.to change { Volume.count }.by (0)
+      }.not_to change { [Volume.count, stack.latest_rev] }
     end
   end
 end

--- a/test/spec/features/volume/common.rb
+++ b/test/spec/features/volume/common.rb
@@ -1,0 +1,21 @@
+module Common
+
+  # Finds a containers "fully qualified" name for inspection etc. container commands
+  #
+  # @param [String] container to find
+  # @return [String] fully qualified container path, i.e. node/stack.container
+  def find_container(name)
+    k = run 'kontena container ls'
+    k.out[/^\w*\/#{name}/]
+  end
+
+  # Get container Mounts
+  #
+  # @param [String] container, full path
+  # @return [Hash] containers mounts
+  def container_mounts(container)
+    k = run "kontena container inspect #{container}"
+    JSON.parse(k.out).dig('Mounts')
+  end
+
+end

--- a/test/spec/features/volume/service_volumes.rb
+++ b/test/spec/features/volume/service_volumes.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 require 'json'
+require_relative 'common'
 
 describe 'service volumes' do
+  include Common
+
   after(:each) do
     run "kontena service rm --force null/redis"
     run "kontena volume rm testVol"
@@ -14,10 +17,9 @@ describe 'service volumes' do
     expect(k.code).to eq(0)
     k = run "kontena service deploy redis"
     expect(k.code).to eq(0)
-    k = run "kontena container inspect moby/redis-1"
-
-    json = JSON.parse(k.out)
-    mount = json.dig('Mounts').find { |m| m['Name'] =~ /testVol/}
+    
+    mount = container_mounts(find_container('redis-1')).find { |m| m['Name'] =~ /testVol/}
+    #mount = json.dig('Mounts').find { |m| m['Name'] =~ /testVol/}
     expect(mount).not_to be_nil
     expect(mount['Name']).to eq("redis.testVol-1")
     expect(mount['Destination']).to eq('/data')

--- a/test/spec/features/volume/service_volumes.rb
+++ b/test/spec/features/volume/service_volumes.rb
@@ -17,9 +17,8 @@ describe 'service volumes' do
     expect(k.code).to eq(0)
     k = run "kontena service deploy redis"
     expect(k.code).to eq(0)
-    
+
     mount = container_mounts(find_container('redis-1')).find { |m| m['Name'] =~ /testVol/}
-    #mount = json.dig('Mounts').find { |m| m['Name'] =~ /testVol/}
     expect(mount).not_to be_nil
     expect(mount['Name']).to eq("redis.testVol-1")
     expect(mount['Destination']).to eq('/data')

--- a/test/spec/features/volume/stack_volumes.rb
+++ b/test/spec/features/volume/stack_volumes.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'json'
+require_relative 'common'
+
+describe 'stack volumes' do
+  include Common
+
+  after(:each) do
+    run "kontena stack rm --force redis"
+    run "kontena volume rm redis-data"
+  end
+
+  it 'stack creates volumes' do
+    with_fixture_dir("stack/volumes") do
+      k = run 'kontena stack install redis-simple.yml'
+      expect(k.code).to eq(0), k.out
+    end
+    k = run 'kontena volume ls'
+    expect(k.out.match(/redis-data/)).to be_truthy
+    container = find_container('redis.redis-1')
+    puts "****** #{container}"
+    mount = container_mounts(container).find { |m| m['Name'] =~ /redis-data-1/}
+    expect(mount).not_to be_nil
+    expect(mount['Name']).to eq("redis.redis.redis-data-1")
+    expect(mount['Destination']).to eq('/data')
+  end
+
+  it 'fails to install stack with missing volume driver' do
+    with_fixture_dir("stack/volumes") do
+      k = run 'kontena stack install missing-driver.yml'
+      expect(k.code).not_to eq(0)
+    end
+    k = run 'kontena stack show redis'
+    expect(k.code).not_to eq(0)
+  end
+
+  it 'fails to update stack with missing volume driver' do
+    with_fixture_dir("stack/volumes") do
+      k = run 'kontena stack install redis-simple.yml'
+      expect(k.code).to eq(0), k.out
+    end
+    k = run 'kontena stack upgrade redis missing-driver.yml'
+    expect(k.code).not_to eq(0)
+  end
+
+
+
+end

--- a/test/spec/features/volume/stack_volumes.rb
+++ b/test/spec/features/volume/stack_volumes.rb
@@ -18,7 +18,6 @@ describe 'stack volumes' do
     k = run 'kontena volume ls'
     expect(k.out.match(/redis-data/)).to be_truthy
     container = find_container('redis.redis-1')
-    puts "****** #{container}"
     mount = container_mounts(container).find { |m| m['Name'] =~ /redis-data-1/}
     expect(mount).not_to be_nil
     expect(mount['Name']).to eq("redis.redis.redis-data-1")

--- a/test/spec/fixtures/stack/volumes/missing-driver.yml
+++ b/test/spec/fixtures/stack/volumes/missing-driver.yml
@@ -1,0 +1,13 @@
+stack: redis
+description: Just a simple Redis stack with volume
+version: 0.0.1
+services:
+  redis:
+    image: redis:3.2-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:
+    scope: instance

--- a/test/spec/fixtures/stack/volumes/redis-simple.yml
+++ b/test/spec/fixtures/stack/volumes/redis-simple.yml
@@ -1,0 +1,15 @@
+stack: redis
+description: Just a simple Redis stack with volume
+version: 0.0.1
+services:
+  redis:
+    image: redis:3.2-alpine
+    command: redis-server --appendonly yes
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:
+    driver: local
+    scope: instance
+    


### PR DESCRIPTION
Volumes are now fully validated before the stack is created and stack create/update fails if volume validation fails.

fixes #2039 