### PR TITLE
Reduce agent info logging

### DIFF
--- a/agent/lib/kontena/rpc_client.rb
+++ b/agent/lib/kontena/rpc_client.rb
@@ -48,7 +48,7 @@ module Kontena
       id = request_id
       @requests[id] = nil
 
-      if !wait_until("websocket client is connected", timeout: timeout, interval: 0.1) { @client.connected? }
+      if !wait_until("websocket client is connected", timeout: timeout, threshold: 10.0, interval: 0.1) { @client.connected? }
         return nil, TimeoutError.new(500, 'WebsocketClient is not connected')
       end
 

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -64,8 +64,8 @@ module Kontena
           Celluloid::Notifications.publish('lb:remove_config', service_container.service_name_for_lb)
         end
 
-        out = service_container.start!
-        info "service started: #{service_pod.name_for_humans}: #{out}"
+        service_container.start!
+        info "service started: #{service_pod.name_for_humans}"
         log_service_pod_event("service:create_instance", "service #{service_pod.name_for_humans} instance started")
 
         Celluloid::Notifications.publish('service_pod:start', service_pod.name)

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -26,7 +26,7 @@ module Kontena::Workers
         @node = node
       end
 
-      wait_until!("have node info", interval: 0.1) { self.node }
+      wait_until!("have node info", interval: 0.1, threshold: 10.0) { self.node }
       populate_workers_from_docker
 
       subscribe('service_pod:update', :on_update_notify)

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -24,7 +24,7 @@ module Kontena::Workers::Volumes
       observe(Actor[:node_info_worker]) do |node|
         @node = node
       end
-      wait_until!('waiting for node info', interval: 0.5) { self.node }
+      wait_until!('waiting for node info', interval: 0.5, threshold: 10.0) { self.node }
       populate_volumes_from_docker
       loop do
         populate_volumes_from_master


### PR DESCRIPTION
These are not necessarily useful at INFO level:

```
I, [2017-04-13T10:35:54.476962 #1]  INFO -- Kontena::RpcClient: waited 1.6s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.477480 #1]  INFO -- Kontena::RpcClient: waited 1.3s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.495964 #1]  INFO -- Kontena::RpcClient: waited 1.0s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.496689 #1]  INFO -- Kontena::RpcClient: waited 1.5s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.527949 #1]  INFO -- Kontena::RpcClient: waited 1.2s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.528263 #1]  INFO -- Kontena::RpcClient: waited 1.9s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.531801 #1]  INFO -- Kontena::RpcClient: waited 1.4s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.552128 #1]  INFO -- Kontena::RpcClient: waited 1.1s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.552621 #1]  INFO -- Kontena::RpcClient: waited 1.8s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.552930 #1]  INFO -- Kontena::RpcClient: waited 1.3s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.553155 #1]  INFO -- Kontena::RpcClient: waited 1.6s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.567866 #1]  INFO -- Kontena::RpcClient: waited 1.0s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.568365 #1]  INFO -- Kontena::RpcClient: waited 1.5s of 30.0s until: websocket client is connected yielded TrueClass
I, [2017-04-13T10:35:54.568798 #1]  INFO -- Kontena::RpcClient: waited 1.8s of 30.0s until: websocket client is connected yielded TrueClass
```

```
I, [2017-04-13T10:35:59.766420 #1]  INFO -- Kontena::Workers::ServicePodManager: waited 6.5s of 300.0s until: have node info yielded Node
I, [2017-04-13T10:35:59.800979 #1]  INFO -- Kontena::Workers::Volumes::VolumeManager: waited 6.5s of 300.0s until: waiting for node info yielded Node
```

```
I, [2017-04-13T10:35:57.218080 #1]  INFO -- Kontena::ServicePods::Creator: service started: nginx-94: Docker::Container { :id => 56b1ad4a26eaf2316c5e038a43a7222da73177aae706303e21a1663c8220a440, :connection => Docker::Connection { :url => unix:///, :options => {:socket=>"/var/run/docker.sock", :read_timeout=>3600, :write_timeout=>3600} } }
```