### PR TITLE
Fix rake tasks to require the correct variant of celluloid 

### DIFF
--- a/server/lib/tasks/environment.rake
+++ b/server/lib/tasks/environment.rake
@@ -7,7 +7,7 @@ end
 task :environment do
   ENV['RACK_ENV'] = 'development' unless ENV['RACK_ENV']
 
-  require 'celluloid'
+  require 'celluloid/current'
   require 'roda'
   require 'mongoid'
   require 'json'


### PR DESCRIPTION
Fixes the #2168 watchdog `Logger` -> `Celluloid::Internals::Logger` namespacing error in the `Watchdog` actor class. The `environment` rake task was loading celluloid in backported mode early, bypassing the later `require 'celluloid/current'` in the `app/boot.rb`.