### PR TITLE
Fix scheduler to raise better error if given empty nodes

### DIFF
--- a/server/app/services/grid_service_scheduler.rb
+++ b/server/app/services/grid_service_scheduler.rb
@@ -40,6 +40,10 @@ class GridServiceScheduler
   # @raise [Scheduler::Error]
   # @return HostNode
   def select_node(grid_service, instance_number, nodes)
+    if nodes.empty?
+      raise Scheduler::Error, "There are no nodes available"
+    end
+
     selected_node = nil
     @mutex.synchronize {
       filtered_nodes = self.filter_nodes(grid_service, instance_number, nodes)

--- a/server/spec/services/grid_service_scheduler_spec.rb
+++ b/server/spec/services/grid_service_scheduler_spec.rb
@@ -21,6 +21,10 @@ describe GridServiceScheduler do
       node = subject.select_node(grid_service, 'foo-1', nodes)
       expect(nodes.include?(node)).to eq(true)
     end
+
+    it 'fails if all nodes are offline' do
+      expect{subject.select_node(grid_service, 1, [])}.to raise_error(Scheduler::Error, "There are no nodes available")
+    end
   end
 
   describe '#filter_nodes' do


### PR DESCRIPTION
Fixes  #2073
## Example
With all nodes offline,

### Before
```
 [fail] Deploying service redis      
 [error] Kontena::Errors::StandardErrorArray : Cannot find applicable node for service instance development/null/redis-1: Filter Scheduler::Filter::VolumePlugin did not return any nodes:
```

It really has nothing to do with the volume plugins filter...

### After

```
 [fail] Deploying service redis      
 [error] Kontena::Errors::StandardErrorArray : Cannot find applicable node for service instance development/null/redis-1: There are no nodes available:
```