### PR TITLE
Raise puma worker boot timeout & remove background threads

### DIFF
--- a/server/app/services/mongodb/migrator.rb
+++ b/server/app/services/mongodb/migrator.rb
@@ -74,7 +74,7 @@ module Mongodb
       }
       migrate_without_lock
     ensure
-      DistributedLock.release_lock(LOCK_NAME, lock_id)
+      DistributedLock.release_lock(LOCK_NAME, lock_id) if lock_id
     end
 
     def release_stale_lock

--- a/server/app/services/mongodb/migrator.rb
+++ b/server/app/services/mongodb/migrator.rb
@@ -69,7 +69,7 @@ module Mongodb
     def migrate
       ensure_indexes
       release_stale_lock
-      lock_id = wait_until!("lock #{name} is available", timeout: LOCK_TIMEOUT, interval: 0.5) { 
+      lock_id = wait_until!("migration lock is available", timeout: LOCK_TIMEOUT, interval: 0.5) {
         DistributedLock.obtain_lock(LOCK_NAME)
       }
       migrate_without_lock

--- a/server/app/services/mongodb/migrator.rb
+++ b/server/app/services/mongodb/migrator.rb
@@ -8,7 +8,7 @@ module Mongodb
     include DistributedLocks
 
     LOCK_NAME = 'mongodb_migrate'.freeze
-    LOCK_TIMEOUT = 60
+    LOCK_TIMEOUT = (60 * 5)
 
     MigratorError = Class.new(StandardError)
 

--- a/server/config/puma.rb
+++ b/server/config/puma.rb
@@ -3,6 +3,7 @@ require 'etc'
 workers Integer(ENV['WEB_CONCURRENCY'] || Etc.nprocessors)
 threads_count = Integer(ENV['MAX_THREADS'] || 8)
 threads threads_count, threads_count
+worker_boot_timeout (60 * 5)
 on_worker_boot do |worker_num|
   require_relative '../lib/moped_session_tracer' if ENV['DEBUG'] # warn on thread sharing of Moped::Session objects
   require_relative '../app/boot'

--- a/server/db/migrations/19_add_indexes_to_container_log.rb
+++ b/server/db/migrations/19_add_indexes_to_container_log.rb
@@ -1,8 +1,6 @@
 class AddIndexesToContainerLog < Mongodb::Migration
   def self.up
-    Thread.new {
-      Thread.current.abort_on_exception = true
-      ContainerLog.create_indexes # might take a long time
-    }
+    info "recreating container log indexes, this might take a log time"
+    ContainerLog.create_indexes
   end
 end

--- a/server/db/migrations/19_add_indexes_to_container_log.rb
+++ b/server/db/migrations/19_add_indexes_to_container_log.rb
@@ -1,6 +1,6 @@
 class AddIndexesToContainerLog < Mongodb::Migration
   def self.up
-    info "recreating container log indexes, this might take a log time"
+    info "recreating container log indexes, this might take long time"
     ContainerLog.create_indexes
   end
 end

--- a/server/db/migrations/22_create_container_stats_created_at_index.rb
+++ b/server/db/migrations/22_create_container_stats_created_at_index.rb
@@ -1,6 +1,6 @@
 class CreateContainerStatsCreatedAtIndex < Mongodb::Migration
   def self.up
-    info "recreating container stat indexes, this might take a log time"
+    info "recreating container stat indexes, this might take long time"
     ContainerStat.create_indexes
   end
 end

--- a/server/db/migrations/22_create_container_stats_created_at_index.rb
+++ b/server/db/migrations/22_create_container_stats_created_at_index.rb
@@ -1,8 +1,6 @@
 class CreateContainerStatsCreatedAtIndex < Mongodb::Migration
   def self.up
-    Thread.new {
-      Thread.current.abort_on_exception = true
-      ContainerStat.create_indexes # might take a long time
-    }
+    info "recreating container stat indexes, this might take a log time"
+    ContainerStat.create_indexes
   end
 end

--- a/server/db/migrations/23_create_host_node_stats_created_at_index.rb
+++ b/server/db/migrations/23_create_host_node_stats_created_at_index.rb
@@ -1,8 +1,6 @@
 class CreateHostNodeStatsCreatedAtIndex < Mongodb::Migration
   def self.up
-    Thread.new {
-      Thread.current.abort_on_exception = true
-      HostNodeStat.create_indexes # might take a long time
-    }
+    info "recreating node stat indexes, this might take a log time"
+    HostNodeStat.create_indexes
   end
 end

--- a/server/db/migrations/23_create_host_node_stats_created_at_index.rb
+++ b/server/db/migrations/23_create_host_node_stats_created_at_index.rb
@@ -1,6 +1,6 @@
 class CreateHostNodeStatsCreatedAtIndex < Mongodb::Migration
   def self.up
-    info "recreating node stat indexes, this might take a log time"
+    info "recreating node stat indexes, this might take long time"
     HostNodeStat.create_indexes
   end
 end

--- a/server/spec/services/mongodb/migrator_spec.rb
+++ b/server/spec/services/mongodb/migrator_spec.rb
@@ -28,7 +28,7 @@ describe Mongodb::Migrator do
     end
 
     it 'removes lock if stale' do
-      DistributedLock.create(name: described_class::LOCK_NAME, created_at: 4.minutes.ago)
+      DistributedLock.create(name: described_class::LOCK_NAME, created_at: 11.minutes.ago)
       expect {
         subject.release_stale_lock
       }.to change { DistributedLock.count }.by(-1)


### PR DESCRIPTION
Fixes #2164 (partially). Puma worker can still timeout if migrations takes more than 5 minutes to complete.