### PR TITLE
WaitHelper threshold for logging

### DIFF
--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -1,8 +1,9 @@
 module Kontena::Helpers::WaitHelper
   include Kontena::Logging
 
-  WAIT_TIMEOUT = 300
-  WAIT_INTERVAL = 0.5
+  WAIT_TIMEOUT = 300 # seconds
+  WAIT_INTERVAL = 0.5 # seconds
+  WAIT_THRESHOLD = 1.0 # seconds
 
   def _wait_now
     Time.now.to_f
@@ -12,31 +13,43 @@ module Kontena::Helpers::WaitHelper
   #
   # For a zero timeout, only yields exactly once.
   #
+  # @param message [String] Message for debugging
   # @param timeout [Fixnum] How long to wait
   # @param interval [Fixnum] At what interval is the block yielded
-  # @param message [String] Message for debugging
+  # @param threshold [Fixnum] Log slow waits after threshold
   # @param block [Block] Block to yield
   # @return [Object] Return value from block, or nil
-  def wait_until(message = nil, timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, &block)
+  def wait_until(message = nil, timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, threshold: WAIT_THRESHOLD, &block)
     raise ArgumentError, 'no block given' unless block_given?
 
     wait_start = _wait_now
     wait_until = wait_start + timeout
+    wait_time = 0
+    logging_threshold = threshold / 2
 
     value = nil
 
     loop do
       break if value = yield
-      break if _wait_now >= wait_until
+      break if _wait_now >= wait_until # timeout
 
-      debug "waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start + interval, timeout, message || '???']
+      if wait_time > logging_threshold
+        logging_threshold *= 2
+
+        debug "waiting %.1fs of %.1fs until: %s" % [wait_time + interval, timeout, message || '???']
+      end
+
       sleep interval
+
+      wait_time = _wait_now - wait_start
     end
 
-    if value
-      debug "waited %.1fs until: %s yielded %s" % [_wait_now - wait_start, message || '???', value]
+    if !value
+      warn "timeout after waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start, timeout, message || '???']
+    elsif wait_time > threshold
+      info "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
     else
-      debug "timeout after waiting %.1fs until: %s" % [_wait_now - wait_start, message || '???']
+      debug "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
     end
 
     value

--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -24,7 +24,7 @@ module Kontena::Helpers::WaitHelper
 
     wait_start = _wait_now
     wait_until = wait_start + timeout
-    wait_time = 0
+    wait_time = nil
     logging_threshold = threshold / 2
 
     value = nil
@@ -33,7 +33,7 @@ module Kontena::Helpers::WaitHelper
       break if value = yield
       break if _wait_now >= wait_until # timeout
 
-      if wait_time > logging_threshold
+      if wait_time && wait_time > logging_threshold
         logging_threshold *= 2
 
         debug "waiting %.1fs of %.1fs until: %s" % [wait_time + interval, timeout, message || '???']
@@ -46,9 +46,9 @@ module Kontena::Helpers::WaitHelper
 
     if !value
       warn "timeout after waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start, timeout, message || '???']
-    elsif wait_time > threshold
+    elsif wait_time && wait_time > threshold
       info "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
-    else
+    elsif wait_time
       debug "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
     end
 

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -25,16 +25,25 @@ describe Kontena::Helpers::WaitHelper do
       expect(value).to be_truthy
     end
 
-    it 'sleeps between retries and logs debug' do
-      expect(subject).to receive(:debug).with('waiting 0.5s of 2.0s until: something that is true the second time')
-      expect(subject).to receive(:debug).with('waited 0.5s until: something that is true the second time yielded true')
+    it 'sleeps between retries and logs debug while under threshold' do
+      expect(subject).to receive(:debug).with('waiting 1.4s of 3.0s until: something that takes two seconds')
+      expect(subject).to receive(:debug).with('waited 2.0s of 3.0s until: something that takes two seconds yielded true')
 
-      @loop = 0
-      value = subject.wait_until("something that is true the second time", timeout: 2) { (@loop += 1) > 1 }
+      value = subject.wait_until("something that takes two seconds", timeout: 3, interval: 0.1, threshold: 2.5) { @time_elapsed > 2.0 }
 
       expect(value).to be_truthy
-      expect(@loop).to eq 2
-      expect(@time_elapsed).to eq(0.5)
+      expect(@time_elapsed).to be > 2.0
+    end
+
+    it 'logs info if over threshold' do
+      expect(subject).to receive(:debug).with('waiting 1.5s of 3.0s until: something that takes two seconds')
+      expect(subject).to receive(:debug).with('waiting 2.0s of 3.0s until: something that takes two seconds')
+      expect(subject).to receive(:info).with('waited 2.5s of 3.0s until: something that takes two seconds yielded true')
+
+      value = subject.wait_until("something that takes two seconds", timeout: 3, interval: 0.5, threshold: 1.0) { @time_elapsed > 2.0 }
+
+      expect(value).to be_truthy
+      expect(@time_elapsed).to be > 2.0
     end
 
     it 'sleeps between retries before timing out' do

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -17,8 +17,9 @@ describe Kontena::Helpers::WaitHelper do
   end
 
   describe 'wait' do
-    it 'returns true immediately' do
+    it 'returns true immediately without any logging' do
       expect(subject).not_to receive(:sleep)
+      expect(subject).not_to receive(:debug)
 
       value = subject.wait_until { true }
 

--- a/server/app/helpers/wait_helper.rb
+++ b/server/app/helpers/wait_helper.rb
@@ -1,8 +1,9 @@
 module WaitHelper
   include Logging
 
-  WAIT_TIMEOUT = 300
-  WAIT_INTERVAL = 0.5
+  WAIT_TIMEOUT = 300 # seconds
+  WAIT_INTERVAL = 0.5 # seconds
+  WAIT_THRESHOLD = 1.0 # seconds
 
   def _wait_now
     Time.now.to_f
@@ -12,31 +13,43 @@ module WaitHelper
   #
   # For a zero timeout, only yields exactly once.
   #
+  # @param message [String] Message for debugging
   # @param timeout [Fixnum] How long to wait
   # @param interval [Fixnum] At what interval is the block yielded
-  # @param message [String] Message for debugging
+  # @param threshold [Fixnum] Log slow waits after threshold
   # @param block [Block] Block to yield
   # @return [Object] Return value from block, or nil
-  def wait_until(message = nil, timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, &block)
+  def wait_until(message = nil, timeout: WAIT_TIMEOUT, interval: WAIT_INTERVAL, threshold: WAIT_THRESHOLD, &block)
     raise ArgumentError, 'no block given' unless block_given?
 
     wait_start = _wait_now
     wait_until = wait_start + timeout
+    wait_time = nil
+    logging_threshold = threshold / 2
 
     value = nil
 
     loop do
       break if value = yield
-      break if _wait_now >= wait_until
+      break if _wait_now >= wait_until # timeout
 
-      debug "waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start + interval, timeout, message || '???']
+      if wait_time && wait_time > logging_threshold
+        logging_threshold *= 2
+
+        debug "waiting %.1fs of %.1fs until: %s" % [wait_time + interval, timeout, message || '???']
+      end
+
       sleep interval
+
+      wait_time = _wait_now - wait_start
     end
 
-    if value
-      debug "waited %.1fs until: %s yielded %s" % [_wait_now - wait_start, message || '???', value]
-    else
-      debug "timeout after waiting %.1fs until: %s" % [_wait_now - wait_start, message || '???']
+    if !value
+      warn "timeout after waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start, timeout, message || '???']
+    elsif wait_time && wait_time > threshold
+      info "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
+    elsif wait_time
+      debug "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
     end
 
     value


### PR DESCRIPTION
Implement a new `WaitHelper#wait_until(threshold: 1.0)`, which:

* Does not log anything if it does not wait, i.e. the block yields truthy immediately without any sleeps
* Logs debug messages after 0.5, 1.0, 1.0, 2.0, 4.0, ... seconds of waiting
* Logs an info message if the total wait time was over the threshold
* Logs a warning message if the wait timed out

This reduces the high level of DEBUG spam from short-interval waits, and also provides useful INFO-level messages for slow waits.

Copy-pasted to both agent and server codebases.

```
I, [2017-04-05T18:11:52.437912 #31448]  INFO -- GridServiceInstanceDeployer: Deploying service instance development/null/redis-fail-1 to node core-01 at 2017-04-05 15:11:52 UTC...
D, [2017-04-05T18:11:52.982966 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 1.0s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
D, [2017-04-05T18:11:53.484436 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 1.5s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
D, [2017-04-05T18:11:54.487590 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 2.5s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
D, [2017-04-05T18:11:56.494978 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 4.5s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
D, [2017-04-05T18:12:00.514560 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 8.5s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
D, [2017-04-05T18:12:08.548030 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 16.6s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
D, [2017-04-05T18:12:24.752304 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 32.8s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
D, [2017-04-05T18:12:56.884714 #31448] DEBUG -- GridServiceInstanceDeployer: waiting 64.9s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC
I, [2017-04-05T18:13:10.439213 #31448]  INFO -- GridServiceInstanceDeployer: waited 78.0s of 300.0s until: service development/null/redis-fail-1 is running on node development/core-01 at 2017-04-05 15:11:52 UTC yielded #<GridServiceInstance:0x007fb4ccf3cf90>
W, [2017-04-05T18:13:10.439639 #31448]  WARN -- GridServiceInstanceDeployer: Failed to deploy service instance development/null/redis-fail-1 to node core-01: GridServiceInstanceDeployer::ServiceError: Celluloid::DeadActorError: attempted to call a dead actor: ensure_image
```

## TODO
* Tweak threshold for different classes/waits?