### PR TITLE
Bring scheduler node offline grace period back

### DIFF
--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -29,8 +29,6 @@ class HostNode
   field :agent_version, type: String
   field :docker_version, type: String
 
-  attr_accessor :schedule_counter
-
   embeds_many :volume_drivers, class_name: 'HostNodeDriver'
   embeds_many :network_drivers, class_name: 'HostNodeDriver'
 

--- a/server/app/services/grid_service_scheduler.rb
+++ b/server/app/services/grid_service_scheduler.rb
@@ -36,7 +36,7 @@ class GridServiceScheduler
   ##
   # @param [GridService] grid_service
   # @param [Integer] instance_number
-  # @param [Array<HostNode>] nodes
+  # @param [Array<Scheduler::Node>] nodes
   # @raise [Scheduler::Error]
   # @return HostNode
   def select_node(grid_service, instance_number, nodes)
@@ -53,7 +53,7 @@ class GridServiceScheduler
       raise Scheduler::Error, "Strategy #{self.strategy.class.to_s} did not find any node"
     end
 
-    node = nodes.find{|n| n == selected_node}
+    node = nodes.find{ |n| n == selected_node }
     node.schedule_counter += 1
 
     selected_node
@@ -62,7 +62,7 @@ class GridServiceScheduler
   ##
   # @param [GridService] grid_service
   # @param [Integer] instance_number
-  # @param [Array<HostNode>]
+  # @param [Array<Scheduler::Node>]
   # @raise [Scheduler::Error]
   # @return [Array<HostNode>]
   def filter_nodes(grid_service, instance_number, nodes)

--- a/server/app/services/scheduler/node.rb
+++ b/server/app/services/scheduler/node.rb
@@ -1,0 +1,25 @@
+module Scheduler
+  class Node
+
+    attr_accessor :schedule_counter
+
+    def initialize(node)
+      @node = node
+      @schedule_counter = 0
+    end
+
+    def node
+      @node
+    end
+
+    def to_s
+      "#{@node.name}: #{@schedule_counter}"
+    end
+
+    private
+
+    def method_missing(meth, *args, &block)
+      @node.send(meth, *args, &block)
+    end
+  end
+end

--- a/server/app/services/scheduler/strategy/daemon.rb
+++ b/server/app/services/scheduler/strategy/daemon.rb
@@ -10,6 +10,11 @@ module Scheduler
         node_count.to_i * instance_count.to_i
       end
 
+      # @return [ActiveSupport::Duration]
+      def host_grace_period
+        10.minutes
+      end
+
       # @param [Array<HostNode>] nodes
       # @param [GridService] grid_service
       # @param [Integer] instance_number

--- a/server/app/services/scheduler/strategy/high_availability.rb
+++ b/server/app/services/scheduler/strategy/high_availability.rb
@@ -16,7 +16,7 @@ module Scheduler
       ##
       # @param [GridService] grid_service
       # @param [Integer] instance_number
-      # @param [Array<HostNode>] nodes
+      # @param [Array<Scheduler::Node>] nodes
       # @return [HostNode,NilClass]
       def find_node(grid_service, instance_number, nodes)
         if grid_service.stateless?
@@ -44,7 +44,7 @@ module Scheduler
           instance_number: instance_number
         )
         if prev_instance
-          nodes.find{ |n| n == prev_instance.host_node }
+          nodes.find{ |n| n.node == prev_instance.host_node }
         else
           candidates = self.sort_candidates(nodes, grid_service, instance_number)
           candidates.first

--- a/server/app/services/scheduler/strategy/high_availability.rb
+++ b/server/app/services/scheduler/strategy/high_availability.rb
@@ -8,6 +8,11 @@ module Scheduler
         instance_count.to_i
       end
 
+      # @return [ActiveSupport::Duration]
+      def host_grace_period
+        2.minutes
+      end
+
       ##
       # @param [GridService] grid_service
       # @param [Integer] instance_number

--- a/server/app/services/scheduler/strategy/random.rb
+++ b/server/app/services/scheduler/strategy/random.rb
@@ -8,6 +8,11 @@ module Scheduler
         instance_count.to_i
       end
 
+      # @return [ActiveSupport::Duration]
+      def host_grace_period
+        30.seconds
+      end
+
       ##
       # @param [GridService] grid_service
       # @param [Integer] instance_number

--- a/server/spec/services/grid_scheduler_spec.rb
+++ b/server/spec/services/grid_scheduler_spec.rb
@@ -4,9 +4,9 @@ describe GridScheduler do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:nodes) do
     nodes = []
-    3.times {
+    3.times { |i|
       nodes << HostNode.create!(
-        node_id: SecureRandom.uuid, grid: grid, connected: true
+        name: "node-#{i + 1}", node_id: SecureRandom.uuid, grid: grid, connected: true
       )
     }
     nodes
@@ -83,15 +83,41 @@ describe GridScheduler do
         nodes[1].set(connected: false)
       end
 
-      it 'returns true if all instances exist' do
+      let(:strategy) { Scheduler::Strategy::HighAvailability.new }
+
+      it 'returns false if node is offline and not seen' do
         2.times do |i|
           service.grid_service_instances.create!(
             host_node: nodes[i],
-            instance_number: i,
+            instance_number: i + 1,
             deploy_rev: Time.now.to_s
           )
         end
         expect(subject.all_instances_exist?(service)).to be_falsey
+      end
+
+      it 'returns false if node is offline and outside grace period' do
+        nodes[1].set(connected: false, last_seen_at: (strategy.host_grace_period + 2.seconds).ago)
+        2.times do |i|
+          service.grid_service_instances.create!(
+            host_node: nodes[i],
+            instance_number: i + 1,
+            deploy_rev: Time.now.to_s
+          )
+        end
+        expect(subject.all_instances_exist?(service)).to be_falsey
+      end
+
+      it 'returns true if node is offline and within grace period' do
+        nodes[1].set(connected: false, last_seen_at: (10.seconds).ago)
+        2.times do |i|
+          service.grid_service_instances.create!(
+            host_node: nodes[i],
+            instance_number: i + 1,
+            deploy_rev: Time.now.to_s
+          )
+        end
+        expect(subject.all_instances_exist?(service)).to be_truthy
       end
     end
   end

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -137,9 +137,6 @@ describe GridServiceDeployer do
             deploy_futures << Celluloid::Future.new {
               sleep 0.01
 
-              $stderr.puts "deploy 1: success"
-
-
               grid_service_deploy.grid_service_instance_deploys.create(
                 instance_number: instance_number,
                 host_node: grid.host_nodes.first,
@@ -150,8 +147,6 @@ describe GridServiceDeployer do
           expect(subject).to receive(:deploy_service_instance).once.with(2, Array, 2, String) do |total_instances, deploy_futures, instance_number, deploy_rev|
             deploy_futures << Celluloid::Future.new {
               sleep 0.01
-
-              $stderr.puts "deploy 2: error"
 
               grid_service_deploy.grid_service_instance_deploys.create(
                 instance_number: instance_number,

--- a/server/spec/services/grid_service_scheduler_spec.rb
+++ b/server/spec/services/grid_service_scheduler_spec.rb
@@ -6,7 +6,7 @@ describe GridServiceScheduler do
   let(:nodes) do
     nodes = []
     3.times { nodes << HostNode.create!(node_id: SecureRandom.uuid) }
-    nodes
+    nodes.map { |n| Scheduler::Node.new(n) }
   end
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
   let(:subject) { described_class.new(strategy) }

--- a/server/spec/services/scheduler/strategy/high_availability_spec.rb
+++ b/server/spec/services/scheduler/strategy/high_availability_spec.rb
@@ -18,7 +18,7 @@ describe Scheduler::Strategy::HighAvailability do
         )
       end
     end
-    nodes
+    nodes.map { |n| Scheduler::Node.new(n) }
   end
 
   let(:stateful_service) do
@@ -40,7 +40,7 @@ describe Scheduler::Strategy::HighAvailability do
 
       it 'returns node that has data volume container' do
         stateful_service.grid_service_instances.create!(
-          instance_number: 3, host_node: nodes[2]
+          instance_number: 3, host_node: nodes[2].node
         )
         expect(subject.find_node(stateful_service, 3, nodes)).to eq(nodes[2])
       end
@@ -69,14 +69,14 @@ describe Scheduler::Strategy::HighAvailability do
 
     it 'returns zero rank if instance is not already scheduled to node' do
       stateless_service.grid_service_instances.create!(
-        instance_number: 2, host_node: nodes[2]
+        instance_number: 2, host_node: nodes[2].node
       )
       expect(subject.instance_rank(node, stateless_service, 1)).to eq(0.0)
     end
 
     it 'returns negative rank if instance is already scheduled to node' do
       stateless_service.grid_service_instances.create!(
-        instance_number: 2, host_node: node
+        instance_number: 2, host_node: node.node
       )
       expect(subject.instance_rank(node, stateless_service, 2) < 0.0).to be_truthy
     end


### PR DESCRIPTION
Previous versions had a grace period, this PR brings that functionality back to 1.2 series.