### PR TITLE
Added prompt to commands that wait for input from STDIN

### DIFF
--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -22,6 +22,9 @@ module Kontena
         @pastel ||= Pastel.new(enabled: $stdout.tty?)
       end
 
+      # Read from STDIN. If stdin is a console, use prompt to ask.
+      # @param [String] message
+      # @param [Symbol] mode (prompt method: :ask, :multiline, etc)
       def stdin_input(message = nil, mode = :ask)
         if $stdin.tty?
           Array(prompt.send(mode, message)).join.chomp

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -22,9 +22,9 @@ module Kontena
         @pastel ||= Pastel.new(enabled: $stdout.tty?)
       end
 
-      def stdin_input(message = nil)
+      def stdin_input(message = nil, mode = :ask)
         if $stdin.tty?
-          prompt.multiline(message).join.chomp
+          Array(prompt.send(mode, message)).join.chomp
         elsif !$stdin.eof?
           $stdin.read.chomp
         else

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -22,6 +22,16 @@ module Kontena
         @pastel ||= Pastel.new(enabled: $stdout.tty?)
       end
 
+      def stdin_input(message = nil)
+        if $stdin.tty?
+          prompt.multiline(message).join.chomp
+        elsif !$stdin.eof?
+          $stdin.read.chomp
+        else
+          exit_with_error 'Missing input'
+        end
+      end
+
       def running_silent?
         self.respond_to?(:silent?) && self.silent?
       end

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -30,7 +30,7 @@ module Kontena::Cli::Master::Config
         path = File.join(Kontena.root, 'lib/kontena/presets', "#{self.preset}.yml")
         File.read(path)
       else
-        stdin_input("Enter master configuration as #{format.upcase}")
+        stdin_input("Enter master configuration as #{format.upcase}", :multiline)
       end
     end
 

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -30,7 +30,7 @@ module Kontena::Cli::Master::Config
         path = File.join(Kontena.root, 'lib/kontena/presets', "#{self.preset}.yml")
         File.read(path)
       else
-        Kontena.stdinput("Enter master configuration as #{format.upcase}")
+        stdin_input("Enter master configuration as #{format.upcase}")
       end
     end
 

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Master::Config
 
     banner "Updates configuration from a file into Master"
 
-    parameter '[PATH]', "Input from file in PATH, default: STDIN", required: false
+    parameter '[PATH]', "Input from file in PATH (default: STDIN)", required: false
 
     option ['--preset'], '[NAME]', 'Load preset', hidden: true
 
@@ -30,7 +30,7 @@ module Kontena::Cli::Master::Config
         path = File.join(Kontena.root, 'lib/kontena/presets', "#{self.preset}.yml")
         File.read(path)
       else
-        STDIN.read
+        Kontena.stdinput("Enter master configuration as #{format.upcase}")
       end
     end
 

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -23,7 +23,7 @@ module Kontena::Cli::Vault
     end
 
     def input
-      path ? File.read(path) : Kontena.stdinput("Enter secrets YAML")
+      path ? File.read(path) : stdin_input("Enter secrets YAML")
     end
 
     def execute

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Vault
     option '--skip-null', :flag, "Do not remove keys with null values"
     option '--empty-is-null', :flag, "Treat empty values as null"
 
-    parameter '[PATH]', "Input from file in PATH, default: STDIN"
+    parameter '[PATH]', "Input from file in PATH (default: STDIN)"
 
     requires_current_master
 
@@ -23,7 +23,7 @@ module Kontena::Cli::Vault
     end
 
     def input
-      path ? File.read(path) : STDIN.read
+      path ? File.read(path) : Kontena.stdinput("Enter secrets YAML")
     end
 
     def execute

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -23,7 +23,7 @@ module Kontena::Cli::Vault
     end
 
     def input
-      path ? File.read(path) : stdin_input("Enter secrets YAML")
+      path ? File.read(path) : stdin_input("Enter secrets YAML", :multiline)
     end
 
     def execute

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -12,7 +12,7 @@ module Kontena::Cli::Vault
     requires_current_master
 
     def default_value
-      stdin_input("Enter value for secret '#{name}'")
+      stdin_input("Enter value for secret '#{name}'", :mask)
     end
 
     def execute

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -1,6 +1,7 @@
 module Kontena::Cli::Vault
   class UpdateCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
     parameter 'NAME', 'Secret name'
     parameter '[VALUE]', 'Secret value (default: STDIN)'

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -3,29 +3,20 @@ module Kontena::Cli::Vault
     include Kontena::Cli::Common
 
     parameter 'NAME', 'Secret name'
-    parameter '[VALUE]', 'Secret value'
+    parameter '[VALUE]', 'Secret value (default: STDIN)'
 
     option ['-u', '--upsert'], :flag, 'Create secret unless already exists', default: false
     option '--silent', :flag, "Reduce output verbosity"
-    option ['-i', '--stdin'], :flag, 'Read value from stdin', default: false
+
+    requires_current_master
 
     def default_value
-      exit_with_error('No value provided') unless stdin?
-      STDIN.read.chomp
+      Kontena.stdinput("Enter value for secret '#{name}'")
     end
 
     def execute
-      require_api_url
-      require_current_grid
-
-      token = require_token
-      data = {
-        name: name,
-        value: value,
-        upsert: upsert?
-      }
       vspinner "Updating #{name.colorize(:cyan)} value in the vault " do
-        client(token).put("secrets/#{current_grid}/#{name}", data)
+        client.put("secrets/#{current_grid}/#{name}", {name: name, value: value, upsert: upsert? })
       end
     end
   end

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -12,7 +12,7 @@ module Kontena::Cli::Vault
     requires_current_master
 
     def default_value
-      Kontena.stdinput("Enter value for secret '#{name}'")
+      stdin_input("Enter value for secret '#{name}'")
     end
 
     def execute

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -7,13 +7,18 @@ module Kontena::Cli::Vault
 
     option ['-u', '--upsert'], :flag, 'Create secret unless already exists', default: false
     option '--silent', :flag, "Reduce output verbosity"
+    option ['-i', '--stdin'], :flag, 'Read value from stdin', default: false
+
+    def default_value
+      exit_with_error('No value provided') unless stdin?
+      STDIN.read.chomp
+    end
 
     def execute
       require_api_url
       require_current_grid
 
       token = require_token
-      value ||= STDIN.read.chomp
       data = {
         name: name,
         value: value,

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Vault
     requires_current_master
 
     def default_value
-      stdin_input("Enter value for secret '#{name}'")
+      stdin_input("Enter value for secret '#{name}'", :mask)
     end
 
     def execute

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -4,26 +4,19 @@ module Kontena::Cli::Vault
     include Kontena::Cli::GridOptions
 
     parameter 'NAME', 'Secret name'
-    parameter '[VALUE]', 'Secret value'
+    parameter '[VALUE]', 'Secret value (default: STDIN)'
 
     option '--silent', :flag, "Reduce output verbosity"
 
-    def execute
-      require_api_url
-      require_current_grid
+    requires_current_master
 
-      token = require_token
-      secret = value
-      if secret.to_s == ''
-        secret = STDIN.read
-      end
-      exit_with_error('No value provided') if secret.to_s == ''
-      data = {
-          name: name,
-          value: secret
-      }
+    def default_value
+      Kontena.stdinput("Enter value for secret '#{name}'")
+    end
+
+    def execute
       vspinner "Writing #{name.colorize(:cyan)} to the vault " do
-        client(token).post("grids/#{current_grid}/secrets", data)
+        client.post("grids/#{current_grid}/secrets", { name: name, value: value })
       end
     end
   end

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Vault
     requires_current_master
 
     def default_value
-      Kontena.stdinput("Enter value for secret '#{name}'")
+      stdin_input("Enter value for secret '#{name}'")
     end
 
     def execute

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -82,16 +82,6 @@ module Kontena
       File.join(Kontena.root, 'lib/kontena/cli', *joinables)
     end
   end
-
-  def self.stdinput(message = nil)
-    if $stdin.tty?
-      prompt.multiline(message).join.chomp
-    elsif !$stdin.eof?
-      $stdin.read.chomp
-    else
-      exit_with_error 'Missing input'
-    end
-  end
 end
 
 # Monkeypatching string to mimick 'colorize' gem

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -82,6 +82,16 @@ module Kontena
       File.join(Kontena.root, 'lib/kontena/cli', *joinables)
     end
   end
+
+  def self.stdinput(message = nil)
+    if $stdin.tty?
+      prompt.multiline(message).join.chomp
+    elsif !$stdin.eof?
+      $stdin.read.chomp
+    else
+      exit_with_error 'Missing input'
+    end
+  end
 end
 
 # Monkeypatching string to mimick 'colorize' gem

--- a/cli/spec/kontena/cli/vault/update_command_spec.rb
+++ b/cli/spec/kontena/cli/vault/update_command_spec.rb
@@ -6,48 +6,71 @@ describe Kontena::Cli::Vault::UpdateCommand do
   include RequirementsHelper
   include ClientHelpers
 
-  let(:subject) do
-    described_class.new(File.basename($0))
-  end
-
-  let(:client) do
-    double
-  end
-
-  let(:token) do
-    'token'
-  end
-
+  let(:subject) { described_class.new(File.basename($0)) }
 
   describe '#execute' do
-    before(:each) do
-      allow(subject).to receive(:client).with(token).and_return(client)
-      allow(subject).to receive(:current_grid).and_return('test-grid')
-    end
 
-    it 'returns error if value not provided' do
-      allow(STDIN).to receive(:read).once.and_return('')
-      expect(subject).to receive(:exit_with_error).with('No value provided').and_call_original
-      subject.run(['mysql_password'])
-    end
+    context 'without value parameter' do
 
-    it 'sends update request' do
-      expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: false})
-      subject.run(['mysql_password', 'secret'])
-    end
+      let(:stdin) { double(:stdin) }
 
-    context 'when value not given' do
-      it 'reads value from STDIN' do
-        expect(STDIN).to receive(:read).once.and_return('very-secret')
-        expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'very-secret', upsert: false})
-        subject.run(['mysql_password'])
+      before(:each) do
+        @old_stdin = $stdin
+        $stdin = stdin
+      end
+
+      after(:each) { $stdin = @old_stdin }
+
+      context 'without tty' do
+        before(:each) { allow(stdin).to receive(:tty?).and_return(false) }
+        after(:each) { $stdin = @old_stdin }
+
+        context 'nothing in stdin' do
+          before(:each) do
+            allow(stdin).to receive(:eof?).and_return(true)
+          end
+
+          it 'returns error if value not provided' do
+            expect{subject.run(['mysql_password'])}.to exit_with_error.and output(/Missing/).to_stderr
+          end
+        end
+
+        context 'value in stdin' do
+          it 'sends update request' do
+            expect(stdin).to receive(:eof?).and_return(false)
+            expect(stdin).to receive(:read).and_return('secret')
+            expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: false})
+            expect{subject.run(['mysql_password'])}.not_to exit_with_error
+          end
+        end
+      end
+
+      context 'with tty' do
+        before(:each) do
+          allow(stdin).to receive(:tty?).and_return(true)
+        end
+
+        context 'when value not given' do
+          it 'prompts for value' do
+            expect(subject.prompt).to receive(:multiline).once.and_return(['very-secret'])
+            expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'very-secret', upsert: false})
+            expect{subject.run(['mysql_password'])}.not_to exit_with_error
+          end
+        end
       end
     end
 
-    context 'when giving --upsert flag' do
-      it 'sets upsert true' do
-        expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: true})
-        subject.run(['-u', 'mysql_password', 'secret'])
+    context 'with value parameter' do
+      it 'sends update request' do
+        expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: false})
+        expect{subject.run(['mysql_password', 'secret'])}.not_to exit_with_error
+      end
+
+      context 'when giving --upsert flag' do
+        it 'sets upsert true' do
+          expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: true})
+          subject.run(['-u', 'mysql_password', 'secret'])
+        end
       end
     end
   end

--- a/cli/spec/kontena/cli/vault/update_command_spec.rb
+++ b/cli/spec/kontena/cli/vault/update_command_spec.rb
@@ -51,8 +51,10 @@ describe Kontena::Cli::Vault::UpdateCommand do
         end
 
         context 'when value not given' do
+          let(:prompt) { double(:prompt) }
           it 'prompts for value' do
-            expect(subject.prompt).to receive(:multiline).once.and_return(['very-secret'])
+            expect(subject).to receive(:prompt).and_return(prompt)
+            expect(prompt).to receive(:mask).once.and_return('very-secret')
             expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'very-secret', upsert: false})
             expect{subject.run(['mysql_password'])}.not_to exit_with_error
           end

--- a/cli/spec/kontena/cli/vault/update_command_spec.rb
+++ b/cli/spec/kontena/cli/vault/update_command_spec.rb
@@ -1,0 +1,54 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/vault/update_command'
+
+describe Kontena::Cli::Vault::UpdateCommand do
+
+  include RequirementsHelper
+  include ClientHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:client) do
+    double
+  end
+
+  let(:token) do
+    'token'
+  end
+
+
+  describe '#execute' do
+    before(:each) do
+      allow(subject).to receive(:client).with(token).and_return(client)
+      allow(subject).to receive(:current_grid).and_return('test-grid')
+    end
+
+    it 'returns error if value not provided' do
+      allow(STDIN).to receive(:read).once.and_return('')
+      expect(subject).to receive(:exit_with_error).with('No value provided').and_call_original
+      subject.run(['mysql_password'])
+    end
+
+    it 'sends update request' do
+      expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: false})
+      subject.run(['mysql_password', 'secret'])
+    end
+
+    context 'when value not given' do
+      it 'reads value from STDIN' do
+        expect(STDIN).to receive(:read).once.and_return('very-secret')
+        expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'very-secret', upsert: false})
+        subject.run(['mysql_password'])
+      end
+    end
+
+    context 'when giving --upsert flag' do
+      it 'sets upsert true' do
+        expect(client).to receive(:put).with('secrets/test-grid/mysql_password', { name: 'mysql_password', value: 'secret', upsert: true})
+        subject.run(['-u', 'mysql_password', 'secret'])
+      end
+    end
+  end
+end

--- a/cli/spec/kontena/cli/vault/write_command_spec.rb
+++ b/cli/spec/kontena/cli/vault/write_command_spec.rb
@@ -1,0 +1,47 @@
+require_relative "../../../spec_helper"
+require 'kontena/cli/vault/write_command'
+
+describe Kontena::Cli::Vault::WriteCommand do
+
+  include RequirementsHelper
+  include ClientHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  let(:client) do
+    double
+  end
+
+  let(:token) do
+    'token'
+  end
+
+
+  describe '#execute' do
+    before(:each) do
+      allow(subject).to receive(:client).with(token).and_return(client)
+      allow(subject).to receive(:current_grid).and_return('test-grid')
+    end
+
+    it 'returns error if value not provided' do
+      allow(STDIN).to receive(:read).once.and_return('')
+      expect(subject).to receive(:exit_with_error).with('No value provided').and_call_original
+      subject.run(['mysql_password'])
+    end
+
+    it 'sends create request' do
+      expect(client).to receive(:post).with('grids/test-grid/secrets', { name: 'mysql_password', value: 'secret'})
+      subject.run(['mysql_password', 'secret'])
+    end
+
+    context 'when value not given' do
+      it 'reads value from STDIN' do
+        expect(STDIN).to receive(:read).once.and_return('very-secret')
+        expect(client).to receive(:post).with('grids/test-grid/secrets', { name: 'mysql_password', value: 'very-secret'})
+        subject.run(['mysql_password'])
+      end
+    end
+  end
+end

--- a/cli/spec/kontena/cli/vault/write_command_spec.rb
+++ b/cli/spec/kontena/cli/vault/write_command_spec.rb
@@ -41,9 +41,11 @@ describe Kontena::Cli::Vault::WriteCommand do
       end
 
       context 'with tty' do
+        let(:prompt) { double(:prompt) }
         it 'prompts value from STDIN' do
           expect(stdin).to receive(:tty?).and_return(true)
-          expect(subject.prompt).to receive(:multiline).and_return(['secret'])
+          expect(subject).to receive(:prompt).and_return(prompt)
+          expect(prompt).to receive(:mask).and_return('secret')
           expect(client).to receive(:post).with('grids/test-grid/secrets', { name: 'mysql_password', value: 'secret'})
           expect{subject.run(['mysql_password'])}.not_to exit_with_error
         end


### PR DESCRIPTION
The import command only works with a single value and it doesn't even always work then, it just spins forever. The update command also was broken due to the change in handling parameters. Also the design is confusing because if the user doesn't provide a value or somehow accidentally or intentionally provides an empty value it will just hang waiting for stdin input but this is not at all obvious. This change adds a -i or --stdin option to explicitly indicate that the value should be read from stdin so that if it is blank and this is not specified then it will provide a useful error message. This coincidentally fixes the `vault import` command when used with more than one value.