### PR TITLE
Fix CLI stack logs missing requires, spec

### DIFF
--- a/cli/lib/kontena/cli/stacks/logs_command.rb
+++ b/cli/lib/kontena/cli/stacks/logs_command.rb
@@ -1,3 +1,5 @@
+require_relative '../helpers/log_helper'
+
 module Kontena::Cli::Stacks
   class LogsCommand < Kontena::Command
     include Kontena::Cli::Common

--- a/cli/spec/kontena/cli/stacks/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/logs_command_spec.rb
@@ -1,0 +1,28 @@
+require "kontena/cli/stacks/logs_command"
+
+describe Kontena::Cli::Stacks::LogsCommand do
+  include ClientHelpers
+  include OutputHelpers
+
+  let (:logs) do
+    [
+      {
+        'id' => '57cff2e8cfee65c8b6efc8bd',
+        'name' => 'test-stack.mysql-1',
+        'created_at' => '2016-09-07T15:19:04.362690',
+        'data' => "mysql log message 1",
+      },
+    ]
+  end
+
+  it "shows stack logs" do
+    expect(client).to receive(:get).with('stacks/test-grid/test-stack/container_logs', {
+      limit: 100,
+    }) { { 'logs' => logs } }
+
+    expect{subject.run(['test-stack'])}.to output_lines [
+      "2016-09-07T15:19:04.362690 [test-stack.mysql-1]: mysql log message 1",
+    ]
+  end
+
+end

--- a/cli/spec/kontena/cli/stacks/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/logs_command_spec.rb
@@ -14,6 +14,10 @@ describe Kontena::Cli::Stacks::LogsCommand do
       },
     ]
   end
+  
+  before(:each) do
+    Kontena.pastel.resolver.color.disable!
+  end
 
   it "shows stack logs" do
     expect(client).to receive(:get).with('stacks/test-grid/test-stack/container_logs', {


### PR DESCRIPTION
Fixes #2088 for `kontena stack logs`, which is the only known case.

Also adds a minimal spec.