### PR TITLE
Refactor stacks api to always require extenal name for a volume

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -110,6 +110,11 @@ module Kontena::Cli::Stacks
     def generate_volumes(yaml_volumes)
       return [] unless yaml_volumes
       yaml_volumes.map do |name, config|
+        if config['external'].is_a?(TrueClass)
+          config['external'] = name
+        elsif config['external']['name']
+          config['external'] = config['external']['name']
+        end
         config.merge('name' => name)
       end
     end

--- a/cli/lib/kontena/cli/stacks/yaml/validator_v3.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validator_v3.rb
@@ -92,21 +92,7 @@ module Kontena::Cli::Stacks
             yaml['volumes'].each do |volume, options|
               if options.is_a?(Hash)
                 option_errors = validate_volume_options(options)
-                if option_errors.valid?
-                  if !options.key?('driver') && options.key?('driver_opts')
-                    result[:errors] << { 'volumes' => { volume => { 'driver_opts' => 'defined without defining driver' } } }
-                  end
-                  if options.key?('external')
-                    unless options['external'].is_a?(FalseClass)
-                      ['driver', 'driver_opts', 'scope'].each do |key|
-                        result[:errors] << { 'volumes' => { volume => { key => 'specified together with external' } } } if options.key?(key)
-                      end
-                    end
-                  end
-                  if options.key?('driver') && !options.key?('scope')
-                    result[:errors] << { 'volumes' => { volume => { 'scope' => 'required value missing' } } }
-                  end
-                else
+                unless option_errors.valid?
                   result[:errors] << { 'volumes' => { volume => option_errors.errors } }
                 end
               else

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -99,7 +99,7 @@ module GridServices
               v['name'] == vol_spec[:volume]
             }
             # Use external volume definition if given
-            volume_name = stack_volume_name(stack_volume)
+            volume_name = stack_volume['external']
           end
           volume = grid.volumes.find_by(name: volume_name)
           vol_spec[:volume] = volume
@@ -107,16 +107,6 @@ module GridServices
         service_volumes << ServiceVolume.new(**vol_spec)
       end
       service_volumes
-    end
-
-    def stack_volume_name(stack_volume)
-      if stack_volume['external'] == true
-        # Use the plain volume name
-        stack_volume['name']
-      else
-        # Use either explicitly defined external name or plain name
-        stack_volume.dig('external', 'name') || stack_volume['name']
-      end
     end
 
     # @param [Grid] grid

--- a/server/app/mutations/stacks/common.rb
+++ b/server/app/mutations/stacks/common.rb
@@ -52,10 +52,9 @@ module Stacks
 
       self.volumes.each do |volume|
         if volume['external']
-          volume_name = volume['external'] == true ? volume['name'] : volume.dig('external', 'name')
-          vol = self.grid.volumes.where(name: volume_name).first
+          vol = self.grid.volumes.where(name: volume['external']).first
           unless vol
-            add_error(:volumes, :not_found, "External volume #{volume_name} not found")
+            add_error(:volumes, :not_found, "External volume #{volume['external']} not found")
           end
         else
           add_error(:volumes, :invalid, "Only external volumes supported")

--- a/server/spec/api/v1/grid_stacks_spec.rb
+++ b/server/spec/api/v1/grid_stacks_spec.rb
@@ -48,7 +48,7 @@ describe '/v1/grids/:grid/stacks', celluloid: true do
       source: '..',
       services: services,
       volumes: [
-        { name: 'vol1', external: { name: 'someVolume'}}
+        { name: 'vol1', external: 'someVolume'}
       ]
     }
   end

--- a/server/spec/mutations/stacks/create_spec.rb
+++ b/server/spec/mutations/stacks/create_spec.rb
@@ -312,33 +312,13 @@ describe Stacks::Create do
           source: '...',
           variables: {foo: 'bar'},
           services: [{name: 'redis', image: 'redis:2.8', stateful: true, volumes: ['vol1:/data'] }],
-          volumes: [{name: 'vol1', external: {name: 'someVolume'}}]
+          volumes: [{name: 'vol1', external: 'someVolume'}]
         ).run
         expect(outcome.success?).to be_truthy
         redis = outcome.result.grid_services.first
         expect(outcome.result.latest_rev.volumes.size).to eq(1)
         expect(redis.service_volumes.first.volume).to eq(volume)
       end
-    end
-
-    it 'creates stack with external volumes with no external name' do
-      volume = Volume.create(name: 'someVolume', grid: grid, scope: 'node')
-
-      outcome = described_class.new(
-        grid: grid,
-        name: 'stack',
-        stack: 'foo/bar',
-        version: '0.1.0',
-        registry: 'file://',
-        source: '...',
-        variables: {foo: 'bar'},
-        services: [{name: 'redis', image: 'redis:2.8', stateful: true, volumes: ['someVolume:/data'] }],
-        volumes: [{name: 'someVolume', external: true}]
-      ).run
-      expect(outcome.success?).to be_truthy
-      redis = outcome.result.grid_services.first
-      expect(redis.service_volumes.first.volume).to eq(volume)
-
     end
 
     it 'fails to create stack when external volume does not exist' do
@@ -352,7 +332,7 @@ describe Stacks::Create do
         source: '...',
         variables: {foo: 'bar'},
         services: [{name: 'redis', image: 'redis:2.8', stateful: true }],
-        volumes: [{name: 'vol1', external: {name: 'foo'}}]
+        volumes: [{name: 'vol1', external: 'foo'}]
       ).run
       expect(outcome).not_to be_success
 
@@ -371,7 +351,7 @@ describe Stacks::Create do
         volumes: [{name: 'vol1', driver: 'foo', scope: 'foobar'}]
       ).run
       expect(outcome.success?).to be_falsey
-      
+
     end
   end
 end

--- a/server/spec/mutations/stacks/deploy_spec.rb
+++ b/server/spec/mutations/stacks/deploy_spec.rb
@@ -90,7 +90,7 @@ describe Stacks::Deploy, celluloid: true do
           {name: 'redis', image: 'redis:2.8', volumes: ['vol:/data'] }
         ],
         volumes: [
-          {name: 'vol', external: true}
+          {name: 'vol', external: 'vol'}
         ]
       )
       outcome = described_class.run(stack: stack)


### PR DESCRIPTION
Now the stacks api requires always the external name to be given:
```
"volumes": [
  {"name": "vol", "external":"ext-name"}
]
```

