### PR TITLE
Include CPU in HostNode JSON

### DIFF
--- a/server/app/serializers/host_node_serializer.rb
+++ b/server/app/serializers/host_node_serializer.rb
@@ -75,7 +75,8 @@ class HostNodeSerializer < KontenaJsonSerializer
         memory: stats.memory,
         load: stats.load,
         filesystem: stats.filesystem,
-        usage: stats.usage
+        usage: stats.usage,
+        cpu: stats.cpu
       }
     end
   end


### PR DESCRIPTION
This PR will add missing CPU field to `resource_usage` when serialising HostNode.