### PR TITLE
Warn, don't exit, when a plugin fails to load

### DIFF
--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -13,6 +13,6 @@ if ARGV[0] == 'complete'
   require 'kontena/scripts/completer'
 else
   require 'kontena_cli'
-  Kontena::PluginManager.instance.init unless ARGV.find { |arg| !arg.start_with?('-') } == 'plugin'
+  Kontena::PluginManager.instance.init
   Kontena::MainCommand.run
 end

--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -13,6 +13,6 @@ if ARGV[0] == 'complete'
   require 'kontena/scripts/completer'
 else
   require 'kontena_cli'
-  Kontena::PluginManager.instance.init unless ARGV.include?('plugin')
+  Kontena::PluginManager.instance.init unless ARGV.find { |arg| !arg.start_with?('-') } == 'plugin'
   Kontena::MainCommand.run
 end

--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -13,6 +13,6 @@ if ARGV[0] == 'complete'
   require 'kontena/scripts/completer'
 else
   require 'kontena_cli'
-  Kontena::PluginManager.instance.init
+  Kontena::PluginManager.instance.init unless ARGV.include?('plugin')
   Kontena::MainCommand.run
 end

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -174,7 +174,7 @@ module Kontena
                 $stderr.puts " [#{Kontena.pastel.red('error')}] Plugin #{Kontena.pastel.cyan(plugin_name)} (#{spec.version}) is not compatible with the current cli version."
                 $stderr.puts "         To update the plugin, run 'kontena plugin install #{plugin_name}'"
               end
-            rescue Exception => ex
+            rescue LoadError, StandardError => ex
               warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}\n\tRerun the command with environment DEBUG=true set to get the full exception."
               ENV['DEBUG'] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
             end

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -176,7 +176,7 @@ module Kontena
                 $stderr.puts "         To update the plugin, run 'kontena plugin install #{plugin_name}'"
               end
             rescue ScriptError, StandardError => ex
-              warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}\n\tRerun the command with environment DEBUG=true set to get the full exception.\nYou can uninstall the plugin using: kontena plugin uninstall #{spec.name.sub('kontena-plugin-', '')}\n"
+              warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}\n\tRerun the command with environment DEBUG=true set to get the full exception."
               ENV['DEBUG'] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
             end
           end

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -167,6 +167,7 @@ module Kontena
           if File.exist?(plugin) && !plugins.find{ |p| p.name == spec.name }
             begin
               if spec_has_valid_dependency?(spec)
+                ENV["DEBUG"] && $stderr.puts("Loading plugin #{spec.name}")
                 load(plugin)
                 plugins << spec
               else
@@ -175,7 +176,7 @@ module Kontena
                 $stderr.puts "         To update the plugin, run 'kontena plugin install #{plugin_name}'"
               end
             rescue LoadError, StandardError => ex
-              warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}\n\tRerun the command with environment DEBUG=true set to get the full exception."
+              warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}\n\tRerun the command with environment DEBUG=true set to get the full exception.\nYou can uninstall the plugin using: kontena plugin uninstall #{spec.name.sub('kontena-plugin-', '')}\n"
               ENV['DEBUG'] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
             end
           end

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -174,10 +174,9 @@ module Kontena
                 $stderr.puts " [#{Kontena.pastel.red('error')}] Plugin #{Kontena.pastel.cyan(plugin_name)} (#{spec.version}) is not compatible with the current cli version."
                 $stderr.puts "         To update the plugin, run 'kontena plugin install #{plugin_name}'"
               end
-            rescue LoadError => ex
-              $stderr.puts " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}"
+            rescue Exception => ex
+              warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}\n\tRerun the command with environment DEBUG=true set to get the full exception."
               ENV['DEBUG'] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
-              exit 1
             end
           end
         end

--- a/cli/lib/kontena/plugin_manager.rb
+++ b/cli/lib/kontena/plugin_manager.rb
@@ -175,7 +175,7 @@ module Kontena
                 $stderr.puts " [#{Kontena.pastel.red('error')}] Plugin #{Kontena.pastel.cyan(plugin_name)} (#{spec.version}) is not compatible with the current cli version."
                 $stderr.puts "         To update the plugin, run 'kontena plugin install #{plugin_name}'"
               end
-            rescue LoadError, StandardError => ex
+            rescue ScriptError, StandardError => ex
               warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name}\n\tRerun the command with environment DEBUG=true set to get the full exception.\nYou can uninstall the plugin using: kontena plugin uninstall #{spec.name.sub('kontena-plugin-', '')}\n"
               ENV['DEBUG'] && $stderr.puts("#{ex.class.name} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
             end


### PR DESCRIPTION
A broken / outdated plugin would otherwise prevent you from starting the kontena-cli at all, also making it impossible to uninstall the plugin without something like `GEM_HOME=~/.kontena/gems/2.4.0 gem uninstall kontena-plugin-foo`.
