### PR TITLE
Check volume driver match when ensuring volume existence

### DIFF
--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -149,7 +149,7 @@ module Kontena
         volume_manager = Celluloid::Actor[:volume_manager]
         service_pod.volumes.each do |volume|
           if volume['name']
-            return false unless volume_manager.volume_exist?(volume['name'])
+            return false unless volume_manager.volume_exist?(volume['name'], volume['driver'])
           end
         end
         true

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -70,9 +70,8 @@ module Kontena::Workers::Volumes
     # @param [Kontena::Models::Volume] volume
     def ensure_volume(volume)
       debug "ensuring volume existence: #{volume.inspect}"
-
       begin
-        unless __volume_exist?(volume.name, volume.driver)
+        unless volume_exist?(volume.name, volume.driver)
           info "creating volume"
           v = Docker::Volume.create(volume.name, {
             'Driver' => volume.driver,
@@ -103,7 +102,7 @@ module Kontena::Workers::Volumes
     # @param [String] name of the volume
     # @param [String] driver to expect on the volume if already existing
     # @raise [DriverMismatchError] If the volume is found but using a different driver than expected
-    def __volume_exist?(volume_name, driver)
+    def volume_exist?(volume_name, driver)
       begin
         debug "volume #{volume_name} exists"
         volume = Docker::Volume.get(volume_name)
@@ -115,12 +114,6 @@ module Kontena::Workers::Volumes
       rescue Docker::Error::NotFoundError
         debug "volume #{volume_name} does NOT exist"
         false
-      end
-    end
-
-    def volume_exist?(volume_name, driver)
-      begin
-        __volume_exist?(volume_name, driver)
       rescue => error
         abort error
       end

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -9,6 +9,9 @@ module Kontena::Workers::Volumes
     include Kontena::Helpers::WaitHelper
     include Kontena::Observer
 
+    class DriverMismatchError < StandardError
+    end
+
     attr_reader :node
 
     def initialize(autostart = true)
@@ -94,10 +97,20 @@ module Kontena::Workers::Volumes
       rpc_client.async.request('/node_volumes/set_state', [node.id, volume])
     end
 
-    def volume_exist?(volume_name)
+    # Checks if given volume exists with the expected driver
+    #
+    # @param [String] name of the volume
+    # @param [String] driver to expect on the volume if already existing
+    # @raise [DriverMismatchError] If the volume is found but using a different driver than expected
+    def volume_exist?(volume_name, driver)
       begin
         debug "volume #{volume_name} exists"
-        true if Docker::Volume.get(volume_name)
+        volume = Docker::Volume.get(volume_name)
+        if volume && volume.info['Driver'] == driver
+          return true
+        elsif volume && volume.info['Driver'] != driver
+          raise DriverMismatchError.new("Volume driver not as expected. Expected #{driver}, existing volume has #{volume.info['Driver']}")
+        end
       rescue Docker::Error::NotFoundError
         debug "volume #{volume_name} does NOT exist"
         false

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -72,7 +72,8 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
     end
 
     it 'does not create a volume if it already exists' do
-      expect(Docker::Volume).to receive(:get).with('foo').and_return(double)
+      expect(subject.wrapped_object).to receive(:__volume_exist?).with('foo', 'local').and_return(true)
+      expect(Docker::Volume).not_to receive(:create)
       subject.ensure_volume(volume)
     end
 
@@ -85,6 +86,15 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
       }).and_return(double)
       expect(subject.wrapped_object).to receive(:sync_volume_to_master)
       subject.ensure_volume(volume)
+    end
+
+    it 'does not crash actor if random failure from docker' do
+      expect(subject.wrapped_object).to receive(:__volume_exist?).with('foo', 'local').and_return(false)
+      expect(Docker::Volume).to receive(:create).and_raise(StandardError)
+      expect(subject.wrapped_object).not_to receive(:sync_volume_to_master)
+      subject.ensure_volume(volume)
+      # The actor should be still alive
+      expect(subject.alive?).to eq(true)
     end
 
   end
@@ -103,25 +113,41 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
     end
   end
 
-  describe '#volume_exist?' do
+  describe '#__volume_exist?' do
     it 'return true if volume exists' do
       expect(Docker::Volume).to receive(:get).with('foo').and_return(double(:volume, :info => {'Driver' => 'local'}))
-      expect(subject.volume_exist?('foo', 'local')).to be_truthy
+      expect(subject.__volume_exist?('foo', 'local')).to be_truthy
     end
 
     it 'return false if volume not exists' do
       expect(Docker::Volume).to receive(:get).with('foo').and_raise(Docker::Error::NotFoundError)
-      expect(subject.volume_exist?('foo', 'local')).to be_falsey
+      expect(subject.__volume_exist?('foo', 'local')).to be_falsey
     end
 
     it 'raises if volume drivers do not match' do
       expect(Docker::Volume).to receive(:get).with('foo').and_return(double(:volume, :info => {'Driver' => 'foo'}))
       expect {
         # Call through wrapped object to avoid ugly logs in test trace
-        subject.wrapped_object.volume_exist?('foo', 'local')
+        subject.wrapped_object.__volume_exist?('foo', 'local')
       }.to raise_error(Kontena::Workers::Volumes::VolumeManager::DriverMismatchError)
     end
 
+  end
+
+  describe '#volume_exist?' do
+    it 'return the status of __volume_exist?' do
+      expect(subject.wrapped_object).to receive(:__volume_exist?).with('foo', 'local').and_return(true)
+      expect(subject.volume_exist?('foo', 'local')).to eq(true)
+    end
+
+    it 'abort if __volume_exist? throws' do
+      expect(subject.wrapped_object).to receive(:__volume_exist?).with('foo', 'local').and_raise(Kontena::Workers::Volumes::VolumeManager::DriverMismatchError)
+      expect {
+        subject.volume_exist?('foo', 'local')
+      }.to raise_error(Kontena::Workers::Volumes::VolumeManager::DriverMismatchError)
+      # The actor should be still alive
+      expect(subject.alive?).to eq(true)
+    end
   end
 
   describe '#terminate_volumes' do


### PR DESCRIPTION
fixes #2089 

Volume manager did not check volume driver match when it checked volume existence. Now it does :)

## After
With existence of a expected volume but with a wrong driver:
```
$ k service deploy redis
 [done] Deploying service redis      
⊗ Failed to deploy instance test/null/redis-1 to node moby: GridServiceInstanceDeployer::ServiceError: Kontena::Workers::Volumes::VolumeManager::DriverMismatchError: Volume driver not as expected. Expected foo, existing volume has local
```