### PR TITLE
Service instances api & related cli enhancements

### DIFF
--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -190,8 +190,8 @@ module Kontena
 
         def show_service_instances(token, service_id)
           puts "  instances:"
+          instances = client(token).get("services/#{parse_service_id(service_id)}/instancess")['instances']
           containers = client(token).get("services/#{parse_service_id(service_id)}/containers")['containers']
-          instances = client(token).get("services/#{parse_service_id(service_id)}/instances")['instances']
           instances.each do |i|
             puts "    #{name}/#{i['instance_number']}:"
             puts "      scheduled_to: #{i.dig('node', 'name') || '-'}"

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -41,12 +41,11 @@ module Kontena
         # @param [String] service_id
         def show_service(token, service_id)
           service = get_service(token, service_id)
-          grid = service['id'].split('/')[0]
           puts "#{service['id']}:"
           puts "  created: #{service['created_at']}"
           puts "  updated: #{service['updated_at']}"
           puts "  stack: #{service['stack']['id'] }"
-          puts "  state: #{service['state'] }"
+          puts "  desired_state: #{service['state'] }"
           puts "  image: #{service['image']}"
           puts "  revision: #{service['revision']}"
           puts "  stack_revision: #{service['stack_revision']}" if service['stack_revision']
@@ -54,7 +53,9 @@ module Kontena
           puts "  scaling: #{service['instances'] }"
           puts "  strategy: #{service['strategy']}"
           puts "  deploy_opts:"
-          puts "    min_health: #{service['deploy_opts']['min_health']}"
+          if service['deploy_opts']['min_health']
+            puts "    min_health: #{service['deploy_opts']['min_health']}"
+          end
           if service['deploy_opts']['wait_for_port']
             puts "    wait_for_port: #{service['deploy_opts']['wait_for_port']}"
           end
@@ -104,7 +105,7 @@ module Kontena
             end
           end
 
-          unless service['net'].to_s.empty?
+          if service['net'].to_s != 'bridge'
             puts "  net: #{service['net']}"
           end
 
@@ -188,6 +189,40 @@ module Kontena
         end
 
         def show_service_instances(token, service_id)
+          puts "  instances:"
+          containers = client(token).get("services/#{parse_service_id(service_id)}/containers")['containers']
+          instances = client(token).get("services/#{parse_service_id(service_id)}/instances")['instances']
+          instances.each do |i|
+            puts "    #{name}/#{i['instance_number']}:"
+            puts "      scheduled_to: #{i.dig('node', 'name') || '-'}"
+            puts "      deploy_rev: #{i['deploy_rev']}"
+            puts "      rev: #{i['rev']}"
+            puts "      state: #{i['state']}"
+            puts "      error: #{i['error'] || '-'}" if i['error']
+            puts "      containers:"
+            containers.select { |c|
+              c['instance_number'] == i['instance_number']
+            }.each do |container|
+              puts "        #{container['name']} (on #{container.dig('node', 'name')}):"
+              puts "          dns: #{container['hostname']}.#{container['domainname']}"
+              puts "          ip: #{container['ip_address']}"
+              puts "          public ip: #{container['node']['public_ip'] rescue 'unknown'}"
+              if container['health_status']
+                health_time = Time.now - Time.parse(container.dig('health_status', 'updated_at'))
+                puts "          health: #{container.dig('health_status', 'status')} (#{health_time.to_i}s ago)"
+              end
+              puts "          status: #{container['status']}"
+              if container.dig('state', 'error') != ''
+                puts "          reason: #{container['state']['error']}"
+              end
+              if container.dig('state', 'exit_code').to_i != 0
+                puts "          exit code: #{container['state']['exit_code']}"
+              end
+            end
+          end
+        end
+
+        def show_service_containers(token, service_id)
           puts "  instances:"
           result = client(token).get("services/#{parse_service_id(service_id)}/containers")
           result['containers'].each do |container|

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -190,7 +190,7 @@ module Kontena
 
         def show_service_instances(token, service_id)
           puts "  instances:"
-          instances = client(token).get("services/#{parse_service_id(service_id)}/instancess")['instances']
+          instances = client(token).get("services/#{parse_service_id(service_id)}/instances")['instances']
           containers = client(token).get("services/#{parse_service_id(service_id)}/containers")['containers']
           instances.each do |i|
             puts "    #{name}/#{i['instance_number']}:"

--- a/cli/lib/kontena/cli/services/show_command.rb
+++ b/cli/lib/kontena/cli/services/show_command.rb
@@ -13,7 +13,14 @@ module Kontena::Cli::Services
       token = require_token
 
       show_service(token, name)
-      show_service_instances(token, name)
+      begin
+        show_service_instances(token, name)
+      rescue Kontena::Errors::StandardError => exc
+        if exc.status == 404
+          # fallback to old behaviour
+          show_service_containers(token, name)
+        end
+      end
     end
   end
 end

--- a/server/app/routes/v1/services/service_instances.rb
+++ b/server/app/routes/v1/services/service_instances.rb
@@ -25,7 +25,7 @@ V1::ServicesApi.route('service_instances') do |r|
     r.on ':id' do |id|
       instance = @grid_service.grid_service_instances.find(id)
       if instance
-        instance.destroy
+        instance.set(host_node_id: nil)
         response.status = 200
         {}
       else

--- a/server/app/routes/v1/services/service_instances.rb
+++ b/server/app/routes/v1/services/service_instances.rb
@@ -1,0 +1,36 @@
+V1::ServicesApi.route('service_instances') do |r|
+
+  # GET /v1/services/:grid_name/:service_name/instances
+  r.get do
+    r.is do
+      @service_instances = @grid_service.grid_service_instances.includes(:host_node, :grid_service)
+
+      render('grid_service_instances/index')
+    end
+
+    r.on ':id' do |id|
+      @service_instance = @grid_service.grid_service_instances.find(id)
+
+      r.is do
+        if @service_instance
+          render('grid_service_instances/show')
+        else
+          response.status = 404
+        end
+      end
+    end
+  end
+
+  r.delete do
+    r.on ':id' do |id|
+      instance = @grid_service.grid_service_instances.find(id)
+      if instance
+        instance.destroy
+        response.status = 200
+        {}
+      else
+        response.status = 404
+      end
+    end
+  end
+end

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -34,6 +34,11 @@ module V1
       r.on ':grid_name/:stack_name/:service_name' do |grid_name, stack_name, service_name|
         @grid_service = load_grid_service(grid_name, stack_name, service_name)
 
+        # /v1/services/:grid_name/:stack_name/:service_name/instances
+        r.on 'instances' do
+          r.route 'service_instances'
+        end
+
         # /v1/services/:grid_name/:stack_name/:service_name/containers
         r.on 'containers' do
           r.route 'service_containers'

--- a/server/app/views/v1/grid_service_instances/_grid_service_instance.json.jbuilder
+++ b/server/app/views/v1/grid_service_instances/_grid_service_instance.json.jbuilder
@@ -1,0 +1,16 @@
+json.id service_instance.id.to_s
+json.created_at service_instance.created_at
+json.updated_at service_instance.updated_at
+json.instance_number service_instance.instance_number
+json.desired_state service_instance.desired_state
+json.state service_instance.state
+json.deploy_rev service_instance.deploy_rev
+json.rev service_instance.rev
+json.error service_instance.error
+json.node do
+  if node = service_instance.host_node
+    json.id node.to_path
+    json.name node.name
+    json.public_ip node.public_ip
+  end
+end

--- a/server/app/views/v1/grid_service_instances/index.json.jbuilder
+++ b/server/app/views/v1/grid_service_instances/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.instances @service_instances do |instance|
+  json.partial! 'app/views/v1/grid_service_instances/grid_service_instance', service_instance: instance
+end

--- a/server/app/views/v1/grid_service_instances/show.json.jbuilder
+++ b/server/app/views/v1/grid_service_instances/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'app/views/v1/grid_service_instances/grid_service_instance', service_instance: @service_instance

--- a/server/spec/api/v1/service_instances_spec.rb
+++ b/server/spec/api/v1/service_instances_spec.rb
@@ -1,0 +1,73 @@
+describe '/v1/services/:id/event_logs' do
+
+  let(:request_headers) do
+    {
+        'HTTP_AUTHORIZATION' => "Bearer #{valid_token.token_plain}"
+    }
+  end
+
+  let! :grid do
+    Grid.create!(name: 'terminal-a')
+  end
+
+  let(:david) do
+    user = User.create!(email: 'david@domain.com', external_id: '123456')
+    grid.users << user
+
+    user
+  end
+
+  let(:valid_token) do
+    AccessToken.create!(user: david, scopes: ['user'])
+  end
+
+  let! :redis_service do
+    grid.grid_services.create!(
+      name: 'redis',
+      image_name: 'redis:2.8',
+      stateful: true,
+      env: ['FOO=BAR']
+    )
+  end
+
+  describe 'GET' do
+    it 'returns service instances' do
+      redis_service.grid_service_instances.create!(
+        instance_number: 2,
+        deploy_rev: Time.now.utc.to_s
+      )
+      get "/v1/services/#{redis_service.to_path}/instances", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['instances'].size).to eq(1)
+    end
+  end
+
+  describe 'GET /:id' do
+    it 'returns service instance' do
+      instance = redis_service.grid_service_instances.create!(
+        instance_number: 2,
+        deploy_rev: Time.now.utc.to_s
+      )
+      get "/v1/services/#{redis_service.to_path}/instances/#{instance.id.to_s}", nil, request_headers
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns error if instance not found' do
+      get "/v1/services/#{redis_service.to_path}/instances/00", nil, request_headers
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe 'DELETE /:id' do
+    it 'removes service instance' do
+      instance = redis_service.grid_service_instances.create!(
+        instance_number: 2,
+        deploy_rev: Time.now.utc.to_s
+      )
+      expect {
+        delete "/v1/services/#{redis_service.to_path}/instances/#{instance.id.to_s}", nil, request_headers
+        expect(response.status).to eq(200)
+      }.to change { redis_service.grid_service_instances.count }.by(-1)
+    end
+  end
+end

--- a/server/spec/api/v1/service_instances_spec.rb
+++ b/server/spec/api/v1/service_instances_spec.rb
@@ -60,14 +60,16 @@ describe '/v1/services/:id/event_logs' do
 
   describe 'DELETE /:id' do
     it 'removes service instance' do
+      node = HostNode.create(grid: grid, node_id: 'a')
       instance = redis_service.grid_service_instances.create!(
         instance_number: 2,
-        deploy_rev: Time.now.utc.to_s
+        deploy_rev: Time.now.utc.to_s,
+        host_node: node
       )
       expect {
         delete "/v1/services/#{redis_service.to_path}/instances/#{instance.id.to_s}", nil, request_headers
         expect(response.status).to eq(200)
-      }.to change { redis_service.grid_service_instances.count }.by(-1)
+      }.to change { instance.reload.host_node }.from(node).to(nil)
     end
   end
 end


### PR DESCRIPTION
Adds REST API for new service instance objects. 

Also enhances cli: 

- `kontena service show <name>` shows instance information
- `kontena service rm --instance <number> <name>` allows to remove service instance

## Examples

```
$ kontena service show redis-sentinel/lb
test/redis-sentinel/lb:
  created: 2017-04-06T14:53:57.679Z
  updated: 2017-04-06T14:53:57.679Z
  stack: test/redis-sentinel
  desired_state: running
  image: kontena/lb:latest
  revision: 1
  stack_revision: 1
  stateful: no
  scaling: 2
  strategy: ha
  deploy_opts:
  dns: lb.redis-sentinel.test.kontena.local
  instances:
    redis-sentinel/lb-2:
      scheduled_to: core-02
      deploy_rev: 2017-04-06 17:52:04 UTC
      rev: 2017-04-06 17:52:04 UTC
      state: running
      containers:
        redis-sentinel.lb-2 (on core-02):
          dns: lb-2.redis-sentinel.test.kontena.local
          ip: 10.81.128.50
          public ip: 91.158.130.116
          status: running
    redis-sentinel/lb-1:
      scheduled_to: core-01
      deploy_rev: 2017-04-06 17:52:04 UTC
      rev: 2017-04-06 17:52:04 UTC
      state: running
      containers:
        redis-sentinel.lb-1 (on core-01):
          dns: lb-1.redis-sentinel.test.kontena.local
          ip: 10.81.128.90
          public ip: 91.158.130.116
          status: running
```

``` 
$ kontena service rm --instance 2 redis-sentinel/lb
Destructive command. To proceed, type "redis-sentinel/lb/2" or re-run this command with --force option.
> Enter 'redis-sentinel/lb/2' to confirm:  redis-sentinel/lb/2
 [done] Removing service instance redis-sentinel/lb/2   
```