### PR TITLE
Fix agent to raise on service container start, stop, restart errors

### DIFF
--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -64,8 +64,8 @@ module Kontena
           Celluloid::Notifications.publish('lb:remove_config', service_container.service_name_for_lb)
         end
 
-        service_container.start
-        info "service started: #{service_pod.name_for_humans}"
+        out = service_container.start!
+        info "service started: #{service_pod.name_for_humans}: #{out}"
         log_service_pod_event("service:create_instance", "service #{service_pod.name_for_humans} instance started")
 
         Celluloid::Notifications.publish('service_pod:start', service_pod.name)

--- a/agent/lib/kontena/service_pods/restarter.rb
+++ b/agent/lib/kontena/service_pods/restarter.rb
@@ -22,7 +22,7 @@ module Kontena
         service_container = get_container(self.service_id, self.instance_number)
         if service_container.running?
           info "restarting service: #{service_container.name_for_humans}"
-          service_container.restart('timeout' => 10)
+          service_container.restart!('timeout' => 10)
           log_service_pod_event(
             self.service_id, self.instance_number,
             "service:restart_instance", "service #{service_container.name_for_humans} instance restarted successfully"

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -26,7 +26,7 @@ module Kontena
             self.service_id, self.instance_number,
             "service:start_instance", "starting service instance #{service_container.name_for_humans}"
           )
-          service_container.restart('timeout' => 10)
+          service_container.restart!('timeout' => 10)
           log_service_pod_event(
             self.service_id, self.instance_number,
             "service:start_instance", "service instance #{service_container.name_for_humans} started successfully"

--- a/agent/lib/kontena/service_pods/stopper.rb
+++ b/agent/lib/kontena/service_pods/stopper.rb
@@ -27,7 +27,7 @@ module Kontena
             self.service_id, self.instance_number,
             "service:stop_instance", "stopping service instance #{service_container.name_for_humans}"
           )
-          service_container.stop('timeout' => 10)
+          service_container.stop!('timeout' => 10)
           log_service_pod_event(
             self.service_id, self.instance_number,
             "service:stop_instance", "service instance #{service_container.name_for_humans} stopped successfully"

--- a/agent/spec/lib/kontena/service_pods/restarter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/restarter_spec.rb
@@ -14,15 +14,20 @@ describe Kontena::ServicePods::Restarter do
       allow(subject).to receive(:get_container).and_return(container)
     end
 
-    it 'restarts container if running' do
-      expect(container).to receive(:restart).with({'timeout' => 10})
+    it 'does notthing if container if not running' do
+      allow(container).to receive(:running?).and_return(false)
+      expect(container).not_to receive(:restart!)
       subject.perform
     end
 
-    it 'does not start container if not running' do
-      allow(container).to receive(:running?).and_return(false)
-      expect(container).not_to receive(:start)
+    it 'restarts container if running' do
+      expect(container).to receive(:restart!).with({'timeout' => 10})
       subject.perform
+    end
+
+    it 'fails if container restart fails' do
+      expect(container).to receive(:restart!).with({'timeout' => 10}).and_raise(Docker::Error::ServerError, "failed")
+      expect{subject.perform}.to raise_error(Docker::Error::ServerError)
     end
   end
 end

--- a/agent/spec/lib/kontena/service_pods/starter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/starter_spec.rb
@@ -14,9 +14,20 @@ describe Kontena::ServicePods::Starter do
       allow(subject).to receive(:get_container).and_return(container)
     end
 
-    it 'restarts container if not running' do
-      expect(container).to receive(:restart).with({'timeout' => 10})
+    it 'does nothing if container is running' do
+      allow(container).to receive(:running?).and_return(true)
+      expect(container).to_not receive(:restart!)
       subject.perform
+    end
+
+    it 'restarts container if not running' do
+      expect(container).to receive(:restart!).with({'timeout' => 10})
+      subject.perform
+    end
+
+    it 'fails if container restart fails' do
+      expect(container).to receive(:restart!).with({'timeout' => 10}).and_raise(Docker::Error::ServerError, "failed")
+      expect{subject.perform}.to raise_error(Docker::Error::ServerError)
     end
   end
 end

--- a/agent/spec/lib/kontena/service_pods/stopper_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/stopper_spec.rb
@@ -14,9 +14,20 @@ describe Kontena::ServicePods::Stopper do
       allow(subject).to receive(:get_container).and_return(container)
     end
 
-    it 'stops container' do
-      expect(container).to receive(:stop).with({'timeout' => 10})
+    it 'does nothing if container is not running' do
+      allow(container).to receive(:running?).and_return(false)
+      expect(container).not_to receive(:stop!)
       subject.perform
+    end
+
+    it 'stops container if running' do
+      expect(container).to receive(:stop!).with({'timeout' => 10})
+      subject.perform
+    end
+
+    it 'fails if container stop fails' do
+      expect(container).to receive(:stop!).with({'timeout' => 10}).and_raise(Docker::Error::ServerError, "failed")
+      expect{subject.perform}.to raise_error(Docker::Error::ServerError)
     end
   end
 end

--- a/test/spec/features/service/deploy_spec.rb
+++ b/test/spec/features/service/deploy_spec.rb
@@ -8,4 +8,25 @@ describe 'service deploy' do
 
     run("kontena service rm --force test-1")
   end
+
+  context "For a service that fails to deploy" do
+    before do
+      k = run("kontena service create -v /dev/null/wtf:/dev/wtf test-fail redis")
+      expect(k.code).to eq(0), k.out
+    end
+
+    after do
+      k = run("kontena service rm --force test-fail")
+      fail k.out unless k.code == 0
+    end
+
+    it "fails to deploy with an error" do
+      k = run("kontena service deploy test-fail")
+
+      expect(k.code).not_to eq(0), k.out
+
+      expect(k.out).to match /halting deploy of .+, one or more instances failed/
+      expect(k.out).to match /Failed to deploy instance .+ to node .+: GridServiceInstanceDeployer::ServiceError: .*stat \/dev\/null\/wtf: not a directory/
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2134

* Have the agent raise Docker API errors on service pod actions

* Add a spec for service deploy errors using `-v /dev/null/wtf:/dev/wtf`, which will fail to start

## Examples

### Before

Testing with `kontena service create -v /dev/null/wtf:/dev/wtf test-fail redis`:

#### `kontena service deploy test-fail`
```
[error] Kontena::Errors::StandardErrorArray : halting deploy of e2e/null/test-fail, one or more instances failed:
	⊗ Failed to deploy instance e2e/null/test-fail-1 to node localhost: GridServiceInstanceDeployer::StateError: Service instance is not running, but stopped
```

#### `kontena service show test-fail`
```
e2e/null/test-fail:
  ...
  desired_state: running
  ...
  instances:
    test-fail/1:
      ...
      state: stopped
      containers:
        test-fail-1 (on localhost):
          ...
          status: stopped
          reason: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"process_linux.go:359: container init caused \\\"rootfs_linux.go:53: mounting \\\\\\\"/dev/null/wtf\\\\\\\" to rootfs \\\\\\\"/var/lib/docker/overlay/11737453df3e9f59f1c0d8e97c4d4fb833d4b160a864d00b91b6f7f14455cb4a/merged\\\\\\\" at \\\\\\\"/dev/wtf\\\\\\\" caused \\\\\\\"stat /dev/null/wtf: not a directory\\\\\\\"\\\"\"\n"
          exit code: 128
```

### After

#### `kontena service deploy test-fail`

```
 [error] Kontena::Errors::StandardErrorArray : halting deploy of e2e/null/test-fail, one or more instances failed:
	⊗ Failed to deploy instance e2e/null/test-fail-1 to node localhost: GridServiceInstanceDeployer::ServiceError: Docker::Error::ServerError: invalid header field value "oci runtime error: container_linux.go:247: starting container process caused \"process_linux.go:359: container init caused \\\"rootfs_linux.go:53: mounting \\\\\\\"/dev/null/wtf\\\\\\\" to rootfs \\\\\\\"/var/lib/docker/overlay/98aafa6d430feaa89c3aea9e9df186b3717243230fc613dc25beec85970bb941/merged\\\\\\\" at \\\\\\\"/dev/wtf\\\\\\\" caused \\\\\\\"stat /dev/null/wtf: not a directory\\\\\\\"\\\"\"\n"
```