### PR TITLE
Fix observable spec races

### DIFF
--- a/agent/spec/lib/kontena/observable_spec.rb
+++ b/agent/spec/lib/kontena/observable_spec.rb
@@ -79,6 +79,11 @@ describe Kontena::Observable do
 
     expect{observer.crash}.to raise_error(RuntimeError)
 
+    # make sure the observer is really dead
+    expect{observer.ping}.to raise_error(Celluloid::DeadActorError)
+    expect(observer).to_not be_alive
+    subject.ping
+
     subject.update_observable(object)
     expect(subject.observers).to be_empty
   end

--- a/agent/spec/lib/kontena/observable_spec.rb
+++ b/agent/spec/lib/kontena/observable_spec.rb
@@ -48,6 +48,10 @@ describe Kontena::Observable do
         end
       end
 
+      def ping
+
+      end
+
       def ready?
         !@value.nil?
       end
@@ -106,8 +110,12 @@ describe Kontena::Observable do
     # run updates sync while the observers are starting
     subject.spam_updates(1..update_count, interval: 0.001)
 
-    # wait...
+    # wait for observable to notify all observers
     subject.ping
+
+    # wait for all observers to observe and update
+    observers.each do |obs| obs.ping end
+    observers.each do |obs| obs.ping end # and maybe a second round for the async update
 
     # all observers got the final value
     expect(observers.map{|obs| obs.value}).to eq [update_count] * observer_count

--- a/agent/spec/lib/kontena/observable_spec.rb
+++ b/agent/spec/lib/kontena/observable_spec.rb
@@ -91,7 +91,7 @@ describe Kontena::Observable do
   end
 
   it "handles concurrent observers", :celluloid => true do
-    observer_count = 10
+    observer_count = 20
     update_count = 10
 
     # setup


### PR DESCRIPTION
Fixes #2065

### `Kontena::Observable handles concurrent observers`

The last Observer was occasionally only observing after the last Observable update, which meant that the intial async update for the final observe could still be waiting.

```
D, [2017-04-07T12:33:05.281031 #18389] DEBUG -- : update: 10
D, [2017-04-07T12:33:05.285509 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.291277 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.296196 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.302032 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.312436 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 9
D, [2017-04-07T12:33:05.325438 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 9
D, [2017-04-07T12:33:05.333055 #18389] DEBUG -- : observed 8 -> 9
D, [2017-04-07T12:33:05.326486 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.329208 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.331258 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.336338 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.321126 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.337478 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.332203 #18389] DEBUG -- : observed  -> 9
D, [2017-04-07T12:33:05.333895 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.341243 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.340274 #18389] DEBUG -- : observed 9 -> 9
D, [2017-04-07T12:33:05.343017 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.360852 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.346564 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.366975 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.335589 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.390870 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.356166 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.392097 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.389717 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.393226 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.393382 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.394256 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.385222 #18389] DEBUG -- : notify: Observer<> <- 10...
D, [2017-04-07T12:33:05.396048 #18389] DEBUG -- : observer: Observer<> <- 10...
D, [2017-04-07T12:33:05.397546 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.402290 #18389] DEBUG -- : observe Observable<#<Class:0x00000003dfd9e8>> -> 10
D, [2017-04-07T12:33:05.411916 #18389] DEBUG -- : observed 9 -> 10
D, [2017-04-07T12:33:05.466666 #18389] DEBUG -- : observed  -> 10
F

Failures:

  1) Kontena::Observable handles concurrent observers
     Failure/Error: expect(observers.map{|obs| obs.value}).to eq [update_count] * observer_count
       
       expected: [10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
            got: [10, 10, 10, 10, 10, 10, 10, 10, nil, 10]
      
```

### `Kontena::Observable stops notifying any crashed observers`

Not sure what was going on here... the crashed Observer actor's proxy is still showing up as `alive?` for the `Observable` actor.... added some more expects.