### PR TITLE
Remove bundler from bin/kontena-console

### DIFF
--- a/server/bin/kontena-console
+++ b/server/bin/kontena-console
@@ -6,8 +6,6 @@ ENV['NO_MONGO_PUBSUB'] = 'true'
 
 require "irb"
 require "irb/completion"
-require "bundler/setup"
-Bundler.require
 require File.expand_path('../../app/boot.rb', __FILE__)
 
 IRB.start


### PR DESCRIPTION
`bin/kontena-console` was loading wrong version of celluloid because it loaded all libraries via bundler. This is unnecessary because we already load all needed libraries in `boot.rb` (that is required in `bin/kontena-console`.