### PR TITLE
Fix pod manager to populate service name from docker containers

### DIFF
--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -65,6 +65,7 @@ module Kontena::Workers
         service_pod = Kontena::Models::ServicePod.new(
           'id' => "#{c.service_id}/#{c.instance_number}",
           'service_id' => c.service_id,
+          'service_name' => c.service_name,
           'instance_number' => c.instance_number,
           'desired_state' => 'unknown'
         )

--- a/agent/spec/lib/kontena/workers/service_pod_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_manager_spec.rb
@@ -73,8 +73,8 @@ describe Kontena::Workers::ServicePodManager do
   describe '#populate_workers_from_docker' do
     it 'calls ensure_service_worker for each container' do
       allow(subject.wrapped_object).to receive(:fetch_containers).and_return([
-        double(:a, id: 'a', service_id: 'foo', instance_number: 2),
-        double(:b, id: 'b', service_id: 'bar', instance_number: 1)
+        double(:a, id: 'a', service_id: 'foo', instance_number: 2, service_name: 'foo'),
+        double(:b, id: 'b', service_id: 'bar', instance_number: 1, service_name: 'bar')
       ])
       expect(subject.wrapped_object).to receive(:ensure_service_worker).twice
       subject.populate_workers_from_docker


### PR DESCRIPTION
fixes #2051 

## After:
```
kontena-agent | D, [2017-04-04T14:31:01.305010 #1] DEBUG -- Kontena::Workers::ServicePodWorker: state of spammer-3: unknown
kontena-agent | I, [2017-04-04T14:31:01.310169 #1]  INFO -- Kontena::Workers::ServicePodWorker: desired state is unknown for spammer-3, not doing anything
kontena-agent | D, [2017-04-04T14:31:01.320547 #1] DEBUG -- Kontena::Workers::ServicePodWorker: state of spammer-2: unknown
kontena-agent | I, [2017-04-04T14:31:01.336989 #1]  INFO -- Kontena::Workers::ServicePodWorker: desired state is unknown for spammer-2, not doing anything
kontena-agent | D, [2017-04-04T14:31:01.357521 #1] DEBUG -- Kontena::Workers::ServicePodWorker: state of spammer-1: unknown
kontena-agent | I, [2017-04-04T14:31:01.368522 #1]  INFO -- Kontena::Workers::ServicePodWorker: desired state is unknown for spammer-1, not doing anything
kontena-agent | D, [2017-04-04T14:31:01.400896 #1] DEBUG -- Kontena::Workers::ServicePodWorker: state of redis-1: unknown
kontena-agent | I, [2017-04-04T14:31:01.404991 #1]  INFO -- Kontena::Workers::ServicePodWorker: desired state is unknown for redis-1, not doing anything
```