### PR TITLE
Fix server NodePlugger.plugin logging of new nodes without names

### DIFF
--- a/server/app/services/agent/node_plugger.rb
+++ b/server/app/services/agent/node_plugger.rb
@@ -16,7 +16,7 @@ module Agent
 
     # @return [Celluloid::Future]
     def plugin!
-      info "connect node #{node.name || node_id}"
+      info "connect node #{node.name || node.node_id}"
 
       begin
         prev_seen_at = node.last_seen_at

--- a/server/spec/services/agent/node_plugger_spec.rb
+++ b/server/spec/services/agent/node_plugger_spec.rb
@@ -1,12 +1,5 @@
 describe Agent::NodePlugger do
   let(:grid) { Grid.create! name: 'test-grid' }
-  let(:node) {
-    HostNode.create!(
-      node_id: 'xyz',
-      grid: grid, name: 'test-node', labels: ['region=ams2'],
-      private_ip: '10.12.1.2', public_ip: '80.240.128.3'
-    )
-  }
   let(:subject) { described_class.new(grid, node) }
   let(:rpc_client) { instance_double(RpcClient) }
 
@@ -14,7 +7,11 @@ describe Agent::NodePlugger do
     allow(subject).to receive(:rpc_client).and_return(rpc_client)
   end
 
-  describe '#plugin!' do
+  context 'for a brand new node' do
+    let(:node) {
+      HostNode.create!(node_id: 'xyz')
+    }
+
     it 'marks node as connected' do
       expect(subject).to receive(:send_master_info)
       expect(subject).to receive(:send_node_info)
@@ -24,23 +21,43 @@ describe Agent::NodePlugger do
     end
   end
 
-  describe '#send_master_info' do
-    it "sends version" do
-      expect(rpc_client).to receive(:notify).with('/agent/master_info', hash_including(version: String))
-      subject.send_master_info
+  context 'for an existing node' do
+    let(:node) {
+      HostNode.create!(
+        node_id: 'xyz',
+        grid: grid, name: 'test-node', labels: ['region=ams2'],
+        private_ip: '10.12.1.2', public_ip: '80.240.128.3'
+      )
+    }
+
+    describe '#plugin!' do
+      it 'marks node as connected' do
+        expect(subject).to receive(:send_master_info)
+        expect(subject).to receive(:send_node_info)
+        expect {
+          subject.plugin!
+        }.to change{ node.reload.connected? }.to be_truthy
+      end
     end
-  end
 
-  describe '#send_node_info' do
-    it "sends node info" do
-      expect(rpc_client).to receive(:notify).with('/agent/node_info', hash_including(
-        name: 'test-node',
-        grid: hash_including(
-          name: 'test-grid',
-        ),
-      ))
+    describe '#send_master_info' do
+      it "sends version" do
+        expect(rpc_client).to receive(:notify).with('/agent/master_info', hash_including(version: String))
+        subject.send_master_info
+      end
+    end
 
-      subject.send_node_info
+    describe '#send_node_info' do
+      it "sends node info" do
+        expect(rpc_client).to receive(:notify).with('/agent/node_info', hash_including(
+          name: 'test-node',
+          grid: hash_including(
+            name: 'test-grid',
+          ),
+        ))
+
+        subject.send_node_info
+      end
     end
   end
 end


### PR DESCRIPTION
```
  1) Agent::NodePlugger for a brand new node marks node as connected
     Failure/Error: subject.plugin!
     NameError:
       undefined local variable or method `node_id' for #<Agent::NodePlugger:0x000000057e63c8>
       Did you mean?  node
     # ./app/services/agent/node_plugger.rb:19:in `plugin!'
     # ./spec/services/agent/node_plugger_spec.rb:19:in `block (4 levels) in <top (required)>'
     # ./spec/services/agent/node_plugger_spec.rb:18:in `block (3 levels) in <top (required)>'
```