### PR TITLE
Bump hash-validator to 0.7.1

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
-  spec.add_runtime_dependency "hash_validator", "~> 0.7.0"
+  spec.add_runtime_dependency "hash_validator", "~> 0.7.1"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
   spec.add_runtime_dependency "opto", "1.8.4"
   spec.add_runtime_dependency "semantic", "~> 1.5"


### PR DESCRIPTION
fixes #2092 

## After

```
$ cat ~/code/stacks/volumes/ext-vols.yml 
stack: jussi/redis-ext-vol-no-name
description: Just a simple Redis stack with volume
version: 0.0.1
services:
  redis:
    image: redis:3.2-alpine
    command: redis-server --appendonly yes
    volumes:
      - redis-data:/data

volumes:
  redis-data:
    external: false

$ k stack install ~/code/stacks/volumes/ext-vols.yml 
YAML validation failed! Aborting.

- "/Users/jussi/code/stacks/volumes/ext-vols.yml":
  - volumes:
      redis-data:
        external: is not valid
```
