### PR TITLE
Do not add nice when calculating node CPU usage

### DIFF
--- a/server/app/models/host_node_stat.rb
+++ b/server/app/models/host_node_stat.rb
@@ -179,8 +179,7 @@ class HostNodeStat
           '$avg': {
             '$add': [
               { '$ifNull': ['$cpu.user', 0] },
-              { '$ifNull': ['$cpu.system', 0] },
-              { '$ifNull': ['$cpu.nice', 0] }
+              { '$ifNull': ['$cpu.system', 0] }
             ]
           }
         },


### PR DESCRIPTION
This PR will remove `nice` value from node's CPU usage calculation. Although it's consuming(?) CPU it can give wrong impression about how busy the server is or how much free capacity there are.