### PR TITLE
Invite and invite hook were using the deprecated "master users" (#1984)

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -32,7 +32,7 @@ module Kontena
 
         invite_response = nil
         spinner "Creating user #{cloud_user_data[:email]} into Kontena Master" do |spin|
-          invite_response = Kontena.run("master users invite --external-id #{cloud_user_data[:id]} --return #{cloud_user_data[:email].shellescape}", returning: :result)
+          invite_response = Kontena.run(["master", "user", "invite", "--external-id", cloud_user_data[:id], "--return", cloud_user_data[:email]], returning: :result)
           unless invite_response.kind_of?(Hash) && invite_response.has_key?('invite_code')
             spin.fail
           end
@@ -44,7 +44,7 @@ module Kontena
         role_status = nil
 
         spinner "Adding master_admin role for #{cloud_user_data[:email]}" do |spin|
-          role_status = Kontena.run("master users role add --silent master_admin #{cloud_user_data[:email].shellescape}")
+          role_status = Kontena.run(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]])
           spin.fail if role_status.to_i > 0
         end
 
@@ -52,7 +52,7 @@ module Kontena
 
         if current_master.grid
           spinner "Adding #{cloud_user_data[:email]} to grid '#{current_master.grid}'" do |spin|
-            grid_add_status = Kontena.run("grid user add --grid #{current_master.grid} #{cloud_user_data[:email].shellescape}")
+            grid_add_status = Kontena.run(["grid", "user", "add", "--grid", current_master.grid, cloud_user_data[:email]])
             spin.fail if grid_add_status.to_i > 0
           end
         end
@@ -61,7 +61,7 @@ module Kontena
 
         new_user_token = nil
         spinner "Creating an access token for #{cloud_user_data[:email]}" do |spin|
-          new_user_token = Kontena.run("master token create -e 0 -s user --return -u #{cloud_user_data[:email].shellescape}", returning: :result)
+          new_user_token = Kontena.run(["master", "token", "create", "-e", "0", "-s", "user", "--return", "-u", cloud_user_data[:email]], returning: :result)
         end
 
         master_name = current_master.name.dup

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -39,7 +39,7 @@ module Kontena::Cli::Master::User
             puts "  * command: kontena master join #{current_master.url} #{response['invite_code']}"
           end
           roles.each do |role|
-            Kontena.run("master users role add #{role.shellescape} #{email.shellescape}")
+            Kontena.run(["master", "user", "role", "add", role, email])
           end
         rescue => ex
           $stderr.puts pastel.red("Failed to invite #{email}")


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/224971/24743015/3f9d56f0-1ab5-11e7-9a97-d5533d817fa5.png)

This PR fixes that.
