### PR TITLE
Do not log entire yield value from wait_helper

### DIFF
--- a/agent/lib/kontena/helpers/wait_helper.rb
+++ b/agent/lib/kontena/helpers/wait_helper.rb
@@ -47,9 +47,9 @@ module Kontena::Helpers::WaitHelper
     if !value
       warn "timeout after waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start, timeout, message || '???']
     elsif wait_time && wait_time > threshold
-      info "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
+      info "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value.class]
     elsif wait_time
-      debug "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
+      debug "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value.class]
     end
 
     value

--- a/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
+++ b/agent/spec/lib/kontena/helpers/wait_helper_spec.rb
@@ -28,7 +28,7 @@ describe Kontena::Helpers::WaitHelper do
 
     it 'sleeps between retries and logs debug while under threshold' do
       expect(subject).to receive(:debug).with('waiting 1.4s of 3.0s until: something that takes two seconds')
-      expect(subject).to receive(:debug).with('waited 2.0s of 3.0s until: something that takes two seconds yielded true')
+      expect(subject).to receive(:debug).with('waited 2.0s of 3.0s until: something that takes two seconds yielded TrueClass')
 
       value = subject.wait_until("something that takes two seconds", timeout: 3, interval: 0.1, threshold: 2.5) { @time_elapsed > 2.0 }
 
@@ -39,7 +39,7 @@ describe Kontena::Helpers::WaitHelper do
     it 'logs info if over threshold' do
       expect(subject).to receive(:debug).with('waiting 1.5s of 3.0s until: something that takes two seconds')
       expect(subject).to receive(:debug).with('waiting 2.0s of 3.0s until: something that takes two seconds')
-      expect(subject).to receive(:info).with('waited 2.5s of 3.0s until: something that takes two seconds yielded true')
+      expect(subject).to receive(:info).with('waited 2.5s of 3.0s until: something that takes two seconds yielded TrueClass')
 
       value = subject.wait_until("something that takes two seconds", timeout: 3, interval: 0.5, threshold: 1.0) { @time_elapsed > 2.0 }
 

--- a/server/app/helpers/wait_helper.rb
+++ b/server/app/helpers/wait_helper.rb
@@ -47,9 +47,9 @@ module WaitHelper
     if !value
       warn "timeout after waiting %.1fs of %.1fs until: %s" % [_wait_now - wait_start, timeout, message || '???']
     elsif wait_time && wait_time > threshold
-      info "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
+      info "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value.class]
     elsif wait_time
-      debug "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value]
+      debug "waited %.1fs of %.1fs until: %s yielded %s" % [_wait_now - wait_start, timeout, message || '???', value.class]
     end
 
     value

--- a/server/spec/helpers/wait_helper_spec.rb
+++ b/server/spec/helpers/wait_helper_spec.rb
@@ -29,7 +29,7 @@ describe WaitHelper do
 
     it 'sleeps between retries and logs debug while under threshold' do
       expect(subject).to receive(:debug).with('waiting 1.4s of 3.0s until: something that takes two seconds')
-      expect(subject).to receive(:debug).with('waited 2.0s of 3.0s until: something that takes two seconds yielded true')
+      expect(subject).to receive(:debug).with('waited 2.0s of 3.0s until: something that takes two seconds yielded TrueClass')
 
       value = subject.wait_until("something that takes two seconds", timeout: 3, interval: 0.1, threshold: 2.5) { @time_elapsed > 2.0 }
 
@@ -40,7 +40,7 @@ describe WaitHelper do
     it 'logs info if over threshold' do
       expect(subject).to receive(:debug).with('waiting 1.5s of 3.0s until: something that takes two seconds')
       expect(subject).to receive(:debug).with('waiting 2.0s of 3.0s until: something that takes two seconds')
-      expect(subject).to receive(:info).with('waited 2.5s of 3.0s until: something that takes two seconds yielded true')
+      expect(subject).to receive(:info).with('waited 2.5s of 3.0s until: something that takes two seconds yielded TrueClass')
 
       value = subject.wait_until("something that takes two seconds", timeout: 3, interval: 0.5, threshold: 1.0) { @time_elapsed > 2.0 }
 


### PR DESCRIPTION
fixes #2110 

WaitHelper logged the whole value from `yield` which could leak secrets if it logs slow RPC calls for example.

This PR makes it log only the class name of the yielded value.