### PR TITLE
Make stack validate not connect to master unless asked

### DIFF
--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -14,10 +14,15 @@ module Kontena::Cli::Stacks
     include Common::StackValuesToOption
     include Common::StackValuesFromOption
 
-    requires_current_master # the stack may use a vault resolver
-    requires_current_master_token
+    option '--online', :flag, "Enable connections to current master", default: false
 
     def execute
+      unless online?
+        config.current_master = nil
+        values ||= {}
+        values.merge!('GRID' => 'validate')
+      end
+
       reader = reader_from_yaml(filename, name: name, values: values)
       outcome = reader.execute
       hint_on_validation_notifications(outcome[:notifications]) unless outcome[:notifications].empty?

--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
@@ -2,6 +2,7 @@ module Kontena::Cli::Stacks
   module YAML
     class Opto::Resolvers::ServiceInstances < ::Opto::Resolver
       def resolve
+        return nil unless current_master && current_grid
         read_command = Kontena::Cli::Stacks::ShowCommand.new([self.stack])
         stack = read_command.fetch_stack(self.stack)
         service = stack['services'].find { |s| s['name'] == hint }

--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_link_resolver.rb
@@ -3,6 +3,7 @@ module Kontena::Cli::Stacks::YAML::Opto::Resolvers
     include Kontena::Cli::Common
 
     def resolve
+      return nil unless current_master && current_grid
       message = hint['prompt']
       name_filter = hint['name']
       image_filter = hint['image']

--- a/cli/lib/kontena/cli/stacks/yaml/opto/vault_cert_prompt_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/vault_cert_prompt_resolver.rb
@@ -3,6 +3,7 @@ module Kontena::Cli::Stacks::YAML::Opto::Resolvers
     include Kontena::Cli::Common
 
     def resolve
+      return nil unless current_master && current_grid
       message = hint || 'Select SSL certs'
       secrets = get_secrets.select{ |s|
         s['name'].match(/(ssl|cert)/i)

--- a/cli/lib/kontena/cli/stacks/yaml/opto/vault_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/vault_resolver.rb
@@ -1,10 +1,12 @@
 module Kontena::Cli::Stacks
   module YAML
     class Opto::Resolvers::Vault < ::Opto::Resolver
+      include Kontena::Cli::Common
       def resolve
         raise RuntimeError, "Missing or empty vault secret name" if hint.to_s.empty?
-        require 'shellwords'
-        Kontena.run("vault read --return #{hint.shellescape}", returning: :result)
+        if current_master && current_grid
+          client.get("secrets/#{current_grid}/#{hint}")['value'] rescue nil
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/stacks/yaml/opto/vault_setter.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/vault_setter.rb
@@ -1,10 +1,11 @@
 module Kontena::Cli::Stacks
   module YAML
     class Opto::Setters::Vault < ::Opto::Setter
+      include Kontena::Cli::Common
       def set(value)
-        require 'shellwords'
-        ENV["DEBUG"] && STDERR.puts("Setting to vault: #{hint}")
-        Kontena.run("vault write --silent #{hint} #{value.to_s.shellescape}")
+        if current_master && current_grid
+          client.put("secrets/#{current_grid}/#{hint}", {name: hint, value: value, upsert: true})
+        end
       end
     end
   end

--- a/cli/spec/kontena/cli/stacks/yaml/opto/service_link_resolver_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/opto/service_link_resolver_spec.rb
@@ -6,6 +6,11 @@ describe Kontena::Cli::Stacks::YAML::Opto::Resolvers::ServiceLink do
     described_class.new({'prompt' => 'foo'})
   end
 
+  before(:each) do
+    allow(subject).to receive(:current_master).and_return("foo")
+    allow(subject).to receive(:current_grid).and_return("foo")
+  end
+
   describe '#resolve' do
     it 'returns nil if no matching services' do
       expect(subject).to receive(:get_services).and_return([])

--- a/cli/spec/kontena/cli/stacks/yaml/opto/vault_cert_prompt_resolver_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/opto/vault_cert_prompt_resolver_spec.rb
@@ -2,6 +2,12 @@ require 'opto'
 require 'kontena/cli/stacks/yaml/opto/vault_cert_prompt_resolver'
 
 describe Kontena::Cli::Stacks::YAML::Opto::Resolvers::VaultCertPrompt do
+
+  before(:each) do
+    allow(subject).to receive(:current_master).and_return("foo")
+    allow(subject).to receive(:current_grid).and_return("foo")
+  end
+
   describe '#resolve' do
     it 'returns nil if no matching secrets' do
       expect(subject).to receive(:get_secrets).and_return([])


### PR DESCRIPTION
Also make the resolvers/setters use direct api calls instead of `Kontena.run`.

Fixes #2059
Fixes #1886

