### PR TITLE
Require force or confirmation to remove a volume

### DIFF
--- a/cli/lib/kontena/cli/volumes/remove_command.rb
+++ b/cli/lib/kontena/cli/volumes/remove_command.rb
@@ -7,11 +7,14 @@ module Kontena::Cli::Volumes
 
     banner "Removes a volume"
     parameter 'VOLUME', 'Volume'
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     requires_current_master
     requires_current_master_token
 
     def execute
+      confirm_command(volume) unless forced?
+
       spinner "Removing volume #{pastel.cyan(volume)} " do
         remove_volume(volume)
       end

--- a/test/spec/features/volume/create_spec.rb
+++ b/test/spec/features/volume/create_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'volume create' do
   after(:each) do
-    run "kontena volume rm testVol"
+    run "kontena volume rm --force testVol"
   end
 
   it 'creates a volume' do
@@ -28,7 +28,7 @@ describe 'volume create' do
     k = run "kontena volume create --driver local --scope instance testVol"
     expect(k.code).to eq(0)
 
-    k = run "kontena volume rm testVol"
+    k = run "kontena volume rm --force testVol"
     expect(k.code).to eq(0)
 
     k = run "kontena volume ls"

--- a/test/spec/features/volume/service_volumes.rb
+++ b/test/spec/features/volume/service_volumes.rb
@@ -7,7 +7,7 @@ describe 'service volumes' do
 
   after(:each) do
     run "kontena service rm --force null/redis"
-    run "kontena volume rm testVol"
+    run "kontena volume rm --force testVol"
   end
 
   it 'service uses a volume' do
@@ -29,7 +29,7 @@ describe 'service volumes' do
     expect(k.code).to eq(0)
     k = run "kontena service create -v testVol:/data redis redis:alpine"
     expect(k.code).to eq(0)
-    k = run "kontena volume rm testVol"
+    k = run "kontena volume rm --force testVol"
     expect(k.code).not_to eq(0)
   end
 

--- a/test/spec/features/volume/stack_volumes.rb
+++ b/test/spec/features/volume/stack_volumes.rb
@@ -7,7 +7,7 @@ describe 'stack volumes' do
 
   after(:each) do
     run "kontena stack rm --force redis"
-    run "kontena volume rm redis-data"
+    run "kontena volume rm --force redis-data"
   end
 
 


### PR DESCRIPTION
## After:
```
$ k volume rm foo-volume
Destructive command. To proceed, type "foo-volume" or re-run this command with --force option.
> Enter 'foo-volume' to confirm:  ^C

$ k volume rm --force foo-volume
 [done] Removing volume foo-volume
```

fixes #2080 