### PR TITLE
Change CLI log --tail/follow options to match Docker

### DIFF
--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Helpers
     def self.included(base)
       if base.respond_to?(:option)
         base.option ["-f", "--follow"], :flag, "Follow log output", :attribute_name => :tail, default: false
-        base.option "--tail", "LINES", "Number of lines to show from the end of the logs", :attribute_name => :lines, default: 100 do |s|
+        base.option ['--tail', '--lines'], "LINES", "Number of lines to show from the end of the logs", :attribute_name => :lines, default: 100 do |s|
           Integer(s)
         end
         base.option "--since", "SINCE", "Show logs since given timestamp"

--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -3,8 +3,8 @@ module Kontena::Cli::Helpers
 
     def self.included(base)
       if base.respond_to?(:option)
-        base.option ["-t", "--tail"], :flag, "Tail (follow) logs", default: false
-        base.option "--lines", "LINES", "Number of lines to show from the end of the logs", default: 100 do |s|
+        base.option ["-f", "--follow"], :flag, "Follow log output", :attribute_name => :tail, default: false
+        base.option "--tail", "LINES", "Number of lines to show from the end of the logs", :attribute_name => :lines, default: 100 do |s|
           Integer(s)
         end
         base.option "--since", "SINCE", "Show logs since given timestamp"


### PR DESCRIPTION
In Docker "--tail" means show the last lines only (like `tail -n`) but in Kontena it means the same as Docker's `--follow` and tail's own `--follow`. This changes Kontena to follow the option names of Docker which I think makes sense given that Kontena is a Docker-based tool.

```
$ docker logs --help

Usage:  docker logs [OPTIONS] CONTAINER

Fetch the logs of a container

Options:
      --details        Show extra details provided to logs
  -f, --follow         Follow log output
      --help           Print usage
      --since string   Show logs since timestamp
      --tail string    Number of lines to show from the end of the logs (default "all")
  -t, --timestamps     Show timestamps
```