### PR TITLE
Remove duplication of some error messages

### DIFF
--- a/cli/lib/kontena/callback.rb
+++ b/cli/lib/kontena/callback.rb
@@ -9,7 +9,7 @@ class Kontena::Callback
   # Register callback for command types it is supposed to run with.
   def self.matches_commands(*commands)
     cmd_types = {}
-    
+
     commands.each do |cmd|
       cmd_class, cmd_type = cmd.split(' ', 2)
 
@@ -44,7 +44,7 @@ class Kontena::Callback
           if klass.instance_methods.include?(state)
             cb = klass.new(obj)
             if cb.send(state).kind_of?(FalseClass)
-              ENV["DEBUG"] && STDERR.puts("Execution aborted by #{klass}")
+              ENV["DEBUG"] && $stderr.puts("Execution aborted by #{klass}")
               exit 1
             end
           end

--- a/cli/lib/kontena/callbacks/master/01_clear_current_master_after_terminate.rb
+++ b/cli/lib/kontena/callbacks/master/01_clear_current_master_after_terminate.rb
@@ -10,7 +10,7 @@ module Kontena
         return unless command.exit_code == 0
         return unless config.current_master
 
-        ENV["DEBUG"] && STDERR.puts("Removing current master from config")
+        ENV["DEBUG"] && $stderr.puts("Removing current master from config")
         config.servers.delete_at(config.find_server_index(config.current_master.name))
         config.current_server = nil
         config.write

--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -8,8 +8,8 @@ module Kontena
       matches_commands 'master create'
 
       def after
-        ENV["DEBUG"] && STDERR.puts("Command result: #{command.result.inspect}")
-        ENV["DEBUG"] && STDERR.puts("Command exit code: #{command.exit_code.inspect}")
+        ENV["DEBUG"] && $stderr.puts("Command result: #{command.result.inspect}")
+        ENV["DEBUG"] && $stderr.puts("Command exit code: #{command.exit_code.inspect}")
         return unless command.exit_code == 0
         return unless command.result.kind_of?(Hash)
         return unless command.result.has_key?(:public_ip)
@@ -35,11 +35,11 @@ module Kontena
 
         # Figure out if HTTPS works, if not, try HTTP
         begin
-          ENV["DEBUG"] && STDERR.puts("Trying to request / from #{new_master.url}")
+          ENV["DEBUG"] && $stderr.puts("Trying to request / from #{new_master.url}")
           client = Kontena::Client.new(new_master.url, nil, ignore_ssl_errors: true)
           client.get('/')
-        rescue
-          ENV["DEBUG"] && STDERR.puts("HTTPS test failed: #{$!} #{$!.message}")
+        rescue => ex
+          ENV["DEBUG"] && $stderr.puts("HTTPS test failed: #{ex.class.name} #{ex.message}")
           unless retried
             new_master.url = "http://#{command.result[:public_ip]}"
             retried = true
@@ -51,7 +51,7 @@ module Kontena
         require 'shellwords'
         cmd = "master login --no-login-info --skip-grid-auto-select --verbose --name #{command.result[:name].shellescape} --code #{command.result[:code].shellescape} #{new_master.url.shellescape}"
         Retriable.retriable do
-          ENV["DEBUG"] && STDERR.puts("Running: #{cmd}")
+          ENV["DEBUG"] && $stderr.puts("Running: #{cmd}")
           Kontena.run(cmd)
         end
       end

--- a/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
@@ -12,7 +12,7 @@ module Kontena
         return unless config.current_master.name == command.result[:name]
 
         cmd = "grid create --silent test"
-        ENV["DEBUG"] && STDERR.puts("Running: #{cmd}")
+        ENV["DEBUG"] && $stderr.puts("Running: #{cmd}")
         Retriable.retriable do
           Kontena.run(cmd)
         end

--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -39,7 +39,7 @@ module Kontena
         end
 
         return nil unless invite_response
-        ENV["DEBUG"] && STDERR.puts("Got invite code: #{invite_response['invite_code']}")
+        ENV["DEBUG"] && $stderr.puts("Got invite code: #{invite_response['invite_code']}")
 
         role_status = nil
 

--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -108,15 +108,15 @@ module Kontena::Cli::Apps
     def display_notifications(messages, color = :yellow)
       messages.each do |files|
         files.each do |file, services|
-          STDERR.puts "#{file}:".colorize(color)
+          $stderr.puts "#{file}:".colorize(color)
           services.each do |service|
             service.each do |name, errors|
-              STDERR.puts "  #{name}:".colorize(color)
+              $stderr.puts "  #{name}:".colorize(color)
               if errors.is_a?(String)
-                STDERR.puts "    - #{errors}".colorize(color)
+                $stderr.puts "    - #{errors}".colorize(color)
               else
                 errors.each do |key, error|
-                  STDERR.puts "    - #{key}: #{error.to_json}".colorize(color)
+                  $stderr.puts "    - #{key}: #{error.to_json}".colorize(color)
                 end
               end
             end
@@ -126,12 +126,12 @@ module Kontena::Cli::Apps
     end
 
     def hint_on_validation_notifications(errors)
-      STDERR.puts "YAML contains the following unsupported options and they were rejected:".colorize(:yellow)
+      $stderr.puts "YAML contains the following unsupported options and they were rejected:".colorize(:yellow)
       display_notifications(errors)
     end
 
     def abort_on_validation_errors(errors)
-      STDERR.puts "YAML validation failed! Aborting.".colorize(:red)
+      $stderr.puts "YAML validation failed! Aborting.".colorize(:red)
       display_notifications(errors, :red)
       abort
     end

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -53,8 +53,8 @@ module Kontena::Cli::Apps
         replace_dollar_dollars(content)
         begin
           @yaml = ::YAML.safe_load(content)
-        rescue Psych::SyntaxError => e
-          raise "Error while parsing #{file}".colorize(:red)+ " "+e.message
+        rescue Psych::SyntaxError => ex
+          raise ex.class, "Error while parsing #{file} : #{ex.message}"
         end
       end
 

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -52,10 +52,10 @@ module Kontena::Cli::Cloud
 
     def web_flow
       if Kontena.browserless? && !force?
-        STDERR.puts "Your current environment does not seem to support opening a local graphical WWW browser."
-        STDERR.puts
-        STDERR.puts "You can perorm a login on another computer, copy the token and use it with 'kontena cloud login --token <token>'."
-        STDERR.puts "There will be an easier way to log in from a browserless environment soon."
+        $stderr.puts "Your current environment does not seem to support opening a local graphical WWW browser."
+        $stderr.puts
+        $stderr.puts "You can perorm a login on another computer, copy the token and use it with 'kontena cloud login --token <token>'."
+        $stderr.puts "There will be an easier way to log in from a browserless environment soon."
         exit_with_error 'Unable to launch a web browser'
       end
 

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -12,7 +12,7 @@ module Kontena
 
       def logger
         return @logger if @logger
-        @logger = Logger.new(ENV["DEBUG"] ? STDERR : STDOUT)
+        @logger = Logger.new(ENV["DEBUG"] ? $stderr : $stdout)
         @logger.level = ENV["DEBUG"].nil? ? Logger::INFO : Logger::DEBUG
         @logger.progname = 'COMMON'
         @logger
@@ -131,8 +131,8 @@ module Kontena
         client = Kontena::Client.new(server.url, server.token)
         logger.debug "Trying to invalidate refresh token on #{server.name}"
         client.refresh_token
-      rescue
-        logger.debug "Refreshing failed: #{$!} : #{$!.message}"
+      rescue => ex
+        logger.debug "Refreshing failed: #{ex.class.name} : #{ex.message}"
       end
 
       def require_current_master
@@ -289,7 +289,7 @@ module Kontena
         msg = "Press any key to continue or ctrl-c to cancel.. (Automatically continuing in ? seconds)"
 
         reader_thread = Thread.new do
-          Thread.main['any_key.char'] = STDIN.getch
+          Thread.main['any_key.char'] = $stdin.getch
         end
 
         countdown_thread = Thread.new do
@@ -316,7 +316,7 @@ module Kontena
         return any_key_to_continue_with_timeout(timeout) if timeout
         msg = "Press any key to continue or ctrl-c to cancel.. "
         print pastel.bright_cyan("#{msg}")
-        char = STDIN.getch
+        char = $stdin.getch
         print "\r#{' ' * msg.length}\r"
         if char == "\u0003"
           error "Canceled"

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -26,7 +26,7 @@ module Kontena
 
       def initialize
         super
-        @logger = Logger.new(ENV["DEBUG"] ? STDERR : STDOUT)
+        @logger = Logger.new(ENV["DEBUG"] ? $stderr : $stdout)
         @logger.level = ENV["DEBUG"].nil? ? Logger::INFO : Logger::DEBUG
         @logger.progname = 'CONFIG'
         load_settings_from_env || load_settings_from_config_file
@@ -41,7 +41,7 @@ module Kontena
         return nil unless ENV['KONTENA_URL']
         logger.debug 'Loading configuration from ENV'
         servers << Server.new(
-          url: ENV['KONTENA_URL'], 
+          url: ENV['KONTENA_URL'],
           name: 'default',
           token: Token.new(access_token: ENV['KONTENA_TOKEN'], parent_type: :master, parent_name: 'default'),
           grid: ENV['KONTENA_GRID'],
@@ -172,7 +172,7 @@ module Kontena
         logger.debug "Migrating from legacy style configuration"
         {
           'current_server' => 'default',
-          'servers' => [ 
+          'servers' => [
             settings['server'].merge(
               'name' => 'default',
               'account' => 'kontena'
@@ -303,7 +303,7 @@ module Kontena
       def require_current_master_token
         require_current_master
         token = current_master.token
-        if token && token.access_token 
+        if token && token.access_token
           return token unless token.expired?
           raise TokenExpiredError, "The access token has expired and needs to be refreshed."
         end
@@ -364,7 +364,7 @@ module Kontena
         raise ArgumentError, "You have not selected a grid. Use: kontena grid"
       end
 
-      # Name of the currently selected grid. Can override using 
+      # Name of the currently selected grid. Can override using
       # KONTENA_GRID environment variable.
       #
       # @return [String, NilClass]
@@ -433,7 +433,7 @@ module Kontena
         JSON.pretty_generate(to_hash)
       end
 
-      # Write the current configuration to config file. 
+      # Write the current configuration to config file.
       # Does nothing if using settings from environment variables.
       def write
         return nil if ENV['KONTENA_URL']
@@ -518,7 +518,7 @@ module Kontena
         def account
           return @account if @account
           return config.find_account('master') unless parent
-          @account = 
+          @account =
             case parent_type
             when :master then config.find_account(parent.account)
             when :account then parent

--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Containers
       result = client(token).post("containers/#{current_grid}/#{container_id}/exec", payload)
 
       puts result[0].join(" ") unless result[0].size == 0
-      STDERR.puts result[1].join(" ") unless result[1].size == 0
+      $stderr.puts result[1].join(" ") unless result[1].size == 0
       exit result[2]
     end
   end

--- a/cli/lib/kontena/cli/localhost_web_server.rb
+++ b/cli/lib/kontena/cli/localhost_web_server.rb
@@ -39,7 +39,7 @@ module Kontena
     #
     # @return [Hash] query_params
     def serve_one
-      ENV["DEBUG"] && STDERR.puts("Waiting for connection on port #{port}..")
+      ENV["DEBUG"] && $stderr.puts("Waiting for connection on port #{port}..")
       socket = server.accept
 
       content = socket.recvfrom(2048).first.split(/(?:\r)?\n/)
@@ -56,7 +56,7 @@ module Kontena
 
       body = content.join("\n")
 
-      ENV["DEBUG"] && STDERR.puts("Got request: \"#{request.inspect}\n  Headers: #{headers.inspect}\n  Body: #{body}\"")
+      ENV["DEBUG"] && $stderr.puts("Got request: \"#{request.inspect}\n  Headers: #{headers.inspect}\n  Body: #{body}\"")
 
       get_request = request[/GET (\/cb.+?) HTTP/, 1]
       if get_request
@@ -82,7 +82,7 @@ module Kontena
         socket.close
         server.close
         uri = URI.parse("http://localhost#{get_request}")
-        ENV["DEBUG"] && STDERR.puts("  * Parsing params: \"#{uri.query}\"")
+        ENV["DEBUG"] && $stderr.puts("  * Parsing params: \"#{uri.query}\"")
         params = {}
         URI.decode_www_form(uri.query).each do |key, value|
           if value.to_s == ''

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -41,9 +41,9 @@ module Kontena::Cli::Master::User
           roles.each do |role|
             Kontena.run("master users role add #{role.shellescape} #{email.shellescape}")
           end
-        rescue
-          STDERR.puts "Failed to invite #{email}".colorize(:red)
-          ENV["DEBUG"] && STDERR.puts("#{$!} - #{$!.message} -- #{$!.backtrace}")
+        rescue => ex
+          $stderr.puts pastel.red("Failed to invite #{email}")
+          ENV["DEBUG"] && $stderr.puts("#{ex} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
         end
       end
     end

--- a/cli/lib/kontena/cli/master/user/remove_command.rb
+++ b/cli/lib/kontena/cli/master/user/remove_command.rb
@@ -15,9 +15,8 @@ module Kontena::Cli::Master::User
       email_list.each do |email|
         begin
           client(token).delete("users/#{email}")
-        rescue => exc
-          STDERR.puts "Failed to remove user #{email}".colorize(:red)
-          STDERR.puts exc.message
+        rescue => ex
+          $stderr.puts pastel.red("Failed to remove user #{email} : #{ex.message}")
         end
       end
     end

--- a/cli/lib/kontena/cli/master/user/role/add_command.rb
+++ b/cli/lib/kontena/cli/master/user/role/add_command.rb
@@ -19,8 +19,8 @@ module Kontena::Cli::Master::User
           begin
             response = client(token).post("users/#{email}/roles", data)
             puts "Added role #{role} to #{email}" unless running_silent?
-          rescue => exc
-            abort "Failed to add role #{role} to #{email} : #{exc.message}".colorize(:red)
+          rescue => ex
+            abort pastel.red("Failed to add role #{role} to #{email} : #{ex.message}")
           end
         end
       end

--- a/cli/lib/kontena/cli/master/user/role/remove_command.rb
+++ b/cli/lib/kontena/cli/master/user/role/remove_command.rb
@@ -18,9 +18,8 @@ module Kontena::Cli::Master::User::Role
         begin
           response = client(token).delete("users/#{email}/roles/#{role}")
           puts "Removed role #{role} from #{email}" if response
-        rescue => exc
-          puts "Failed to remove role #{role} from #{email}".colorize(:red)
-          puts exc.message
+        rescue => ex
+          $stderr.puts pastel.red("Failed to remove role #{role} from #{email} : #{ex.message}")
         end
       end
     end

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -18,8 +18,8 @@ module Kontena::Cli::Plugins
           begin
             Kontena::PluginManager.instance.upgrade_plugin(name, pre: pre?)
           rescue => ex
-            puts Kontena.pastel.red(ex.message)
-            ENV["DEBUG"] && puts(ex.backtrace.join("\n  "))
+            $stderr.puts pastel.red("#{ex.class.name} : #{ex.message}")
+            ENV["DEBUG"] && $stderr.puts(ex.backtrace.join("\n  "))
             spin.fail!
           end
         end
@@ -32,8 +32,8 @@ module Kontena::Cli::Plugins
           begin
             Kontena::PluginManager.instance.install_plugin(name, pre: pre?, version: version)
           rescue => ex
-            puts Kontena.pastel.red(ex.message)
-            ENV["DEBUG"] && puts(ex.backtrace.join("\n  "))
+            $stderr.puts pastel.red("#{ex.class.name} : #{ex.message}")
+            ENV["DEBUG"] && $stderr.puts(ex.backtrace.join("\n  "))
             spin.fail!
           end
         end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -10,11 +10,12 @@ module Kontena::Cli::Plugins
 
     def execute
       confirm unless forced?
-      spinner "Uninstalling plugin #{name.colorize(:cyan)}" do |spin|
+      spinner "Uninstalling plugin #{pastel.cyan(name)}" do |spin|
         begin
           Kontena::PluginManager.instance.uninstall_plugin(name)
         rescue => ex
-          puts Kontena.pastel.red(ex.message)
+          $stderr.puts pastel.red("#{ex.class.name} : #{ex.message}")
+          ENV["DEBUG"] && $stderr.puts(ex.backtrace.join("\n  "))
           spin.fail
         end
       end

--- a/cli/lib/kontena/cli/spinner.rb
+++ b/cli/lib/kontena/cli/spinner.rb
@@ -69,9 +69,7 @@ module Kontena
           end
         rescue Exception => ex
           Kernel.puts "* #{msg}.. fail"
-          if ENV["DEBUG"]
-            Kernel.puts "#{ex} #{ex.message}\n#{ex.backtrace.join("\n")}"
-          end
+          ENV["DEBUG"] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
           raise ex
         end
         exit(status) if status
@@ -159,14 +157,12 @@ module Kontena
           spin_thread.kill
           Kernel.puts "\r [" + "fail".colorize(:red)   + "] #{msg}     "
           if ENV["DEBUG"]
-            STDERR.puts "Spin aborted through fail!"
+            $stderr.puts "Spin aborted through fail!"
           end
         rescue Exception => ex
           spin_thread.kill
           Kernel.puts "\r [" + "fail".colorize(:red)   + "] #{msg}     "
-          if ENV["DEBUG"]
-            STDERR.puts "#{ex} #{ex.message}\n#{ex.backtrace.join("\n")}"
-          end
+          ENV["DEBUG"] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
           raise ex
         ensure
           unless Thread.main['spinner_msgs'].empty?

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -133,16 +133,16 @@ module Kontena::Cli::Stacks
     end
 
     def display_notifications(messages, color = :yellow)
-      STDERR.puts(Kontena.pastel.send(color, messages.to_yaml.gsub(/^---$/, '')))
+      $stderr.puts(Kontena.pastel.send(color, messages.to_yaml.gsub(/^---$/, '')))
     end
 
     def hint_on_validation_notifications(errors)
-      STDERR.puts "YAML contains the following unsupported options and they were rejected:".colorize(:yellow)
+      $stderr.puts "YAML contains the following unsupported options and they were rejected:".colorize(:yellow)
       display_notifications(errors)
     end
 
     def abort_on_validation_errors(errors)
-      STDERR.puts "YAML validation failed! Aborting.".colorize(:red)
+      $stderr.puts "YAML validation failed! Aborting.".colorize(:red)
       display_notifications(errors, :red)
       abort
     end

--- a/cli/lib/kontena/cli/stacks/yaml/opto/vault_setter.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/vault_setter.rb
@@ -3,7 +3,6 @@ module Kontena::Cli::Stacks
     class Opto::Setters::Vault < ::Opto::Setter
       def set(value)
         require 'shellwords'
-        ENV["DEBUG"] && STDERR.puts("Setting to vault: #{hint}")
         Kontena.run("vault write --silent #{hint} #{value.to_s.shellescape}")
       end
     end

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -74,8 +74,8 @@ module Kontena::Cli::Stacks
             )
           )
         )
-      rescue Psych::SyntaxError => e
-        raise "Error while parsing #{file}".colorize(:red)+ " " + e.message
+      rescue Psych::SyntaxError => ex
+        raise ex, "Error while parsing #{file} : #{ex.message}"
       end
 
       def fully_interpolated_yaml
@@ -93,8 +93,8 @@ module Kontena::Cli::Stacks
             )
           )
         )
-      rescue Psych::SyntaxError => e
-        raise "Error while parsing #{file}".colorize(:red)+ " " + e.message
+      rescue Psych::SyntaxError => ex
+        raise ex, "Error while parsing #{file} : #{ex.message}"
       end
 
       def raw_yaml

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -47,7 +47,7 @@ module Kontena
       uri = URI.parse(@api_url)
       @host = uri.host
 
-      @logger = Logger.new(ENV["DEBUG"] ? STDERR : STDOUT)
+      @logger = Logger.new(ENV["DEBUG"] ? $stderr : $stdout)
       @logger.level = ENV["DEBUG"].nil? ? Logger::INFO : Logger::DEBUG
       @logger.progname = 'CLIENT'
 
@@ -139,8 +139,8 @@ module Kontena
       logger.debug "Requesting user info from #{final_path}"
       request(path: final_path)
       true
-    rescue
-      logger.debug "Authentication verification exception: #{$!} #{$!.message} #{$!.backtrace}"
+    rescue => ex
+      logger.debug "Authentication verification exception: #{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}"
       false
     end
 
@@ -172,8 +172,8 @@ module Kontena
     # @return [String] version_string
     def server_version
       request(auth: false, expects: 200)['version']
-    rescue
-      logger.debug "Server version exception: #{$!} #{$!.message}"
+    rescue => ex
+      logger.debug "Server version exception: #{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}"
       nil
     end
 
@@ -369,8 +369,8 @@ module Kontena
       else
         {}
       end
-    rescue
-      logger.debug "Access token refresh exception: #{$!} - #{$!.message} #{$!.backtrace}"
+    rescue => ex
+      logger.debug "Access token refresh exception: #{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}"
       false
     end
 
@@ -418,8 +418,8 @@ module Kontena
         logger.debug "Got null or bad response to refresh request: #{last_response.inspect}"
         false
       end
-    rescue
-      logger.debug "Access token refresh exception: #{$!} - #{$!.message} #{$!.backtrace}"
+    rescue => ex
+      logger.debug "Access token refresh exception: #{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}"
       false
     end
 
@@ -509,8 +509,8 @@ module Kontena
     # @return [Hash,Object,NilClass]
     def parse_json(json)
       JSON.parse(json)
-    rescue
-      logger.debug "JSON parse exception: #{$!} : #{$!.message}"
+    rescue => ex
+      logger.debug "JSON parse exception: #{ex.class.name} : #{ex.message}"
       nil
     end
 

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -171,23 +171,21 @@ module Kontena
                 plugins << spec
               else
                 plugin_name = spec.name.sub('kontena-plugin-', '')
-                STDERR.puts " [#{Kontena.pastel.red('error')}] Plugin #{Kontena.pastel.cyan(plugin_name)} (#{spec.version}) is not compatible with the current cli version."
-                STDERR.puts "         To update the plugin, run 'kontena plugin install #{plugin_name}'"
+                $stderr.puts " [#{Kontena.pastel.red('error')}] Plugin #{Kontena.pastel.cyan(plugin_name)} (#{spec.version}) is not compatible with the current cli version."
+                $stderr.puts "         To update the plugin, run 'kontena plugin install #{plugin_name}'"
               end
-            rescue LoadError => exc
-              STDERR.puts " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}"
-              if ENV['DEBUG']
-                STDERR.puts exc.message
-                STDERR.puts exc.backtrace.join("\n")
-              end
+            rescue LoadError => ex
+              $stderr.puts " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}"
+              ENV['DEBUG'] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
               exit 1
             end
           end
         end
       end
       plugins
-    rescue => exc
-      STDERR.puts exc.message
+    rescue => ex
+      $stderr.puts Kontena.pastel.red(ex.message)
+      ENV['DEBUG'] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
     end
 
     def prefix(plugin_name)

--- a/cli/lib/kontena/stacks_cache.rb
+++ b/cli/lib/kontena/stacks_cache.rb
@@ -69,7 +69,7 @@ module Kontena
       end
 
       def dputs(msg)
-        ENV["DEBUG"] && STDERR.puts(msg)
+        ENV["DEBUG"] && $stderr.puts(msg)
       end
 
       def cache(stack, version = nil)

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -19,11 +19,11 @@ module Kontena
     ENV["DEBUG"] && puts("Command completed, result: #{result.inspect} status: 0")
     return 0 if returning == :status
     return result if returning == :result
-  rescue SystemExit
-    ENV["DEBUG"] && STDERR.puts("Command completed with failure, result: #{result.inspect} status: #{$!.status}")
+  rescue SystemExit => ex
+    ENV["DEBUG"] && $stderr.puts("Command completed with failure, result: #{result.inspect} status: #{ex.status}")
     returning == :status ? $!.status : nil
-  rescue
-    ENV["DEBUG"] && STDERR.puts("Command raised #{$!} with message: #{$!.message}\n  #{$!.backtrace.join("  \n")}")
+  rescue => ex
+    ENV["DEBUG"] && $stderr.puts("Command raised #{ex} with message: #{ex.message}\n#{ex.backtrace.join("\n  ")}")
     returning == :status ? 1 : nil
   end
 
@@ -95,7 +95,7 @@ require 'retriable'
 Retriable.configure do |c|
   c.on_retry = Proc.new do |exception, try, elapsed_time, next_interval|
     return true unless ENV["DEBUG"]
-    puts "Retriable retry: #{try} - Exception: #{exception} - #{exception.message}. Elapsed: #{elapsed_time} Next interval: #{next_interval}"
+    puts "Retriable retry: #{try} - Exception: #{exception.class.name} - #{exception.message}. Elapsed: #{elapsed_time} Next interval: #{next_interval}"
   end
 end
 

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -51,10 +51,12 @@ RSpec.configure do |config|
 
   config.before(:each) do
     $stdout = StringIO.new
+    $stderr = StringIO.new
   end
 
   config.after(:each) do
     $stdout = STDOUT
+    $stderr = STDERR
   end
 end
 


### PR DESCRIPTION
Fixes #1812

Replaces all 

`#{$!} : #{$!.message}` which outputs "Not Found : Not Found"
with 
`#{ex.class.name} : #{ex.message}` which outputs "HTTPStatusError : Not Found"

And changes all STDOUT/STDERR to $stdout/$stderr while at it.
