### PR TITLE
Add missing DuplicateMigrationVersionError

### DIFF
--- a/server/app/services/mongodb/migrator.rb
+++ b/server/app/services/mongodb/migrator.rb
@@ -15,6 +15,12 @@ module Mongodb
       end
     end
 
+    class DuplicateMigrationVersionError < MigratorError
+      def initialize(version)
+        super("Multiple migrations have the version #{version}")
+      end
+    end
+
     class UnknownMigrationVersionError < MigratorError
       def initialize(version)
         super("No migration with version number #{version}")


### PR DESCRIPTION
Fixes  #1126

```
/home/kontena/kontena/kontena/server/app/services/mongodb/migrator.rb:52:in `block in migrations': Multiple migrations have the version 22 (Mongodb::Migrator::DuplicateMigrationVersionError)
	from /home/kontena/kontena/kontena/server/app/services/mongodb/migrator.rb:45:in `each'
	from /home/kontena/kontena/kontena/server/app/services/mongodb/migrator.rb:45:in `migrations'
	from /home/kontena/kontena/kontena/server/app/services/mongodb/migrator.rb:73:in `migrate_without_lock'
	from /home/kontena/kontena/kontena/server/app/services/mongodb/migrator.rb:68:in `block in migrate'
	from /home/kontena/kontena/kontena/server/app/helpers/distributed_locks.rb:7:in `block in with_dlock'
	from /home/kontena/kontena/kontena/server/app/models/distributed_lock.rb:24:in `with_lock'
	from /home/kontena/kontena/kontena/server/app/helpers/distributed_locks.rb:6:in `with_dlock'
	from /home/kontena/kontena/kontena/server/app/services/mongodb/migrator.rb:67:in `migrate'
	from config/puma.rb:10:in `block in _load_from'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/configuration.rb:271:in `block in run_hooks'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/configuration.rb:271:in `each'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/configuration.rb:271:in `run_hooks'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:237:in `worker'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:120:in `block (2 levels) in spawn_workers'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:120:in `fork'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:120:in `block in spawn_workers'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:116:in `times'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:116:in `spawn_workers'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cluster.rb:426:in `run'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/launcher.rb:172:in `run'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/lib/puma/cli.rb:74:in `run'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/puma-3.6.0/bin/puma:10:in `<top (required)>'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/bin/puma:23:in `load'
	from /home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/bin/puma:23:in `<main>'
```