### PR TITLE
Use tty-table for volume ls

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "safe_yaml", "~> 1.0"
   spec.add_runtime_dependency "liquid", "~> 4.0.0"
+  spec.add_runtime_dependency "tty-table", "~> 0.8.0"
 end

--- a/cli/lib/kontena/cli/volumes/list_command.rb
+++ b/cli/lib/kontena/cli/volumes/list_command.rb
@@ -10,11 +10,9 @@ module Kontena::Cli::Volumes
 
     def execute
       volumes = client.get("volumes/#{current_grid}")['volumes']
-      columns = '%-25.25s %-25.25s %-25.25s %-25.25s'
-      puts columns % ['NAME', 'SCOPE', 'DRIVER', 'CREATED AT']
-      volumes.each do |volume|
-        puts columns % [volume['name'], volume['scope'], volume['driver'], volume['created_at']]
-      end
+      table = TTY::Table.new ['NAME', 'SCOPE', 'DRIVER', 'CREATED AT'],
+          volumes.map {|volume| [volume['name'], volume['scope'], volume['driver'], volume['created_at']]}
+      puts table.render(:basic)
     end
 
   end

--- a/cli/lib/kontena/cli/volumes/list_command.rb
+++ b/cli/lib/kontena/cli/volumes/list_command.rb
@@ -10,8 +10,9 @@ module Kontena::Cli::Volumes
 
     def execute
       volumes = client.get("volumes/#{current_grid}")['volumes']
-      table = TTY::Table.new ['NAME', 'SCOPE', 'DRIVER', 'CREATED AT'],
-          volumes.map {|volume| [volume['name'], volume['scope'], volume['driver'], volume['created_at']]}
+      table = TTY::Table.new ['NAME', 'SCOPE', 'DRIVER', 'CREATED AT'], volumes.map { |volume|
+        [volume['name'], volume['scope'], volume['driver'], volume['created_at']]
+      }
       puts table.render(:basic)
     end
 

--- a/cli/lib/kontena/cli/volumes/list_command.rb
+++ b/cli/lib/kontena/cli/volumes/list_command.rb
@@ -9,6 +9,8 @@ module Kontena::Cli::Volumes
     requires_current_master_token
 
     def execute
+      require 'tty-table'
+      
       volumes = client.get("volumes/#{current_grid}")['volumes']
       table = TTY::Table.new ['NAME', 'SCOPE', 'DRIVER', 'CREATED AT'], volumes.map { |volume|
         [volume['name'], volume['scope'], volume['driver'], volume['created_at']]

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -107,7 +107,6 @@ end
 require 'ruby_dig'
 require 'shellwords'
 require "safe_yaml"
-require 'tty-table'
 SafeYAML::OPTIONS[:default_mode] = :safe
 require_relative 'kontena/cli/version'
 require_relative 'kontena/cli/common'

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -107,6 +107,7 @@ end
 require 'ruby_dig'
 require 'shellwords'
 require "safe_yaml"
+require 'tty-table'
 SafeYAML::OPTIONS[:default_mode] = :safe
 require_relative 'kontena/cli/version'
 require_relative 'kontena/cli/common'


### PR DESCRIPTION
`kontena volume ls` cuts long volume names. This PR takes `tty-table` gem into use which provides dynamic-size table functionality and makes these tabular form cli output much nicer to write.

If this is ok to use, we can utilise it in other tabular command outputs.

fixes #2083 

## TODO

Test that it actually works on Win platforms too, some of the tty stuff has had bad track record in the past.