### PR TITLE
Server WebsocketBackend EventMachine watchdog

### DIFF
--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -7,7 +7,7 @@ require_relative '../services/agent/node_unplugger'
 class WebsocketBackend
   WATCHDOG_INTERVAL = 0.5.seconds
   WATCHDOG_THRESHOLD = 1.0.seconds
-  WATCHDOG_TIMEOUT = 60.0.seconds # XXX: testing
+  WATCHDOG_TIMEOUT = 60.0.seconds
 
   KEEPALIVE_TIME = 30 # in seconds
   RPC_MSG_TYPES = %w(request notify)

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -5,9 +5,9 @@ require_relative '../services/agent/node_plugger'
 require_relative '../services/agent/node_unplugger'
 
 class WebsocketBackend
-  WATCHDOG_INTERVAL = 0.5 # seconds
-  WATCHDOG_THRESHOLD = 1.0 # seconds
-  WATCHDOG_TIMEOUT = 10.0 # seconds # XXX: testing
+  WATCHDOG_INTERVAL = 0.5.seconds
+  WATCHDOG_THRESHOLD = 1.0.seconds
+  WATCHDOG_TIMEOUT = 60.0.seconds # XXX: testing
 
   KEEPALIVE_TIME = 30 # in seconds
   RPC_MSG_TYPES = %w(request notify)

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -271,9 +271,11 @@ class WebsocketBackend
     end
   end
 
-  # Start a Watchdog actor, and ping it every interval
+  # Start a Watchdog actor, and ping it every interval.
+  # It will log warnings and finally abort the EM thread if the timer does not get run on time.
   def watchdog
     EM.next_tick {
+      # must be called within the EM thread
       @watchdog = Watchdog.new(self.class.name, Thread.current,
         interval: WATCHDOG_INTERVAL,
         threshold: WATCHDOG_THRESHOLD,

--- a/server/app/services/watchdog.rb
+++ b/server/app/services/watchdog.rb
@@ -1,6 +1,11 @@
 class Watchdog
   include Celluloid
 
+  # this is not a StandardError, it is supposed to abort the thread
+  class Abort < Exception
+
+  end
+
   INTERVAL = 0.5
   THRESHOLD = 1.0
   TIMEOUT = 60.0
@@ -62,6 +67,6 @@ class Watchdog
 
   def abort
     # XXX: let's assume that the thread has abort_on_exception and it does not rescue non-StandardError
-    @thread.raise SystemExit, "ABORT #{@subject} watchdog timeout"
+    @thread.raise Abort, "ABORT #{@subject} watchdog timeout"
   end
 end

--- a/server/app/services/watchdog.rb
+++ b/server/app/services/watchdog.rb
@@ -3,7 +3,7 @@ class Watchdog
 
   INTERVAL = 0.5
   THRESHOLD = 1.0
-  TIMEOUT = 10.0
+  TIMEOUT = 60.0
   ABORT = true
 
   def self.logger(subject, target: STDOUT, level: ENV["WATCHDOG_DEBUG"] ? Logger::DEBUG : Logger::INFO)

--- a/server/app/services/watchdog.rb
+++ b/server/app/services/watchdog.rb
@@ -1,0 +1,67 @@
+class Watchdog
+  include Celluloid
+
+  INTERVAL = 0.5
+  THRESHOLD = 1.0
+  TIMEOUT = 10.0
+  ABORT = true
+
+  def self.logger(subject, target: STDOUT, level: ENV["WATCHDOG_DEBUG"] ? Logger::DEBUG : Logger::INFO)
+    logger = Logger.new(target)
+    logger.progname = "#{self.name}<#{subject}>"
+    logger.level = level
+    logger
+  end
+
+  attr_reader :logger
+
+  def initialize(subject, thread, interval: INTERVAL, threshold: THRESHOLD, timeout: TIMEOUT, abort: ABORT, start: true)
+    @logger = self.class.logger(subject)
+
+    @subject = subject
+    @thread = thread
+    @interval = interval
+    @threshold = threshold
+    @timeout = timeout
+    @abort = abort
+
+    @ping = Time.now
+
+    async.start if start
+  end
+
+  def ping
+    @ping = Time.now
+  end
+
+  def start
+    logger.info "watchdog start"
+    every(@interval) do
+      check
+    end
+  end
+
+  def check
+    delay = Time.now - @ping
+
+    if delay > @timeout
+      logger.fatal "watchdog timeout after %.3fs @\n\t%s" % [delay, trace.join("\n\t")]
+      abort if @abort
+
+    elsif delay > @threshold
+      logger.warn "watchdog delayed by %.3fs @\n\t%s" % [delay, trace.join("\n\t")]
+
+    else
+      logger.debug { "watchdog delay is %.3fs" % [delay] }
+    end
+  end
+
+  def trace
+    @thread.backtrace
+  end
+
+  def abort
+    # XXX: let's assume that the thread has abort_on_exception and it does not rescue non-StandardError
+    @thread.raise SystemExit, "ABORT #{@subject} watchdog timeout"
+  end
+end

--- a/server/app/services/watchdog.rb
+++ b/server/app/services/watchdog.rb
@@ -11,7 +11,9 @@ class Watchdog
   TIMEOUT = 60.0
   ABORT = true
 
-  def self.logger(subject, target: STDOUT, level: ENV["WATCHDOG_DEBUG"] ? Logger::DEBUG : Logger::INFO)
+  LOG_LEVEL = Logger::INFO
+
+  def self.logger(subject, target: STDOUT, level: ENV["WATCHDOG_DEBUG"] ? Logger::DEBUG : LOG_LEVEL)
     logger = Logger.new(target)
     logger.progname = "#{self.name}<#{subject}>"
     logger.level = level

--- a/server/app/services/watchdog.rb
+++ b/server/app/services/watchdog.rb
@@ -20,6 +20,12 @@ class Watchdog
 
   attr_reader :logger
 
+  # @param subject [String] used for logging, describe what is pinging this watchdog
+  # @param thread [Thread] thread to trace and abort on watchdog timeouts
+  # @param interval [Fixnum] expect to get a ping every interval seconds
+  # @param threshold [Fixnum] log warnings if pings interval goes above threshold seconds
+  # @param timeout [Fixnum] log fatal if ping interval goes above timeout seconds
+  # @param abort [Boolean] abort thread on timeout by raising Watchdog::Abort
   def initialize(subject, thread, interval: INTERVAL, threshold: THRESHOLD, timeout: TIMEOUT, abort: ABORT, start: true)
     @logger = self.class.logger(subject)
 
@@ -35,10 +41,12 @@ class Watchdog
     async.start if start
   end
 
+  # Keep the watchdog happy by pinging it every interval
   def ping
     @ping = Time.now
   end
 
+  # Start checking for pings
   def start
     logger.info "watchdog start"
     @timer = every(@interval) do
@@ -66,6 +74,7 @@ class Watchdog
     end
   end
 
+  # @return [Array<String>] current target thread stack
   def trace
     @thread.backtrace
   end

--- a/server/app/services/watchdog.rb
+++ b/server/app/services/watchdog.rb
@@ -41,9 +41,14 @@ class Watchdog
 
   def start
     logger.info "watchdog start"
-    every(@interval) do
+    @timer = every(@interval) do
       check
     end
+  end
+
+  # Stop the every loop from start
+  def stop
+    @timer.cancel
   end
 
   def check
@@ -65,8 +70,13 @@ class Watchdog
     @thread.backtrace
   end
 
+  # Abort the target thread by raising Watchdog::Abort.
+  # Stops the watchdog, we don't expect to receive any more pings.
   def abort
-    # XXX: let's assume that the thread has abort_on_exception and it does not rescue non-StandardError
+    # only abort once
+    self.stop
+
+    # assume that the thread has abort_on_exception and it does not rescue non-StandardError
     @thread.raise Abort, "ABORT #{@subject} watchdog timeout"
   end
 end


### PR DESCRIPTION
Have each server puma worker `WebsocketBackend` spawn a `Watchdog` actor, and ping it from an `EM::PeriodicTimer`. If the EM thread stalls and the watchdog timer does not run, the watchdog will log warnings after a threshold, and finally abort the EM thread on a timeout.

This would help diagnose (via the log warning threshold), and possibly recover from (via the abort and restart timeout), node connectivity issues caused by server `WebsocketBackend` EventMachine slowness. This kind of slowness could be caused by either overload (more websocket events happening than the server is able to process, particularly as agents start timing out and escalate into even more load), or by any blocking operations (such as mongodb queries) that are performed directly within the EM thread.

## Examples
Simulating some very slow mongod queries:

```patch
diff --git a/server/app/middlewares/websocket_backend.rb b/server/app/middlewares/websocket_backend.rb
index 986e159..7cf7a22 100644
--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -299,7 +300,9 @@ class WebsocketBackend
 
   # @param [Hash] client
   def on_pong(client)
+    logger.debug "on pong from client=#{client[:id]}...."
     node = HostNode.find_by(node_id: client[:id])
+    sleep 3
     if node
       if node.connected?
         node.set(last_seen_at: Time.now.utc)
```

### Threshold warning
```
D, [2017-04-11T12:09:12.165528 #21560] DEBUG -- WebsocketBackend: on pong from client=XI4K:NPOL:EQJ4:S4V7:EN3B:DHC5:KZJD:F3U2:PCAN:46EV:IO4A:63S5....
W, [2017-04-11T12:09:12.853093 #21560]  WARN -- Watchdog<WebsocketBackend>: watchdog delayed by 1.151s @
	/home/kontena/kontena/kontena/server/app/middlewares/websocket_backend.rb:305:in `sleep'
	/home/kontena/kontena/kontena/server/app/middlewares/websocket_backend.rb:305:in `on_pong'
	/home/kontena/kontena/kontena/server/app/middlewares/websocket_backend.rb:297:in `block in verify_client_connection'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:376:in `emit_frame'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:123:in `parse'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/faye-websocket-0.10.7/lib/faye/websocket/api.rb:153:in `parse'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/faye-websocket-0.10.7/lib/faye/websocket.rb:101:in `receive'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/faye-websocket-0.10.7/lib/faye/rack_stream.rb:10:in `receive_data'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/eventmachine-1.2.3/lib/eventmachine.rb:194:in `run_machine'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/eventmachine-1.2.3/lib/eventmachine.rb:194:in `run'
	/home/kontena/kontena/kontena/server/app/initializers/eventmachine.rb:10:in `block in <top (required)>'
```

### Timeout abort
Raises `Watchdog::Abort` in the EM thread... atm this seems to segfault the EM thread... but the puma worker still restarts.