### PR TITLE
Add rb-readline to CLI installer

### DIFF
--- a/cli/omnibus/config/software/kontena.rb
+++ b/cli/omnibus/config/software/kontena.rb
@@ -5,7 +5,6 @@ dependency "ruby"
 dependency "rubygems"
 dependency "libxml2"
 dependency "libxslt"
-
 whitelist_file "./wrappers/sh/kontena"
 build do
   gem "install rb-readline -v 0.5.4 --no-ri --no-doc"

--- a/cli/omnibus/config/software/kontena.rb
+++ b/cli/omnibus/config/software/kontena.rb
@@ -5,8 +5,10 @@ dependency "ruby"
 dependency "rubygems"
 dependency "libxml2"
 dependency "libxslt"
+
 whitelist_file "./wrappers/sh/kontena"
 build do
+  gem "install rb-readline -v 0.5.4 --no-ri --no-doc"
   gem "install nokogiri -v 1.6.8 --no-ri --no-doc"
   gem "install kontena-cli -v #{default_version} --no-ri --no-doc"
   copy "sh/kontena", "#{install_dir}/bin/kontena"


### PR DESCRIPTION
Installs rb-readline into the embedded ruby to support running kosh.

Fixes #2194