### PR TITLE
Make ssl cert path configurable

### DIFF
--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -55,6 +55,7 @@ module Kontena
         connect_timeout: ENV["EXCON_CONNECT_TIMEOUT"] ? ENV["EXCON_CONNECT_TIMEOUT"].to_i : 5,
         read_timeout:    ENV["EXCON_READ_TIMEOUT"]    ? ENV["EXCON_READ_TIMEOUT"].to_i    : 30,
         write_timeout:   ENV["EXCON_WRITE_TIMEOUT"]   ? ENV["EXCON_WRITE_TIMEOUT"].to_i   : 5,
+        ssl_ca_path:     ENV["EXCON_SSL_CA_PATH"]     ? ENV["EXCON_SSL_CA_PATH"] : "/etc/ssl/certs",
         ssl_verify_peer: ignore_ssl_errors? ? false : true
       }
       if ENV["DEBUG"]

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -55,7 +55,6 @@ module Kontena
         connect_timeout: ENV["EXCON_CONNECT_TIMEOUT"] ? ENV["EXCON_CONNECT_TIMEOUT"].to_i : 5,
         read_timeout:    ENV["EXCON_READ_TIMEOUT"]    ? ENV["EXCON_READ_TIMEOUT"].to_i    : 30,
         write_timeout:   ENV["EXCON_WRITE_TIMEOUT"]   ? ENV["EXCON_WRITE_TIMEOUT"].to_i   : 5,
-        ssl_ca_path:     ENV["EXCON_SSL_CA_PATH"]     ? ENV["EXCON_SSL_CA_PATH"] : "/etc/ssl/certs",
         ssl_verify_peer: ignore_ssl_errors? ? false : true
       }
       if ENV["DEBUG"]

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -210,6 +210,7 @@ class Kontena::Command < Clamp::Command
     if ex.message.include?('Unable to verify certificate')
       $stderr.puts " [#{Kontena.pastel.red('error')}] The server uses a certificate signed by an unknown authority."
       $stderr.puts "         You can trust this server by copying server CA pem file to: #{Kontena.pastel.yellow("~/.kontena/certs/<hostname>.pem")}"
+      $stderr.puts "         If kontena cannot find your system ca bundle, you can set #{Kontena.pastel.yellow('SSL_CERT_DIR=/etc/ssl/certs')} env variable to load them from another location."
       $stderr.puts "         Protip: you can bypass the certificate check by setting #{Kontena.pastel.yellow('SSL_IGNORE_ERRORS=true')} env variable, but any data you send to the server could be intercepted by others."
       abort
     else


### PR DESCRIPTION
so that Excon can load the certs from global cert repo.
The default is set for ubuntu here. After inserting this
line i could connect to my master with letencrypt certs
on the haproxy, as i inserted the ca to ubuntu global
cert repos.