### PR TITLE
Fix cli master logout module definition

### DIFF
--- a/cli/lib/kontena/cli/master/logout_command.rb
+++ b/cli/lib/kontena/cli/master/logout_command.rb
@@ -1,23 +1,25 @@
-class Kontena::Cli::Master::LogoutCommand < Kontena::Command
-  include Kontena::Cli::Common
+module Kontena::Cli::Master
+  class LogoutCommand < Kontena::Command
+    include Kontena::Cli::Common
 
-  option ['-A', '--all'], :flag, 'Log out from all masters. By default only log out from current master.'
+    option ['-A', '--all'], :flag, 'Log out from all masters. By default only log out from current master.'
 
-  def execute
-    if self.all?
-      config.servers.each do |server|
-        use_refresh_token(server)
-        server.token = nil
-        puts "Logged out of #{server.name.colorize(:green)}"
+    def execute
+      if self.all?
+        config.servers.each do |server|
+          use_refresh_token(server)
+          server.token = nil
+          puts "Logged out of #{server.name.colorize(:green)}"
+        end
+      elsif config.current_master
+        use_refresh_token(config.current_master)
+        config.current_master.token = nil
+        puts "Logged out of #{config.current_master.name.colorize(:green)}"
+      else
+        warn "Current master has not been selected"
+        exit 0 # exiting with 0 not 1, it's not really an error situation (kontena logout && kontena master login...)
       end
-    elsif config.current_master
-      use_refresh_token(config.current_master)
-      config.current_master.token = nil
-      puts "Logged out of #{config.current_master.name.colorize(:green)}"
-    else
-      warn "Current master has not been selected"
-      exit 0 # exiting with 0 not 1, it's not really an error situation (kontena logout && kontena master login...)
+      config.write
     end
-    config.write
   end
 end


### PR DESCRIPTION
Makes it consistent with the other `master` commands.

```
NameError: uninitialized constant Kontena::Cli::Master
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/master/logout_command.rb:1:in `<top (required)>'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/subcommand_loader.rb:46:in `require'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/subcommand_loader.rb:46:in `safe_require'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/subcommand_loader.rb:54:in `klass'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/subcommand_loader.rb:61:in `new'
```