### PR TITLE
Remove volume creation as part of stacks

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -76,11 +76,7 @@ module Kontena::Cli::Stacks::YAML
 
     def volume_schema
       {
-        'secrets' => optional('stacks_valid_secrets'),
-        'scope' => optional(['instance', 'service', 'stack', 'grid']),
-        'driver' => optional('string'),
-        'driver_opts' => optional( -> (value) { value.is_a?(Hash) }),
-        'external' => optional(-> (value) { value.is_a?(TrueClass) || value.is_a?(FalseClass) || (value.is_a?(Hash) && value['name'].is_a?(String)) })
+        'external' => optional(-> (value) { value.is_a?(TrueClass) || (value.is_a?(Hash) && value['name'].is_a?(String)) })
       }
     end
   end

--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -53,15 +53,12 @@ module Stacks
       self.volumes.each do |volume|
         if volume['external']
           volume_name = volume['external'] == true ? volume['name'] : volume.dig('external', 'name')
-          vol = self.grid.volumes.where(name: volume_name, grid: self.grid).first
+          vol = self.grid.volumes.where(name: volume_name).first
           unless vol
             add_error(:volumes, :not_found, "External volume #{volume_name} not found")
           end
         else
-          outcome = Volumes::Create.validate(grid: self.grid, **volume.symbolize_keys)
-          unless outcome.success?
-            handle_volume_outcome_errors(volume['name'], outcome.errors)
-          end
+          add_error(:volumes, :invalid, "Only external volumes supported")
         end
       end
     end

--- a/server/app/mutations/stacks/create.rb
+++ b/server/app/mutations/stacks/create.rb
@@ -48,8 +48,6 @@ module Stacks
         return
       end
 
-      create_volumes(attributes.delete(:volumes))
-
       services = sort_services(attributes.delete(:services))
       attributes[:services] = services
       attributes[:volumes] = self.volumes
@@ -59,20 +57,6 @@ module Stacks
       create_services(stack, services)
 
       stack
-    end
-
-    # @param [Array<Hash>] volumes
-    def create_volumes(volumes)
-      return unless volumes
-      volumes.each do |volume|
-        unless volume[:external]
-          outcome = Volumes::Create.run(grid: self.grid, **volume.symbolize_keys)
-          unless outcome.success?
-            handle_volume_outcome_errors(volume[:name], outcome.errors)
-            return
-          end
-        end
-      end
     end
 
     # @param [Stack] stack

--- a/server/app/mutations/stacks/update.rb
+++ b/server/app/mutations/stacks/update.rb
@@ -60,7 +60,6 @@ module Stacks
         new_rev = latest_rev.dup
         new_rev.revision += 1
         new_rev.save
-        create_new_volumes(self.volumes) if self.volumes
         create_new_services(self.stack_instance, sort_services(self.services))
       end
       self.stack_instance.reload
@@ -82,17 +81,6 @@ module Stacks
         end
       end
     end
-
-    def create_new_volumes(volumes)
-      volumes.each do |volume|
-        existing = self.stack_instance.grid.volumes.find_by(name: volume[:name])
-        unless existing
-          outcome = Volumes::Create.run(grid: self.stack_instance.grid, **volume.symbolize_keys)
-          unless outcome.success?
-            handle_volume_outcome_errors(volume[:name], outcome.errors)
-          end
-        end
-      end
-    end
+    
   end
 end

--- a/server/spec/api/v1/grid_stacks_spec.rb
+++ b/server/spec/api/v1/grid_stacks_spec.rb
@@ -48,8 +48,7 @@ describe '/v1/grids/:grid/stacks', celluloid: true do
       source: '..',
       services: services,
       volumes: [
-        { name: 'vol1', external: { name: 'someVolume'}},
-        { name: 'vol2', scope: 'grid', driver: 'local'}
+        { name: 'vol1', external: { name: 'someVolume'}}
       ]
     }
   end
@@ -85,7 +84,7 @@ describe '/v1/grids/:grid/stacks', celluloid: true do
       expect {
         post "/v1/grids/#{grid.name}/stacks", stack_with_volumes.to_json, request_headers
         expect(response.status).to eq(201)
-      }.to change{ Volume.count }.by(1)
+      }.not_to change{ Volume.count }
     end
 
     it 'fails to create new stack with volumes when external volume does not exist' do

--- a/server/spec/mutations/stacks/create_spec.rb
+++ b/server/spec/mutations/stacks/create_spec.rb
@@ -36,23 +36,6 @@ describe Stacks::Create do
       expect(outcome.result.stack_revisions.count).to eq(1)
     end
 
-    it 'creates stack revision with volumes' do
-      outcome = described_class.new(
-        grid: grid,
-        name: 'stack',
-        stack: 'foo/bar',
-        version: '0.1.0',
-        registry: 'file://',
-        source: '...',
-        variables: {foo: 'bar'},
-        services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
-        volumes: [{name: 'vol1', scope: 'grid', driver: 'local'}]
-      ).run
-      expect(outcome.success?).to be_truthy
-      expect(outcome.result.stack_revisions.count).to eq(1)
-      expect(outcome.result.latest_rev.volumes.count).to eq(1)
-    end
-
     it 'creates stack services' do
       outcome = described_class.new(
         grid: grid,
@@ -318,99 +301,77 @@ describe Stacks::Create do
     end
 
     context 'volumes' do
-      it 'creates volumes' do
-        grid
-        expect {
-          outcome = described_class.new(
-            grid: grid,
-            name: 'stack',
-            stack: 'foo/bar',
-            version: '0.1.0',
-            registry: 'file://',
-            source: '...',
-            variables: {foo: 'bar'},
-            services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
-            volumes: [{name: 'vol1', scope: 'grid', driver: 'local'}]
-          ).run
-          expect(outcome.success?).to be_truthy
-        }.to change{ Volume.count }.by(1)
-      end
-
-      it 'mutation fails to create volumes' do
-        grid
-        expect {
-          outcome = described_class.new(
-            grid: grid,
-            name: 'stack',
-            stack: 'foo/bar',
-            version: '0.1.0',
-            registry: 'file://',
-            source: '...',
-            variables: {foo: 'bar'},
-            services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
-            volumes: [{name: 'vol1', scope: 'grid'}]
-          ).run
-          expect(outcome.success?).to be_falsey
-        }.not_to change{ Stack.count }
-      end
-
       it 'creates stack with external volumes with name' do
         volume = Volume.create(name: 'someVolume', grid: grid, scope: 'node')
-        expect {
-          outcome = described_class.new(
-            grid: grid,
-            name: 'stack',
-            stack: 'foo/bar',
-            version: '0.1.0',
-            registry: 'file://',
-            source: '...',
-            variables: {foo: 'bar'},
-            services: [{name: 'redis', image: 'redis:2.8', stateful: true, volumes: ['vol1:/data'] }],
-            volumes: [{name: 'vol1', external: {name: 'someVolume'}}]
-          ).run
-          expect(outcome.success?).to be_truthy
-          redis = outcome.result.grid_services.first
-          expect(redis.service_volumes.first.volume).to eq(volume)
-        }.to change{ Volume.count }.by(0)
+        outcome = described_class.new(
+          grid: grid,
+          name: 'stack',
+          stack: 'foo/bar',
+          version: '0.1.0',
+          registry: 'file://',
+          source: '...',
+          variables: {foo: 'bar'},
+          services: [{name: 'redis', image: 'redis:2.8', stateful: true, volumes: ['vol1:/data'] }],
+          volumes: [{name: 'vol1', external: {name: 'someVolume'}}]
+        ).run
+        expect(outcome.success?).to be_truthy
+        redis = outcome.result.grid_services.first
+        expect(outcome.result.latest_rev.volumes.size).to eq(1)
+        expect(redis.service_volumes.first.volume).to eq(volume)
       end
     end
 
     it 'creates stack with external volumes with no external name' do
       volume = Volume.create(name: 'someVolume', grid: grid, scope: 'node')
-      expect {
-        outcome = described_class.new(
-          grid: grid,
-          name: 'stack',
-          stack: 'foo/bar',
-          version: '0.1.0',
-          registry: 'file://',
-          source: '...',
-          variables: {foo: 'bar'},
-          services: [{name: 'redis', image: 'redis:2.8', stateful: true, volumes: ['someVolume:/data'] }],
-          volumes: [{name: 'someVolume', external: true}]
-        ).run
-        expect(outcome.success?).to be_truthy
-        redis = outcome.result.grid_services.first
-        expect(redis.service_volumes.first.volume).to eq(volume)
-      }.not_to change{ Volume.count }
+
+      outcome = described_class.new(
+        grid: grid,
+        name: 'stack',
+        stack: 'foo/bar',
+        version: '0.1.0',
+        registry: 'file://',
+        source: '...',
+        variables: {foo: 'bar'},
+        services: [{name: 'redis', image: 'redis:2.8', stateful: true, volumes: ['someVolume:/data'] }],
+        volumes: [{name: 'someVolume', external: true}]
+      ).run
+      expect(outcome.success?).to be_truthy
+      redis = outcome.result.grid_services.first
+      expect(redis.service_volumes.first.volume).to eq(volume)
+
     end
 
-
     it 'fails to create stack when external volume does not exist' do
-      expect {
-        outcome = described_class.new(
-          grid: grid,
-          name: 'stack',
-          stack: 'foo/bar',
-          version: '0.1.0',
-          registry: 'file://',
-          source: '...',
-          variables: {foo: 'bar'},
-          services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
-          volumes: [{name: 'vol1', external: {name: 'foo'}}]
-        ).run
-        expect(outcome.success?).to be_falsey
-      }.not_to change{ Volume.count }
+
+      outcome = described_class.new(
+        grid: grid,
+        name: 'stack',
+        stack: 'foo/bar',
+        version: '0.1.0',
+        registry: 'file://',
+        source: '...',
+        variables: {foo: 'bar'},
+        services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
+        volumes: [{name: 'vol1', external: {name: 'foo'}}]
+      ).run
+      expect(outcome).not_to be_success
+
+    end
+
+    it 'fails to create stack with unsupported volume definition' do
+      outcome = described_class.new(
+        grid: grid,
+        name: 'stack',
+        stack: 'foo/bar',
+        version: '0.1.0',
+        registry: 'file://',
+        source: '...',
+        variables: {foo: 'bar'},
+        services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
+        volumes: [{name: 'vol1', driver: 'foo', scope: 'foobar'}]
+      ).run
+      expect(outcome.success?).to be_falsey
+      
     end
   end
 end

--- a/server/spec/mutations/stacks/update_spec.rb
+++ b/server/spec/mutations/stacks/update_spec.rb
@@ -67,29 +67,6 @@ describe Stacks::Update do
       }.to change{ stack.grid_services.count }.by(1)
     end
 
-    it 'creates new volumes' do
-      services = [
-        {name: 'redis', image: 'redis:3.0', volumes: ['vol:/data']},
-      ]
-      volumes = [
-        {name: 'vol', driver: 'local', scope: 'instance'}
-      ]
-      subject = described_class.new(
-        stack_instance: stack,
-        stack: 'foo/bar',
-        version: '0.1.0',
-        registry: 'file://',
-        source: '...',
-        services: services,
-        volumes: volumes
-      )
-      expect {
-        outcome = subject.run
-        expect(outcome.success?).to be_truthy
-        expect(outcome.result.latest_rev.volumes.size).to eq(1)
-      }.to change { Volume.count }.by (1)
-    end
-
     it 'fails to create new volumes' do
       services = [
         {name: 'redis', image: 'redis:3.0', volumes: ['vol:/data']},

--- a/test/spec/features/volume/stack_volumes.rb
+++ b/test/spec/features/volume/stack_volumes.rb
@@ -10,13 +10,15 @@ describe 'stack volumes' do
     run "kontena volume rm redis-data"
   end
 
-  it 'stack creates volumes' do
+
+  it 'creates stack with reference to external volume' do
+    k = run 'kontena volume create --scope instance --driver local redis-data'
+    expect(k.code).to eq(0)
     with_fixture_dir("stack/volumes") do
       k = run 'kontena stack install redis-simple.yml'
       expect(k.code).to eq(0), k.out
     end
-    k = run 'kontena volume ls'
-    expect(k.out.match(/redis-data/)).to be_truthy
+
     container = find_container('redis.redis-1')
     mount = container_mounts(container).find { |m| m['Name'] =~ /redis-data-1/}
     expect(mount).not_to be_nil
@@ -24,24 +26,20 @@ describe 'stack volumes' do
     expect(mount['Destination']).to eq('/data')
   end
 
-  it 'fails to install stack with missing volume driver' do
+  it 'fails to create stack with reference to non-existing external volume' do
     with_fixture_dir("stack/volumes") do
-      k = run 'kontena stack install missing-driver.yml'
+      k = run 'kontena stack install redis-simple.yml'
+      expect(k.code).not_to eq(0)
+    end
+  end
+
+  it 'fails to install stack with stack scoped volume' do
+    with_fixture_dir("stack/volumes") do
+      k = run 'kontena stack install redis-with-volume.yml'
       expect(k.code).not_to eq(0)
     end
     k = run 'kontena stack show redis'
     expect(k.code).not_to eq(0)
   end
-
-  it 'fails to update stack with missing volume driver' do
-    with_fixture_dir("stack/volumes") do
-      k = run 'kontena stack install redis-simple.yml'
-      expect(k.code).to eq(0), k.out
-    end
-    k = run 'kontena stack upgrade redis missing-driver.yml'
-    expect(k.code).not_to eq(0)
-  end
-
-
 
 end

--- a/test/spec/fixtures/stack/volumes/redis-with-volume.yml
+++ b/test/spec/fixtures/stack/volumes/redis-with-volume.yml
@@ -10,4 +10,5 @@ services:
 
 volumes:
   redis-data:
-    external: true
+    scope: instance
+    driver: local


### PR DESCRIPTION
```
$ k stack install ~/code/stacks/volumes/ext-vols-with-name.yml 
 [fail] Creating stack redis-ext-vol      
 [error] Kontena::Errors::StandardErrorHash : Unprocessable Entity:
	volumes: External volume testVol not found
```

```
$ k stack install ~/code/stacks/volumes/redis-simple.yml 
YAML validation failed! Aborting.

- "/Users/jussi/code/stacks/volumes/redis-simple.yml":
  - volumes:
      redis-data:
        driver: key not expected
        scope: key not expected
        driver_opts: key not expected
```
