### PR TITLE
Fix stack deploy service removal

### DIFF
--- a/server/app/jobs/stack_deploy_worker.rb
+++ b/server/app/jobs/stack_deploy_worker.rb
@@ -64,6 +64,7 @@ class StackDeployWorker
 
   # @param [Stack] stack
   # @param [StackRevision] stack_rev
+  # @raise [RuntimeError]
   def remove_services(stack, stack_rev)
     removed_services = []
     stack.grid_services.each do |s|
@@ -72,8 +73,10 @@ class StackDeployWorker
       end
     end
     info "removing following services: #{removed_services.map{ |s| s.name}.join(', ')}"
-    removed_services.each do |s|
-      s.destroy
+    removed_services.each do |service|
+      outcome = GridServices::Delete.run(grid_service: service)
+
+      raise "service #{service.to_path} remove failed: #{outcome.errors.message}" unless outcome.success?
     end
   end
 end

--- a/server/app/mutations/stacks/update.rb
+++ b/server/app/mutations/stacks/update.rb
@@ -42,6 +42,15 @@ module Stacks
           handle_service_outcome_errors(service[:name], outcome.errors)
         end
       end
+
+      removed_services = self.stack_instance.grid_services.reject{ |grid_service| self.services.any? {|s| s[:name] == grid_service.name} }
+      removed_services.each do |grid_service|
+        outcome = GridServices::Delete.validate(grid_service: grid_service)
+
+        unless outcome.success?
+          handle_service_outcome_errors(grid_service.name, outcome.errors)
+        end
+      end
     end
 
     def execute
@@ -81,6 +90,6 @@ module Stacks
         end
       end
     end
-    
+
   end
 end

--- a/server/spec/jobs/stack_deploy_worker_spec.rb
+++ b/server/spec/jobs/stack_deploy_worker_spec.rb
@@ -128,10 +128,7 @@ describe StackDeployWorker, celluloid: true do
       end
 
       it 'fails if removing a linked service' do
-        linking_service
-        expect(stack.grid_services.find_by(name: 'bar').linked_from_services.to_a).to_not be_empty
-
-        Stacks::Update.run(
+        Stacks::Update.run!(
           stack_instance: stack,
           name: 'stack',
           stack: 'foo/bar',
@@ -142,6 +139,11 @@ describe StackDeployWorker, celluloid: true do
             {name: 'foo', image: 'redis', stateful: false },
           ],
         )
+
+        # link to the service after the update, but before the deploy
+        linking_service
+        expect(stack.grid_services.find_by(name: 'bar').linked_from_services.to_a).to_not be_empty
+
         stack_rev = stack.latest_rev
         expect {
           subject.remove_services(stack, stack_rev)

--- a/server/spec/jobs/stack_deploy_worker_spec.rb
+++ b/server/spec/jobs/stack_deploy_worker_spec.rb
@@ -42,12 +42,14 @@ describe StackDeployWorker, celluloid: true do
   describe '#remove_services' do
     it 'does not remove anything if stack rev has stayed the same' do
       stack_rev = stack.latest_rev
-      expect(subject.wrapped_object).not_to receive(:remove_service)
-      subject.remove_services(stack, stack_rev)
+      expect(GridServices::Delete).not_to receive(:run)
+      expect {
+        subject.remove_services(stack, stack_rev)
+      }.not_to change{ stack.grid_services.to_a }
     end
 
     it 'does not remove anything if stack rev has additional services' do
-      outcome = Stacks::Update.run(
+      Stacks::Update.run!(
         stack_instance: stack,
         name: 'stack',
         stack: 'foo/bar',
@@ -59,10 +61,12 @@ describe StackDeployWorker, celluloid: true do
           {name: 'lb', image: 'kontena/lb:latest', stateful: false }
         ]
       )
-      expect(outcome.success?).to be_truthy
+
       stack_rev = stack.latest_rev
-      expect(subject.wrapped_object).not_to receive(:remove_service)
-      subject.remove_services(stack, stack_rev)
+      expect(GridServices::Delete).not_to receive(:run)
+      expect {
+        subject.remove_services(stack, stack_rev)
+      }.not_to change{ stack.grid_services.to_a }
     end
 
     it 'removes services that are gone from latest stack rev' do
@@ -97,36 +101,38 @@ describe StackDeployWorker, celluloid: true do
         subject.remove_services(stack, stack_rev)
       }.to change { stack.grid_services.find_by(name: 'lb') }.from(lb).to(nil)
     end
+  end
 
-    context "for a stack with externally linked services" do
-      let(:stack) do
-        Stacks::Create.run!(
-          grid: grid,
-          name: 'stack',
-          stack: 'foo/bar',
-          version: '0.1.0',
-          registry: 'file://',
-          source: '...',
-          services: [
-            {name: 'foo', image: 'redis', stateful: false },
-            {name: 'bar', image: 'redis', stateful: false },
-          ]
-        )
-      end
+  context "for a stack with externally linked services" do
+    let(:stack) do
+      Stacks::Create.run!(
+        grid: grid,
+        name: 'stack',
+        stack: 'foo/bar',
+        version: '0.1.0',
+        registry: 'file://',
+        source: '...',
+        services: [
+          {name: 'foo', image: 'redis', stateful: false },
+          {name: 'bar', image: 'redis', stateful: false },
+        ]
+      )
+    end
 
-      let(:linking_service) do
-        GridServices::Create.run!(
-          grid: grid,
-          stack: stack,
-          name: 'asdf',
-          image: 'redis',
-          stateful: false,
-          links: [
-            {name: 'stack/bar', alias: 'bar'},
-          ],
-        )
-      end
+    let(:linking_service) do
+      GridServices::Create.run!(
+        grid: grid,
+        stack: stack,
+        name: 'asdf',
+        image: 'redis',
+        stateful: false,
+        links: [
+          {name: 'stack/bar', alias: 'bar'},
+        ],
+      )
+    end
 
+    describe '#remove_services' do
       it 'fails if removing a linked service' do
         Stacks::Update.run!(
           stack_instance: stack,

--- a/server/spec/mutations/stacks/deploy_spec.rb
+++ b/server/spec/mutations/stacks/deploy_spec.rb
@@ -130,10 +130,7 @@ describe Stacks::Deploy, celluloid: true do
       end
 
       it 'does not remove a linked service' do
-        linking_service
-        expect(stack.grid_services.find_by(name: 'bar').linked_from_services.to_a).to_not be_empty
-
-        Stacks::Update.run(
+        Stacks::Update.run!(
           stack_instance: stack,
           name: 'stack',
           stack: 'foo/bar',
@@ -144,6 +141,10 @@ describe Stacks::Deploy, celluloid: true do
             {name: 'foo', image: 'redis', stateful: false },
           ],
         )
+
+        # link to the service after the update, but before the deploy
+        linking_service
+        expect(stack.grid_services.find_by(name: 'bar').linked_from_services.to_a).to_not be_empty
 
         expect(outcome = described_class.run(stack: stack)).to be_success
 

--- a/server/spec/mutations/stacks/deploy_spec.rb
+++ b/server/spec/mutations/stacks/deploy_spec.rb
@@ -70,8 +70,11 @@ describe Stacks::Deploy, celluloid: true do
       )
       worker = Celluloid::Actor[:stack_deploy_worker]
       redis = stack.grid_services.find_by(name: 'redis')
-      mutation = described_class.new(stack: stack)
-      mutation.run
+      
+      subject = described_class.new(stack: stack)
+      outcome = subject.run
+      expect(outcome).to be_success
+
       sleep 0.01 until worker.mailbox.size == 0
       expect(GridService.find(redis.id)).to be_nil
     end
@@ -99,62 +102,64 @@ describe Stacks::Deploy, celluloid: true do
       expect(redis.service_volumes.count).to eq(1)
       expect(redis.service_volumes.first.volume).to eq(volume)
     end
+  end
 
-    context "for a stack with externally linked services" do
-      let(:stack) do
-        Stacks::Create.run!(
-          grid: grid,
-          name: 'stack',
-          stack: 'foo/bar',
-          version: '0.1.0',
-          registry: 'file://',
-          source: '...',
-          services: [
-            {name: 'foo', image: 'redis', stateful: false },
-            {name: 'bar', image: 'redis', stateful: false },
-          ]
-        )
-      end
+  context "for a stack with externally linked services" do
+    let(:stack) do
+      Stacks::Create.run!(
+        grid: grid,
+        name: 'stack',
+        stack: 'foo/bar',
+        version: '0.1.0',
+        registry: 'file://',
+        source: '...',
+        services: [
+          {name: 'foo', image: 'redis', stateful: false },
+          {name: 'bar', image: 'redis', stateful: false },
+        ]
+      )
+    end
 
-      let(:linking_service) do
-        GridServices::Create.run!(
-          grid: grid,
-          stack: stack,
-          name: 'asdf',
-          image: 'redis',
-          stateful: false,
-          links: [
-            {name: 'stack/bar', alias: 'bar'},
-          ],
-        )
-      end
+    let(:linking_service) do
+      GridServices::Create.run!(
+        grid: grid,
+        stack: stack,
+        name: 'asdf',
+        image: 'redis',
+        stateful: false,
+        links: [
+          {name: 'stack/bar', alias: 'bar'},
+        ],
+      )
+    end
 
-      it 'does not remove a linked service' do
-        Stacks::Update.run!(
-          stack_instance: stack,
-          name: 'stack',
-          stack: 'foo/bar',
-          version: '0.1.0',
-          registry: 'file://',
-          source: '...',
-          services: [
-            {name: 'foo', image: 'redis', stateful: false },
-          ],
-        )
+    it 'does not remove a linked service' do
+      Stacks::Update.run!(
+        stack_instance: stack,
+        name: 'stack',
+        stack: 'foo/bar',
+        version: '0.1.0',
+        registry: 'file://',
+        source: '...',
+        services: [
+          {name: 'foo', image: 'redis', stateful: false },
+        ],
+      )
 
-        # link to the service after the update, but before the deploy
-        linking_service
-        expect(stack.grid_services.find_by(name: 'bar').linked_from_services.to_a).to_not be_empty
+      # link to the service after the update, but before the deploy
+      linking_service
+      expect(stack.grid_services.find_by(name: 'bar').linked_from_services.to_a).to_not be_empty
 
-        expect(outcome = described_class.run(stack: stack)).to be_success
+      subject = described_class.new(stack: stack)
+      outcome = subject.run
+      expect(outcome).to be_success
 
-        worker = Celluloid::Actor[:stack_deploy_worker]
-        sleep 0.01 until worker.mailbox.size == 0
+      worker = Celluloid::Actor[:stack_deploy_worker]
+      sleep 0.01 until worker.mailbox.size == 0
 
-        stack_deploy = outcome.result.reload
+      stack_deploy = outcome.result.reload
 
-        expect(stack_deploy).to be_error # XXX: where does the error message go?
-      end
+      expect(stack_deploy).to be_error
     end
   end
 end

--- a/server/spec/mutations/stacks/deploy_spec.rb
+++ b/server/spec/mutations/stacks/deploy_spec.rb
@@ -1,5 +1,5 @@
 
-describe Stacks::Deploy, celluloid: true do
+describe Stacks::Deploy do
   let(:grid) { Grid.create!(name: 'test-grid') }
 
   let(:stack) {
@@ -14,19 +14,24 @@ describe Stacks::Deploy, celluloid: true do
     ).result
   }
 
+  let(:worker) { instance_double(StackDeployWorker) }
+  let(:worker_async) { instance_double(StackDeployWorker) }
+
   before(:each) do
-    Celluloid::Actor[:stack_deploy_worker] = StackDeployWorker.new
+    allow_any_instance_of(described_class).to receive(:worker).with(:stack_deploy).and_return(worker)
+    allow(worker).to receive(:async).and_return(worker_async)
   end
 
   describe '#run' do
     it 'creates a stack deploy' do
+      expect(worker_async).to receive(:perform).once
       expect {
         described_class.run(stack: stack)
       }.to change{ stack.stack_deploys.count }.by(1)
     end
 
     it 'creates missing services' do
-      Stacks::Update.run(
+      Stacks::Update.run!(
         stack_instance: stack,
         name: 'stack',
         stack: 'foo/bar',
@@ -39,50 +44,16 @@ describe Stacks::Deploy, celluloid: true do
         ]
       )
       stack.grid_services.destroy_all
+      expect(worker_async).to receive(:perform).once
       expect {
         described_class.run(stack: stack)
       }.to change{ stack.grid_services.count }.by(2)
     end
 
-    it 'removes services that are removed from a stack' do
-      Stacks::Update.run(
-        stack_instance: stack,
-        name: 'stack',
-        stack: 'foo/bar',
-        version: '0.1.0',
-        registry: 'file://',
-        source: '...',
-        services: [
-          {name: 'redis', image: 'redis:2.8', stateful: true },
-          {name: 'nginx', image: 'nginx:latest', stateful: false }
-        ]
-      )
-      Stacks::Update.run(
-        stack_instance: stack,
-        name: 'stack',
-        stack: 'foo/bar',
-        version: '0.1.0',
-        registry: 'file://',
-        source: '...',
-        services: [
-          {name: 'nginx', image: 'nginx:latest', stateful: false }
-        ]
-      )
-      worker = Celluloid::Actor[:stack_deploy_worker]
-      redis = stack.grid_services.find_by(name: 'redis')
-      
-      subject = described_class.new(stack: stack)
-      outcome = subject.run
-      expect(outcome).to be_success
-
-      sleep 0.01 until worker.mailbox.size == 0
-      expect(GridService.find(redis.id)).to be_nil
-    end
-
     it 'updates services with volumes' do
       volume = Volume.create(grid: grid, name: 'vol', scope: 'instance', driver: 'local')
 
-      Stacks::Update.run(
+      Stacks::Update.run!(
         stack_instance: stack,
         name: 'stack',
         stack: 'foo/bar',
@@ -96,70 +67,12 @@ describe Stacks::Deploy, celluloid: true do
           {name: 'vol', external: 'vol'}
         ]
       )
+      expect(worker_async).to receive(:perform).once
       outcome = described_class.run(stack: stack)
       expect(outcome.success?).to be_truthy
       redis = stack.reload.grid_services.find_by(name: 'redis')
       expect(redis.service_volumes.count).to eq(1)
       expect(redis.service_volumes.first.volume).to eq(volume)
-    end
-  end
-
-  context "for a stack with externally linked services" do
-    let(:stack) do
-      Stacks::Create.run!(
-        grid: grid,
-        name: 'stack',
-        stack: 'foo/bar',
-        version: '0.1.0',
-        registry: 'file://',
-        source: '...',
-        services: [
-          {name: 'foo', image: 'redis', stateful: false },
-          {name: 'bar', image: 'redis', stateful: false },
-        ]
-      )
-    end
-
-    let(:linking_service) do
-      GridServices::Create.run!(
-        grid: grid,
-        stack: stack,
-        name: 'asdf',
-        image: 'redis',
-        stateful: false,
-        links: [
-          {name: 'stack/bar', alias: 'bar'},
-        ],
-      )
-    end
-
-    it 'does not remove a linked service' do
-      Stacks::Update.run!(
-        stack_instance: stack,
-        name: 'stack',
-        stack: 'foo/bar',
-        version: '0.1.0',
-        registry: 'file://',
-        source: '...',
-        services: [
-          {name: 'foo', image: 'redis', stateful: false },
-        ],
-      )
-
-      # link to the service after the update, but before the deploy
-      linking_service
-      expect(stack.grid_services.find_by(name: 'bar').linked_from_services.to_a).to_not be_empty
-
-      subject = described_class.new(stack: stack)
-      outcome = subject.run
-      expect(outcome).to be_success
-
-      worker = Celluloid::Actor[:stack_deploy_worker]
-      sleep 0.01 until worker.mailbox.size == 0
-
-      stack_deploy = outcome.result.reload
-
-      expect(stack_deploy).to be_error
     end
   end
 end

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -45,10 +45,10 @@ describe 'stack install' do
 
   context 'For a stack with a broken link' do
     it 'Returns an error' do
-      with_fixture_dir("stack/links-broken") do
-        k = run 'kontena stack install kontena.yml'
+      with_fixture_dir("stack/links") do
+        k = run 'kontena stack install broken.yml'
         expect(k.code).to eq(1)
-        expect(k.out).to match /Service validate failed for service 'a': Linked service 'nope' does not exist/
+        expect(k.out).to match /services:\s*a:\s*links: Linked service 'nope' does not exist/m
       end
     end
   end

--- a/test/spec/fixtures/stack/links/broken.yml
+++ b/test/spec/fixtures/stack/links/broken.yml
@@ -1,4 +1,4 @@
-stack: test/links
+stack: test/links-broken
 services:
   a:
     image: redis

--- a/test/spec/fixtures/stack/links/external-linked_1.yml
+++ b/test/spec/fixtures/stack/links/external-linked_1.yml
@@ -1,0 +1,6 @@
+stack: test/links-external-linked
+services:
+  foo:
+    image: redis
+  bar:
+    image: redis

--- a/test/spec/fixtures/stack/links/external-linked_2.yml
+++ b/test/spec/fixtures/stack/links/external-linked_2.yml
@@ -1,0 +1,4 @@
+stack: test/links-external-linked
+services:
+  foo:
+    image: redis


### PR DESCRIPTION
Fixes #1769
Also fixes #2116

The `StackRemoveWorker` used `GridService.destroy` to remove deployed stack services that are no longer in the newly deployed stack. This skipped all of the validations, node service pod terminate notifications and lb removals in the `GridServices::Delete` mutation.

* Fix the `Stacks::Update` mutation to validate removed services

    This will fail `kontena stack upgrade` early if removing a linked service.

* Fix the `Stacks::Deploy` -> `StackRemoveWorker` to use `GridServices::Delete` for service removal

  * This validates and fails if removing a linked service. Even with the `Stacks::Update` validation, this can still happen if a new linking service is created between the stack update and deploy.

  * Changes the stack service removal to also send notify nodes of the service instance/pod termination, and perform any LB service removal

* Add e2e specs

## TODO

* The stack deploy errors are only logged, not returned via the stacks deploy API
