### PR TITLE
Refactor agent WeaveHelper to avoid unnecessary sync actor calls

### DIFF
--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -8,6 +8,49 @@ module Kontena
     module WeaveHelper
       include WaitHelper
 
+      WEAVE_VERSION = ENV['WEAVE_VERSION'] || '1.9.3'
+      WEAVE_IMAGE = ENV['WEAVE_IMAGE'] || 'weaveworks/weave'
+      WEAVEEXEC_IMAGE = ENV['WEAVEEXEC_IMAGE'] || 'weaveworks/weaveexec'
+
+      # @return [String]
+      def weave_version
+        WEAVE_VERSION
+      end
+
+      # @return [String]
+      def weave_image
+        "#{WEAVE_IMAGE}:#{WEAVE_VERSION}"
+      end
+
+      # @return [String]
+      def weave_exec_image
+        "#{WEAVEEXEC_IMAGE}:#{WEAVE_VERSION}"
+      end
+
+      # @param [Docker::Container] container
+      # @return [Boolean]
+      def adapter_container?(container)
+        adapter_image?(container.config['Image'])
+      rescue Docker::Error::NotFoundError
+        false
+      end
+
+      # @param [String] image
+      # @return [Boolean]
+      def adapter_image?(image)
+        image.to_s.include?(WEAVEEXEC_IMAGE)
+      rescue
+        false
+      end
+
+      # @param [String] image
+      # @return [Boolean]
+      def router_image?(image)
+        image.to_s == "#{WEAVE_IMAGE}:#{WEAVE_VERSION}"
+      rescue
+        false
+      end
+
       def network_adapter
         Celluloid::Actor[:network_adapter]
       end

--- a/agent/lib/kontena/helpers/weave_helper.rb
+++ b/agent/lib/kontena/helpers/weave_helper.rb
@@ -66,60 +66,6 @@ module Kontena
           network_adapter.network_ready?
         }
       end
-
-      def weave_api_ready?
-        # getting status should be pretty fast, set low timeouts to fail faster
-        response = dns_client.get(path: '/status', :connect_timeout => 5, :read_timeout => 5)
-        response.status == 200
-      rescue Excon::Error
-        false
-      end
-
-      # @param [String] container_id
-      # @param [String] ip
-      # @param [String] name
-      def add_dns(container_id, ip, name)
-        retries = 0
-        begin
-          dns_client.put(
-            path: "/name/#{container_id}/#{ip}",
-            body: URI.encode_www_form('fqdn' => name),
-            headers: { "Content-Type" => "application/x-www-form-urlencoded" }
-          )
-        rescue Docker::Error::NotFoundError
-
-        rescue Excon::Errors::SocketError => exc
-          @dns_client = nil
-          retries += 1
-          if retries < 20
-            sleep 0.1
-            retry
-          end
-          raise exc
-        end
-      end
-
-      # @param [String] container_id
-      def remove_dns(container_id)
-        retries = 0
-        begin
-          dns_client.delete(path: "/name/#{container_id}")
-        rescue Docker::Error::NotFoundError
-
-        rescue Excon::Errors::SocketError => exc
-          @dns_client = nil
-          retries += 1
-          if retries < 20
-            sleep 0.1
-            retry
-          end
-          raise exc
-        end
-      end
-
-      def dns_client
-        @dns_client ||= Excon.new("http://127.0.0.1:6784")
-      end
     end
   end
 end

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -13,10 +13,6 @@ module Kontena::NetworkAdapters
     include Kontena::Logging
     include Kontena::Observer
 
-    WEAVE_VERSION = ENV['WEAVE_VERSION'] || '1.9.3'
-    WEAVE_IMAGE = ENV['WEAVE_IMAGE'] || 'weaveworks/weave'
-    WEAVEEXEC_IMAGE = ENV['WEAVEEXEC_IMAGE'] || 'weaveworks/weaveexec'
-
     DEFAULT_NETWORK = 'kontena'.freeze
 
     finalizer :finalizer
@@ -48,43 +44,6 @@ module Kontena::NetworkAdapters
       @executor_pool.terminate if @executor_pool.alive?
     rescue
       # If Celluloid manages to terminate the pool (through GC or by explicit shutdown) it will raise
-    end
-
-    # @return [String]
-    def weave_version
-      WEAVE_VERSION
-    end
-
-    # @return [String]
-    def weave_image
-      "#{WEAVE_IMAGE}:#{WEAVE_VERSION}"
-    end
-
-    # @return [String]
-    def weave_exec_image
-      "#{WEAVEEXEC_IMAGE}:#{WEAVE_VERSION}"
-    end
-
-    # @param [Docker::Container] container
-    # @return [Boolean]
-    def adapter_container?(container)
-      adapter_image?(container.config['Image'])
-    rescue Docker::Error::NotFoundError
-      false
-    end
-
-    # @param [String] image
-    # @return [Boolean]
-    def adapter_image?(image)
-      image.to_s.include?(WEAVEEXEC_IMAGE)
-    rescue
-      false
-    end
-
-    def router_image?(image)
-      image.to_s == "#{WEAVE_IMAGE}:#{WEAVE_VERSION}"
-    rescue
-      false
     end
 
     # @return [Boolean]

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -46,6 +46,18 @@ module Kontena::NetworkAdapters
       # If Celluloid manages to terminate the pool (through GC or by explicit shutdown) it will raise
     end
 
+    def api_client
+      @api_client ||= Excon.new("http://127.0.0.1:6784")
+    end
+
+    def weave_api_ready?
+      # getting status should be pretty fast, set low timeouts to fail faster
+      response = api_client.get(path: '/status', :connect_timeout => 5, :read_timeout => 5)
+      response.status == 200
+    rescue Excon::Error
+      false
+    end
+
     # @return [Boolean]
     def running?
       return false unless weave_container_running?

--- a/agent/lib/kontena/workers/event_worker.rb
+++ b/agent/lib/kontena/workers/event_worker.rb
@@ -1,4 +1,5 @@
 require_relative '../helpers/rpc_helper'
+require_relative '../helpers/weave_helper'
 
 module Kontena::Workers
   class EventWorker
@@ -6,6 +7,7 @@ module Kontena::Workers
     include Celluloid::Notifications
     include Kontena::Logging
     include Kontena::Helpers::RpcHelper
+    include Kontena::Helpers::WeaveHelper
 
     EVENT_NAME = 'container:event'
 
@@ -73,7 +75,7 @@ module Kontena::Workers
 
     # @param [Docker::Event] event
     def publish_event(event)
-      return if Actor[:network_adapter].adapter_image?(event.from)
+      return if adapter_image?(event.from)
 
       data = {
         id: event.id,

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -195,5 +195,51 @@ module Kontena::Workers
         "#{stack}-#{instance_number}.#{base_domain}"
       ]
     end
+
+    # @param [String] container_id
+    # @param [String] ip
+    # @param [String] name
+    def add_dns(container_id, ip, name)
+      retries = 0
+      begin
+        dns_client.put(
+          path: "/name/#{container_id}/#{ip}",
+          body: URI.encode_www_form('fqdn' => name),
+          headers: { "Content-Type" => "application/x-www-form-urlencoded" }
+        )
+      rescue Docker::Error::NotFoundError
+
+      rescue Excon::Errors::SocketError => exc
+        @dns_client = nil
+        retries += 1
+        if retries < 20
+          sleep 0.1
+          retry
+        end
+        raise exc
+      end
+    end
+
+    # @param [String] container_id
+    def remove_dns(container_id)
+      retries = 0
+      begin
+        dns_client.delete(path: "/name/#{container_id}")
+      rescue Docker::Error::NotFoundError
+
+      rescue Excon::Errors::SocketError => exc
+        @dns_client = nil
+        retries += 1
+        if retries < 20
+          sleep 0.1
+          retry
+        end
+        raise exc
+      end
+    end
+
+    def dns_client
+      @dns_client ||= Excon.new("http://127.0.0.1:6784")
+    end
   end
 end

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -56,7 +56,7 @@ module Kontena::Workers
           warn "skip start event for missing container=#{event.id}"
         end
       elsif event.status == 'restart'
-        if network_adapter.router_image?(event.from)
+        if router_image?(event.from)
           wait_weave_running?
 
           self.start

--- a/agent/spec/lib/kontena/workers/event_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/event_worker_spec.rb
@@ -3,7 +3,6 @@ describe Kontena::Workers::EventWorker do
   include RpcClientMocks
 
   let(:subject) { described_class.new(false) }
-  let(:network_adapter) { spy(:network_adapter) }
   let(:event) {
     {
       'Action' => 'start',
@@ -25,9 +24,6 @@ describe Kontena::Workers::EventWorker do
 
   before(:each) {
     Celluloid.boot
-    allow(network_adapter).to receive(:adapter_image?).and_return(false)
-    allow(Celluloid::Actor).to receive(:[])
-    allow(Celluloid::Actor).to receive(:[]).with(:network_adapter).and_return(network_adapter)
     mock_rpc_client
   }
   after(:each) { Celluloid.shutdown }
@@ -136,16 +132,10 @@ describe Kontena::Workers::EventWorker do
       subject.publish_event(event)
     end
 
-    it 'does not send event if source is from network adapter' do
-      event = spy(:event)
-      expect(rpc_client).not_to receive(:request)
-      allow(network_adapter).to receive(:adapter_image?).and_return(true)
-      subject.publish_event(event)
-    end
-
     it 'does not publish event if source is from network adapter' do
       event = spy(:event)
-      allow(network_adapter).to receive(:adapter_image?).and_return(true)
+      allow(subject.wrapped_object).to receive(:adapter_image?).and_return(true)
+      expect(rpc_client).not_to receive(:request)
       expect(subject.wrapped_object).not_to receive(:publish)
       subject.publish_event(event)
     end

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -43,7 +43,7 @@ describe Kontena::Workers::WeaveWorker do
 
     it 'calls #start on weave restart event' do
       event = spy(:event, id: 'foobar', status: 'restart', from: 'weaveworks/weave:1.4.5')
-      expect(network_adapter).to receive(:router_image?).with('weaveworks/weave:1.4.5').and_return(true)
+      expect(subject.wrapped_object).to receive(:router_image?).with('weaveworks/weave:1.4.5').and_return(true)
       expect(subject.wrapped_object).to receive(:start).once
       subject.on_container_event('topic', event)
     end


### PR DESCRIPTION
Avoid unnecessary remote actor calls like `Actor[:network_adapter].adapter_image?(event.from)`, when the same logic can easily be implemented as a local helper method call. This avoids side-effects like having the `EventWorker` actor crash with `DeadActorError`s if the `Weave` actor crashes.

Also moves the Weave API client stuff out of the `WeaveHelper` into the classes where they are actually used.