### PR TITLE
Do nothing if secret value does not change on update

### DIFF
--- a/server/app/mutations/grid_secrets/common.rb
+++ b/server/app/mutations/grid_secrets/common.rb
@@ -7,7 +7,6 @@ module GridSecrets
     def refresh_grid_services(secret)
       secret.grid.grid_services.where(:'secrets.secret' => secret.name).each do |grid_service|
         grid_service.set(updated_at: Time.now.utc)
-        GridServiceDeploy.create(grid_service: grid_service)
       end
     end
   end

--- a/server/app/mutations/grid_secrets/update.rb
+++ b/server/app/mutations/grid_secrets/update.rb
@@ -10,6 +10,8 @@ module GridSecrets
     end
 
     def execute
+      return grid_secret if grid_secret.value == value
+
       grid_secret.value = value
       grid_secret.save
       if grid_secret.errors.size > 0

--- a/server/app/mutations/grid_secrets/update.rb
+++ b/server/app/mutations/grid_secrets/update.rb
@@ -10,9 +10,9 @@ module GridSecrets
     end
 
     def execute
-      return grid_secret if grid_secret.value == value
-
       grid_secret.value = value
+      return grid_secret unless grid_secret.changed?
+      
       grid_secret.save
       if grid_secret.errors.size > 0
         grid_secret.errors.each do |key, message|

--- a/server/spec/mutations/grid_secrets/create_spec.rb
+++ b/server/spec/mutations/grid_secrets/create_spec.rb
@@ -36,13 +36,5 @@ describe GridSecrets::Create do
       expect(web.reload.updated_at.to_s).not_to eq(hour_ago.to_s)
       expect(db.reload.updated_at.to_s).to eq(hour_ago.to_s)
     end
-
-    it 'schedules deploy for related grid services' do
-      web # create
-      db # create
-      expect {
-        subject.run
-      }.to change{ web.grid_service_deploys.count }.by(1)
-    end
   end
 end


### PR DESCRIPTION
Fixes #2094

Also removes manual deployment triggering, it's not needed anymore because scheduler will notice timestamp change.