### PR TITLE
Improve RpcServer performance

### DIFF
--- a/agent/lib/kontena/rpc_client.rb
+++ b/agent/lib/kontena/rpc_client.rb
@@ -36,26 +36,22 @@ module Kontena
 
     # @param [String] method
     # @param [Array] params
-    # @return [Celluloid::Future]
+    # @return [Object]
     def request(method, params)
       id = request_id
       @requests[id] = nil
-      future = Celluloid::Future.new {
-        sleep 0.01 until @client.connected?
-        @client.send_request(id, method, params)
-        time = Time.now.utc
-        until !@requests[id].nil?
-          sleep 0.01
-          raise TimeoutError.new(500, 'Request timed out') if time < (Time.now.utc - 30)
-        end
-        result, error = @requests.delete(id)
-        if error
-          raise Error.new(error['code'], error['message'], error['backtrace'])
-        end
-        result
-      }
-
-      future
+      sleep 0.01 until @client.connected?
+      @client.send_request(id, method, params)
+      time = Time.now.utc
+      until !@requests[id].nil?
+        sleep 0.01
+        raise TimeoutError.new(500, 'Request timed out') if time < (Time.now.utc - 30)
+      end
+      result, error = @requests.delete(id)
+      if error
+        raise Error.new(error['code'], error['message'])
+      end
+      result
     end
 
     def handle_response(response)

--- a/agent/lib/kontena/workers/container_health_check_worker.rb
+++ b/agent/lib/kontena/workers/container_health_check_worker.rb
@@ -43,7 +43,7 @@ module Kontena::Workers
       else
         msg = check_tcp_status(ip, port, timeout)
       end
-      rpc_client.async.notification('/containers/health', [msg])
+      rpc_client.async.request('/containers/health', [msg])
 
       handle_action(msg)
     end

--- a/agent/lib/kontena/workers/container_info_worker.rb
+++ b/agent/lib/kontena/workers/container_info_worker.rb
@@ -67,7 +67,7 @@ module Kontena::Workers
         node: self.node_info['ID'],
         container: data
       }
-      rpc_client.async.notification('/containers/save', [data])
+      rpc_client.async.request('/containers/save', [data])
     rescue Docker::Error::NotFoundError
     rescue => exc
       error exc.message
@@ -82,7 +82,7 @@ module Kontena::Workers
         from: event.from,
         time: event.time
       }
-      rpc_client.async.notification('/containers/event', [data])
+      rpc_client.async.request('/containers/event', [data])
     end
 
     # @return [Hash]

--- a/agent/lib/kontena/workers/event_worker.rb
+++ b/agent/lib/kontena/workers/event_worker.rb
@@ -81,7 +81,7 @@ module Kontena::Workers
         from: event.from,
         time: event.time
       }
-      rpc_client.async.notification('/containers/event', [data])
+      rpc_client.async.request('/containers/event', [data])
       publish(EVENT_NAME, event)
     rescue => exc
       error "#{exc.class.name}: #{exc.message}"

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -79,7 +79,7 @@ module Kontena::Workers
       docker_info['PublicIp'] = self.public_ip
       docker_info['PrivateIp'] = self.private_ip
       docker_info['AgentVersion'] = Kontena::Agent::VERSION
-      rpc_client.async.notification('/nodes/update', [docker_info])
+      rpc_client.async.request('/nodes/update', [docker_info])
     rescue => exc
       error "publish_node_info: #{exc.message}"
     end

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -42,7 +42,7 @@ module Kontena::Workers
 
     def populate_workers_from_master
       exclusive {
-        request = rpc_client.request("/node_service_pods/list", [node.id])
+        request = rpc_client.future.request("/node_service_pods/list", [node.id])
         response = request.value
         unless response['service_pods'].is_a?(Array)
           warn "failed to get list of service pods from master: #{response['error']}"

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -134,7 +134,7 @@ module Kontena::Workers
         state: current_state,
         rev: service_pod.deploy_rev
       }
-      rpc_client.async.notification('/node_service_pods/set_state', [node.id, data])
+      rpc_client.async.request('/node_service_pods/set_state', [node.id, data])
       @prev_state = current_state
     end
   end

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -35,7 +35,7 @@ module Kontena::Workers::Volumes
 
     def populate_volumes_from_master
       exclusive {
-        request = rpc_client.request("/node_volumes/list", [node.id])
+        request = rpc_client.future.request("/node_volumes/list", [node.id])
         response = request.value
         unless response['volumes'].is_a?(Array)
           warn "failed to get list of volumes from master: #{response['error']}"
@@ -87,7 +87,7 @@ module Kontena::Workers::Volumes
         'volume_instance_id' => data.dig('Labels', 'io.kontena.volume_instance.id'),
         'volume_id' => data.dig('Labels', 'io.kontena.volume.id')
       }
-      rpc_client.async.notification('/node_volumes/set_state', [node.id, volume])
+      rpc_client.async.request('/node_volumes/set_state', [node.id, volume])
     end
 
     def volume_exist?(volume_name)

--- a/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_health_check_worker_spec.rb
@@ -33,7 +33,7 @@ describe Kontena::Workers::ContainerHealthCheckWorker do
         expect(subject.wrapped_object).to receive(:sleep).with(20)
         expect(subject.wrapped_object).to receive(:check_http_status).with('1.2.3.4', 8080, '/', 10).twice.and_return({})
         expect(subject.wrapped_object).to receive(:handle_action).twice
-        expect(rpc_client).to receive(:notification).twice
+        expect(rpc_client).to receive(:request).twice
         subject.start
       end
     end
@@ -58,7 +58,7 @@ describe Kontena::Workers::ContainerHealthCheckWorker do
         expect(subject.wrapped_object).to receive(:sleep).with(20)
         expect(subject.wrapped_object).to receive(:check_tcp_status).with('1.2.3.4', 1234, 10).twice.and_return({})
         expect(subject.wrapped_object).to receive(:handle_action).twice
-        expect(rpc_client).to receive(:notification).twice
+        expect(rpc_client).to receive(:request).twice
         subject.start
       end
     end

--- a/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
@@ -73,13 +73,13 @@ describe Kontena::Workers::ContainerInfoWorker do
 
   describe '#publish_info' do
     it 'publishes event to queue' do
-      expect(rpc_client).to receive(:notification).once
+      expect(rpc_client).to receive(:request).once
       subject.publish_info(spy(:container, json: {'Config' => {}}))
     end
 
     it 'publishes valid message' do
       container = double(:container, json: {'Config' => {}})
-      expect(rpc_client).to receive(:notification).once.with(
+      expect(rpc_client).to receive(:request).once.with(
         '/containers/save', [hash_including(node: 'host_id')]
       )
       allow(subject.wrapped_object).to receive(:node_info).and_return({'ID' => 'host_id'})

--- a/agent/spec/lib/kontena/workers/event_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/event_worker_spec.rb
@@ -42,7 +42,7 @@ describe Kontena::Workers::EventWorker do
 
     it 'streams and processes events' do
       times = 100
-      expect(rpc_client).to receive(:notification).exactly(times).times
+      expect(rpc_client).to receive(:request).exactly(times).times
       subject
       allow(Docker::Event).to receive(:stream) {|params, &block|
         times.times {
@@ -125,12 +125,12 @@ describe Kontena::Workers::EventWorker do
 
   describe '#publish_event' do
     it 'sends event via rpc' do
-      expect(rpc_client).to receive(:notification).with('/containers/event', [anything])
+      expect(rpc_client).to receive(:request).with('/containers/event', [anything])
       subject.publish_event(spy)
     end
 
     it 'publishes event' do
-      expect(rpc_client).to receive(:notification)
+      expect(rpc_client).to receive(:request)
       event = spy(:event)
       expect(subject.wrapped_object).to receive(:publish).with(described_class::EVENT_NAME, event)
       subject.publish_event(event)
@@ -138,7 +138,7 @@ describe Kontena::Workers::EventWorker do
 
     it 'does not send event if source is from network adapter' do
       event = spy(:event)
-      expect(rpc_client).not_to receive(:notification)
+      expect(rpc_client).not_to receive(:request)
       allow(network_adapter).to receive(:adapter_image?).and_return(true)
       subject.publish_event(event)
     end

--- a/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
@@ -24,6 +24,7 @@ describe Kontena::Workers::NodeInfoWorker do
     allow(Net::HTTP).to receive(:get).and_return('8.8.8.8')
     allow(subject.wrapped_object).to receive(:calculate_containers_time).and_return(100)
     allow(rpc_client).to receive(:request)
+    allow(rpc_client).to receive(:notification)
   }
   after(:each) { Celluloid.shutdown }
 

--- a/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
@@ -16,7 +16,7 @@ describe Kontena::Workers::ServicePodWorker do
   describe '#ensure_desired_state' do
     before(:each) do
       mock_rpc_client
-      allow(rpc_client).to receive(:notification)
+      allow(rpc_client).to receive(:request)
     end
 
     it 'calls ensure_running if container does not exist and service_pod desired_state is running' do
@@ -116,11 +116,11 @@ describe Kontena::Workers::ServicePodWorker do
   describe '#sync_state_to_master' do
     before(:each) do
       mock_rpc_client
-      allow(rpc_client).to receive(:notification)
+      allow(rpc_client).to receive(:request)
     end
 
     it 'sends correct data' do
-      expect(rpc_client).to receive(:notification).with(
+      expect(rpc_client).to receive(:request).with(
         '/node_service_pods/set_state',
         [node.id, hash_including(state: 'running', rev: service_pod.deploy_rev)]
       )

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -96,7 +96,7 @@ describe Kontena::Workers::Volumes::VolumeManager do
 
   describe '#sync_volume_to_master' do
     it 'sends volume data to master' do
-      expect(rpc_client).to receive(:notification).with(
+      expect(rpc_client).to receive(:request).with(
         '/node_volumes/set_state',
         [node.id, hash_including('name' => 'foo', 'volume_id' => '123', 'volume_instance_id' => '456')]
       )

--- a/agent/spec/support/rpc_client_mocks.rb
+++ b/agent/spec/support/rpc_client_mocks.rb
@@ -7,6 +7,7 @@ module RpcClientMocks
   def mock_rpc_client
     allow(subject.wrapped_object).to receive(:rpc_client).and_return(rpc_client)
     allow(rpc_client).to receive(:async).and_return(rpc_client)
+    allow(rpc_client).to receive(:future).and_return(rpc_client)
   end
 
   def rpc_future(value)

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -291,4 +291,8 @@ class WebsocketBackend
       self.on_close(client[:ws])
     end
   end
+
+  def stop_rpc_server
+    Celluloid::Actor.kill(@rpc_server) if @rpc_server.alive?
+  end
 end

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -246,11 +246,14 @@ class WebsocketBackend
   end
 
   def watch_connections
-    EM::PeriodicTimer.new(KEEPALIVE_TIME) do
-      @clients.each do |client|
-        self.verify_client_connection(client)
+    Thread.new {
+      sleep 1 until EM.reactor_running?
+      EM::PeriodicTimer.new(KEEPALIVE_TIME) do
+        @clients.each do |client|
+          self.verify_client_connection(client)
+        end
       end
-    end
+    }
   end
 
   def watch_queue

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -14,7 +14,7 @@ module Rpc
       @logs = []
       @stats = []
       @cached_containers = {}
-      @logs_buffer_size = 10
+      @logs_buffer_size = 5
       @stats_buffer_size = 5
       @containers_cache_size = 50
       @db_session = ContainerLog.collection.session.with(

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -3,7 +3,6 @@ require_relative 'container_info_mapper'
 
 module Rpc
   class ContainerHandler
-    include Celluloid
     include FixnumHelper
     include Logging
 
@@ -14,9 +13,10 @@ module Rpc
       @grid = grid
       @logs = []
       @stats = []
-      @cached_container = nil
-      @logs_buffer_size = 5
+      @cached_containers = {}
+      @logs_buffer_size = 10
       @stats_buffer_size = 5
+      @containers_cache_size = 50
       @db_session = ContainerLog.collection.session.with(
         write: {
           w: 0, fsync: false, j: false
@@ -28,6 +28,8 @@ module Rpc
     def save(data)
       info_mapper = ContainerInfoMapper.new(@grid)
       info_mapper.from_agent(data)
+
+      {}
     end
 
     # @param [Hash] data
@@ -52,13 +54,9 @@ module Rpc
         }
         if @logs.size >= @logs_buffer_size
           flush_logs
+          gc_cache
         end
       end
-    end
-
-    def flush_logs
-      @db_session[:container_logs].insert(@logs)
-      @logs.clear
     end
 
     # @param [Hash] data
@@ -97,13 +95,9 @@ module Rpc
         }
         if @stats.size >= @stats_buffer_size
           flush_stats
+          gc_cache
         end
       end
-    end
-
-    def flush_stats
-      @db_session[:container_stats].insert(@stats.dup)
-      @stats.clear
     end
 
     # @param [Hash] data
@@ -115,18 +109,36 @@ module Rpc
           container.destroy
         end
       end
+
+      {}
+    end
+
+    def flush_logs
+      @db_session[:container_logs].insert(@logs)
+      @logs.clear
+    end
+
+    def flush_stats
+      @db_session[:container_stats].insert(@stats.dup)
+      @stats.clear
+    end
+
+    def gc_cache
+      if @cached_containers.keys.size > @containers_cache_size
+        (@containers_cache_size / 5).times { @cached_containers.shift }
+      end
     end
 
     # @param [String] id
     # @return [Hash, NilClass]
     def cached_container(id)
-      if @cached_container && @cached_container['container_id'] == id
-        container = @cached_container
+      if @cached_containers[id]
+        container = @cached_containers[id]
       else
         container = @db_session[:containers].find(
             grid_id: @grid.id, container_id: id
           ).limit(1).one
-        @cached_container = container if container
+        @cached_containers[id] = container if container
       end
 
       container

--- a/server/app/services/rpc/node_handler.rb
+++ b/server/app/services/rpc/node_handler.rb
@@ -2,7 +2,6 @@ require_relative 'fixnum_helper'
 
 module Rpc
   class NodeHandler
-    include Celluloid
     include FixnumHelper
 
     def initialize(grid)

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -1,6 +1,5 @@
 module Rpc
   class NodeServicePodHandler
-    include Celluloid
 
     def initialize(grid)
       @grid = grid
@@ -25,7 +24,8 @@ module Rpc
     # @param [Hash] pod
     def set_state(id, pod)
       node = @grid.host_nodes.find_by(node_id: id)
-      return unless node
+      return { error: 'Node not found' } unless node
+
       service_instance = node.grid_service_instances.find_by(
         grid_service_id: pod['service_id'], instance_number: pod['instance_number']
       )
@@ -34,6 +34,9 @@ module Rpc
           state: pod['state'],
           rev: pod['rev']
         )
+        {}
+      else
+        { error: 'Instance not found' }
       end
     end
 

--- a/server/app/services/rpc/node_volume_handler.rb
+++ b/server/app/services/rpc/node_volume_handler.rb
@@ -28,7 +28,7 @@ module Rpc
     # @param [Hash] volume
     def set_state(id, data)
       node = @grid.host_nodes.find_by(node_id: id)
-      return unless node
+      return { error: 'Node not found' } unless node
 
       volume_instance = node.volume_instances.find_by(id: data['volume_instance_id'])
       unless volume_instance
@@ -36,13 +36,18 @@ module Rpc
         if volume_id
           volume = @grid.volumes.find_by(id: volume_id)
           if volume
-            VolumeInstance.create!(host_node: node, volume: volume, name: data['name'])
+            volume_instance = VolumeInstance.create!(host_node: node, volume: volume, name: data['name'])
           else
             warn "Could not find volume with id: #{volume_id}"
           end
         end
       end
-    end
 
+      if volume_instance
+        { }
+      else
+        { error: 'Instance not found' }
+      end
+    end
   end
 end

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -36,6 +36,7 @@ class RpcServer
   end
 
   def process!
+    sleep 0.1 # avoid busy loop block in actor
     @processing = true
     while @processing && data = @queue.pop
       @counter += 1
@@ -114,7 +115,7 @@ class RpcServer
   # @param [Faye::Websocket] ws
   # @param [Object] message
   def send_message(ws, message)
-    EM.next_tick {
+    EM.next_tick { # important to push sending back to EM reactor thread
       ws.send(MessagePack.dump(message.as_json).bytes)
     }
   end

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -36,7 +36,6 @@ class RpcServer
   end
 
   def process!
-    sleep 0.1 # avoid busy loop block in actor
     @processing = true
     while @processing && data = @queue.pop
       @counter += 1

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -39,10 +39,10 @@ class RpcServer
   end
 
   def report_queue
-    #if @queue.size > QUEUE_WARN_LIMIT
+    if @queue.size > QUEUE_WARN_LIMIT
       warn "#{@queue.size} messages in queue"
       info "#{@counter / REPORT_EVERY} requests per second"
-    #end
+    end
     @counter = 0
   end
 

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -13,8 +13,7 @@ class RpcServer
     'node_volumes' => Rpc::NodeVolumeHandler
   }
 
-  QUEUE_WARN_LIMIT = 500
-  REPORT_EVERY = 60
+  finalizer :finalize
 
   class Error < StandardError
     attr_accessor :code, :message, :backtrace
@@ -28,38 +27,26 @@ class RpcServer
 
   attr_reader :handlers
 
+  # @param [SizedQueue] queue
   def initialize(queue)
     @queue = queue
     @handlers = {}
     @counter = 0
     @processing = false
-    every(REPORT_EVERY) {
-      report_queue
-    }
-  end
-
-  def report_queue
-    if @queue.size > QUEUE_WARN_LIMIT
-      warn "#{@queue.size} messages in queue"
-      info "#{@counter / REPORT_EVERY} requests per second"
-    end
-    @counter = 0
   end
 
   def process!
     @processing = true
-    defer {
-      while @processing && data = @queue.pop
-        @counter += 1
-        size = data.size
-        if size == 2
-          handle_notification(data[0], data[1])
-        elsif size == 3
-          handle_request(data[0], data[1], data[2])
-        end
-        Thread.pass
+    while @processing && data = @queue.pop
+      @counter += 1
+      size = data.size
+      if size == 2
+        handle_notification(data[0], data[1])
+      elsif size == 3
+        handle_request(data[0], data[1], data[2])
       end
-    }
+      Thread.pass
+    end
   end
 
   # @param [Faye::Websocket] ws_client
@@ -70,16 +57,16 @@ class RpcServer
     msg_id = message[1]
     handler = message[2].split('/')[1]
     method = message[2].split('/')[2]
-    if actor = handling_actor(grid_id, handler)
+    if instance = handling_instance(grid_id, handler)
       begin
-        result = actor.send(method, *message[3])
+        result = instance.send(method, *message[3])
         send_message(ws_client, [1, msg_id, nil, result])
       rescue RpcServer::Error => exc
         send_message(ws_client, [1, msg_id, {code: exc.code, message: exc.message}, nil])
         @handlers[grid_id].delete(handler)
       rescue => exc
         error "#{exc.class.name}: #{exc.message}"
-        debug exc.backtrace.join("\n") if exc.backtrace
+        debug exc.backtrace.join("\n")
         send_message(ws_client, [1, msg_id, {code: 500, message: "#{exc.class.name}: #{exc.message}"}, nil])
         @handlers[grid_id].delete(handler)
       end
@@ -94,10 +81,9 @@ class RpcServer
   def handle_notification(grid_id, message)
     handler = message[1].split('/')[1]
     method = message[1].split('/')[2]
-    if actor = handling_actor(grid_id, handler)
+    if instance = handling_instance(grid_id, handler)
       begin
-        debug "rpc notification: #{actor.class.name}##{method} #{message[2]}"
-        actor.send(method, *message[2])
+        instance.send(method, *message[2])
       rescue => exc
         error "#{exc.class.name}: #{exc.message}"
         error exc.backtrace.join("\n")
@@ -110,7 +96,8 @@ class RpcServer
 
   # @param [String] grid_id
   # @param [String] name
-  def handling_actor(grid_id, name)
+  # @return [Object]
+  def handling_instance(grid_id, name)
     return unless HANDLERS[name]
 
     @handlers[grid_id] ||= {}
@@ -130,5 +117,9 @@ class RpcServer
     EM.next_tick {
       ws.send(MessagePack.dump(message.as_json).bytes)
     }
+  end
+
+  def finalize
+    @processing = false
   end
 end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -5,7 +5,7 @@ describe WebsocketBackend, celluloid: true do
   let(:subject) { described_class.new(app) }
 
   before(:all) do
-    EM.run
+    Thread.new { EM.run }
     sleep 0.1 until EM.reactor_running?
   end
 

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -4,11 +4,9 @@ describe WebsocketBackend, celluloid: true do
   let(:app) { spy(:app) }
   let(:subject) { described_class.new(app) }
 
-  around(:each) do |example|
-    EM.run {
-      example.run
-      EM.stop
-    }
+  before(:all) do
+    EM.run
+    sleep 0.1 until EM.reactor_running?
   end
 
   before(:each) do
@@ -17,6 +15,10 @@ describe WebsocketBackend, celluloid: true do
 
   after(:each) do
     subject.stop_rpc_server
+  end
+
+  after(:all) do
+    EM.stop if EM.reactor_running?
   end
 
   describe '#our_version' do

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -15,6 +15,10 @@ describe WebsocketBackend, celluloid: true do
     stub_const('Server::VERSION', '0.9.1')
   end
 
+  after(:each) do
+    subject.stop_rpc_server
+  end
+
   describe '#our_version' do
     it 'retuns baseline version with patch level 0' do
       expect(subject.our_version).to eq('0.9.0')

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -4,6 +4,13 @@ describe WebsocketBackend, celluloid: true do
   let(:app) { spy(:app) }
   let(:subject) { described_class.new(app) }
 
+  around(:each) do |example|
+    EM.run {
+      example.run
+      EM.stop
+    }
+  end
+
   before(:each) do
     stub_const('Server::VERSION', '0.9.1')
   end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -4,9 +4,11 @@ describe WebsocketBackend, celluloid: true do
   let(:app) { spy(:app) }
   let(:subject) { described_class.new(app) }
 
-  before(:all) do
-    Thread.new { EM.run }
-    sleep 0.1 until EM.reactor_running?
+  around(:each) do |example|
+    EM.run {
+      example.run
+      EM.stop
+    }
   end
 
   before(:each) do
@@ -15,10 +17,6 @@ describe WebsocketBackend, celluloid: true do
 
   after(:each) do
     subject.stop_rpc_server
-  end
-
-  after(:all) do
-    EM.stop if EM.reactor_running?
   end
 
   describe '#our_version' do

--- a/server/spec/services/rpc/container_handler_spec.rb
+++ b/server/spec/services/rpc/container_handler_spec.rb
@@ -1,5 +1,4 @@
-
-describe Rpc::ContainerHandler, celluloid: true do
+describe Rpc::ContainerHandler do
   let(:grid) { Grid.create! }
   let(:subject) { described_class.new(grid) }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }

--- a/server/spec/services/rpc/node_handler_spec.rb
+++ b/server/spec/services/rpc/node_handler_spec.rb
@@ -1,5 +1,4 @@
-
-describe Rpc::NodeHandler, celluloid: true do
+describe Rpc::NodeHandler do
   let(:grid) { Grid.create! }
   let(:subject) { described_class.new(grid) }
   let(:node) do

--- a/server/spec/services/rpc_server_spec.rb
+++ b/server/spec/services/rpc_server_spec.rb
@@ -12,6 +12,9 @@ describe RpcServer, celluloid: true do
     end
   end
 
+  let(:queue) { SizedQueue.new(800) }
+  let(:subject) { described_class.new(queue) }
+
   let(:grid) { Grid.create!(name: 'test') }
 
   let(:ws_client) do

--- a/server/spec/services/rpc_server_spec.rb
+++ b/server/spec/services/rpc_server_spec.rb
@@ -26,7 +26,7 @@ describe RpcServer, celluloid: true do
   end
 
   describe '#handle_request' do
-    before(:each) { allow(ws_client).to receive(:send) }
+    before(:each) { allow(subject.wrapped_object).to receive(:send_message) }
 
     it 'calls handler and sends response back to ws_client' do
       expect(subject.wrapped_object).to receive(:send_message).with(ws_client, [1, 99, nil, {msg: 'hello world'}])


### PR DESCRIPTION
1.2.0.dev had performance regression in RpcServer message handling. This PR should fix this problem and bring rpc performance to at least same level as in 1.1.x.

Improvements:
- requests are prioritized over notifications
- if queue is full notifications are discarded
- agent sends all priority messages as requests
- `Rpc::ContainerHandler` has much better container caching -> should improve performance a lot

Fixes:
- fix EM threading issue in `RpcServer#send_message`