### PR TITLE
Improve agent resource usage

### DIFF
--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -32,8 +32,8 @@ module Kontena::Workers
       subscribe('service_pod:update', :on_update_notify)
       subscribe('service_pod:event', :on_pod_event)
       loop do
-        sleep 30
         populate_workers_from_master
+        sleep 30
       end
     end
 
@@ -70,6 +70,7 @@ module Kontena::Workers
       warn "failed to get list of service pods from master: #{exc}"
     rescue => exc
       error exc.message
+      error exc.backtrace.join("\n")
     end
 
     def populate_workers_from_docker

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -31,7 +31,8 @@ module Kontena::Workers
 
       subscribe('service_pod:update', :on_update_notify)
       subscribe('service_pod:event', :on_pod_event)
-      every(30) do
+      loop do
+        sleep 30
         populate_workers_from_master
       end
     end
@@ -62,10 +63,13 @@ module Kontena::Workers
 
         service_pods.each do |s|
           ensure_service_worker(Kontena::Models::ServicePod.new(s))
+          sleep 0.05
         end
       }
     rescue Kontena::RpcClient::Error => exc
       warn "failed to get list of service pods from master: #{exc}"
+    rescue => exc
+      error exc.message
     end
 
     def populate_workers_from_docker

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -7,24 +7,49 @@ require_relative '../helpers/event_log_helper'
 module Kontena::Workers
   class ServicePodWorker
     include Celluloid
+    include Celluloid::Notifications
     include Kontena::Logging
     include Kontena::ServicePods::Common
     include Kontena::Helpers::RpcHelper
     include Kontena::Helpers::EventLogHelper
 
     attr_reader :node, :prev_state, :service_pod
-    attr_accessor :service_pod
+    attr_accessor :service_pod, :container_state_changed
 
     def initialize(node, service_pod)
       @node = node
       @service_pod = service_pod
       @prev_state = nil # sync'd to master
+      @container_state_changed = true
+      subscribe('container:event', :on_container_event)
     end
 
     # @param [Kontena::Models::ServicePod] service_pod
     def update(service_pod)
-      @service_pod = service_pod
-      apply
+      if needs_apply?(service_pod)
+        @service_pod = service_pod
+        apply
+      else
+        @service_pod = service_pod
+      end
+    end
+
+    # @param [Kontena::Models::ServicePod] service_pod
+    # @return [Boolean]
+    def needs_apply?(service_pod)
+      @container_state_changed ||
+        @service_pod.desired_state != service_pod.desired_state ||
+          @service_pod.deploy_rev != service_pod.deploy_rev
+    end
+
+    # @param [String] topic
+    # @param [Docker::Event] e
+    def on_container_event(topic, e)
+      attrs = e.actor.attributes
+      if attrs['io.kontena.service.id'] == @service_pod.service_id &&
+          attrs['io.kontena.service.instance_number'].to_i == @service_pod.instance_number
+        @container_state_changed = true
+      end
     end
 
     def destroy
@@ -40,6 +65,7 @@ module Kontena::Workers
           warn "failed to sync #{service_pod.name} at #{service_pod.deploy_rev}: #{error}"
           sync_state_to_master(current_state, error)
         else
+          @container_state_changed = false
           sync_state_to_master(current_state)
 
           # Only terminate this actor after we have succesfully ensure_terminated the Docker container


### PR DESCRIPTION
With following changes:

- change `ServicePodManager` every to loop -> does not queue multiple tasks
- throttle worker creation
- `ServicePodWorker` only checks state from Docker Engine after it receives an event from Docker / or worker receives a new state/deploy_rev from manager