### PR TITLE
Fix service, stack deploy errors

### DIFF
--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -37,7 +37,7 @@ module Kontena::Workers
         begin
           ensure_desired_state
         rescue => error
-          warn "failed to sync #{service_pod.name}: #{error}"
+          warn "failed to sync #{service_pod.name} at #{service_pod.deploy_rev}: #{error}"
           sync_state_to_master(current_state, error)
         else
           sync_state_to_master(current_state)

--- a/server/app/jobs/stack_deploy_worker.rb
+++ b/server/app/jobs/stack_deploy_worker.rb
@@ -60,6 +60,10 @@ class StackDeployWorker
     }
 
     service_deploy.reload
+
+    raise "service #{service.to_path} deploy failed: #{service_deploy.reason}" if service_deploy.error?
+
+    service_deploy
   end
 
   # @param [Stack] stack

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -30,10 +30,10 @@ class GridServiceInstanceDeployer
 
   rescue => error
     warn "Failed to deploy service instance #{@grid_service.to_path}-#{@instance_number} to node #{@host_node.name}: #{error.class}: #{error}\n#{error.backtrace.join("\n")}"
-    @grid_service_instance_deploy.set(:deploy_state => :error, :error => "#{error.class}: #{error}")
     log_service_event("Failed to deploy service instance #{@grid_service.to_path}-#{@instance_number} to node #{@host_node.name}: #{error.class}: #{error}", EventLog::ERROR)
+    return @grid_service_instance_deploy.set(:deploy_state => :error, :error => "#{error.class}: #{error}")
   else
-    @grid_service_instance_deploy.set(:deploy_state => :success)
+    return @grid_service_instance_deploy.set(:deploy_state => :success)
   end
 
   # Ensure the ServiceInstance matches the desired GridServiceInstanceDeploy configuration.

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -6,6 +6,7 @@ describe GridServiceDeployer do
   let(:node1) { HostNode.create!(node_id: SecureRandom.uuid, grid: grid) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
   let(:subject) { described_class.new(strategy, grid_service_deploy, grid.host_nodes.to_a) }
+  let(:deploy_rev) { Time.now.utc.to_s }
 
   describe '#selected_nodes' do
     before(:each) do
@@ -66,12 +67,8 @@ describe GridServiceDeployer do
     end
   end
 
-  describe '#deploy_service_instance' do
-    let(:deploy_rev) { Time.now.utc.to_s }
-
-    let(:instance_deployer) { instance_double(GridServiceInstanceDeployer) }
-
-    context "for a grid without host nodes" do
+  context "for a grid without host nodes" do
+    describe '#deploy_service_instance' do
       it "fails with a scheduler error" do
         total_instances = 2
         deploy_futures = []
@@ -81,14 +78,17 @@ describe GridServiceDeployer do
           subject.deploy_service_instance(total_instances, deploy_futures, instance_number, deploy_rev)
         }.to raise_error(GridServiceDeployer::DeployError, 'Cannot find applicable node for service instance test-grid/null/redis-1: There are no nodes available')
       end
+    end
+  end
 
+  context "for a grid with host nodes" do
+    before(:each) do
+      grid.host_nodes.create!(name: 'node1', node_id: SecureRandom.uuid)
+      grid.host_nodes.create!(name: 'node2', node_id: SecureRandom.uuid)
     end
 
-    context "for a grid with host nodes" do
-      before(:each) do
-        grid.host_nodes.create!(name: 'node1', node_id: SecureRandom.uuid)
-        grid.host_nodes.create!(name: 'node2', node_id: SecureRandom.uuid)
-      end
+    describe '#deploy_service_instance' do
+      let(:instance_deployer) { instance_double(GridServiceInstanceDeployer) }
 
       it "aborts the service deploy if the instance deploy fails" do
         total_instances = 2
@@ -111,5 +111,69 @@ describe GridServiceDeployer do
         }.to raise_error(GridServiceDeployer::DeployError, 'halting deploy of test-grid/null/redis, one or more instances failed')
       end
     end
+
+    describe '#deploy' do
+
+      context "for multiple concurrent instance deploys" do
+        let(:grid_service) {
+          grid.grid_services.create!(
+            name: 'redis',
+            image_name: 'kontena/redis:2.8',
+            deploy_opts: {
+              min_health: 0.0,
+            },
+            container_count: 2,
+          )
+        }
+        let(:grid_service_deploy) { GridServiceDeploy.create(grid_service: grid_service) }
+        let(:subject) { described_class.new(strategy, grid_service_deploy, grid.host_nodes.to_a) }
+
+        before do
+          grid_service_deploy.started_at = Time.now.utc
+        end
+
+        it "fails the service deploy if one of the concurrent instance deploys fail" do
+          expect(subject).to receive(:deploy_service_instance).once.with(2, Array, 1, String) do |total_instances, deploy_futures, instance_number, deploy_rev|
+            deploy_futures << Celluloid::Future.new {
+              sleep 0.01
+
+              $stderr.puts "deploy 1: success"
+
+
+              grid_service_deploy.grid_service_instance_deploys.create(
+                instance_number: instance_number,
+                host_node: grid.host_nodes.first,
+                deploy_state: :success,
+              )
+            }
+          end
+          expect(subject).to receive(:deploy_service_instance).once.with(2, Array, 2, String) do |total_instances, deploy_futures, instance_number, deploy_rev|
+            deploy_futures << Celluloid::Future.new {
+              sleep 0.01
+
+              $stderr.puts "deploy 2: error"
+
+              grid_service_deploy.grid_service_instance_deploys.create(
+                instance_number: instance_number,
+                host_node: grid.host_nodes.first,
+                deploy_state: :error,
+                error: "testfail 2"
+              )
+            }
+          end
+
+          allow(grid_service).to receive(:deploying?).and_return(true) # XXX: why is it not deploying?
+
+          expect{
+            subject.deploy
+          }.to change{grid_service_deploy.grid_service_instance_deploys.count}.from(0).to(2)
+
+          grid_service_deploy.reload
+
+          expect(grid_service_deploy).to be_error
+        end
+      end
+    end
   end
+
 end

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -90,7 +90,7 @@ describe GridServiceDeployer do
     describe '#deploy_service_instance' do
       let(:instance_deployer) { instance_double(GridServiceInstanceDeployer) }
 
-      it "aborts the service deploy if the instance deploy fails" do
+      it "aborts the service deploy if the instance deploy fails", :celluloid => true do
         total_instances = 2
         deploy_futures = []
         instance_number = 1
@@ -132,7 +132,7 @@ describe GridServiceDeployer do
           grid_service_deploy.started_at = Time.now.utc
         end
 
-        it "fails the service deploy if one of the concurrent instance deploys fail" do
+        it "fails the service deploy if one of the concurrent instance deploys fail", :celluloid => true do
           expect(subject).to receive(:deploy_service_instance).once.with(2, Array, 1, String) do |total_instances, deploy_futures, instance_number, deploy_rev|
             deploy_futures << Celluloid::Future.new {
               sleep 0.01

--- a/server/spec/services/grid_service_instance_deployer_spec.rb
+++ b/server/spec/services/grid_service_instance_deployer_spec.rb
@@ -24,14 +24,24 @@ describe GridServiceInstanceDeployer do
         expect(instance_deploy).to be_ongoing
       end
 
-      expect{subject.deploy(deploy_rev)}.to change{instance_deploy.reload.deploy_state}.from(:created).to(:success)
+      expect{
+        result = subject.deploy(deploy_rev)
+
+        expect(result).to be_a GridServiceInstanceDeploy
+        expect(result).to_not be_error
+      }.to change{instance_deploy.reload.deploy_state}.from(:created).to(:success)
     end
 
     it "updates the instance deploy state to error on failure" do
       expect(subject).to receive(:ensure_volume_instance)
       expect(subject).to receive(:ensure_service_instance).with(deploy_rev).and_raise(GridServiceInstanceDeployer::ServiceError, "Docker::Error::NotFoundError: No such image: redis:nonexist")
 
-      expect{subject.deploy(deploy_rev)}.to change{instance_deploy.reload.deploy_state}.from(:created).to(:error)
+      expect{
+        result = subject.deploy(deploy_rev)
+
+        expect(result).to be_a GridServiceInstanceDeploy
+        expect(result).to be_error
+      }.to change{instance_deploy.reload.deploy_state}.from(:created).to(:error)
       expect(instance_deploy.reload.error).to eq "GridServiceInstanceDeployer::ServiceError: Docker::Error::NotFoundError: No such image: redis:nonexist"
     end
   end


### PR DESCRIPTION
Fixes #2127

* Add specs for `GridServiceInstanceDeployer#deploy` return value, and fix it to return the `GridServiceInstanceDeploy` in error cases
* Fix and add specs for `GridServiceDeployer`'s handling of the `Celluloid::Future` `f.value.error? -> GridServiceInstanceDeploy.error?` handling
* Fix the `StackDeployWorker` to `StackDeploy.error!` if any `GridServiceDeploy.error?`

## TODO
* e2e specs