### PR TITLE
Agent: WeaveWorker reload containers in both weave restart and re-create cases

### DIFF
--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -28,6 +28,8 @@ describe Kontena::Workers::WeaveWorker do
     before(:each) do
       allow(network_adapter).to receive(:running?).and_return(true)
       allow(subject.wrapped_object).to receive(:started?).and_return(true)
+      allow(network_adapter).to receive(:router_image?).and_return(false)
+      allow(network_adapter).to receive(:router_image?).with('weaveworks/weave:1.4.5').and_return(true)
     end
 
     it 'calls #weave_attach on start event' do
@@ -42,9 +44,14 @@ describe Kontena::Workers::WeaveWorker do
       subject.on_container_event('topic', event)
     end
 
-    it 'calls #start on weave restart event' do
+    it 'does not call #start on weave restart event' do
       event = spy(:event, id: 'foobar', status: 'restart', from: 'weaveworks/weave:1.4.5')
-      expect(network_adapter).to receive(:router_image?).with('weaveworks/weave:1.4.5').and_return(true)
+      expect(subject.wrapped_object).not_to receive(:start)
+      subject.on_container_event('topic', event)
+    end
+
+    it 'calls #start on weave start event' do
+      event = spy(:event, id: 'foobar', status: 'start', from: 'weaveworks/weave:1.4.5')
       expect(subject.wrapped_object).to receive(:start).once
       subject.on_container_event('topic', event)
     end


### PR DESCRIPTION
Fixes #2158

Extends the existing `WeaveWorker` logic that re-runs start` logic on all weave container `start` events, not just `restart` events. This fixes the missing container DNS names on weave re-configurations by both re-attaching all containers and re-registering their DNS names after the weave container is re-created.

The difference between the two is that `restart` events would only happen if the weave router crashes, and Docker restarts it. If the `Weave` worker decides to re-create the container to change the configuration, then it will not be a `restart` event, but rather a `destroy` event followed by `create` and `start`. Currently the attached containers remain attached, but weave forgets the DNS registrations.

There is some trickyness going on here, because this will avoid triggering on the initial `start` event when the `Weave` actor is first creating the `weave` router container, as it only subscribes to `container:event` notifications after the `Weave` actor signals `network_adapter:start`, so this logic should not kick in before that.