### PR TITLE
Refactor node stats to NodeStatsWorker

### DIFF
--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -36,6 +36,7 @@ require_relative 'kontena/launchers/ipam_plugin'
 
 require_relative 'kontena/workers/log_worker'
 require_relative 'kontena/workers/node_info_worker'
+require_relative 'kontena/workers/node_stats_worker'
 require_relative 'kontena/workers/container_info_worker'
 require_relative 'kontena/workers/stats_worker'
 require_relative 'kontena/workers/event_worker'

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -113,6 +113,10 @@ module Kontena
         as: :event_worker
       )
       @supervisor.supervise(
+        type: Kontena::Workers::NodeStatsWorker,
+        as: :node_stats_worker
+      )
+      @supervisor.supervise(
         type: Kontena::Workers::StatsWorker,
         as: :stats_worker
       )

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -1,11 +1,8 @@
 require 'net/http'
-require 'vmstat'
-
 require_relative '../models/node'
 require_relative '../helpers/node_helper'
 require_relative '../helpers/iface_helper'
 require_relative '../helpers/rpc_helper'
-require_relative '../helpers/stats_helper'
 
 module Kontena::Workers
   class NodeInfoWorker
@@ -16,19 +13,13 @@ module Kontena::Workers
     include Kontena::Helpers::NodeHelper
     include Kontena::Helpers::IfaceHelper
     include Kontena::Helpers::RpcHelper
-    include Kontena::Helpers::StatsHelper
 
-    attr_reader :statsd, :stats_since, :node
+    attr_reader :node
 
     PUBLISH_INTERVAL = 60
 
     # @param [Boolean] autostart
     def initialize(autostart = true)
-      @statsd = nil
-      @stats_since = Time.now
-      @container_seconds = 0
-      @previous_cpu = Vmstat.cpu
-      @previous_network = Vmstat.network_interfaces
       subscribe('websocket:connected', :on_websocket_connected)
       subscribe('agent:node_info', :on_node_info)
       subscribe('container:event', :on_container_event)
@@ -40,38 +31,20 @@ module Kontena::Workers
     # @param [Hash] data
     def on_websocket_connected(topic, data)
       self.publish_node_info
-      self.publish_node_stats
     end
 
     def start
       loop do
         sleep PUBLISH_INTERVAL
         self.publish_node_info
-        self.publish_node_stats
       end
     end
 
     # @param [String] topic
     # @param [Node] node
     def on_node_info(topic, node)
-      if @node.nil? || (@node.statsd_conf != node.statsd_conf)
-        configure_statsd(node)
-      end
       @node = node
       update_observable(node)
-    end
-
-    # @param [Node] node
-    def configure_statsd(node)
-      statsd_conf = node.statsd_conf
-      if statsd_conf && statsd_conf['server']
-        info "exporting stats via statsd to udp://#{statsd_conf['server']}:#{statsd_conf['port']}"
-        @statsd = Statsd.new(
-          statsd_conf['server'], statsd_conf['port'].to_i || 8125
-        ).tap{ |sd| sd.namespace = node.grid['name'] }
-      else
-        @statsd = nil
-      end
     end
 
     def publish_node_info
@@ -160,233 +133,6 @@ module Kontena::Workers
     # @return [String]
     def private_interface
       ENV['KONTENA_PEER_INTERFACE'] || 'eth1'
-    end
-
-    # @param [String] topic
-    # @param [Docker::Event] event
-    def on_container_event(topic, event)
-      if event.status == 'die'.freeze
-        container = Docker::Container.get(event.id) rescue nil
-        if container
-          @container_seconds += calculate_container_time(container)
-        end
-      end
-    end
-
-    def publish_node_stats
-      disk = Vmstat.disk('/')
-      load_avg = Vmstat.load_average
-      current_cpu = Vmstat.cpu
-      cpu_usage = calculate_cpu_usage(@previous_cpu, current_cpu)
-      @previous_cpu = current_cpu
-
-      current_network = Vmstat.network_interfaces
-      network_traffic = calculate_network_traffic(@previous_network, current_network, Time.now - @stats_since)
-      @previous_network = current_network
-
-      container_partial_seconds = @container_seconds.to_i
-      @container_seconds = 0
-      container_seconds = calculate_containers_time + container_partial_seconds
-      @stats_since = Time.now
-
-      data = {
-        id: docker_info['ID'],
-        memory: calculate_memory,
-        usage: {
-          container_seconds: container_seconds
-        },
-        load: {
-          :'1m' => load_avg.one_minute,
-          :'5m' => load_avg.five_minutes,
-          :'15m' => load_avg.fifteen_minutes
-        },
-        filesystem: [
-          {
-            name: docker_info['DockerRootDir'],
-            free: disk.free_bytes,
-            available: disk.available_bytes,
-            used: disk.used_bytes,
-            total: disk.total_bytes
-          }
-        ],
-        cpu: cpu_usage,
-        network: network_traffic,
-        time: Time.now.utc.to_s
-      }
-      rpc_client.async.notification('/nodes/stats', [data])
-      send_statsd_metrics(data)
-    end
-
-    # @param [Hash] event
-    def send_statsd_metrics(event)
-      return unless statsd
-      key_base = "#{docker_info['Name']}"
-      statsd.gauge("#{key_base}.cpu.load.1m", event[:load][:'1m'])
-      statsd.gauge("#{key_base}.cpu.load.5m", event[:load][:'5m'])
-      statsd.gauge("#{key_base}.cpu.load.15m", event[:load][:'15m'])
-      statsd.gauge("#{key_base}.cpu.system", event[:cpu][:system])
-      statsd.gauge("#{key_base}.cpu.user", event[:cpu][:user])
-      statsd.gauge("#{key_base}.cpu.nice", event[:cpu][:nice])
-      statsd.gauge("#{key_base}.cpu.idle", event[:cpu][:idle])
-      statsd.gauge("#{key_base}.memory.active", event[:memory][:active])
-      statsd.gauge("#{key_base}.memory.free", event[:memory][:free])
-      statsd.gauge("#{key_base}.memory.total", event[:memory][:total])
-      statsd.gauge("#{key_base}.usage.container_seconds", event[:usage][:container_seconds])
-      statsd.gauge("#{key_base}.network.internal.rx_bytes", event[:network][:internal][:rx_bytes])
-      statsd.gauge("#{key_base}.network.internal.tx_bytes", event[:network][:internal][:tx_bytes])
-      statsd.gauge("#{key_base}.network.external.rx_bytes", event[:network][:external][:rx_bytes])
-      statsd.gauge("#{key_base}.network.external.tx_bytes", event[:network][:external][:tx_bytes])
-      event[:filesystem].each do |fs|
-        name = fs[:name] ? fs[:name].split("/")[1..-1].join(".") : ""
-        statsd.gauge("#{key_base}.filesystem.#{name}.free", fs[:free])
-        statsd.gauge("#{key_base}.filesystem.#{name}.available", fs[:available])
-        statsd.gauge("#{key_base}.filesystem.#{name}.used", fs[:used])
-        statsd.gauge("#{key_base}.filesystem.#{name}.total", fs[:total])
-      end
-    rescue => exc
-      error "#{exc.class.name}: #{exc.message}"
-      error exc.backtrace.join("\n")
-    end
-
-    # @return [Hash]
-    def calculate_memory
-      memory = {}
-      return memory unless File.exist?('/proc/meminfo')
-      File.open('/proc/meminfo').each do |line|
-        case line
-        when /^MemTotal:\s+(\d+) (.+)$/
-          memory[:total] = $1.to_i * 1024
-        when /^MemFree:\s+(\d+) (.+)$/
-          memory[:free] = $1.to_i * 1024
-        when /^Active:\s+(\d+) (.+)$/
-          memory[:active] = $1.to_i * 1024
-        when /^Inactive:\s+(\d+) (.+)$/
-          memory[:inactive] = $1.to_i * 1024
-        when /^Cached:\s+(\d+) (.+)$/
-          memory[:cached] = $1.to_i * 1024
-        when /^Buffers:\s+(\d+) (.+)$/
-          memory[:buffers] = $1.to_i * 1024
-        end
-      end
-      memory[:used] = memory[:total] - memory[:free]
-
-      memory
-    end
-
-    # @param [Time] since
-    def calculate_containers_time
-      seconds = 0
-      Docker::Container.all.each do |container|
-        seconds += calculate_container_time(container)
-      end
-
-      seconds
-    rescue => exc
-      error exc.message
-    end
-
-    # @param [Docker::Container] container
-    # @return [Integer]
-    def calculate_container_time(container)
-      state = container.state
-      since = stats_since.to_time.utc
-      started_at = DateTime.parse(state['StartedAt']).to_time.utc rescue nil
-      finished_at = DateTime.parse(state['FinishedAt']).to_time.utc rescue nil
-      seconds = 0
-      return seconds unless started_at
-      if state['Running']
-        now = Time.now.utc.to_i
-        if started_at < since
-          # container has started before last check
-          seconds = now - since.to_i
-        elsif started_at >= since
-          # container has started after last check
-          seconds = now - started_at.to_time.to_i
-        end
-      else
-        if finished_at && started_at < finished_at && started_at > since
-          # container has started before last check
-          seconds = finished_at.to_i - started_at.to_i
-        elsif finished_at && started_at < finished_at && started_at <= since
-          # container has started after last check
-          seconds = finished_at.to_i - since.to_i
-        end
-      end
-
-      seconds
-    rescue => exc
-      debug exc.message
-      0
-    end
-
-    # @param [Array<Vmstat::Cpu>] prev_cpus
-    # @param [Array<Vmstat::Cpu>] current_cpu
-    # @return [Hash] { :num_cores, :system, :user, :idle }
-    def calculate_cpu_usage(prev_cpus, current_cpus)
-      result = {
-        num_cores: prev_cpus.size,
-        system: 0.0,
-        user: 0.0,
-        nice: 0.0,
-        idle: 0.0
-      }
-
-      prev_cpus.zip(current_cpus).map { |prev_cpu, current_cpu|
-        system_ticks = current_cpu.system - prev_cpu.system
-        user_ticks = current_cpu.user - prev_cpu.user
-        nice_ticks = current_cpu.nice = prev_cpu.nice
-        idle_ticks = current_cpu.idle - prev_cpu.idle
-
-        total_ticks = (system_ticks + user_ticks + nice_ticks + idle_ticks).to_f
-
-        {
-          system: (system_ticks / total_ticks) * 100.0,
-          user: (user_ticks / total_ticks) * 100.0,
-          nice: (nice_ticks / total_ticks) * 100.0,
-          idle: (idle_ticks / total_ticks) * 100.0
-        }
-      }.inject(result) { |memo, cpu_core|
-        memo[:system] += cpu_core[:system]
-        memo[:user] += cpu_core[:user]
-        memo[:nice] += cpu_core[:nice]
-        memo[:idle] += cpu_core[:idle]
-        memo
-      }
-    end
-
-    # @param [Array<Vmstat::NetworkInterface>] prev_interfaces
-    # @param [Array<Vmstat::NetworkInterface>] current_interfaces
-    # @param [Number] interval_seconds
-    # @return [Hash]
-    def calculate_network_traffic(prev_interfaces, current_interfaces, interval_seconds)
-      prev_interfaces = prev_interfaces.map { |iface| {
-        name: iface.name,
-        rx_bytes: iface.in_bytes,
-        tx_bytes: iface.out_bytes
-      }}
-
-      internal_interfaces = current_interfaces.select { |iface|
-        iface.name.to_s == "weave" or iface.name.to_s.start_with?("vethwe")
-      }
-      .map { |iface| {
-          name: iface.name,
-          rx_bytes: iface.in_bytes,
-          tx_bytes: iface.out_bytes
-      }}
-
-      external_interfaces = current_interfaces.select { |iface|
-        iface.name.to_s == "docker0"
-      }
-      .map { |iface| {
-          name: iface.name,
-          rx_bytes: iface.in_bytes,
-          tx_bytes: iface.out_bytes
-      }}
-
-      {
-        internal: calculate_interface_traffic(prev_interfaces, internal_interfaces, interval_seconds),
-        external: calculate_interface_traffic(prev_interfaces, external_interfaces, interval_seconds)
-      }
     end
 
     # @return [Hash]

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -22,7 +22,6 @@ module Kontena::Workers
     def initialize(autostart = true)
       subscribe('websocket:connected', :on_websocket_connected)
       subscribe('agent:node_info', :on_node_info)
-      subscribe('container:event', :on_container_event)
       info 'initialized'
       async.start if autostart
     end

--- a/agent/lib/kontena/workers/node_stats_worker.rb
+++ b/agent/lib/kontena/workers/node_stats_worker.rb
@@ -116,7 +116,7 @@ module Kontena::Workers
         network: network_traffic,
         time: Time.now.utc.to_s
       }
-      rpc_client.async.notification('/nodes/stats', [data]) if rpc_client.connected?
+      rpc_client.async.notification('/nodes/stats', [data])
       send_statsd_metrics(data)
     end
 

--- a/agent/lib/kontena/workers/node_stats_worker.rb
+++ b/agent/lib/kontena/workers/node_stats_worker.rb
@@ -1,0 +1,298 @@
+require 'net/http'
+require 'vmstat'
+
+require_relative '../models/node'
+require_relative '../helpers/rpc_helper'
+require_relative '../helpers/stats_helper'
+
+module Kontena::Workers
+  class NodeStatsWorker
+    include Celluloid
+    include Celluloid::Notifications
+    include Kontena::Logging
+    include Kontena::Observer
+    include Kontena::Helpers::RpcHelper
+    include Kontena::Helpers::StatsHelper
+
+    attr_reader :statsd, :stats_since
+
+    PUBLISH_INTERVAL = 60
+
+    def initialize
+      @node = nil
+      @statsd = nil
+      @stats_since = Time.now
+      @container_seconds = 0
+      @previous_cpu = Vmstat.cpu
+      @previous_network = Vmstat.network_interfaces
+      subscribe('container:event', :on_container_event)
+      info 'initialized'
+    end
+
+    def start
+      observe(Actor[:node_info_worker]) do |node|
+        configure_statsd(node)
+        @node = node
+      end
+
+      start_publish_loop
+    end
+
+    def start_publish_loop
+      loop do
+        sleep PUBLISH_INTERVAL
+        self.publish_node_stats if rpc_client.connected?
+      end
+    end
+
+    # @param [Node] node
+    def configure_statsd(node)
+      return if @node && @node.statsd_conf == node.statsd_conf
+
+      statsd_conf = node.statsd_conf
+      if statsd_conf && statsd_conf['server']
+        info "exporting stats via statsd to udp://#{statsd_conf['server']}:#{statsd_conf['port']}"
+        @statsd = Statsd.new(
+          statsd_conf['server'], statsd_conf['port'].to_i || 8125
+        ).tap{ |sd| sd.namespace = node.grid['name'] }
+      else
+        @statsd = nil
+      end
+    rescue => exc
+      error "failed to configure statsd: #{exc.message}"
+      error exc.backtrace.join("\n")
+    end
+
+    # @param [String] topic
+    # @param [Docker::Event] event
+    def on_container_event(topic, event)
+      if event.status == 'die'.freeze
+        container = Docker::Container.get(event.id) rescue nil
+        if container
+          @container_seconds += calculate_container_time(container)
+        end
+      end
+    end
+
+    def publish_node_stats
+      disk = Vmstat.disk('/')
+      load_avg = Vmstat.load_average
+      current_cpu = Vmstat.cpu
+      cpu_usage = calculate_cpu_usage(@previous_cpu, current_cpu)
+      @previous_cpu = current_cpu
+
+      current_network = Vmstat.network_interfaces
+      network_traffic = calculate_network_traffic(@previous_network, current_network, Time.now - @stats_since)
+      @previous_network = current_network
+
+      container_partial_seconds = @container_seconds.to_i
+      @container_seconds = 0
+      container_seconds = calculate_containers_time + container_partial_seconds
+      @stats_since = Time.now
+
+      data = {
+        id: docker_info['ID'],
+        memory: calculate_memory,
+        usage: {
+          container_seconds: container_seconds
+        },
+        load: {
+          :'1m' => load_avg.one_minute,
+          :'5m' => load_avg.five_minutes,
+          :'15m' => load_avg.fifteen_minutes
+        },
+        filesystem: [
+          {
+            name: docker_info['DockerRootDir'],
+            free: disk.free_bytes,
+            available: disk.available_bytes,
+            used: disk.used_bytes,
+            total: disk.total_bytes
+          }
+        ],
+        cpu: cpu_usage,
+        network: network_traffic,
+        time: Time.now.utc.to_s
+      }
+      rpc_client.async.notification('/nodes/stats', [data])
+      send_statsd_metrics(data)
+    end
+
+    # @param [Hash] event
+    def send_statsd_metrics(event)
+      return unless statsd
+      key_base = "#{docker_info['Name']}"
+      statsd.gauge("#{key_base}.cpu.load.1m", event[:load][:'1m'])
+      statsd.gauge("#{key_base}.cpu.load.5m", event[:load][:'5m'])
+      statsd.gauge("#{key_base}.cpu.load.15m", event[:load][:'15m'])
+      statsd.gauge("#{key_base}.cpu.system", event[:cpu][:system])
+      statsd.gauge("#{key_base}.cpu.user", event[:cpu][:user])
+      statsd.gauge("#{key_base}.cpu.nice", event[:cpu][:nice])
+      statsd.gauge("#{key_base}.cpu.idle", event[:cpu][:idle])
+      statsd.gauge("#{key_base}.memory.active", event[:memory][:active])
+      statsd.gauge("#{key_base}.memory.free", event[:memory][:free])
+      statsd.gauge("#{key_base}.memory.total", event[:memory][:total])
+      statsd.gauge("#{key_base}.usage.container_seconds", event[:usage][:container_seconds])
+      statsd.gauge("#{key_base}.network.internal.rx_bytes", event[:network][:internal][:rx_bytes])
+      statsd.gauge("#{key_base}.network.internal.tx_bytes", event[:network][:internal][:tx_bytes])
+      statsd.gauge("#{key_base}.network.external.rx_bytes", event[:network][:external][:rx_bytes])
+      statsd.gauge("#{key_base}.network.external.tx_bytes", event[:network][:external][:tx_bytes])
+      event[:filesystem].each do |fs|
+        name = fs[:name] ? fs[:name].split("/")[1..-1].join(".") : ""
+        statsd.gauge("#{key_base}.filesystem.#{name}.free", fs[:free])
+        statsd.gauge("#{key_base}.filesystem.#{name}.available", fs[:available])
+        statsd.gauge("#{key_base}.filesystem.#{name}.used", fs[:used])
+        statsd.gauge("#{key_base}.filesystem.#{name}.total", fs[:total])
+      end
+    rescue => exc
+      error "#{exc.class.name}: #{exc.message}"
+      error exc.backtrace.join("\n")
+    end
+
+    # @return [Hash]
+    def calculate_memory
+      memory = {}
+      return memory unless File.exist?('/proc/meminfo')
+      File.open('/proc/meminfo').each do |line|
+        case line
+        when /^MemTotal:\s+(\d+) (.+)$/
+          memory[:total] = $1.to_i * 1024
+        when /^MemFree:\s+(\d+) (.+)$/
+          memory[:free] = $1.to_i * 1024
+        when /^Active:\s+(\d+) (.+)$/
+          memory[:active] = $1.to_i * 1024
+        when /^Inactive:\s+(\d+) (.+)$/
+          memory[:inactive] = $1.to_i * 1024
+        when /^Cached:\s+(\d+) (.+)$/
+          memory[:cached] = $1.to_i * 1024
+        when /^Buffers:\s+(\d+) (.+)$/
+          memory[:buffers] = $1.to_i * 1024
+        end
+      end
+      memory[:used] = memory[:total] - memory[:free]
+
+      memory
+    end
+
+    # @param [Time] since
+    def calculate_containers_time
+      seconds = 0
+      Docker::Container.all.each do |container|
+        seconds += calculate_container_time(container)
+      end
+
+      seconds
+    rescue => exc
+      error exc.message
+    end
+
+    # @param [Docker::Container] container
+    # @return [Integer]
+    def calculate_container_time(container)
+      state = container.state
+      since = stats_since.to_time.utc
+      started_at = DateTime.parse(state['StartedAt']).to_time.utc rescue nil
+      finished_at = DateTime.parse(state['FinishedAt']).to_time.utc rescue nil
+      seconds = 0
+      return seconds unless started_at
+      if state['Running']
+        now = Time.now.utc.to_i
+        if started_at < since
+          # container has started before last check
+          seconds = now - since.to_i
+        elsif started_at >= since
+          # container has started after last check
+          seconds = now - started_at.to_time.to_i
+        end
+      else
+        if finished_at && started_at < finished_at && started_at > since
+          # container has started before last check
+          seconds = finished_at.to_i - started_at.to_i
+        elsif finished_at && started_at < finished_at && started_at <= since
+          # container has started after last check
+          seconds = finished_at.to_i - since.to_i
+        end
+      end
+
+      seconds
+    rescue => exc
+      debug exc.message
+      0
+    end
+
+    # @param [Array<Vmstat::Cpu>] prev_cpus
+    # @param [Array<Vmstat::Cpu>] current_cpu
+    # @return [Hash] { :num_cores, :system, :user, :idle }
+    def calculate_cpu_usage(prev_cpus, current_cpus)
+      result = {
+        num_cores: prev_cpus.size,
+        system: 0.0,
+        user: 0.0,
+        nice: 0.0,
+        idle: 0.0
+      }
+
+      prev_cpus.zip(current_cpus).map { |prev_cpu, current_cpu|
+        system_ticks = current_cpu.system - prev_cpu.system
+        user_ticks = current_cpu.user - prev_cpu.user
+        nice_ticks = current_cpu.nice = prev_cpu.nice
+        idle_ticks = current_cpu.idle - prev_cpu.idle
+
+        total_ticks = (system_ticks + user_ticks + nice_ticks + idle_ticks).to_f
+
+        {
+          system: (system_ticks / total_ticks) * 100.0,
+          user: (user_ticks / total_ticks) * 100.0,
+          nice: (nice_ticks / total_ticks) * 100.0,
+          idle: (idle_ticks / total_ticks) * 100.0
+        }
+      }.inject(result) { |memo, cpu_core|
+        memo[:system] += cpu_core[:system]
+        memo[:user] += cpu_core[:user]
+        memo[:nice] += cpu_core[:nice]
+        memo[:idle] += cpu_core[:idle]
+        memo
+      }
+    end
+
+    # @param [Array<Vmstat::NetworkInterface>] prev_interfaces
+    # @param [Array<Vmstat::NetworkInterface>] current_interfaces
+    # @param [Number] interval_seconds
+    # @return [Hash]
+    def calculate_network_traffic(prev_interfaces, current_interfaces, interval_seconds)
+      prev_interfaces = prev_interfaces.map { |iface| {
+        name: iface.name,
+        rx_bytes: iface.in_bytes,
+        tx_bytes: iface.out_bytes
+      }}
+
+      internal_interfaces = current_interfaces.select { |iface|
+        iface.name.to_s == "weave" or iface.name.to_s.start_with?("vethwe")
+      }
+      .map { |iface| {
+          name: iface.name,
+          rx_bytes: iface.in_bytes,
+          tx_bytes: iface.out_bytes
+      }}
+
+      external_interfaces = current_interfaces.select { |iface|
+        iface.name.to_s == "docker0"
+      }
+      .map { |iface| {
+          name: iface.name,
+          rx_bytes: iface.in_bytes,
+          tx_bytes: iface.out_bytes
+      }}
+
+      {
+        internal: calculate_interface_traffic(prev_interfaces, internal_interfaces, interval_seconds),
+        external: calculate_interface_traffic(prev_interfaces, external_interfaces, interval_seconds)
+      }
+    end
+
+    # @return [Hash]
+    def docker_info
+      @docker_info ||= Docker.info
+    end
+  end
+end

--- a/agent/lib/kontena/workers/node_stats_worker.rb
+++ b/agent/lib/kontena/workers/node_stats_worker.rb
@@ -18,7 +18,8 @@ module Kontena::Workers
 
     PUBLISH_INTERVAL = 60
 
-    def initialize
+    # @param [Boolean] autostart
+    def initialize(autostart = true)
       @node = nil
       @statsd = nil
       @stats_since = Time.now
@@ -27,6 +28,7 @@ module Kontena::Workers
       @previous_network = Vmstat.network_interfaces
       subscribe('container:event', :on_container_event)
       info 'initialized'
+      async.start if autostart
     end
 
     def start

--- a/agent/lib/kontena/workers/node_stats_worker.rb
+++ b/agent/lib/kontena/workers/node_stats_worker.rb
@@ -43,7 +43,7 @@ module Kontena::Workers
     def start_publish_loop
       loop do
         sleep PUBLISH_INTERVAL
-        self.publish_node_stats if rpc_client.connected?
+        self.publish_node_stats
       end
     end
 
@@ -116,7 +116,7 @@ module Kontena::Workers
         network: network_traffic,
         time: Time.now.utc.to_s
       }
-      rpc_client.async.notification('/nodes/stats', [data])
+      rpc_client.async.notification('/nodes/stats', [data]) if rpc_client.connected?
       send_statsd_metrics(data)
     end
 

--- a/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_info_worker_spec.rb
@@ -1,8 +1,7 @@
-describe Kontena::Workers::NodeInfoWorker do
+describe Kontena::Workers::NodeInfoWorker, celluloid: true do
   include RpcClientMocks
 
   let(:subject) { described_class.new(false) }
-  let(:statsd) { double(:statsd) }
   let(:node) do
     Node.new(
       'id' => 'U3CZ:W2PA:2BRD:66YG:W5NJ:CI2R:OQSK:FYZS:NMQQ:DIV5:TE6K:R6GS',
@@ -13,8 +12,7 @@ describe Kontena::Workers::NodeInfoWorker do
     )
   end
 
-  before(:each) {
-    Celluloid.boot
+  before(:each) do
     mock_rpc_client
     allow(Docker).to receive(:info).and_return({
       'Name' => 'node-1',
@@ -29,11 +27,9 @@ describe Kontena::Workers::NodeInfoWorker do
       { 'Name' => 'foo:latest', 'Enabled' => true, 'Config' => { 'Interface' => { 'Types' => ['docker.volumedriver/1.0']} } }
     ])
     allow(Net::HTTP).to receive(:get).and_return('8.8.8.8')
-    allow(subject.wrapped_object).to receive(:calculate_containers_time).and_return(100)
     allow(rpc_client).to receive(:request)
     allow(rpc_client).to receive(:notification)
-  }
-  after(:each) { Celluloid.shutdown }
+  end
 
   describe '#initialize' do
     it 'subscribes to websocket:connected channel' do
@@ -53,44 +49,6 @@ describe Kontena::Workers::NodeInfoWorker do
       subject.async.start
       sleep 0.1
       subject.terminate
-    end
-
-    it 'calls #publish_node_info' do
-      stub_const('Kontena::Workers::NodeInfoWorker::PUBLISH_INTERVAL', 0.01)
-      allow(subject.wrapped_object).to receive(:fetch_node).and_return(node)
-      expect(subject.wrapped_object).to receive(:publish_node_stats).at_least(:once)
-      subject.async.start
-      sleep 0.1
-      subject.terminate
-    end
-  end
-
-  describe '#on_node_info' do
-    it 'initializes statsd client if node has statsd config' do
-      node = Node.new(
-        'grid' => {
-          'stats' => {
-            'statsd' => {
-              'server' => '192.168.24.33',
-              'port' => 8125
-            }
-          }
-        }
-      )
-      expect(subject.statsd).to be_nil
-      subject.on_node_info('agent:on_node_info', node)
-      expect(subject.statsd).not_to be_nil
-    end
-
-    it 'does not initialize statsd if no statsd config exists' do
-      node = Node.new(
-        'grid' => {
-          'stats' => {}
-        }
-      )
-      expect(subject.statsd).to be_nil
-      subject.on_node_info('agent:on_node_info', node)
-      expect(subject.statsd).to be_nil
     end
   end
 
@@ -146,83 +104,6 @@ describe Kontena::Workers::NodeInfoWorker do
     end
   end
 
-  describe '#publish_node_stats' do
-    it 'sends node stats via rpc' do
-      expect(rpc_client).to receive(:notification).once.with(
-        '/nodes/stats', [hash_including(id: 'U3CZ:W2PA:2BRD:66YG:W5NJ:CI2R:OQSK:FYZS:NMQQ:DIV5:TE6K:R6GS')]
-      )
-      subject.publish_node_stats
-    end
-  end
-
-  describe '#calculate_container_time' do
-    context 'container is running' do
-      it 'calculates container time since last check' do
-        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 30)
-        container = double(:container, state: {
-          'StartedAt' => (Time.now - 300).to_s,
-          'Running' => true
-        })
-        time = subject.calculate_container_time(container)
-        expect(time).to eq(30)
-      end
-
-      it 'calculates container time since container is started' do
-        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 60)
-        container = double(:container, state: {
-          'StartedAt' => (Time.now - 50).to_s,
-          'Running' => true
-        })
-        time = subject.calculate_container_time(container)
-        expect(time).to eq(50)
-      end
-    end
-
-    context 'container is not running' do
-      it 'calculates partial container time since last check' do
-        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 60)
-        container = double(:container, state: {
-          'StartedAt' => (Time.now - 300).to_s,
-          'FinishedAt' => (Time.now - 2).to_s,
-          'Running' => false
-        })
-        time = subject.calculate_container_time(container)
-        expect(time).to eq(58)
-      end
-
-      it 'calculates partial container time since container is started' do
-        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 60)
-        container = double(:container, state: {
-          'StartedAt' => (Time.now - 50).to_s,
-          'FinishedAt' => (Time.now - 2).to_s,
-          'Running' => false
-        })
-        time = subject.calculate_container_time(container)
-        expect(time).to eq(48)
-      end
-    end
-  end
-
-  describe '#on_container_event' do
-    context 'die' do
-      it 'calculates container time if container is found' do
-        event = double(:event, status: 'die', id: 'aaa')
-        container = double(:container, id: 'aaa')
-        allow(Docker::Container).to receive(:get).and_return(container)
-        expect(subject.wrapped_object).to receive(:calculate_container_time).and_return(1)
-        subject.on_container_event('on_container_event', event)
-      end
-
-      it 'does not calculate container time if container does not exist' do
-        event = double(:event, status: 'die', id: 'aaa')
-        allow(Docker::Container).to receive(:get).and_return(nil)
-        expect(subject.wrapped_object).not_to receive(:calculate_container_time)
-        subject.on_container_event('on_container_event', event)
-      end
-    end
-  end
-
-
   describe '#public_ip' do
     it 'returns ip from env if set' do
       allow(ENV).to receive(:[]).with('KONTENA_PUBLIC_IP').and_return('128.105.39.11')
@@ -243,91 +124,6 @@ describe Kontena::Workers::NodeInfoWorker do
     it 'returns ip from private interface by default' do
       allow(subject.wrapped_object).to receive(:interface_ip).and_return('192.168.2.10')
       expect(subject.private_ip).to eq('192.168.2.10')
-    end
-  end
-
-  describe '#publish_node_stats' do
-
-    before(:each) do
-      allow(rpc_client).to receive(:notification)
-    end
-
-    it 'sends stats via rpc' do
-      expect(rpc_client).to receive(:notification).once.with('/nodes/stats',
-        [hash_including(id: String, memory: Hash, usage: Hash, load: Hash,
-                        filesystem: Array, cpu: Hash, network: Hash, time: String)])
-      subject.publish_node_stats
-    end
-
-    it 'sends stats to statsd' do
-      subject.instance_variable_set("@statsd", statsd)
-
-      # Will be called 18 times if there is one file system
-      expect(statsd).to receive(:gauge).at_least(18).times
-      subject.publish_node_stats
-    end
-  end
-
-  describe '#calculate_cpu_usage' do
-    it 'calculates cpu usage' do
-      prev = [
-        # cpu-num, user ticks, system ticks, nice ticks, idle ticks
-        Vmstat::Cpu.new(0, 926444, 1715744, 0, 8413871),
-        Vmstat::Cpu.new(1, 67122, 93965, 0, 10891139)
-      ]
-      cur = [
-        Vmstat::Cpu.new(0, 926482, 1715820, 0, 8414258),
-        Vmstat::Cpu.new(1, 67123, 93967, 0, 10891637)
-      ]
-
-      result = subject.calculate_cpu_usage(prev, cur)
-
-      expect(result).to eq({
-        num_cores: 2,
-        system: 15.568862275449103,
-        user: 7.784431137724551,
-        nice: 0,
-        idle: 176.64670658682633
-      })
-    end
-  end
-
-  describe '#calculate_network_traffic' do
-    it 'calculates network traffic' do
-      num_seconds = 60.0
-
-      prev = [
-        #  name=nil, in_bytes=nil, in_errors=nil, in_drops=nil, out_bytes=nil, out_errors=nil, type=nil
-        Vmstat::NetworkInterface.new("weave", 50, 51, 52, 70, 71, 0),
-        Vmstat::NetworkInterface.new("vethwe123", 100, 101, 102, 110, 111, 0),
-        Vmstat::NetworkInterface.new("docker0", 1000, 1001, 1002, 1010, 1011, 1),
-        Vmstat::NetworkInterface.new("other", 9999, 9999, 9999, 9999, 9999, 1)
-      ]
-      cur = [
-        Vmstat::NetworkInterface.new("weave", 70, 71, 72, 90, 91, 0),
-        Vmstat::NetworkInterface.new("vethwe123", 200, 201, 202, 210, 211, 0),
-        Vmstat::NetworkInterface.new("docker0", 2800, 2801, 2802, 3410, 3411, 1),
-        Vmstat::NetworkInterface.new("other", 9999, 9999, 9999, 9999, 9999, 1)
-      ]
-
-      result = subject.calculate_network_traffic(prev, cur, num_seconds)
-
-      expect(result).to eq({
-          internal: {
-            interfaces: ["weave", "vethwe123"],
-            rx_bytes: 270,
-            rx_bytes_per_second: 2, # ((200+70) - (50+100)) / 60
-            tx_bytes: 300,
-            tx_bytes_per_second: 2 # ((210+90) - (110+70)) / 60
-          },
-          external: {
-            interfaces: ["docker0"],
-            rx_bytes: 2800,
-            rx_bytes_per_second: 30, # (2800 - 1000) / 60
-            tx_bytes: 3410,
-            tx_bytes_per_second: 40 # (3410 - 1010) / 60
-          }
-      })
     end
   end
 end

--- a/agent/spec/lib/kontena/workers/node_stats_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_stats_worker_spec.rb
@@ -27,6 +27,7 @@ describe Kontena::Workers::NodeStatsWorker, celluloid: true do
     allow(subject.wrapped_object).to receive(:calculate_containers_time).and_return(100)
     allow(rpc_client).to receive(:request)
     allow(rpc_client).to receive(:notification)
+    allow(rpc_client).to receive(:connected?).and_return(true)
   end
 
   describe '#configure_statsd' do

--- a/agent/spec/lib/kontena/workers/node_stats_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_stats_worker_spec.rb
@@ -1,6 +1,7 @@
 describe Kontena::Workers::NodeStatsWorker, celluloid: true do
   include RpcClientMocks
 
+  let(:subject) { described_class.new(false) }
   let(:statsd) { double(:statsd) }
   let(:node) do
     Node.new(

--- a/agent/spec/lib/kontena/workers/node_stats_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/node_stats_worker_spec.rb
@@ -1,0 +1,220 @@
+describe Kontena::Workers::NodeStatsWorker, celluloid: true do
+  include RpcClientMocks
+
+  let(:statsd) { double(:statsd) }
+  let(:node) do
+    Node.new(
+      'id' => 'U3CZ:W2PA:2BRD:66YG:W5NJ:CI2R:OQSK:FYZS:NMQQ:DIV5:TE6K:R6GS',
+      'instance_number' => 1,
+      'grid' => {
+
+      }
+    )
+  end
+
+  before(:each) do
+    mock_rpc_client
+    allow(Docker).to receive(:info).and_return({
+      'Name' => 'node-1',
+      'Labels' => nil,
+      'ID' => 'U3CZ:W2PA:2BRD:66YG:W5NJ:CI2R:OQSK:FYZS:NMQQ:DIV5:TE6K:R6GS',
+      'Plugins' => {
+        'Network' => ['bridge', 'host'],
+        'Volume' => ['local']
+      }
+    })
+    allow(subject.wrapped_object).to receive(:calculate_containers_time).and_return(100)
+    allow(rpc_client).to receive(:request)
+    allow(rpc_client).to receive(:notification)
+  end
+
+  describe '#configure_statsd' do
+    it 'initializes statsd client if node has statsd config' do
+      node = Node.new(
+        'grid' => {
+          'stats' => {
+            'statsd' => {
+              'server' => '192.168.24.33',
+              'port' => 8125
+            }
+          }
+        }
+      )
+      expect {
+        subject.configure_statsd(node)
+      }.to change { subject.statsd }
+    end
+
+    it 'does not initialize statsd if no statsd config exists' do
+      node = Node.new(
+        'grid' => {
+          'stats' => {}
+        }
+      )
+      expect {
+        subject.configure_statsd(node)
+      }.not_to change { subject.statsd }
+    end
+  end
+
+  describe '#publish_node_stats' do
+    it 'sends node stats via rpc' do
+      expect(rpc_client).to receive(:notification).once.with(
+        '/nodes/stats', [hash_including(id: 'U3CZ:W2PA:2BRD:66YG:W5NJ:CI2R:OQSK:FYZS:NMQQ:DIV5:TE6K:R6GS')]
+      )
+      subject.publish_node_stats
+    end
+  end
+
+  describe '#calculate_container_time' do
+    context 'container is running' do
+      it 'calculates container time since last check' do
+        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 30)
+        container = double(:container, state: {
+          'StartedAt' => (Time.now - 300).to_s,
+          'Running' => true
+        })
+        time = subject.calculate_container_time(container)
+        expect(time).to eq(30)
+      end
+
+      it 'calculates container time since container is started' do
+        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 60)
+        container = double(:container, state: {
+          'StartedAt' => (Time.now - 50).to_s,
+          'Running' => true
+        })
+        time = subject.calculate_container_time(container)
+        expect(time).to eq(50)
+      end
+    end
+
+    context 'container is not running' do
+      it 'calculates partial container time since last check' do
+        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 60)
+        container = double(:container, state: {
+          'StartedAt' => (Time.now - 300).to_s,
+          'FinishedAt' => (Time.now - 2).to_s,
+          'Running' => false
+        })
+        time = subject.calculate_container_time(container)
+        expect(time).to eq(58)
+      end
+
+      it 'calculates partial container time since container is started' do
+        allow(subject.wrapped_object).to receive(:stats_since).and_return(Time.now - 60)
+        container = double(:container, state: {
+          'StartedAt' => (Time.now - 50).to_s,
+          'FinishedAt' => (Time.now - 2).to_s,
+          'Running' => false
+        })
+        time = subject.calculate_container_time(container)
+        expect(time).to eq(48)
+      end
+    end
+  end
+
+  describe '#on_container_event' do
+    context 'die' do
+      it 'calculates container time if container is found' do
+        event = double(:event, status: 'die', id: 'aaa')
+        container = double(:container, id: 'aaa')
+        allow(Docker::Container).to receive(:get).and_return(container)
+        expect(subject.wrapped_object).to receive(:calculate_container_time).and_return(1)
+        subject.on_container_event('on_container_event', event)
+      end
+
+      it 'does not calculate container time if container does not exist' do
+        event = double(:event, status: 'die', id: 'aaa')
+        allow(Docker::Container).to receive(:get).and_return(nil)
+        expect(subject.wrapped_object).not_to receive(:calculate_container_time)
+        subject.on_container_event('on_container_event', event)
+      end
+    end
+  end
+
+  describe '#publish_node_stats' do
+
+    before(:each) do
+      allow(rpc_client).to receive(:notification)
+    end
+
+    it 'sends stats via rpc' do
+      expect(rpc_client).to receive(:notification).once.with('/nodes/stats',
+        [hash_including(id: String, memory: Hash, usage: Hash, load: Hash,
+                        filesystem: Array, cpu: Hash, network: Hash, time: String)])
+      subject.publish_node_stats
+    end
+
+    it 'sends stats to statsd' do
+      subject.instance_variable_set("@statsd", statsd)
+
+      # Will be called 18 times if there is one file system
+      expect(statsd).to receive(:gauge).at_least(18).times
+      subject.publish_node_stats
+    end
+  end
+
+  describe '#calculate_cpu_usage' do
+    it 'calculates cpu usage' do
+      prev = [
+        # cpu-num, user ticks, system ticks, nice ticks, idle ticks
+        Vmstat::Cpu.new(0, 926444, 1715744, 0, 8413871),
+        Vmstat::Cpu.new(1, 67122, 93965, 0, 10891139)
+      ]
+      cur = [
+        Vmstat::Cpu.new(0, 926482, 1715820, 0, 8414258),
+        Vmstat::Cpu.new(1, 67123, 93967, 0, 10891637)
+      ]
+
+      result = subject.calculate_cpu_usage(prev, cur)
+
+      expect(result).to eq({
+        num_cores: 2,
+        system: 15.568862275449103,
+        user: 7.784431137724551,
+        nice: 0,
+        idle: 176.64670658682633
+      })
+    end
+  end
+
+  describe '#calculate_network_traffic' do
+    it 'calculates network traffic' do
+      num_seconds = 60.0
+
+      prev = [
+        #  name=nil, in_bytes=nil, in_errors=nil, in_drops=nil, out_bytes=nil, out_errors=nil, type=nil
+        Vmstat::NetworkInterface.new("weave", 50, 51, 52, 70, 71, 0),
+        Vmstat::NetworkInterface.new("vethwe123", 100, 101, 102, 110, 111, 0),
+        Vmstat::NetworkInterface.new("docker0", 1000, 1001, 1002, 1010, 1011, 1),
+        Vmstat::NetworkInterface.new("other", 9999, 9999, 9999, 9999, 9999, 1)
+      ]
+      cur = [
+        Vmstat::NetworkInterface.new("weave", 70, 71, 72, 90, 91, 0),
+        Vmstat::NetworkInterface.new("vethwe123", 200, 201, 202, 210, 211, 0),
+        Vmstat::NetworkInterface.new("docker0", 2800, 2801, 2802, 3410, 3411, 1),
+        Vmstat::NetworkInterface.new("other", 9999, 9999, 9999, 9999, 9999, 1)
+      ]
+
+      result = subject.calculate_network_traffic(prev, cur, num_seconds)
+
+      expect(result).to eq({
+          internal: {
+            interfaces: ["weave", "vethwe123"],
+            rx_bytes: 270,
+            rx_bytes_per_second: 2, # ((200+70) - (50+100)) / 60
+            tx_bytes: 300,
+            tx_bytes_per_second: 2 # ((210+90) - (110+70)) / 60
+          },
+          external: {
+            interfaces: ["docker0"],
+            rx_bytes: 2800,
+            rx_bytes_per_second: 30, # (2800 - 1000) / 60
+            tx_bytes: 3410,
+            tx_bytes_per_second: 40 # (3410 - 1010) / 60
+          }
+      })
+    end
+  end
+end


### PR DESCRIPTION
NodeInfoWorker has grown too big, this PR splits stats related pieces to a separate worker.

Fixes #2165 