### PR TITLE
ContainerInfoWorker fixes

### DIFF
--- a/agent/lib/kontena/actors/container_coroner.rb
+++ b/agent/lib/kontena/actors/container_coroner.rb
@@ -7,14 +7,15 @@ module Kontena::Actors
     INVESTIGATION_PERIOD = 20
 
     # @param [String] node_id
-    def initialize(node_id)
+    # @param [Boolean] autostart
+    def initialize(node_id, autostart = true)
       @node_id = node_id
-      @processing = false
+      async.process if autostart
     end
 
     def process
       prev = nil
-      while @processing do
+      loop do
         ids = all_containers.map { |c| c.id }
         if prev
           diff = prev - ids
@@ -39,23 +40,6 @@ module Kontena::Actors
     # @return [Array<Docker::Container>]
     def all_containers
       Docker::Container.all(all: true)
-    end
-
-    def start
-      return if @processing
-
-      @processing = true
-      async.process
-    end
-
-    def stop
-      return unless @processing
-
-      @processing = false
-    end
-
-    def processing?
-      @processing == true
     end
   end
 end

--- a/agent/lib/kontena/actors/container_coroner.rb
+++ b/agent/lib/kontena/actors/container_coroner.rb
@@ -29,7 +29,10 @@ module Kontena::Actors
     end
 
     def report(data)
-      rpc_client.async.request('/containers/cleanup', [@node_id, data])
+      rpc_request('/containers/cleanup', [@node_id, data])
+    rescue => exc
+      warn "failed to send report: #{exc.message}"
+      retry
     end
 
     # @return [Array<Docker::Container>]
@@ -48,6 +51,10 @@ module Kontena::Actors
       return unless @processing
 
       @processing = false
+    end
+
+    def processing?
+      @processing == true
     end
   end
 end

--- a/agent/lib/kontena/actors/container_coroner.rb
+++ b/agent/lib/kontena/actors/container_coroner.rb
@@ -32,6 +32,7 @@ module Kontena::Actors
       rpc_request('/containers/cleanup', [@node_id, data])
     rescue => exc
       warn "failed to send report: #{exc.message}"
+      sleep 1
       retry
     end
 

--- a/agent/lib/kontena/actors/container_coroner.rb
+++ b/agent/lib/kontena/actors/container_coroner.rb
@@ -2,53 +2,52 @@ module Kontena::Actors
   class ContainerCoroner
     include Celluloid
     include Kontena::Logging
+    include Kontena::Helpers::RpcHelper
 
-    INVESTIGATION_TIME = (5 * 60)
-    INVESTIGATION_PERIOD = 5
+    INVESTIGATION_PERIOD = 20
 
-    # @param [Docker::Container]
-    # @param [Boolean] autostart
-    def initialize(container, autostart = true)
-      @container = container
-      async.start if autostart
+    # @param [String] node_id
+    def initialize(node_id)
+      @node_id = node_id
+      @processing = false
+    end
+
+    def process
+      prev = nil
+      while @processing do
+        ids = all_containers.map { |c| c.id }
+        if prev
+          diff = prev - ids
+          report(diff) if diff.size > 0
+        end
+        prev = ids
+        sleep INVESTIGATION_PERIOD
+      end
+    rescue => exc
+      warn "process loop failed: #{exc.message}"
+      retry
+    end
+
+    def report(data)
+      rpc_client.async.request('/containers/cleanup', [@node_id, data])
+    end
+
+    # @return [Array<Docker::Container>]
+    def all_containers
+      Docker::Container.all(all: true)
     end
 
     def start
-      @started = Time.now.to_i
-      info "starting to investigate #{@container.name}"
-      every(INVESTIGATION_PERIOD) {
-        if @started >= (Time.now.to_i - INVESTIGATION_TIME)
-          investigate
-        else
-          self.terminate
-        end
-      }
-    rescue Docker::Error::NotFoundError
-      self.terminate
+      return if @processing
+
+      @processing = true
+      async.process
     end
 
-    def investigate
-      exists = Docker::Container.get(@container.id) rescue nil
-      unless exists
-        confirm
-      end
-    end
+    def stop
+      return unless @processing
 
-    def confirm
-      info "container #{@container.name} has gone"
-      event = Docker::Event.new(
-        'Action' => 'destroy'.freeze,
-        'status' => 'destroy'.freeze,
-        'id' => @container.id,
-        'time' => Time.now.utc.to_s
-      )
-      event_worker.publish_event(event)
-      self.terminate
-    end
-
-    # @return [Kontena::Workers::EventWorker]
-    def event_worker
-      Actor[:event_worker]
+      @processing = false
     end
   end
 end

--- a/agent/lib/kontena/rpc_client.rb
+++ b/agent/lib/kontena/rpc_client.rb
@@ -30,6 +30,10 @@ module Kontena
       info 'initialized'
     end
 
+    def connected?
+      @client.connected?
+    end
+
     # @param [String] method
     # @param [Array] params
     def notification(method, params)

--- a/agent/lib/kontena/workers/container_info_worker.rb
+++ b/agent/lib/kontena/workers/container_info_worker.rb
@@ -14,10 +14,9 @@ module Kontena::Workers
       subscribe('container:event', :on_container_event)
       subscribe('container:publish_info', :on_container_publish_info)
       subscribe('websocket:connected', :on_websocket_connected)
-      subscribe('websocket:disconnect', :on_websocket_disconnect)
       info 'initialized'
-      @container_coroner = Kontena::Actors::ContainerCoroner.new(self.node_info['ID'])
-      async.start if @autostart
+      @container_coroner = Kontena::Actors::ContainerCoroner.new(self.node_info['ID'], autostart)
+      async.start if autostart
     end
 
     def start
@@ -59,11 +58,6 @@ module Kontena::Workers
 
     def on_websocket_connected(topic, data)
       publish_all_containers
-      container_coroner.start
-    end
-
-    def on_websocket_disconnect(topic, data)
-      container_coroner.stop
     end
 
     ##

--- a/agent/spec/lib/kontena/actors/container_coroner_spec.rb
+++ b/agent/spec/lib/kontena/actors/container_coroner_spec.rb
@@ -1,6 +1,45 @@
 
 describe Kontena::Actors::ContainerCoroner, celluloid: true do
-  let(:subject) { described_class.new('id', false) }
+  let(:subject) { described_class.new('id') }
 
-  
+  describe '#start' do
+    it 'calls process' do
+      expect(subject.wrapped_object).to receive(:process).once
+      subject.start
+    end
+
+    it 'does not call process if already processing' do
+      expect(subject.wrapped_object).to receive(:process).once
+      subject.start
+      subject.start
+    end
+  end
+
+  describe '#stop' do
+    it 'sets processing to false' do
+      expect(subject.wrapped_object).to receive(:process).once
+      subject.start
+      expect {
+        subject.stop
+      }.to change { subject.processing? }.from(true).to(false)
+    end
+  end
+
+  describe '#report' do
+    it 'retries if request throws error' do
+      retries = 0
+      success = false
+      allow(subject.wrapped_object).to receive(:rpc_request) {
+        if retries == 0
+          retries += 1
+          raise "error"
+        else
+          success = true
+        end
+      }
+      expect {
+        subject.report([])
+      }.to change { success }.from(false).to(true)
+    end
+  end
 end

--- a/agent/spec/lib/kontena/actors/container_coroner_spec.rb
+++ b/agent/spec/lib/kontena/actors/container_coroner_spec.rb
@@ -1,29 +1,6 @@
 
 describe Kontena::Actors::ContainerCoroner, celluloid: true do
-  let(:subject) { described_class.new('id') }
-
-  describe '#start' do
-    it 'calls process' do
-      expect(subject.wrapped_object).to receive(:process).once
-      subject.start
-    end
-
-    it 'does not call process if already processing' do
-      expect(subject.wrapped_object).to receive(:process).once
-      subject.start
-      subject.start
-    end
-  end
-
-  describe '#stop' do
-    it 'sets processing to false' do
-      expect(subject.wrapped_object).to receive(:process).once
-      subject.start
-      expect {
-        subject.stop
-      }.to change { subject.processing? }.from(true).to(false)
-    end
-  end
+  let(:subject) { described_class.new('id', false) }
 
   describe '#report' do
     it 'retries if request throws error' do

--- a/agent/spec/lib/kontena/actors/container_coroner_spec.rb
+++ b/agent/spec/lib/kontena/actors/container_coroner_spec.rb
@@ -1,46 +1,6 @@
 
-describe Kontena::Actors::ContainerCoroner do
+describe Kontena::Actors::ContainerCoroner, celluloid: true do
+  let(:subject) { described_class.new('id', false) }
 
-  let(:container) do
-    double(:container, id: 'dead-id', name: '/dead')
-  end
-  let(:subject) { described_class.new(container, false) }
-
-  before(:each) { Celluloid.boot }
-  after(:each) { Celluloid.shutdown }
-
-  describe '#investigate' do
-    it 'confirms if container has gone' do
-      allow(Docker::Container).to receive(:get).with(container.id).and_return(nil)
-      expect(subject.wrapped_object).to receive(:confirm)
-      subject.investigate
-    end
-
-    it 'does not config if container still exists' do
-      allow(Docker::Container).to receive(:get).with(container.id).and_return(container)
-      expect(subject.wrapped_object).not_to receive(:confirm)
-      subject.investigate
-    end
-  end
-
-  describe '#confirm' do
-    let(:event_worker) do
-      double(:event_worker)
-    end
-
-    before(:each) do
-      allow(subject.wrapped_object).to receive(:event_worker).and_return(event_worker)
-    end
-
-    it 'publishes event' do
-      expect(event_worker).to receive(:publish_event)
-      subject.confirm
-    end
-
-    it 'terminates actor' do
-      allow(event_worker).to receive(:publish_event)
-      subject.confirm
-      expect(subject.alive?).to be_falsey
-    end
-  end
+  
 end

--- a/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/container_info_worker_spec.rb
@@ -35,32 +35,11 @@ describe Kontena::Workers::ContainerInfoWorker, celluloid: true do
     before(:each) do
       allow(coroner).to receive(:start)
       allow(subject.wrapped_object).to receive(:publish_all_containers)
-      allow(subject.wrapped_object).to receive(:container_coroner).and_return(coroner)
     end
 
     it 'calls #publish_all_containers' do
       expect(subject.wrapped_object).to receive(:publish_all_containers)
       subject.on_websocket_connected('websocket:connected', nil)
-    end
-
-    it 'starts coroner' do
-      expect(coroner).to receive(:start)
-      subject.on_websocket_connected('websocket:connected', nil)
-    end
-  end
-
-  describe '#on_websocket_disconnect' do
-    let(:coroner) do
-      double(:coroner)
-    end
-
-    before(:each) do
-      allow(subject.wrapped_object).to receive(:container_coroner).and_return(coroner)
-    end
-
-    it 'stops coroner' do
-      expect(coroner).to receive(:stop)
-      subject.on_websocket_disconnect('websocket:disconnect', nil)
     end
   end
 

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -32,6 +32,18 @@ module Rpc
       {}
     end
 
+    # @param [String] node_id
+    # @param [Array<String>] ids
+    def cleanup(node_id, ids)
+      node = @grid.host_nodes.find_by(node_id: node_id)
+      if node
+        @grid.containers.where(
+          :host_node_id => node.id,
+          :container_id.in => ids
+        ).delete
+      end
+    end
+
     # @param [Hash] data
     def log(data)
       container = cached_container(data['id'])

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -37,10 +37,10 @@ module Rpc
     def cleanup(node_id, ids)
       node = @grid.host_nodes.find_by(node_id: node_id)
       if node
-        @grid.containers.where(
+        @grid.containers.unscoped.where(
           :host_node_id => node.id,
           :container_id.in => ids
-        ).delete
+        ).destroy
       end
     end
 

--- a/server/spec/services/rpc/container_handler_spec.rb
+++ b/server/spec/services/rpc/container_handler_spec.rb
@@ -52,6 +52,19 @@ describe Rpc::ContainerHandler do
     end
   end
 
+  describe '#cleanup' do
+    it 'removes given containers ids' do
+      node = grid.host_nodes.create!(node_id: 'aa', name: 'node-1')
+      containers = []
+      containers << grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-1', host_node: node)
+      containers << grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-2', host_node: node)
+
+      expect {
+        subject.cleanup(node.node_id, [containers[0].container_id])
+      }.to change { grid.containers.count }.by(-1)
+    end
+  end
+
   describe '#log' do
     it 'creates new container log entry if container exists' do
       container = grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-1')


### PR DESCRIPTION
- worker starts to send container info only after websocket is connected
- coroner now sweeps all containers and sends list of removed containers to master