### PR TITLE
Only cleanup nodes labeled as ephemeral

### DIFF
--- a/docs/references/kontena-yml.md
+++ b/docs/references/kontena-yml.md
@@ -149,7 +149,7 @@ affinity:
 
 ```
 affinity:
-  - label==AWS
+  - label==provider=aws
 ```
 
 #### hooks

--- a/docs/using-kontena/README.md
+++ b/docs/using-kontena/README.md
@@ -8,6 +8,7 @@ toc_link: false
 
 * [Deploy](deploy.md)
 * [Grids](grids.md)
+* [Nodes](nodes.md)
 * [Image Registry](image-registry.md)
 * [Services](services.md)
 * [Users](users.md)
@@ -15,4 +16,3 @@ toc_link: false
 * [Certificates](certificates.md)
 * [Statistics](stats.md)
 * [Authentication](authentication.md)
-

--- a/docs/using-kontena/nodes.md
+++ b/docs/using-kontena/nodes.md
@@ -23,6 +23,8 @@ The agents will ping the server every 30 seconds, and expect a response within 2
 The server will ping each agent every 30 seconds, and expect a response within 5 seconds.
 
 Grid service instances can be deployed to any online node, unless restricted using [service affinity filters](deploy#Affinity) or the [grid default affinity](grids#Default Affinity).
+When a host node comes online, existing grid services will be re-scheduled by the server to deploy new [`daemon`-strategy](deploy#Daemon) instances or re-balance other service instances onto the new node.
+The re-schduling of grid services will happen within 20 seconds of the node coming online.
 
 ### Offline nodes
 

--- a/docs/using-kontena/nodes.md
+++ b/docs/using-kontena/nodes.md
@@ -22,8 +22,8 @@ Nodes will be considered as online so long as they have an active Websocket conn
 The agents will ping the server every 30 seconds, and expect a response within 2 seconds.
 The server will ping each agent every 30 seconds, and expect a response within 5 seconds.
 
-Grid service instances can be deployed to any online node, unless restricted using [service affinity filters](deploy.md#Affinity) or the [grid default affinity](grids.md#Default Affinity).
-When a host node comes online, existing grid services will be re-scheduled by the server to deploy new [`daemon`-strategy](deploy.md#Daemon) instances or re-balance other service instances onto the new node.
+Grid service instances can be deployed to any online node, unless restricted using [service affinity filters](deploy.md#affinity) or the [grid default affinity](grids.md#default-affinity).
+When a host node comes online, existing grid services will be re-scheduled by the server to deploy new [`daemon`-strategy](deploy.md#daemon) instances or re-balance other service instances onto the new node.
 The re-schduling of grid services will happen within 20 seconds of the node coming online.
 
 ### Offline nodes
@@ -44,7 +44,7 @@ Alternatively, power off and destroy the node instance directly from the provide
 
 ## Node labels
 
-Host nodes can have arbitrary labels of the form `label` or `label=value`. These labels can be used for [service affinity filters](deploy.md#Affinity). Some special labels are also set by the node provisioning plugins, and are recognized by Kontena itself.
+Host nodes can have arbitrary labels of the form `label` or `label=value`. These labels can be used for [service affinity filters](deploy.md#affinity). Some special labels are also set by the node provisioning plugins, and are recognized by Kontena itself.
 
 ### `provider`
 
@@ -54,11 +54,11 @@ Nodes provisioned by `kontena <provider> node create` plugin commands will have 
 
 Nodes provisioned by some plugins (`aws`, `azure`, `digitalocean`) will also have node label such as `az=us-west-a1`.
 
-The `az` label is used by the [`ha` deployment strategy](deploy.md#High Availability (HA)) to distribute service instances across different availability zones.
+The `az` label is used by the [`ha` deployment strategy](deploy.md#high-availability-ha) to distribute service instances across different availability zones.
 
 ### `ephemeral`
 
 Nodes labeled as `ephemeral` will automatically be removed by the Kontena Master after they have been offline for longer than six hours (6h).
-The nodes should not be [initial nodes](grids.md#Initial Nodes), and they should not have any stateful services deployed on them.
+The nodes should not be [initial nodes](grids.md#initial-nodes), and they should not have any stateful services deployed on them.
 
 Ephemeral nodes are intended to be used for autoscaled nodes, which may be provisioned automatically, and then cleaned up once terminated.

--- a/docs/using-kontena/nodes.md
+++ b/docs/using-kontena/nodes.md
@@ -1,0 +1,45 @@
+---
+title: Nodes
+---
+
+# Nodes
+
+Each node is a machine running the `kontena-agent`. The nodes connect to the Kontena Master, which then schedules and deploys services onto those nodes.
+
+## Connecting nodes
+
+Nodes do not need to be explicitly created. The Kontena Master will automatically create new grid nodes for any `kontena-agent` connecting to the Kontena Master with the correct [grid token](grids#Grid Token).  
+
+## Online nodes
+
+Nodes will be considered as online so long as they have an active Websocket connection to the Kontena Master.
+Grid service instances can be deployed to any online node, unless restricted using [service affinity filters](deploy#Affinity) or the [grid default affinity](grids#Default Affinity).
+
+The `kontena node rm` command can not be used to remove online nodes. The node must first be terminated (using the `kontena <provider> node terminate` command), and can then be removed once offline.
+
+## Offline nodes
+
+If the agent's Websocket connection to the master is disconnected or times out, the server will mark the nodes as as offline.
+
+Offline nodes will not have any new service instances scheduled to them. Any services with instances deployed to any offline nodes will be re-scheduled by the server, moving the instances to the remaining online nodes.
+
+## Node labels
+
+Host nodes can have arbitrary labels of the form `label` or `label=value`. These labels can be used for [service affinity filters](deploy#Affinity). Some special labels are also set by the node provisioning plugins, and are recognized by Kontena itself.
+
+### `provider`
+
+Nodes provisioned by `kontena <provider> node create` plugin commands will have node label such as `provider=aws`.
+
+### `az`
+
+Nodes provisioned by some plugins (`aws`, `azure`, `digitalocean`) will also have node label such as `az=us-west-a1`.
+
+The `az` label is used by the [`ha` deployment strategy](deploy#High Availability (HA)) to distribute service instances across different availability zones.
+
+### `ephemeral`
+
+Nodes labeled as `ephemeral` will automatically be removed by the Kontena Master after they have been offline for longer than six hours (6h).
+The nodes should not be [initial nodes](grids#Initial Nodes), and they should not have any stateful services deployed on them.
+
+Ephemeral nodes are intended to be used for autoscaled nodes, which may be provisioned automatically, and then cleaned up once terminated.

--- a/docs/using-kontena/nodes.md
+++ b/docs/using-kontena/nodes.md
@@ -6,22 +6,39 @@ title: Nodes
 
 Each node is a machine running the `kontena-agent`. The nodes connect to the Kontena Master, which then schedules and deploys services onto those nodes.
 
-## Connecting nodes
+### Provisioning nodes
 
-Nodes do not need to be explicitly created. The Kontena Master will automatically create new grid nodes for any `kontena-agent` connecting to the Kontena Master with the correct [grid token](grids#Grid Token).  
+Nodes do not need to be explicitly created. The Kontena Master will automatically create new grid nodes for any `kontena-agent` connecting to the Kontena Master with the correct [grid token](grids#Grid Token).
 
-## Online nodes
+Nodes are identified by their Docker Engine ID, as shown in `docker info`:
+
+```
+ ID: 44C7:P5OM:NBJT:WXHV:6EDU:67T5:YDMX:4YPU:PF6D:VUH5:7LE7:5RC7
+```
+
+### Online nodes
 
 Nodes will be considered as online so long as they have an active Websocket connection to the Kontena Master.
+The agents will ping the server every 30 seconds, and expect a response within 2 seconds.
+The server will ping each agent every 30 seconds, and expect a response within 5 seconds.
+
 Grid service instances can be deployed to any online node, unless restricted using [service affinity filters](deploy#Affinity) or the [grid default affinity](grids#Default Affinity).
 
-The `kontena node rm` command can not be used to remove online nodes. The node must first be terminated (using the `kontena <provider> node terminate` command), and can then be removed once offline.
-
-## Offline nodes
+### Offline nodes
 
 If the agent's Websocket connection to the master is disconnected or times out, the server will mark the nodes as as offline.
 
-Offline nodes will not have any new service instances scheduled to them. Any services with instances deployed to any offline nodes will be re-scheduled by the server, moving the instances to the remaining online nodes.
+Offline nodes will not have any new service instances scheduled to them.
+Any services with instances deployed to any offline nodes will be re-scheduled by the server, moving the instances to the remaining online nodes.
+The re-schduling of grid services will happen within 20 seconds of the node being marked as disconnected.
+
+### Decomissioning nodes
+
+To decomission a node, you must first terminate it, and you can then remove the offline node from the Kontena Master.
+
+The `kontena node rm` command can not be used to remove an online node.
+Use the `kontena <provider> node terminate` plugin commands to terminate nodes and remove them from the Kontena Master.
+Alternatively, power off and destroy the node instance directly from the provider's control panel, and wait for the nodes to be offline before removing them from the CLI.
 
 ## Node labels
 

--- a/docs/using-kontena/nodes.md
+++ b/docs/using-kontena/nodes.md
@@ -8,7 +8,7 @@ Each node is a machine running the `kontena-agent`. The nodes connect to the Kon
 
 ### Provisioning nodes
 
-Nodes do not need to be explicitly created. The Kontena Master will automatically create new grid nodes for any `kontena-agent` connecting to the Kontena Master with the correct [grid token](grids#Grid Token).
+Nodes do not need to be explicitly created. The Kontena Master will automatically create new grid nodes for any `kontena-agent` connecting to the Kontena Master with the correct [grid token](grids.md#Grid Token).
 
 Nodes are identified by their Docker Engine ID, as shown in `docker info`:
 
@@ -22,8 +22,8 @@ Nodes will be considered as online so long as they have an active Websocket conn
 The agents will ping the server every 30 seconds, and expect a response within 2 seconds.
 The server will ping each agent every 30 seconds, and expect a response within 5 seconds.
 
-Grid service instances can be deployed to any online node, unless restricted using [service affinity filters](deploy#Affinity) or the [grid default affinity](grids#Default Affinity).
-When a host node comes online, existing grid services will be re-scheduled by the server to deploy new [`daemon`-strategy](deploy#Daemon) instances or re-balance other service instances onto the new node.
+Grid service instances can be deployed to any online node, unless restricted using [service affinity filters](deploy.md#Affinity) or the [grid default affinity](grids.md#Default Affinity).
+When a host node comes online, existing grid services will be re-scheduled by the server to deploy new [`daemon`-strategy](deploy.md#Daemon) instances or re-balance other service instances onto the new node.
 The re-schduling of grid services will happen within 20 seconds of the node coming online.
 
 ### Offline nodes
@@ -44,7 +44,7 @@ Alternatively, power off and destroy the node instance directly from the provide
 
 ## Node labels
 
-Host nodes can have arbitrary labels of the form `label` or `label=value`. These labels can be used for [service affinity filters](deploy#Affinity). Some special labels are also set by the node provisioning plugins, and are recognized by Kontena itself.
+Host nodes can have arbitrary labels of the form `label` or `label=value`. These labels can be used for [service affinity filters](deploy.md#Affinity). Some special labels are also set by the node provisioning plugins, and are recognized by Kontena itself.
 
 ### `provider`
 
@@ -54,11 +54,11 @@ Nodes provisioned by `kontena <provider> node create` plugin commands will have 
 
 Nodes provisioned by some plugins (`aws`, `azure`, `digitalocean`) will also have node label such as `az=us-west-a1`.
 
-The `az` label is used by the [`ha` deployment strategy](deploy#High Availability (HA)) to distribute service instances across different availability zones.
+The `az` label is used by the [`ha` deployment strategy](deploy.md#High Availability (HA)) to distribute service instances across different availability zones.
 
 ### `ephemeral`
 
 Nodes labeled as `ephemeral` will automatically be removed by the Kontena Master after they have been offline for longer than six hours (6h).
-The nodes should not be [initial nodes](grids#Initial Nodes), and they should not have any stateful services deployed on them.
+The nodes should not be [initial nodes](grids.md#Initial Nodes), and they should not have any stateful services deployed on them.
 
 Ephemeral nodes are intended to be used for autoscaled nodes, which may be provisioned automatically, and then cleaned up once terminated.

--- a/server/app/jobs/node_cleanup_job.rb
+++ b/server/app/jobs/node_cleanup_job.rb
@@ -37,6 +37,8 @@ class NodeCleanupJob
   def cleanup_stale_nodes
     HostNode.where(:last_seen_at.lt => NODE_DESTROY_TIMEOUT.ago).each do |node|
       if !node.grid.initial_node?(node) && !node.connected? && !node.stateful?
+        warn "Destroying disconnected node #{node.to_path}"
+
         node.destroy
       end
     end

--- a/server/app/jobs/node_cleanup_job.rb
+++ b/server/app/jobs/node_cleanup_job.rb
@@ -5,6 +5,9 @@ class NodeCleanupJob
   include Logging
   include CurrentLeader
 
+  NODE_DISCONNECT_TIMEOUT = 1.minute
+  NODE_DESTROY_TIMEOUT = 24.hours
+
   def initialize
     async.perform
   end
@@ -22,7 +25,7 @@ class NodeCleanupJob
   end
 
   def cleanup_stale_connections
-    HostNode.where(:last_seen_at.lt => 1.minute.ago).each do |node|
+    HostNode.where(:last_seen_at.lt => NODE_DISCONNECT_TIMEOUT.ago).each do |node|
       node.set(connected: false)
       deleted_at = Time.now.utc
       node.containers.each do |c|
@@ -32,7 +35,7 @@ class NodeCleanupJob
   end
 
   def cleanup_stale_nodes
-    HostNode.where(:last_seen_at.lt => 1.hour.ago).each do |node|
+    HostNode.where(:last_seen_at.lt => NODE_DESTROY_TIMEOUT.ago).each do |node|
       if !node.grid.initial_node?(node) && !node.connected? && !node.stateful?
         node.destroy
       end

--- a/server/app/jobs/node_cleanup_job.rb
+++ b/server/app/jobs/node_cleanup_job.rb
@@ -6,7 +6,7 @@ class NodeCleanupJob
   include CurrentLeader
 
   NODE_DISCONNECT_TIMEOUT = 1.minute
-  NODE_DESTROY_TIMEOUT = 24.hours
+  NODE_DESTROY_TIMEOUT = 6.hours
 
   def initialize
     async.perform
@@ -36,8 +36,8 @@ class NodeCleanupJob
 
   def cleanup_stale_nodes
     HostNode.where(:last_seen_at.lt => NODE_DESTROY_TIMEOUT.ago).each do |node|
-      if !node.grid.initial_node?(node) && !node.connected? && !node.stateful?
-        warn "Destroying disconnected node #{node.to_path}"
+      if !node.grid.initial_node?(node) && !node.connected? && !node.stateful? && node.ephemeral?
+        warn "Destroying disconnected ephemeral node #{node.to_path}"
 
         node.destroy
       end

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -131,33 +131,44 @@ class HostNode
   end
 
   # @param label [String] match label name before =
-  # @param empty_value value to return if label does not have any value
-  # @param default value to return if label not found
-  # @return [String, true] the string value
-  def lookup_label(lookup_name, empty_value: true, default: nil)
+  # @return [Boolean] label exists
+  def has_label?(lookup_name)
     self.labels.to_a.each do |label|
       name, value = label.split('=', 2)
 
       next if name != lookup_name
 
-      return (value.nil? || value.empty?) ? empty_value : value
+      return true
     end
-    return default
+    return false
+  end
+
+  # @param label [String] match label name before =
+  # @return [String, nil] the label value, or nil if omitted/empty
+  def label_value(lookup_name)
+    self.labels.to_a.each do |label|
+      name, value = label.split('=', 2)
+
+      next if name != lookup_name
+
+      return value
+    end
+    return nil
   end
 
   # @return [String]
   def availability_zone
-    @availability_zone ||= lookup_label('az', empty_value: nil, default: 'default')
+    @availability_zone ||= label_value('az') || 'default'
   end
 
   # @return [String]
   def host_provider
-    @host_provider ||= lookup_label('provider', empty_value: nil, default: 'default')
+    @host_provider ||= label_value('provider') || 'default'
   end
 
   # @return [Boolean]
   def ephemeral?
-    @ephemeral ||= lookup_label('ephemeral', empty_value: true, default: false)
+    @ephemeral ||= has_label?('ephemeral')
   end
 
   # @return [String] Overlay IP, without subnet mask

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -130,30 +130,34 @@ class HostNode
     false
   end
 
+  # @param label [String] match label name before =
+  # @param empty_value value to return if label does not have any value
+  # @param default value to return if label not found
+  # @return [String, true] the string value
+  def lookup_label(lookup_name, empty_value: true, default: nil)
+    self.labels.to_a.each do |label|
+      name, value = label.split('=', 2)
+
+      next if name != lookup_name
+
+      return (value.nil? || value.empty?) ? empty_value : value
+    end
+    return default
+  end
+
   # @return [String]
   def availability_zone
-    if @availability_zone.nil?
-      @availability_zone = 'default'.freeze
-      self.labels.to_a.each do |label|
-        if match = label.match(/^az=(.+)/)
-          @availability_zone = match[1]
-        end
-      end
-    end
-    @availability_zone
+    @availability_zone ||= lookup_label('az', empty_value: nil, default: 'default')
   end
 
   # @return [String]
   def host_provider
-    if @host_provider.nil?
-      @host_provider = 'default'.freeze
-      self.labels.to_a.each do |label|
-        if match = label.match(/^provider=(.+)/)
-          @host_provider = match[1]
-        end
-      end
-    end
-    @host_provider
+    @host_provider ||= lookup_label('provider', empty_value: nil, default: 'default')
+  end
+
+  # @return [Boolean]
+  def ephemeral?
+    @ephemeral ||= lookup_label('ephemeral', empty_value: true, default: false)
   end
 
   # @return [String] Overlay IP, without subnet mask

--- a/server/spec/jobs/node_cleanup_job_spec.rb
+++ b/server/spec/jobs/node_cleanup_job_spec.rb
@@ -4,19 +4,19 @@ describe NodeCleanupJob, celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }
 
   describe '#cleanup_stale_nodes' do
-    it 'removes old nodes' do
-      HostNode.create!(name: "node-1", grid: grid, connected: true, last_seen_at: 30.hours.ago)
-      HostNode.create!(name: "node-2", grid: grid, connected: false, last_seen_at: 30.hours.ago)
-      HostNode.create!(name: "node-3", grid: grid, connected: true, last_seen_at: 2.hours.ago)
+    it 'removes old ephemeral nodes' do
+      HostNode.create!(name: "node-1", grid: grid, connected: true, labels: [ 'ephemeral' ], last_seen_at: 12.hours.ago)
+      HostNode.create!(name: "node-2", grid: grid, connected: false, labels: [ 'ephemeral' ], last_seen_at: 12.hours.ago)
+      HostNode.create!(name: "node-3", grid: grid, connected: true, labels: [ 'ephemeral' ], last_seen_at: 2.hours.ago)
 
       expect {
         subject.cleanup_stale_nodes
       }.to change{ HostNode.count }.by(-1)
     end
 
-    it 'does not remove initial node' do
-      HostNode.create!(name: "node-1", grid: grid, connected: false, last_seen_at: 2.hours.ago)
-      HostNode.create!(name: "node-2", grid: grid, connected: true, last_seen_at: 2.hours.ago)
+    it 'does not remove initial or non-ephemeral node' do
+      HostNode.create!(name: "node-1", grid: grid, connected: false, labels: [], last_seen_at: 2.hours.ago)
+      HostNode.create!(name: "node-2", grid: grid, connected: false, labels: [], last_seen_at: 2.hours.ago)
       HostNode.create!(name: "node-3", grid: grid, connected: true, last_seen_at: 10.minutes.ago)
 
       expect {

--- a/server/spec/jobs/node_cleanup_job_spec.rb
+++ b/server/spec/jobs/node_cleanup_job_spec.rb
@@ -5,9 +5,9 @@ describe NodeCleanupJob, celluloid: true do
 
   describe '#cleanup_stale_nodes' do
     it 'removes old nodes' do
-      HostNode.create!(name: "node-1", grid: grid, connected: true, last_seen_at: 2.hours.ago)
-      HostNode.create!(name: "node-2", grid: grid, connected: false, last_seen_at: 2.hours.ago)
-      HostNode.create!(name: "node-3", grid: grid, connected: true, last_seen_at: 10.minutes.ago)
+      HostNode.create!(name: "node-1", grid: grid, connected: true, last_seen_at: 30.hours.ago)
+      HostNode.create!(name: "node-2", grid: grid, connected: false, last_seen_at: 30.hours.ago)
+      HostNode.create!(name: "node-3", grid: grid, connected: true, last_seen_at: 2.hours.ago)
 
       expect {
         subject.cleanup_stale_nodes

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -228,6 +228,30 @@ describe HostNode do
     end
   end
 
+  describe '#ephemeral?' do
+    it 'returns false if label is not set' do
+      expect(subject).to_not be_ephemeral
+    end
+
+    it 'returns true if label is set' do
+      subject.labels = ['ephemeral']
+
+      expect(subject).to be_ephemeral
+    end
+
+    it 'returns true if label is set with an empty value' do
+      subject.labels = ['ephemeral=']
+
+      expect(subject).to be_ephemeral
+    end
+
+    it 'returns true if label is set with any value' do
+      subject.labels = ['ephemeral=yes']
+
+      expect(subject).to be_ephemeral
+    end
+  end
+
   describe '#destroy' do
     let(:grid) { Grid.create!(name: 'test') }
     let(:stateful_service) {


### PR DESCRIPTION
Fixes #2025

The server `NodeCleanupJob` will first mark host nodes as disconnected after 1 minute of no websocket ping-pongs, and then destroy any disconnected nodes after 1 hour, unless they are initial nodes or have stateful containers. This has some side-effects:

* #2025 Any labels set with `kontena node label add` are forgotten, and will be gone if the node later re-connects
* Any `VolumeInstance`s for that node are destroyed, which currently means that the host node will terminate them after reconnecting

This PR bumps the default destroy timeout to 6h, and only cleans up host nodes that have an explicit `emphemeral` label set.