### PR TITLE
Fix agent WeaveWorker to not start until Weave has started

### DIFF
--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -16,7 +16,7 @@ module Kontena::Workers
 
       @migrate_containers = nil # initialized by #start
 
-      if network_adapter.running?
+      if network_adapter.already_started?
         self.start
       else
         subscribe('network_adapter:start', :on_weave_start)

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -13,7 +13,7 @@ describe Kontena::Workers::WeaveWorker do
     allow(Celluloid::Actor).to receive(:[]).with(:network_adapter).and_return(network_adapter)
 
     # initialize without calling start()
-    allow(network_adapter).to receive(:running?).and_return(false).once
+    allow(network_adapter).to receive(:already_started?).and_return(false).once
     subject
   end
 


### PR DESCRIPTION
Fixes #1923, fixes #2079

#1398 introduced a race condition during weave upgrades, where `WeaveWorker` attaches containers and registers DNS names before (or at the same time as) the `Weave` actor re-creates the `weave` container. This happens because the old `weave` container is already running during startup.

This delays the `WeaveWorker` start to until the `Weave#launch` has completed.