### PR TITLE
Do not send un-managed volume infos to master

### DIFF
--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -94,7 +94,12 @@ module Kontena::Workers::Volumes
         'volume_instance_id' => data.dig('Labels', 'io.kontena.volume_instance.id'),
         'volume_id' => data.dig('Labels', 'io.kontena.volume.id')
       }
-      rpc_client.async.request('/node_volumes/set_state', [node.id, volume])
+      # Only send "managed" volumes to server
+      if volume['volume_instance_id']
+        rpc_client.async.request('/node_volumes/set_state', [node.id, volume])
+      else
+        debug "Skip sending un-managed volume: #{volume['name']}"
+      end
     end
 
     # Checks if given volume exists with the expected driver

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -120,6 +120,15 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
       })
       subject.sync_volume_to_master(docker_volume)
     end
+
+    it 'does not send volume data to master for un-managed volume' do
+      expect(rpc_client).not_to receive(:request)
+      docker_volume = double(:volume, 'id' => 'foo', 'info' => {
+        'Name' => 'foo',
+        'Labels' => { }
+      })
+      subject.sync_volume_to_master(docker_volume)
+    end
   end
 
   describe '#volume_exist?' do


### PR DESCRIPTION
Currently agent sends all volume infos to master and master tries to match those to existing volume instances. It creates two mongo queries per volume plus pub-sub "overhead".

Fixed agent to send only info on volumes where the proper `io.kontena.volume_instance.id` label is in place.