### PR TITLE
Handle empty YAML files in stack commands

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -98,7 +98,7 @@ module Kontena::Cli::Stacks
       end
 
       def raw_yaml
-        @raw_yaml ||= ::YAML.safe_load(raw_content)
+        @raw_yaml ||= ::YAML.safe_load(raw_content) || {}
       end
 
       # @return [Opto::Group]

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -73,7 +73,7 @@ module Kontena::Cli::Stacks
               warnings: false
             )
           )
-        )
+        ) || {}
       rescue Psych::SyntaxError => ex
         raise ex, "Error while parsing #{file} : #{ex.message}"
       end
@@ -92,7 +92,7 @@ module Kontena::Cli::Stacks
               raise_on_unknown: true
             )
           )
-        )
+        ) || {}
       rescue Psych::SyntaxError => ex
         raise ex, "Error while parsing #{file} : #{ex.message}"
       end


### PR DESCRIPTION
Fixes #2204

`YAML.load("")` for some reason returns false. This PR adds `|| {}` to make sure a hash is returned.

With this PR applied:

```
$ touch foo.yml && bin/kontena stack install foo.yml
 [error] Stack MUST have stack name in YAML top level field 'stack'! Aborting.
```
