### PR TITLE
Add service pod caching on Rpc::NodeServicePodHandler

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -23,6 +23,7 @@ gem 'jsonpath'
 gem 'json-serializer'
 gem 'bcrypt'
 gem 'rack-attack'
+gem 'lru_redux', '~> 1.1.0'
 
 group :development, :test do
   gem 'dotenv'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
+    lru_redux (1.1.0)
     minitest (5.9.0)
     mongoid (4.0.2)
       activemodel (~> 4.0)
@@ -168,6 +169,7 @@ DEPENDENCIES
   json-jwt (= 1.5.2)
   json-serializer
   jsonpath
+  lru_redux (~> 1.1.0)
   mongoid (~> 4.0.0)
   mongoid-enum
   mongoid-rspec (~> 2.2.0)

--- a/server/app/boot.rb
+++ b/server/app/boot.rb
@@ -17,6 +17,7 @@ require 'msgpack'
 require 'tilt/jbuilder.rb'
 require 'mongoid/enum'
 require 'json_serializer'
+require 'lru_redux'
 
 def require_glob(glob)
   Dir.glob(glob).sort.each do |path|

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -12,7 +12,8 @@ module Rpc
       # TODO Do we need any other attrbutes for the composed key?
       cache_key = {
         id: service_instance.id,
-        deploy_rev: service_instance.deploy_rev
+        deploy_rev: service_instance.deploy_rev,
+        desired_state: service_instance.desired_state
       }
       @@lru_cache.getset(cache_key) {
         debug "pod_cache miss"

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -2,7 +2,7 @@ module Rpc
   class NodeServicePodHandler
     include Logging
 
-    @@lru_cache ||= LruRedux::ThreadSafeCache.new(100)
+    @@lru_cache ||= LruRedux::ThreadSafeCache.new(1000)
 
     def initialize(grid)
       @grid = grid

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -4,7 +4,7 @@ module Rpc
 
     def initialize(grid)
       @grid = grid
-      @lru_cache ||= LruRedux::ThreadSafeCache.new(1000)
+      @lru_cache = LruRedux::ThreadSafeCache.new(1000)
     end
 
     def cached_pod(service_instance)

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -1,21 +1,38 @@
 module Rpc
   class NodeServicePodHandler
+    include Logging
+
+    @@lru_cache ||= LruRedux::ThreadSafeCache.new(100)
 
     def initialize(grid)
       @grid = grid
     end
 
+    def cached_pod(service_instance)
+      # TODO Do we need any other attrbutes for the composed key?
+      cache_key = {
+        id: service_instance.id,
+        deploy_rev: service_instance.deploy_rev
+      }
+      @@lru_cache.getset(cache_key) {
+        debug "pod_cache miss"
+        ServicePodSerializer.new(service_instance).to_hash if service_instance.grid_service
+      }
+    end
+
     # @param [String] id
     # @return [Array<Hash>]
     def list(id)
+      start = Time.now.to_f
       node = @grid.host_nodes.find_by(node_id: id)
       raise 'Node not found' unless node
       raise 'Migration not done' unless migration_done?
 
       service_pods = node.grid_service_instances.includes(:grid_service).map { |i|
-        ServicePodSerializer.new(i).to_hash if i.grid_service
+        cached_pod(i)
       }.compact
-
+      end_time = Time.now.to_f
+      debug "pod list rpc took: #{((end_time-start) * 1000).to_i}ms"
       { service_pods: service_pods }
     end
 

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -2,10 +2,9 @@ module Rpc
   class NodeServicePodHandler
     include Logging
 
-    @@lru_cache ||= LruRedux::ThreadSafeCache.new(1000)
-
     def initialize(grid)
       @grid = grid
+      @lru_cache ||= LruRedux::ThreadSafeCache.new(1000)
     end
 
     def cached_pod(service_instance)
@@ -15,7 +14,7 @@ module Rpc
         deploy_rev: service_instance.deploy_rev,
         desired_state: service_instance.desired_state
       }
-      @@lru_cache.getset(cache_key) {
+      @lru_cache.getset(cache_key) {
         debug "pod_cache miss"
         ServicePodSerializer.new(service_instance).to_hash if service_instance.grid_service
       }

--- a/server/spec/services/rpc/node_service_pod_handler_spec.rb
+++ b/server/spec/services/rpc/node_service_pod_handler_spec.rb
@@ -5,12 +5,6 @@ describe Rpc::NodeServicePodHandler do
   let(:subject) { described_class.new(grid) }
   let(:node) { HostNode.create!(grid: grid, name: 'test-node', node_id: 'abc') }
 
-  before(:each) do
-    # reset cache between specs
-    cache = described_class.class_variable_get(:@@lru_cache)
-    cache.clear
-  end
-
   describe '#list' do
     before(:each) do
       allow(subject).to receive(:migration_done?).and_return(true)

--- a/server/spec/services/rpc/node_service_pod_handler_spec.rb
+++ b/server/spec/services/rpc/node_service_pod_handler_spec.rb
@@ -115,19 +115,19 @@ describe Rpc::NodeServicePodHandler do
 
   describe '#cached_pod' do
     it 'transforms the service instance into pod if not already in cache' do
-      service_instance = double({id: 'foo', deploy_rev: '12345', grid_service: double})
+      service_instance = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', grid_service: double})
       expect(Rpc::ServicePodSerializer).to receive(:new).once.and_return(double(:to_hash => {}))
       subject.cached_pod(service_instance)
       subject.cached_pod(service_instance)
     end
 
-    it 'uses instance id and deploy_rev as cache key' do
-      service_instance_1 = double({id: 'foo', deploy_rev: '12345', grid_service: double})
+    it 'uses instance id, deploy_rev and desired_state as cache key' do
+      service_instance_1 = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', grid_service: double})
       expect(Rpc::ServicePodSerializer).to receive(:new).twice.and_return(double(:to_hash => {}))
 
       subject.cached_pod(service_instance_1)
 
-      service_instance_2 = double({id: 'foo', deploy_rev: '54321', grid_service: double})
+      service_instance_2 = double({id: 'foo', deploy_rev: '12345', desired_state: 'stopped', grid_service: double})
       subject.cached_pod(service_instance_2)
     end
 


### PR DESCRIPTION
The serializer does quite many queries (~30) while "transforming" the service instance into pod hash to be sent to agent. This slows down the pod rpc quite much and causes significant load into the server and mongo. To avoid unnecessary serialization and thus queries the pod hashes are now cache in [LruRedux](https://github.com/SamSaffron/lru_redux) cache.

The cache key used is a composite of `service_instance.id`, `service_instance.desired_state` and `service_instance.deploy_rev`. That should make the cached pod hash unique per deployment. Desired state is needed since `GridServiceInstance.desired_state` can change `running` -> `stopped` -> `running` in the `GridServiceInstanceDeployer` if it moves the instance to a different node while the `deploy_rev` remains.

With the caching in place, the rpc call execution time dropped from ~80ms to ~8ms for single node setup with ~30 instances running. (Docker for Mac)

At the moment there's no cache cleanup happening but the size should limit memory usage nicely as the cache will evict least recently used items as the cache get full. The cleanup would have to be TTL based with some backgroud worker doing the cleanup. `ObjectSpace.memsize_of` shows about 2kb mem usage per pod hash so should not make mem usage grow that much even if we don't clean it up in the background.