### PR TITLE
Send both legacy & new driver information from a node

### DIFF
--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -123,7 +123,11 @@ module Kontena::Workers
 
     # @return [Array<Hash>]
     def plugins
-      JSON.parse(Docker.connection.get('/plugins'))
+      if docker_api_version >= 1.26
+        JSON.parse(Docker.connection.get('/plugins'))
+      else
+        []
+      end
     rescue => exc
       warn "cannot fetch docker engine plugins: #{exc.message}"
       []
@@ -386,6 +390,16 @@ module Kontena::Workers
     # @return [Hash]
     def docker_info
       @docker_info ||= Docker.info
+    end
+
+    # @return [Hash]
+    def docker_version
+      @docker_version ||= Docker.version
+    end
+
+    # @return [Float]
+    def docker_api_version
+      docker_version["ApiVersion"].to_f
     end
   end
 end

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -95,7 +95,8 @@ module Kontena::Workers
       plugins.each do |plugin|
         config = plugin['Config']
         if config.dig('Interface', 'Types').include?('docker.volumedriver/1.0')
-          drivers << { name: plugin['Name'] } if plugin['Enabled']
+          name, version = plugin['Name'].split(':')
+          drivers << { name: name, version: version } if plugin['Enabled']
         end
       end
       docker_info.dig('Plugins', 'Volume').to_a.each do |plugin|
@@ -111,7 +112,8 @@ module Kontena::Workers
       plugins.each do |plugin|
         config = plugin['Config']
         if config.dig('Interface', 'Types').include?('docker.networkdriver/1.0')
-          drivers << { name: plugin['Name'] } if plugin['Enabled']
+          name, version = plugin['Name'].split(':')
+          drivers << { name: name, version: version } if plugin['Enabled']
         end
       end
       docker_info.dig('Plugins', 'Network').to_a.each do |plugin|

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -76,12 +76,57 @@ module Kontena::Workers
 
     def publish_node_info
       debug 'publishing node information'
-      docker_info['PublicIp'] = self.public_ip
-      docker_info['PrivateIp'] = self.private_ip
-      docker_info['AgentVersion'] = Kontena::Agent::VERSION
-      rpc_client.async.request('/nodes/update', [docker_info])
+      node_info = docker_info.dup
+      node_info['PublicIp'] = self.public_ip
+      node_info['PrivateIp'] = self.private_ip
+      node_info['AgentVersion'] = Kontena::Agent::VERSION
+      node_info['Plugins'] = {
+        'Volume' => volume_drivers,
+        'Network' => network_drivers
+      }
+      rpc_client.async.request('/nodes/update', [node_info])
     rescue => exc
       error "publish_node_info: #{exc.message}"
+    end
+
+    # @return [Array<Hash>]
+    def volume_drivers
+      drivers = []
+      plugins.each do |plugin|
+        config = plugin['Config']
+        if config.dig('Interface', 'Types').include?('docker.volumedriver/1.0')
+          drivers << { name: plugin['Name'] } if plugin['Enabled']
+        end
+      end
+      docker_info.dig('Plugins', 'Volume').to_a.each do |plugin|
+        drivers << { name: plugin }
+      end
+
+      drivers
+    end
+
+    # @return [Array<Hash>]
+    def network_drivers
+      drivers = []
+      plugins.each do |plugin|
+        config = plugin['Config']
+        if config.dig('Interface', 'Types').include?('docker.networkdriver/1.0')
+          drivers << { name: plugin['Name'] } if plugin['Enabled']
+        end
+      end
+      docker_info.dig('Plugins', 'Network').to_a.each do |plugin|
+        drivers << { name: plugin }
+      end
+
+      drivers
+    end
+
+    # @return [Array<Hash>]
+    def plugins
+      JSON.parse(Docker.connection.get('/plugins'))
+    rescue => exc
+      warn "cannot fetch docker engine plugins: #{exc.message}"
+      []
     end
 
     ##

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -80,7 +80,7 @@ module Kontena::Workers
       node_info['PublicIp'] = self.public_ip
       node_info['PrivateIp'] = self.private_ip
       node_info['AgentVersion'] = Kontena::Agent::VERSION
-      node_info['Plugins'] = {
+      node_info['Drivers'] = {
         'Volume' => volume_drivers,
         'Network' => network_drivers
       }

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -123,7 +123,7 @@ module Kontena::Workers
 
     # @return [Array<Hash>]
     def plugins
-      if docker_api_version >= 1.26
+      if docker_api_version >= 1.25
         JSON.parse(Docker.connection.get('/plugins'))
       else
         []

--- a/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
@@ -19,8 +19,15 @@ describe Kontena::Workers::NodeInfoWorker do
     allow(Docker).to receive(:info).and_return({
       'Name' => 'node-1',
       'Labels' => nil,
-      'ID' => 'U3CZ:W2PA:2BRD:66YG:W5NJ:CI2R:OQSK:FYZS:NMQQ:DIV5:TE6K:R6GS'
+      'ID' => 'U3CZ:W2PA:2BRD:66YG:W5NJ:CI2R:OQSK:FYZS:NMQQ:DIV5:TE6K:R6GS',
+      'Plugins' => {
+        'Network' => ['bridge', 'host'],
+        'Volume' => ['local']
+      }
     })
+    allow(subject.wrapped_object).to receive(:plugins).and_return([
+      { 'Name' => 'foo:latest', 'Enabled' => true, 'Config' => { 'Interface' => { 'Types' => ['docker.volumedriver/1.0']} } }
+    ])
     allow(Net::HTTP).to receive(:get).and_return('8.8.8.8')
     allow(subject.wrapped_object).to receive(:calculate_containers_time).and_return(100)
     allow(rpc_client).to receive(:request)
@@ -123,6 +130,19 @@ describe Kontena::Workers::NodeInfoWorker do
         expect(msg['AgentVersion']).to match(/\d+\.\d+\.\d+/)
       end
       subject.publish_node_info
+    end
+  end
+
+  describe '#network_drivers' do
+    it 'returns array of drivers' do
+      expect(subject.network_drivers).to include(hash_including({name: 'bridge'}))
+    end
+  end
+
+  describe '#volume_drivers' do
+    it 'returns array of drivers' do
+      expect(subject.volume_drivers).to include(hash_including({name: 'local'}))
+      expect(subject.volume_drivers).to include(hash_including({name: 'foo:latest'}))
     end
   end
 

--- a/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
@@ -142,7 +142,7 @@ describe Kontena::Workers::NodeInfoWorker do
   describe '#volume_drivers' do
     it 'returns array of drivers' do
       expect(subject.volume_drivers).to include(hash_including({name: 'local'}))
-      expect(subject.volume_drivers).to include(hash_including({name: 'foo:latest'}))
+      expect(subject.volume_drivers).to include(hash_including({name: 'foo', version: 'latest'}))
     end
   end
 

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -26,7 +26,7 @@ module Kontena::Cli::Nodes
       puts "  kernel: #{node['kernel_version']}"
       puts "  drivers:"
       puts "    storage: #{node['driver']}"
-      puts "    volume: #{node.dig('plugins', 'volume').to_a.map{|v| v['name']}.join(',')}"
+      puts "    volume: #{node['volume_drivers'].to_a.map{|v| v['name']}.join(',')}"
       puts "  initial node: #{node['initial_member'] ? 'yes' : 'no'}"
       puts "  labels:"
       if node['labels']

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -23,8 +23,10 @@ module Kontena::Cli::Nodes
       puts "  private ip: #{node['private_ip']}"
       puts "  overlay ip: #{node['overlay_ip']}"
       puts "  os: #{node['os']}"
-      puts "  driver: #{node['driver']}"
       puts "  kernel: #{node['kernel_version']}"
+      puts "  drivers:"
+      puts "    storage: #{node['driver']}"
+      puts "    volume: #{node.dig('plugins', 'volume').to_a.map{|v| v['name']}.join(',')}"
       puts "  initial node: #{node['initial_member'] ? 'yes' : 'no'}"
       puts "  labels:"
       if node['labels']

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -28,11 +28,11 @@ class HostNode
   field :last_seen_at, type: Time
   field :agent_version, type: String
   field :docker_version, type: String
-  field :plugins, type: Hash, default: {}
-  field :volume_drivers, type: Array, default: []
-  field :network_drivers, type: Array, default: []
 
   attr_accessor :schedule_counter
+
+  embeds_many :volume_drivers, class_name: 'HostNodeDriver'
+  embeds_many :network_drivers, class_name: 'HostNodeDriver'
 
   belongs_to :grid
   has_many :grid_service_instances

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -29,6 +29,8 @@ class HostNode
   field :agent_version, type: String
   field :docker_version, type: String
   field :plugins, type: Hash, default: {}
+  field :volume_drivers, type: Array, default: []
+  field :network_drivers, type: Array, default: []
 
   attr_accessor :schedule_counter
 
@@ -76,10 +78,8 @@ class HostNode
       private_ip: attrs['PrivateIp'],
       agent_version: attrs['AgentVersion'],
       docker_version: attrs['ServerVersion'],
-      plugins: {
-        'volume' => attrs.dig('Plugins', 'Volume') || [],
-        'network' => attrs.dig('Plugins', 'Network') || []
-      }
+      volume_drivers: attrs.dig('Drivers', 'Volume') || [],
+      network_drivers: attrs.dig('Drivers', 'Network') || [],
     }
     if self.name.nil?
       self.name = attrs['Name']

--- a/server/app/models/host_node_driver.rb
+++ b/server/app/models/host_node_driver.rb
@@ -1,0 +1,8 @@
+class HostNodeDriver
+  include Mongoid::Document
+
+  field :name, type: String
+  field :version, type: String
+
+  embedded_in :host_node
+end

--- a/server/app/services/scheduler/filter/volume_plugin.rb
+++ b/server/app/services/scheduler/filter/volume_plugin.rb
@@ -19,7 +19,8 @@ module Scheduler
         }.compact
 
         nodes = nodes.select { |node|
-          (needed_drivers - node.plugins['volume']).empty?
+          volume_plugins = node.plugins['volume'].map { |v| v['name'] }
+          (needed_drivers - volume_plugins).empty?
         }
 
         if nodes.empty?

--- a/server/app/services/scheduler/filter/volume_plugin.rb
+++ b/server/app/services/scheduler/filter/volume_plugin.rb
@@ -19,8 +19,8 @@ module Scheduler
         }.compact
 
         nodes = nodes.select { |node|
-          volume_plugins = node.plugins['volume'].map { |v| v['name'] }
-          (needed_drivers - volume_plugins).empty?
+          volume_drivers = node.volume_drivers.map { |v| v['name'] }
+          (needed_drivers - volume_drivers).empty?
         }
 
         if nodes.empty?

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -7,8 +7,8 @@ json.name node.name
 json.os node.os
 json.engine_root_dir node.docker_root_dir
 json.driver node.driver
-json.network_drivers node.network_drivers
-json.volume_drivers node.volume_drivers
+json.network_drivers node.network_drivers.as_json(only: [:name, :version])
+json.volume_drivers node.volume_drivers.as_json(only: [:name, :version])
 json.kernel_version node.kernel_version
 json.labels node.labels
 json.mem_total node.mem_total

--- a/server/app/views/v1/host_nodes/_host_node.json.jbuilder
+++ b/server/app/views/v1/host_nodes/_host_node.json.jbuilder
@@ -7,10 +7,8 @@ json.name node.name
 json.os node.os
 json.engine_root_dir node.docker_root_dir
 json.driver node.driver
-json.plugins do
-  json.network node.plugins['network'] || []
-  json.volume node.plugins['volume'] || []
-end
+json.network_drivers node.network_drivers
+json.volume_drivers node.volume_drivers
 json.kernel_version node.kernel_version
 json.labels node.labels
 json.mem_total node.mem_total

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -253,8 +253,14 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
 	"kernel_version": "4.7.3-coreos-r2",
 	"driver": "overlay",
 	"plugins": {
-		"network": ["bridge", "host", "null"],
-		"volume": ["local"]
+		"network": [
+			{"name": "bridge"}, 
+			{"name": "host"}, 
+			{"name": "null"}
+		],
+		"volume": [
+			{"name": "local"}
+		]
 	},
 	"cpus": 2,
 	"mem_total": 0.0,

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -252,16 +252,14 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
 	"os": "CoreOS 1185.3.0 (MoreOS)",
 	"kernel_version": "4.7.3-coreos-r2",
 	"driver": "overlay",
-	"plugins": {
-		"network": [
-			{"name": "bridge"}, 
-			{"name": "host"}, 
-			{"name": "null"}
-		],
-		"volume": [
-			{"name": "local"}
-		]
-	},
+	"network_drivers": [
+		{"name": "bridge"}, 
+		{"name": "host"}, 
+		{"name": "null"}
+	],
+	"volume_drivers": [
+		{"name": "local"}
+	],
 	"cpus": 2,
 	"mem_total": 0.0,
 	"mem_limit": 0.0,

--- a/server/spec/models/host_node_driver_spec.rb
+++ b/server/spec/models/host_node_driver_spec.rb
@@ -1,0 +1,5 @@
+
+describe HostNodeDriver do
+  it { should be_embedded_in(:host_node) }
+  it { should have_fields(:name, :version).of_type(String) }
+end

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -10,7 +10,8 @@ describe HostNode do
   it { should have_fields(:labels).of_type(Array) }
   it { should have_fields(:mem_total, :mem_limit).of_type(Integer) }
   it { should have_fields(:last_seen_at).of_type(Time) }
-  it { should have_fields(:plugins).of_type(Hash) }
+  it { should have_fields(:network_drivers).of_type(Array) }
+  it { should have_fields(:volume_drivers).of_type(Array) }
 
   it { should belong_to(:grid) }
   it { should have_many(:grid_service_instances) }

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -130,8 +130,12 @@ describe HostNode do
     end
 
     it 'sets volume plugins' do
-      subject.attributes_from_docker({'Plugins' => {'Volume' => ['local', 'foobar']}})
-      expect(subject.plugins['volume']).to eq(['local', 'foobar'])
+      subject.attributes_from_docker({'Drivers' => {'Volume' => [
+        { 'name' => 'local' }, { 'name' => 'foobar' }
+      ]}})
+      expect(subject.volume_drivers).to eq([
+        { 'name' => 'local' }, { 'name' => 'foobar' }
+      ])
     end
   end
 

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -10,9 +10,9 @@ describe HostNode do
   it { should have_fields(:labels).of_type(Array) }
   it { should have_fields(:mem_total, :mem_limit).of_type(Integer) }
   it { should have_fields(:last_seen_at).of_type(Time) }
-  it { should have_fields(:network_drivers).of_type(Array) }
-  it { should have_fields(:volume_drivers).of_type(Array) }
 
+  it { should embed_many(:volume_drivers) }
+  it { should embed_many(:network_drivers) }
   it { should belong_to(:grid) }
   it { should have_many(:grid_service_instances) }
   it { should have_many(:containers) }
@@ -129,13 +129,13 @@ describe HostNode do
       }.to change{ subject.agent_version }.to('1.2.3')
     end
 
-    it 'sets volume plugins' do
+    it 'sets volume drivers' do
       subject.attributes_from_docker({'Drivers' => {'Volume' => [
-        { 'name' => 'local' }, { 'name' => 'foobar' }
+        { 'name' => 'local' }, { 'name' => 'foobar', 'version' => 'latest' }
       ]}})
-      expect(subject.volume_drivers).to eq([
-        { 'name' => 'local' }, { 'name' => 'foobar' }
-      ])
+      expect(subject.volume_drivers.first.name).to eq('local')
+      expect(subject.volume_drivers.last.name).to eq('foobar')
+      expect(subject.volume_drivers.last.version).to eq('latest')
     end
   end
 

--- a/server/spec/services/scheduler/filter/volume_plugin_spec.rb
+++ b/server/spec/services/scheduler/filter/volume_plugin_spec.rb
@@ -4,9 +4,18 @@ describe Scheduler::Filter::VolumePlugin do
   let(:grid) { Grid.create(name: 'test') }
   let(:nodes) do
     nodes = []
-    nodes << HostNode.create!(grid: grid, node_id: 'node1', name: 'node-1', plugins: {'volume' => ['local', 'foo']})
-    nodes << HostNode.create!(grid: grid, node_id: 'node2', name: 'node-2', plugins: {'volume' => ['foo']})
-    nodes << HostNode.create!(grid: grid, node_id: 'node3', name: 'node-3', plugins: {'volume' => ['local', 'bar']})
+    nodes << HostNode.create!(
+      grid: grid, node_id: 'node1', name: 'node-1',
+      plugins: {'volume' => [{'name' => 'local'}, {'name' => 'foo'}]}
+    )
+    nodes << HostNode.create!(
+      grid: grid, node_id: 'node2', name: 'node-2',
+      plugins: {'volume' => [{'name' => 'foo'}]}
+    )
+    nodes << HostNode.create!(
+      grid: grid, node_id: 'node3', name: 'node-3',
+      plugins: {'volume' => [{'name' => 'local'}, {'name' => 'bar'}]}
+    )
     nodes
   end
 

--- a/server/spec/services/scheduler/filter/volume_plugin_spec.rb
+++ b/server/spec/services/scheduler/filter/volume_plugin_spec.rb
@@ -6,15 +6,15 @@ describe Scheduler::Filter::VolumePlugin do
     nodes = []
     nodes << HostNode.create!(
       grid: grid, node_id: 'node1', name: 'node-1',
-      plugins: {'volume' => [{'name' => 'local'}, {'name' => 'foo'}]}
+      volume_drivers: [{'name' => 'local'}, {'name' => 'foo'}]
     )
     nodes << HostNode.create!(
       grid: grid, node_id: 'node2', name: 'node-2',
-      plugins: {'volume' => [{'name' => 'foo'}]}
+      volume_drivers: [{'name' => 'foo'}]
     )
     nodes << HostNode.create!(
       grid: grid, node_id: 'node3', name: 'node-3',
-      plugins: {'volume' => [{'name' => 'local'}, {'name' => 'bar'}]}
+      volume_drivers: [{'name' => 'local'}, {'name' => 'bar'}]
     )
     nodes
   end


### PR DESCRIPTION
Also adds volume plugin information to `k node show <name>` output.


Example:

```
$ kontena node show core-01
core-01:
  id: YZCH:NO2R:UB3N:5B4M:KEZD:OTEY:NY7A:XFKX:HAHU:BV2R:WCCD:HAGJ
  agent version: 1.2.0.dev
  docker version: 1.13.1
  connected: yes
  last connect: 2017-04-04T10:15:21.818Z
  last seen: 2017-04-04T12:27:58.007Z
  public ip: 82.181.164.219
  private ip: 192.168.66.101
  overlay ip: 10.81.0.1
  os: Container Linux by CoreOS 1367.5.0 (Ladybug)
  kernel: 4.10.4-coreos-r1
  drivers:
    storage: overlay
    volume: rexray/s3fs:latest,local
  initial node: yes
  labels:
  stats:
    cpus: 1
    load: 0.0 0.01 0.0
    memory: 0.4 of 0.97 GB
    filesystem:
      - /var/lib/docker: 2.53 of 15.57 GB
```