### PR TITLE
CLI: Fix node ssh command API URLs

### DIFF
--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -18,7 +18,7 @@ module Kontena::Cli::Nodes
       exit_with_error "Cannot combine --any with a node name" if node_id && any?
 
       if node_id
-        node = client.get("grids/#{current_grid}/nodes/#{node_id}")
+        node = client.get("nodes/#{current_grid}/#{node_id}")
       elsif any?
         nodes = client.get("grids/#{current_grid}/nodes")['nodes']
         node = nodes.select{ |node| node['connected'] }.first


### PR DESCRIPTION
#1359 accidentially changed the `kontena node ssh` command to use the old `/v1/grids/:grid/nodes/:node` API URLs removed in #1427. The#1359  PR was originally written before #1427, and updating it for 1.2 accidentially re-introduced the old URLs.