### PR TITLE
Exit with non-zero exit code when commands run other commands that fail 

### DIFF
--- a/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
+++ b/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
@@ -20,7 +20,7 @@ module Kontena
         return unless command.exit_code == 0
         return unless current_master.grid.nil?
 
-        Kontena.run(%w(grid list --use --verbose))
+        Kontena.run(%w(grid list --use --verbose), returning: :status)
       end
     end
   end

--- a/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
+++ b/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
@@ -20,7 +20,7 @@ module Kontena
         return unless command.exit_code == 0
         return unless current_master.grid.nil?
 
-        Kontena.run(%w(grid list --use --verbose), returning: :status)
+        Kontena.run(%w(grid list --use --verbose))
       end
     end
   end

--- a/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
+++ b/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
@@ -20,7 +20,7 @@ module Kontena
         return unless command.exit_code == 0
         return unless current_master.grid.nil?
 
-        Kontena.run('grid list --use --verbose')
+        Kontena.run(%w(grid list --use --verbose))
       end
     end
   end

--- a/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
@@ -39,7 +39,7 @@ module Kontena
         puts
         puts "You don't seem to be logged in to Kontena Cloud"
         puts
-        Kontena.run("cloud login --verbose")
+        Kontena.run(%w(cloud login --verbose))
         config.reset_instance
         reset_cloud_client
         result = false

--- a/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
@@ -39,7 +39,7 @@ module Kontena
         puts
         puts "You don't seem to be logged in to Kontena Cloud"
         puts
-        Kontena.run(%w(cloud login --verbose))
+        Kontena.run!(%w(cloud login --verbose))
         config.reset_instance
         reset_cloud_client
         result = false

--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -57,7 +57,7 @@ module Kontena
         ]
         Retriable.retriable do
           ENV["DEBUG"] && $stderr.puts("Running: #{cmd}")
-          Kontena.run(cmd)
+          raise "retry" unless Kontena.run(cmd, returning: :status).zero?
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -57,7 +57,7 @@ module Kontena
         ]
         Retriable.retriable do
           ENV["DEBUG"] && $stderr.puts("Running: #{cmd}")
-          raise "retry" unless Kontena.run?(cmd)
+          Kontena.run!(cmd)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -49,7 +49,12 @@ module Kontena
         end
 
         require 'shellwords'
-        cmd = "master login --no-login-info --skip-grid-auto-select --verbose --name #{command.result[:name].shellescape} --code #{command.result[:code].shellescape} #{new_master.url.shellescape}"
+        cmd = [
+          'master', 'login', '--no-login-info' ,'--skip-grid-auto-select', '--verbose',
+          '--name', command.result[:name],
+          '--code', command.result[:code],
+          new_master.url
+        ]
         Retriable.retriable do
           ENV["DEBUG"] && $stderr.puts("Running: #{cmd}")
           Kontena.run(cmd)

--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -57,7 +57,7 @@ module Kontena
         ]
         Retriable.retriable do
           ENV["DEBUG"] && $stderr.puts("Running: #{cmd}")
-          raise "retry" unless Kontena.run(cmd, returning: :status).zero?
+          raise "retry" unless Kontena.run?(cmd)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
@@ -13,7 +13,7 @@ module Kontena
 
         cmd = %w(grid create --silent test)
         Retriable.retriable do
-          raise "retry" unless Kontena.run?(cmd)
+          Kontena.run!(cmd)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
@@ -13,7 +13,7 @@ module Kontena
 
         cmd = %w(grid create --silent test)
         Retriable.retriable do
-          raise "retry" unless Kontena.run(cmd, returning: :status).zero?
+          raise "retry" unless Kontena.run?(cmd)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
@@ -11,8 +11,7 @@ module Kontena
         return unless config.current_master
         return unless config.current_master.name == command.result[:name]
 
-        cmd = "grid create --silent test"
-        ENV["DEBUG"] && $stderr.puts("Running: #{cmd}")
+        cmd = %w(grid create --silent test)
         Retriable.retriable do
           Kontena.run(cmd)
         end

--- a/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
@@ -13,7 +13,7 @@ module Kontena
 
         cmd = %w(grid create --silent test)
         Retriable.retriable do
-          Kontena.run(cmd)
+          raise "retry" unless Kontena.run(cmd, returning: :status).zero?
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -16,7 +16,7 @@ module Kontena
 
         cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}"]
         spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do |spin|
-          spin.fail! unless Kontena.run(cmd, returning: :status).zero?
+          spin.fail! unless Kontena.run?(cmd)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -16,7 +16,7 @@ module Kontena
 
         cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}"]
         spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do
-          Kontena.run(cmd.shelljoin)
+          Kontena.run(cmd)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -15,8 +15,8 @@ module Kontena
         require 'shellwords'
 
         cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}"]
-        spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do
-          Kontena.run(cmd)
+        spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do |spin|
+          spin.fail! unless Kontena.run(cmd, returning: :status).zero?
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -16,7 +16,7 @@ module Kontena
 
         cmd = ['master', 'config', 'set', "server.provider=#{command.result[:provider]}"]
         spinner "Setting Master configuration server.provider to '#{command.result[:provider]}'" do |spin|
-          spin.fail! unless Kontena.run?(cmd)
+          spin.fail! unless Kontena.run(cmd)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -15,21 +15,16 @@ module Kontena
         args
       end
 
-      def configure_auth_provider
-        Kontena.run(['master', 'init-cloud'] + init_cloud_args, returning: :status)
-      end
-
       def after
         return unless command.exit_code == 0
         return unless command.result.kind_of?(Hash)
         return unless command.result.has_key?(:name)
         return unless config.current_master
         return unless config.current_master.name == command.result[:name]
-        if command.respond_to?(:skip_auth_provider?) && command.skip_auth_provider?
-          return
-        end
 
-        configure_auth_provider
+        unless command.respond_to?(:skip_auth_provider?) && command.skip_auth_provider?
+          Kontena.run?(['master', 'init-cloud'] + init_cloud_args)
+        end
       end
     end
   end

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -8,15 +8,15 @@ module Kontena
 
       def init_cloud_args
         args = []
-        args << '--force' 
+        args << '--force'
         args << "--cloud-master-id #{command.cloud_master_id}" if command.cloud_master_id
         args << "--provider #{command.result[:provider]}" if command.result[:provider]
         args << "--version #{command.result[:version]}" if command.result[:version]
-        args.join(' ')
+        args
       end
 
       def configure_auth_provider
-        Kontena.run("master init-cloud #{init_cloud_args}")
+        Kontena.run(['master', 'init-cloud'] + init_cloud_args)
       end
 
       def after

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -23,7 +23,7 @@ module Kontena
         return unless config.current_master.name == command.result[:name]
 
         unless command.respond_to?(:skip_auth_provider?) && command.skip_auth_provider?
-          Kontena.run?(['master', 'init-cloud'] + init_cloud_args)
+          Kontena.run(['master', 'init-cloud'] + init_cloud_args)
         end
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -16,7 +16,7 @@ module Kontena
       end
 
       def configure_auth_provider
-        Kontena.run(['master', 'init-cloud'] + init_cloud_args)
+        Kontena.run(['master', 'init-cloud'] + init_cloud_args, returning: :status)
       end
 
       def after

--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -33,7 +33,7 @@ module Kontena
         invite_response = nil
         spinner "Creating user #{cloud_user_data[:email]} into Kontena Master" do |spin|
           invite_response = Kontena.run(["master", "user", "invite", "--external-id", cloud_user_data[:id], "--return", cloud_user_data[:email]])
-          spin.fail unless invite_response.kind_of?(Hash) && invite_response.has_key?('invite_code')
+          spin.fail! unless invite_response.kind_of?(Hash) && invite_response.has_key?('invite_code')
         end
 
         return nil unless invite_response
@@ -41,6 +41,7 @@ module Kontena
 
         success = spinner "Adding master_admin role for #{cloud_user_data[:email]}" do |spin|
           spin.fail! unless Kontena.run?(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]])
+          true
         end
 
         return nil unless success

--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -33,35 +33,28 @@ module Kontena
         invite_response = nil
         spinner "Creating user #{cloud_user_data[:email]} into Kontena Master" do |spin|
           invite_response = Kontena.run(["master", "user", "invite", "--external-id", cloud_user_data[:id], "--return", cloud_user_data[:email]])
-          unless invite_response.kind_of?(Hash) && invite_response.has_key?('invite_code')
-            spin.fail
-          end
+          spin.fail unless invite_response.kind_of?(Hash) && invite_response.has_key?('invite_code')
         end
 
         return nil unless invite_response
         ENV["DEBUG"] && $stderr.puts("Got invite code: #{invite_response['invite_code']}")
 
-        role_status = nil
-
-        spinner "Adding master_admin role for #{cloud_user_data[:email]}" do |spin|
-          role_status = Kontena.run(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]], returning: :status)
-          spin.fail if role_status.to_i > 0
+        success = spinner "Adding master_admin role for #{cloud_user_data[:email]}" do |spin|
+          spin.fail! unless Kontena.run?(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]])
         end
 
-        return nil if role_status.to_i > 0
+        return nil unless success
 
         if current_master.grid
           spinner "Adding #{cloud_user_data[:email]} to grid '#{current_master.grid}'" do |spin|
-            grid_add_status = Kontena.run(["grid", "user", "add", "--grid", current_master.grid, cloud_user_data[:email]], returning: :status)
-            spin.fail if grid_add_status.to_i > 0
+            spin.fail! unless Kontena.run?(["grid", "user", "add", "--grid", current_master.grid, cloud_user_data[:email]])
           end
         end
 
-        return unless current_master.username.to_s == 'admin'
+        return nil unless current_master.username.to_s == 'admin'
 
-        new_user_token = nil
-        spinner "Creating an access token for #{cloud_user_data[:email]}" do |spin|
-          new_user_token = Kontena.run(["master", "token", "create", "-e", "0", "-s", "user", "--return", "-u", cloud_user_data[:email]])
+        new_user_token = spinner "Creating an access token for #{cloud_user_data[:email]}" do |spin|
+          Kontena.run(["master", "token", "create", "-e", "0", "-s", "user", "--return", "-u", cloud_user_data[:email]])
         end
 
         master_name = current_master.name.dup

--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -32,7 +32,7 @@ module Kontena
 
         invite_response = nil
         spinner "Creating user #{cloud_user_data[:email]} into Kontena Master" do |spin|
-          invite_response = Kontena.run(["master", "user", "invite", "--external-id", cloud_user_data[:id], "--return", cloud_user_data[:email]], returning: :result)
+          invite_response = Kontena.run(["master", "user", "invite", "--external-id", cloud_user_data[:id], "--return", cloud_user_data[:email]])
           unless invite_response.kind_of?(Hash) && invite_response.has_key?('invite_code')
             spin.fail
           end
@@ -61,7 +61,7 @@ module Kontena
 
         new_user_token = nil
         spinner "Creating an access token for #{cloud_user_data[:email]}" do |spin|
-          new_user_token = Kontena.run(["master", "token", "create", "-e", "0", "-s", "user", "--return", "-u", cloud_user_data[:email]], returning: :result)
+          new_user_token = Kontena.run(["master", "token", "create", "-e", "0", "-s", "user", "--return", "-u", cloud_user_data[:email]])
         end
 
         master_name = current_master.name.dup

--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -40,7 +40,7 @@ module Kontena
         ENV["DEBUG"] && $stderr.puts("Got invite code: #{invite_response['invite_code']}")
 
         success = spinner "Adding master_admin role for #{cloud_user_data[:email]}" do |spin|
-          spin.fail! unless Kontena.run?(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]])
+          spin.fail! unless Kontena.run(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]])
           true
         end
 
@@ -48,14 +48,14 @@ module Kontena
 
         if current_master.grid
           spinner "Adding #{cloud_user_data[:email]} to grid '#{current_master.grid}'" do |spin|
-            spin.fail! unless Kontena.run?(["grid", "user", "add", "--grid", current_master.grid, cloud_user_data[:email]])
+            spin.fail! unless Kontena.run(["grid", "user", "add", "--grid", current_master.grid, cloud_user_data[:email]])
           end
         end
 
         return nil unless current_master.username.to_s == 'admin'
 
         new_user_token = spinner "Creating an access token for #{cloud_user_data[:email]}" do |spin|
-          Kontena.run(["master", "token", "create", "-e", "0", "-s", "user", "--return", "-u", cloud_user_data[:email]])
+          Kontena.run!(["master", "token", "create", "-e", "0", "-s", "user", "--return", "-u", cloud_user_data[:email]])
         end
 
         master_name = current_master.name.dup

--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -44,7 +44,7 @@ module Kontena
         role_status = nil
 
         spinner "Adding master_admin role for #{cloud_user_data[:email]}" do |spin|
-          role_status = Kontena.run(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]])
+          role_status = Kontena.run(["master", "user", "role", "add", "--silent", "master_admin", cloud_user_data[:email]], returning: :status)
           spin.fail if role_status.to_i > 0
         end
 
@@ -52,7 +52,7 @@ module Kontena
 
         if current_master.grid
           spinner "Adding #{cloud_user_data[:email]} to grid '#{current_master.grid}'" do |spin|
-            grid_add_status = Kontena.run(["grid", "user", "add", "--grid", current_master.grid, cloud_user_data[:email]])
+            grid_add_status = Kontena.run(["grid", "user", "add", "--grid", current_master.grid, cloud_user_data[:email]], returning: :status)
             spin.fail if grid_add_status.to_i > 0
           end
         end

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -1,3 +1,6 @@
+require 'kontena/cli/cloud_command'
+require 'kontena/cli/cloud/master_command'
+
 module Kontena::Cli::Cloud::Master
   class AddCommand < Kontena::Command
 
@@ -98,8 +101,8 @@ module Kontena::Cli::Cloud::Master
           if (self.provider && response['data']['attributes']['provider'] != self.provider) || (self.version && response['data']['attributes']['version'] != self.version)
             spinner "Updating provider and version attributes to Kontena Cloud master" do
               args = []
-              args << "--provider #{self.provider.shellescape}" if self.provider
-              args << "--version #{self.version.shellescape}" if self.version
+              args += ['--provider', self.provider] if self.provider
+              args += ['--version', self.version] if self.version
               args << self.cloud_master_id
               Kontena.run(['cloud', 'master', 'update'] + args)
             end

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -99,12 +99,12 @@ module Kontena::Cli::Cloud::Master
         end
         if response && response.kind_of?(Hash) && response.has_key?('data') && response['data']['attributes']
           if (self.provider && response['data']['attributes']['provider'] != self.provider) || (self.version && response['data']['attributes']['version'] != self.version)
-            spinner "Updating provider and version attributes to Kontena Cloud master" do
+            spinner "Updating provider and version attributes to Kontena Cloud master" do |spin|
               args = []
               args += ['--provider', self.provider] if self.provider
               args += ['--version', self.version] if self.version
               args << self.cloud_master_id
-              Kontena.run(['cloud', 'master', 'update'] + args)
+              spin.fail! unless Kontena.run?(['cloud', 'master', 'update'] + args)
             end
           end
         end
@@ -114,12 +114,12 @@ module Kontena::Cli::Cloud::Master
         end
       end
 
-      spinner "Loading Kontena Cloud auth provider base configuration to Kontena Master" do
-        Kontena.run(%w(master config import --force --preset kontena_auth_provider))
+      spinner "Loading Kontena Cloud auth provider base configuration to Kontena Master" do |spin|
+        spin.fail! unless Kontena.run?(%w(master config import --force --preset kontena_auth_provider))
       end
 
-      spinner "Updating OAuth2 client-id and client-secret to Kontena Master" do
-        Kontena.run(
+      spinner "Updating OAuth2 client-id and client-secret to Kontena Master" do |spin|
+        spin.fail! unless Kontena.run?(
           [
             'master', 'config', 'set',
             "oauth2.client_id=#{response['data']['attributes']['client-id'].shellescape}",

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -50,7 +50,7 @@ module Kontena::Cli::Cloud::Master
       masters = []
       spinner "Retrieving a list of your registered Kontena Masters in Kontena Cloud" do |spin|
         begin
-          masters = Kontena.run(%w(cloud master list --return))
+          masters = Kontena.run!(%w(cloud master list --return))
         rescue SystemExit
           spin.fail
         end
@@ -104,7 +104,7 @@ module Kontena::Cli::Cloud::Master
               args += ['--provider', self.provider] if self.provider
               args += ['--version', self.version] if self.version
               args << self.cloud_master_id
-              spin.fail! unless Kontena.run?(['cloud', 'master', 'update'] + args)
+              spin.fail! unless Kontena.run(['cloud', 'master', 'update'] + args)
             end
           end
         end
@@ -115,11 +115,11 @@ module Kontena::Cli::Cloud::Master
       end
 
       spinner "Loading Kontena Cloud auth provider base configuration to Kontena Master" do |spin|
-        spin.fail! unless Kontena.run?(%w(master config import --force --preset kontena_auth_provider))
+        spin.fail! unless Kontena.run(%w(master config import --force --preset kontena_auth_provider))
       end
 
       spinner "Updating OAuth2 client-id and client-secret to Kontena Master" do |spin|
-        spin.fail! unless Kontena.run?(
+        spin.fail! unless Kontena.run(
           [
             'master', 'config', 'set',
             "oauth2.client_id=#{response['data']['attributes']['client-id'].shellescape}",
@@ -134,7 +134,7 @@ module Kontena::Cli::Cloud::Master
 
     def execute
       unless cloud_client.authentication_ok?(kontena_account.userinfo_endpoint)
-        Kontena.run(%w(cloud login))
+        Kontena.run!(%w(cloud login))
         config.reset_instance
         reset_cloud_client
       end

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -50,7 +50,7 @@ module Kontena::Cli::Cloud::Master
       masters = []
       spinner "Retrieving a list of your registered Kontena Masters in Kontena Cloud" do |spin|
         begin
-          masters = Kontena.run(%w(cloud master list --return), returning: :result)
+          masters = Kontena.run(%w(cloud master list --return))
         rescue SystemExit
           spin.fail
         end

--- a/cli/lib/kontena/cli/master/create_command.rb
+++ b/cli/lib/kontena/cli/master/create_command.rb
@@ -67,7 +67,7 @@ module Kontena::Cli::Master
         end
       end
       cmd = [cmd_class.to_s[/Plugin::(.+?)::/, 1].downcase, 'master', 'create'] + options
-      Kontena.run(cmd)
+      Kontena.run!(cmd)
     end
   end
 

--- a/cli/lib/kontena/cli/master/create_command.rb
+++ b/cli/lib/kontena/cli/master/create_command.rb
@@ -66,9 +66,8 @@ module Kontena::Cli::Master
           end
         end
       end
-      command = cmd_class.to_s[/Plugin::(.+?)::/, 1].downcase
-      command << " master create #{options.join(" ")}"
-      Kontena.run(command)
+      cmd = [cmd_class.to_s[/Plugin::(.+?)::/, 1].downcase, 'master', 'create'] + options
+      Kontena.run(cmd)
     end
   end
 

--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -20,7 +20,7 @@ module Kontena::Cli::Master
       args += ["--cloud-master-id", self.cloud_master_id.shellescape] if self.cloud_master_id
       args += ["--provider", self.provider.shellescape] if self.provider
       args += ["--version", self.version.shellescape] if self.version
-      Kontena.run(['cloud', 'master', 'add'] + args)
+      Kontena.run!(['cloud', 'master', 'add'] + args)
     end
   end
 end

--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -20,7 +20,7 @@ module Kontena::Cli::Master
       args += ["--cloud-master-id", self.cloud_master_id.shellescape] if self.cloud_master_id
       args += ["--provider", self.provider.shellescape] if self.provider
       args += ["--version", self.version.shellescape] if self.version
-      Kontena.run("cloud master add #{args.join(' ')}")
+      Kontena.run(['cloud', 'master', 'add'] + args)
     end
   end
 end

--- a/cli/lib/kontena/cli/master/join_command.rb
+++ b/cli/lib/kontena/cli/master/join_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Master
 
       cmd = ['master', 'login'] + params
       cmd << url
-      Kontena.run(cmd)
+      Kontena.run!(cmd)
     end
   end
 end

--- a/cli/lib/kontena/cli/master/join_command.rb
+++ b/cli/lib/kontena/cli/master/join_command.rb
@@ -14,7 +14,9 @@ module Kontena::Cli::Master
       params << "--name #{self.name.shellescape}" if self.name
       params << "--verbose" if self.verbose?
 
-      Kontena.run("master login #{params.join(' ')} #{self.url.shellescape}")
+      cmd = ['master', 'login'] + params
+      cmd << url
+      Kontena.run(cmd)
     end
   end
 end

--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Master
     end
 
     def master_provider
-      Kontena.run(%w(master config get --return server.provider))
+      Kontena.run!(%w(master config get --return server.provider))
     end
 
     def execute
@@ -29,7 +29,7 @@ module Kontena::Cli::Master
         end
         cmd = ['vagrant', 'master', 'ssh']
         cmd += commands_list
-        Kontena.run(cmd)
+        Kontena.run!(cmd)
       else
         cmd = ['ssh']
         cmd << "#{user}@#{master_host}"

--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Master
     end
 
     def master_provider
-      Kontena.run(%w(master config get --return server.provider), returning: :result)
+      Kontena.run(%w(master config get --return server.provider))
     end
 
     def execute

--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Master
     end
 
     def master_provider
-      Kontena.run('master config get --return server.provider', returning: :result)
+      Kontena.run(%w(master config get --return server.provider), returning: :result)
     end
 
     def execute

--- a/cli/lib/kontena/cli/master/token/current_command.rb
+++ b/cli/lib/kontena/cli/master/token/current_command.rb
@@ -33,7 +33,7 @@ module Kontena::Cli::Master::Token
         exit 0
       end
 
-      Kontena.run(['master', 'token', 'show',  current_master.token.access_token])
+      Kontena.run!(['master', 'token', 'show',  current_master.token.access_token])
     end
   end
 end

--- a/cli/lib/kontena/cli/master/token/current_command.rb
+++ b/cli/lib/kontena/cli/master/token/current_command.rb
@@ -33,7 +33,7 @@ module Kontena::Cli::Master::Token
         exit 0
       end
 
-      Kontena.run("master token show #{current_master.token.access_token}")
+      Kontena.run(['master', 'token', 'show',  current_master.token.access_token])
     end
   end
 end

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -39,11 +39,11 @@ module Kontena::Cli::Master::User
             puts "  * command: kontena master join #{current_master.url} #{response['invite_code']}"
           end
           roles.each do |role|
-            Kontena.run(["master", "user", "role", "add", role, email])
+            raise "Failed to add role" unless Kontena.run(["master", "user", "role", "add", role, email], returning: :status).zero?
           end
         rescue => ex
-          $stderr.puts pastel.red("Failed to invite #{email}")
           ENV["DEBUG"] && $stderr.puts("#{ex} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")
+          exit_with_error "Failed to invite #{email} : #{ex.message}"
         end
       end
     end

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -39,7 +39,7 @@ module Kontena::Cli::Master::User
             puts "  * command: kontena master join #{current_master.url} #{response['invite_code']}"
           end
           roles.each do |role|
-            raise "Failed to add role" unless Kontena.run(["master", "user", "role", "add", role, email], returning: :status).zero?
+            raise "Failed to add role" unless Kontena.run?(["master", "user", "role", "add", role, email])
           end
         rescue => ex
           ENV["DEBUG"] && $stderr.puts("#{ex} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -39,7 +39,7 @@ module Kontena::Cli::Master::User
             puts "  * command: kontena master join #{current_master.url} #{response['invite_code']}"
           end
           roles.each do |role|
-            raise "Failed to add role" unless Kontena.run?(["master", "user", "role", "add", role, email])
+            raise "Failed to add role" unless Kontena.run(["master", "user", "role", "add", role, email])
           end
         rescue => ex
           ENV["DEBUG"] && $stderr.puts("#{ex} : #{ex.message}\n#{ex.backtrace.join("\n  ")}")

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -35,7 +35,7 @@ module Kontena::Cli::Nodes
           exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'
         end
         cmd = ['vagrant', 'node', 'ssh', node['name']] + commands_list
-        Kontena.run(cmd)
+        Kontena.run!(cmd)
       else
         cmd = ['ssh']
         cmd += ["-i", identity_file] if identity_file

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -154,7 +154,7 @@ module Kontena::Cli::Stacks
 
     def stacks_client
       return @stacks_client if @stacks_client
-      Kontena.run('cloud login') unless cloud_auth?
+      Kontena.run(%w(cloud login)) unless cloud_auth?
       config.reset_instance
       @stacks_client = Kontena::StacksClient.new(kontena_account.stacks_url, kontena_account.token)
     end

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -154,7 +154,7 @@ module Kontena::Cli::Stacks
 
     def stacks_client
       return @stacks_client if @stacks_client
-      Kontena.run(%w(cloud login)) unless cloud_auth?
+      Kontena.run!(%w(cloud login)) unless cloud_auth?
       config.reset_instance
       @stacks_client = Kontena::StacksClient.new(kontena_account.stacks_url, kontena_account.token)
     end

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -26,7 +26,7 @@ module Kontena::Cli::Stacks
       spinner "Creating stack #{pastel.cyan(stack['name'])} " do
         create_stack(stack)
       end
-      Kontena.run("stack deploy #{stack['name']}") if deploy?
+      Kontena.run(['stack', 'deploy', stack['name']]) if deploy?
     end
 
     def create_stack(stack)

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -26,7 +26,7 @@ module Kontena::Cli::Stacks
       spinner "Creating stack #{pastel.cyan(stack['name'])} " do
         create_stack(stack)
       end
-      Kontena.run(['stack', 'deploy', stack['name']]) if deploy?
+      Kontena.run!(['stack', 'deploy', stack['name']]) if deploy?
     end
 
     def create_stack(stack)

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -37,7 +37,7 @@ module Kontena::Cli::Stacks
         update_stack(stack) || spin.fail!
       end
 
-      Kontena.run(['stack', 'deploy', name]) if deploy?
+      Kontena.run!(['stack', 'deploy', name]) if deploy?
     end
 
     def update_stack(stack)

--- a/cli/lib/kontena/cli/vault/export_command.rb
+++ b/cli/lib/kontena/cli/vault/export_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Vault
       meth = json? ? :to_json : :to_yaml
       puts Hash[
         *Kontena.run('vault ls --return', returning: :result).sort.flat_map do |secret|
-          [secret, Kontena.run("vault read --return #{secret.shellescape}", returning: :result)]
+          [secret, Kontena.run(['vault', 'read', '--return', secret], returning: :result)]
         end
       ].send(meth)
     end

--- a/cli/lib/kontena/cli/vault/export_command.rb
+++ b/cli/lib/kontena/cli/vault/export_command.rb
@@ -13,7 +13,7 @@ module Kontena::Cli::Vault
       require 'shellwords'
       meth = json? ? :to_json : :to_yaml
       puts Hash[
-        *Kontena.run('vault ls --return', returning: :result).sort.flat_map do |secret|
+        *Kontena.run(['vault', 'ls', '--return'], returning: :result).sort.flat_map do |secret|
           [secret, Kontena.run(['vault', 'read', '--return', secret], returning: :result)]
         end
       ].send(meth)

--- a/cli/lib/kontena/cli/vault/export_command.rb
+++ b/cli/lib/kontena/cli/vault/export_command.rb
@@ -13,8 +13,8 @@ module Kontena::Cli::Vault
       require 'shellwords'
       meth = json? ? :to_json : :to_yaml
       puts Hash[
-        *Kontena.run(['vault', 'ls', '--return'], returning: :result).sort.flat_map do |secret|
-          [secret, Kontena.run(['vault', 'read', '--return', secret], returning: :result)]
+        *Kontena.run(['vault', 'ls', '--return']).sort.flat_map do |secret|
+          [secret, Kontena.run(['vault', 'read', '--return', secret])]
         end
       ].send(meth)
     end

--- a/cli/lib/kontena/cli/vault/export_command.rb
+++ b/cli/lib/kontena/cli/vault/export_command.rb
@@ -13,8 +13,8 @@ module Kontena::Cli::Vault
       require 'shellwords'
       meth = json? ? :to_json : :to_yaml
       puts Hash[
-        *Kontena.run(['vault', 'ls', '--return']).sort.flat_map do |secret|
-          [secret, Kontena.run(['vault', 'read', '--return', secret])]
+        *Kontena.run!(['vault', 'ls', '--return']).sort.flat_map do |secret|
+          [secret, Kontena.run!(['vault', 'read', '--return', secret])]
         end
       ].send(meth)
     end

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -57,7 +57,7 @@ module Kontena::Cli::Vault
       unless updates.empty?
         spinner "Updating #{updates.size} secrets" do |spin|
           updates.each do |key_value_pair|
-            spin.fail! unless Kontena.run?(['vault', 'update', '--upsert', '--silent'] + key_value_pair)
+            spin.fail! unless Kontena.run(['vault', 'update', '--upsert', '--silent'] + key_value_pair)
           end
         end
       end
@@ -65,7 +65,7 @@ module Kontena::Cli::Vault
       unless deletes.empty? || skip_null?
         spinner "Deleting #{deletes.size} secrets" do |spin|
           deletes.map(&:shellescape).each do |key_to_delete|
-            spin.fail! unless Kontena.run?(['vault', 'rm', '--silent', '--force', key_to_delete])
+            spin.fail! unless Kontena.run(['vault', 'rm', '--silent', '--force', key_to_delete])
           end
         end
       end

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -57,8 +57,7 @@ module Kontena::Cli::Vault
       unless updates.empty?
         spinner "Updating #{updates.size} secrets" do |spin|
           updates.each do |key_value_pair|
-            result = Kontena.run(['vault', 'update', '--upsert', '--silent'] + key_value_pair)
-            spin.fail! unless result.zero?
+            spin.fail! unless Kontena.run(['vault', 'update', '--upsert', '--silent'] + key_value_pair, returning: :status).zero?
           end
         end
       end
@@ -66,8 +65,7 @@ module Kontena::Cli::Vault
       unless deletes.empty? || skip_null?
         spinner "Deleting #{deletes.size} secrets" do |spin|
           deletes.map(&:shellescape).each do |key_to_delete|
-            result = Kontena.run(['vault', 'rm', '--silent', '--force', key_to_delete])
-            spin.fail! unless result.zero?
+            spin.fail! unless Kontena.run(['vault', 'rm', '--silent', '--force', key_to_delete], returning: :status).zero?
           end
         end
       end

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -57,7 +57,7 @@ module Kontena::Cli::Vault
       unless updates.empty?
         spinner "Updating #{updates.size} secrets" do |spin|
           updates.each do |key_value_pair|
-            spin.fail! unless Kontena.run(['vault', 'update', '--upsert', '--silent'] + key_value_pair, returning: :status).zero?
+            spin.fail! unless Kontena.run?(['vault', 'update', '--upsert', '--silent'] + key_value_pair)
           end
         end
       end
@@ -65,7 +65,7 @@ module Kontena::Cli::Vault
       unless deletes.empty? || skip_null?
         spinner "Deleting #{deletes.size} secrets" do |spin|
           deletes.map(&:shellescape).each do |key_to_delete|
-            spin.fail! unless Kontena.run(['vault', 'rm', '--silent', '--force', key_to_delete], returning: :status).zero?
+            spin.fail! unless Kontena.run?(['vault', 'rm', '--silent', '--force', key_to_delete])
           end
         end
       end

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -14,10 +14,6 @@ module Kontena::Cli::Vault
 
     requires_current_master
 
-    UPDATE_CMD = 'vault update --upsert --silent %{key} %{value}'
-    DELETE_CMD = 'vault rm --silent --force %{key}'
-
-
     def parsed_input
       json? ? JSON.load(input) : YAML.safe_load(input)
     end
@@ -60,8 +56,8 @@ module Kontena::Cli::Vault
 
       unless updates.empty?
         spinner "Updating #{updates.size} secrets" do |spin|
-          updates.each do |pair|
-            result = Kontena.run(UPDATE_CMD % { key: pair.first.shellescape, value: pair.last.shellescape })
+          updates.each do |key_value_pair|
+            result = Kontena.run(['vault', 'update', '--upsert', '--silent'] + key_value_pair)
             spin.fail! unless result.zero?
           end
         end
@@ -69,8 +65,8 @@ module Kontena::Cli::Vault
 
       unless deletes.empty? || skip_null?
         spinner "Deleting #{deletes.size} secrets" do |spin|
-          deletes.map(&:shellescape).each do |del|
-            result = Kontena.run(DELETE_CMD % { key: del })
+          deletes.map(&:shellescape).each do |key_to_delete|
+            result = Kontena.run(['vault', 'rm', '--silent', '--force', key_to_delete])
             spin.fail! unless result.zero?
           end
         end

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -33,7 +33,7 @@ module Kontena
     true
   rescue SystemExit => ex
     ex.status.zero?
-  rescue ScriptError, NoMemoryError, SystemStackError, StandardError => ex
+  rescue
     false
   end
 

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -22,7 +22,7 @@ module Kontena
   rescue SystemExit => ex
     ENV["DEBUG"] && $stderr.puts("Command completed with failure, result: #{result.inspect} status: #{ex.status}")
     return ex.status if returning == :status
-    raise ex
+    raise ex unless ex.status.zero?
   rescue => ex
     ENV["DEBUG"] && $stderr.puts("Command raised #{ex} with message: #{ex.message}\n#{ex.backtrace.join("\n  ")}")
     return 1 if returning == :status

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -6,7 +6,7 @@ module Kontena
   #
   # @param [String,Array<String>] command_line
   # @return [Fixnum] exit_code
-  def self.run(*cmdline, returning: :status)
+  def self.run(*cmdline, returning: nil)
     if cmdline.first.kind_of?(Array)
       command = cmdline.first
     elsif cmdline.size == 1 && cmdline.first.include?(' ')
@@ -21,10 +21,12 @@ module Kontena
     return result if returning == :result
   rescue SystemExit => ex
     ENV["DEBUG"] && $stderr.puts("Command completed with failure, result: #{result.inspect} status: #{ex.status}")
-    returning == :status ? $!.status : nil
+    return ex.status if returning == :status
+    raise ex
   rescue => ex
     ENV["DEBUG"] && $stderr.puts("Command raised #{ex} with message: #{ex.message}\n#{ex.backtrace.join("\n  ")}")
-    returning == :status ? 1 : nil
+    return 1 if returning == :status
+    raise ex
   end
 
 

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -29,7 +29,8 @@ module Kontena
   # @param [String,Array<String>] command_line
   # @return [TrueClass,FalseClass] success
   def self.run(*cmdline)
-    run!(*cmdline)
+    result = run!(*cmdline)
+    result.nil? ? true : result
   rescue SystemExit => ex
     ex.status.zero?
   rescue

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -5,6 +5,7 @@ module Kontena
   #   Kontena.run("grid list --help")
   #
   # @param [String,Array<String>] command_line
+  # @param [Symbol] return_type Use returning: :status to return non-zero exit code if the command fails
   # @return [Fixnum] exit_code
   def self.run(*cmdline, returning: nil)
     if cmdline.first.kind_of?(Array)
@@ -18,7 +19,7 @@ module Kontena
     result = Kontena::MainCommand.new(File.basename(__FILE__)).run(command)
     ENV["DEBUG"] && puts("Command completed, result: #{result.inspect} status: 0")
     return 0 if returning == :status
-    return result if returning == :result
+    result
   rescue SystemExit => ex
     ENV["DEBUG"] && $stderr.puts("Command completed with failure, result: #{result.inspect} status: #{ex.status}")
     return ex.status if returning == :status
@@ -28,7 +29,6 @@ module Kontena
     return 1 if returning == :status
     raise ex
   end
-
 
   # @return [String] x.y
   def self.minor_version

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -4,7 +4,7 @@ module Kontena
   #
   # @param [String,Array<String>] command_line
   # @return command result or nil
-  def self.run(*cmdline)
+  def self.run!(*cmdline)
     if cmdline.first.kind_of?(Array)
       command = cmdline.first
     elsif cmdline.size == 1 && cmdline.first.include?(' ')
@@ -28,9 +28,8 @@ module Kontena
   # Run a kontena command and return true if the command did not raise or exit with a non-zero exit code. Raises nothing.
   # @param [String,Array<String>] command_line
   # @return [TrueClass,FalseClass] success
-  def self.run?(*cmdline)
-    run(*cmdline)
-    true
+  def self.run(*cmdline)
+    run!(*cmdline)
   rescue SystemExit => ex
     ex.status.zero?
   rescue

--- a/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
@@ -95,8 +95,8 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
       subject.provider = 'provider'
       subject.version  = '10.10.10'
 
-      expect(Kontena).to receive(:run).with(%w(master config import --force --preset kontena_auth_provider))
-      expect(Kontena).to receive(:run).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true))
+      expect(Kontena).to receive(:run!).with(%w(master config import --force --preset kontena_auth_provider))
+      expect(Kontena).to receive(:run!).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true))
 
       subject.register_current
     end
@@ -108,9 +108,9 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
       subject.version  = '10.10.10'
       subject.cloud_master_id = 'abcd'
 
-      expect(Kontena).to receive(:run).with(%w(cloud master update --provider provider --version 10.10.10 abcd)).and_return(true)
-      expect(Kontena).to receive(:run).with(%w(master config import --force --preset kontena_auth_provider)).and_return(true)
-      expect(Kontena).to receive(:run).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true)).and_return(true)
+      expect(Kontena).to receive(:run!).with(%w(cloud master update --provider provider --version 10.10.10 abcd)).and_return(true)
+      expect(Kontena).to receive(:run!).with(%w(master config import --force --preset kontena_auth_provider)).and_return(true)
+      expect(Kontena).to receive(:run!).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true)).and_return(true)
 
       subject.register_current
     end

--- a/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
@@ -95,8 +95,8 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
       subject.provider = 'provider'
       subject.version  = '10.10.10'
 
-      expect(Kontena).to receive(:run).with('master config import --force --preset kontena_auth_provider')
-      expect(Kontena).to receive(:run).with('master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true')
+      expect(Kontena).to receive(:run).with(%w(master config import --force --preset kontena_auth_provider))
+      expect(Kontena).to receive(:run).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true))
 
       subject.register_current
     end
@@ -108,9 +108,9 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
       subject.version  = '10.10.10'
       subject.cloud_master_id = 'abcd'
 
-      expect(Kontena).to receive(:run).with('cloud master update --provider provider --version 10.10.10 abcd').and_return(true)
-      expect(Kontena).to receive(:run).with('master config import --force --preset kontena_auth_provider').and_return(true)
-      expect(Kontena).to receive(:run).with('master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true').and_return(true)
+      expect(Kontena).to receive(:run).with(%w(cloud master update --provider provider --version 10.10.10 abcd)).and_return(true)
+      expect(Kontena).to receive(:run).with(%w(master config import --force --preset kontena_auth_provider)).and_return(true)
+      expect(Kontena).to receive(:run).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true)).and_return(true)
 
       subject.register_current
     end

--- a/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
+++ b/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
@@ -20,7 +20,7 @@ describe Kontena::Cli::Master::InitCloudCommand do
   end
 
   it 'runs the invite self after deploy callback' do
-    expect(Kontena).to receive(:run).with(%w(cloud master add --current --force)).and_return(true)
+    expect(Kontena).to receive(:run!).with(%w(cloud master add --current --force)).and_return(true)
     expect_any_instance_of(Kontena::Callbacks::InviteSelfAfterDeploy).to receive(:after).and_return(true)
     subject.run(['--force'])
   end

--- a/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
+++ b/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
@@ -20,7 +20,7 @@ describe Kontena::Cli::Master::InitCloudCommand do
   end
 
   it 'runs the invite self after deploy callback' do
-    expect(Kontena).to receive(:run).with('cloud master add --current --force').and_return(true)
+    expect(Kontena).to receive(:run).with(%w(cloud master add --current --force)).and_return(true)
     expect_any_instance_of(Kontena::Callbacks::InviteSelfAfterDeploy).to receive(:after).and_return(true)
     subject.run(['--force'])
   end

--- a/cli/spec/kontena/cli/master/user/invite_command_spec.rb
+++ b/cli/spec/kontena/cli/master/user/invite_command_spec.rb
@@ -7,8 +7,8 @@ describe Kontena::Cli::Master::User::InviteCommand do
 
   describe "#invite" do
     it 'makes invitation request for all given users' do
-      expect(client).to receive(:post).with("/oauth2/authorize", {email: 'john@example.org', external_id: nil, response_type: "invite"}).once
-      expect(client).to receive(:post).with("/oauth2/authorize", {email: 'jane@example.org', external_id: nil, response_type: "invite"}).once
+      expect(client).to receive(:post).with("/oauth2/authorize", {email: 'john@example.org', external_id: nil, response_type: "invite"}).once.and_return(Hash.new { "foo" })
+      expect(client).to receive(:post).with("/oauth2/authorize", {email: 'jane@example.org', external_id: nil, response_type: "invite"}).once.and_return(Hash.new { "bar" })
 
       subject.run(['john@example.org', 'jane@example.org'])
     end

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -89,7 +89,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       allow(client).to receive(:put).with(
         'stacks/test-grid/stack-a', anything
       ).and_return({})
-      expect(Kontena).to receive(:run).with(['stack', 'deploy', 'stack-a']).once
+      expect(Kontena).to receive(:run!).with(['stack', 'deploy', 'stack-a']).once
       subject.run(['stack-a', './path/to/kontena.yml'])
     end
 
@@ -101,7 +101,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
         allow(client).to receive(:put).with(
           'stacks/test-grid/stack-a', anything
         ).and_return({})
-        expect(Kontena).not_to receive(:run).with(['stack', 'deploy', 'stack-a'])
+        expect(Kontena).not_to receive(:run!).with(['stack', 'deploy', 'stack-a'])
         subject.run(['--no-deploy', 'stack-a', './path/to/kontena.yml'])
       end
     end

--- a/cli/spec/kontena/cli/vault/export_spec.rb
+++ b/cli/spec/kontena/cli/vault/export_spec.rb
@@ -15,16 +15,16 @@ describe Kontena::Cli::Vault::ExportCommand do
   end
 
   it 'goes through the list of vault keys and outputs a yaml' do
-    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return']).and_return(['foo', 'bar'])
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar']).and_return('barbar')
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo']).and_return('foofoo')
+    expect(Kontena).to receive(:run!).with(['vault', 'ls', '--return']).and_return(['foo', 'bar'])
+    expect(Kontena).to receive(:run!).with(['vault', 'read', '--return', 'bar']).and_return('barbar')
+    expect(Kontena).to receive(:run!).with(['vault', 'read', '--return', 'foo']).and_return('foofoo')
     expect{subject.run([])}.to output(/bar: barbar\nfoo: foofoo/).to_stdout
   end
 
   it 'goes through the list of vault keys and outputs a json' do
-    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return']).and_return(['foo', 'bar'])
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar']).and_return('barbar')
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo']).and_return('foofoo')
+    expect(Kontena).to receive(:run!).with(['vault', 'ls', '--return']).and_return(['foo', 'bar'])
+    expect(Kontena).to receive(:run!).with(['vault', 'read', '--return', 'bar']).and_return('barbar')
+    expect(Kontena).to receive(:run!).with(['vault', 'read', '--return', 'foo']).and_return('foofoo')
     expect{subject.run(['--json'])}.to output(/\"bar\":\"barbar\",\"foo\":\"foofoo\"/).to_stdout
   end
 

--- a/cli/spec/kontena/cli/vault/export_spec.rb
+++ b/cli/spec/kontena/cli/vault/export_spec.rb
@@ -15,16 +15,16 @@ describe Kontena::Cli::Vault::ExportCommand do
   end
 
   it 'goes through the list of vault keys and outputs a yaml' do
-    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return'], returning: :result).and_return(['foo', 'bar'])
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar'], returning: :result).and_return('barbar')
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo'], returning: :result).and_return('foofoo')
+    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return']).and_return(['foo', 'bar'])
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar']).and_return('barbar')
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo']).and_return('foofoo')
     expect{subject.run([])}.to output(/bar: barbar\nfoo: foofoo/).to_stdout
   end
 
   it 'goes through the list of vault keys and outputs a json' do
-    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return'], returning: :result).and_return(['foo', 'bar'])
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar'], returning: :result).and_return('barbar')
-    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo'], returning: :result).and_return('foofoo')
+    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return']).and_return(['foo', 'bar'])
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar']).and_return('barbar')
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo']).and_return('foofoo')
     expect{subject.run(['--json'])}.to output(/\"bar\":\"barbar\",\"foo\":\"foofoo\"/).to_stdout
   end
 

--- a/cli/spec/kontena/cli/vault/export_spec.rb
+++ b/cli/spec/kontena/cli/vault/export_spec.rb
@@ -15,16 +15,16 @@ describe Kontena::Cli::Vault::ExportCommand do
   end
 
   it 'goes through the list of vault keys and outputs a yaml' do
-    expect(Kontena).to receive(:run).with(/^vault ls/, returning: :result).and_return(['foo', 'bar'])
-    expect(Kontena).to receive(:run).with(/^vault read.*bar/, returning: :result).and_return('barbar')
-    expect(Kontena).to receive(:run).with(/^vault read.*foo/, returning: :result).and_return('foofoo')
+    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return'], returning: :result).and_return(['foo', 'bar'])
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar'], returning: :result).and_return('barbar')
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo'], returning: :result).and_return('foofoo')
     expect{subject.run([])}.to output(/bar: barbar\nfoo: foofoo/).to_stdout
   end
 
   it 'goes through the list of vault keys and outputs a json' do
-    expect(Kontena).to receive(:run).with(/^vault ls/, returning: :result).and_return(['foo', 'bar'])
-    expect(Kontena).to receive(:run).with(/^vault read.*bar/, returning: :result).and_return('barbar')
-    expect(Kontena).to receive(:run).with(/^vault read.*foo/, returning: :result).and_return('foofoo')
+    expect(Kontena).to receive(:run).with(['vault', 'ls', '--return'], returning: :result).and_return(['foo', 'bar'])
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'bar'], returning: :result).and_return('barbar')
+    expect(Kontena).to receive(:run).with(['vault', 'read', '--return', 'foo'], returning: :result).and_return('foofoo')
     expect{subject.run(['--json'])}.to output(/\"bar\":\"barbar\",\"foo\":\"foofoo\"/).to_stdout
   end
 

--- a/cli/spec/kontena/cli/vault/import_spec.rb
+++ b/cli/spec/kontena/cli/vault/import_spec.rb
@@ -30,37 +30,37 @@ describe Kontena::Cli::Vault::ImportCommand do
 
   it 'runs vault write for kv-pairs in yaml' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: foo\n")
-    expect(Kontena).to receive(:run).with(/vault update.*foo bar/).and_return(0)
-    expect(Kontena).to receive(:run).with(/vault update.*bar foo/).and_return(0)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'bar', 'foo'], returning: :status).and_return(0)
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'runs vault rm for kv-pairs with null value in yaml' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: null\n")
-    expect(Kontena).to receive(:run).with(/vault update.*foo bar/).and_return(0)
-    expect(Kontena).to receive(:run).with(/vault rm.*bar/).and_return(0)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
+    expect(Kontena).to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status).and_return(0)
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'runs vault rm for kv-pairs with empty value in yaml when --empty-is-null' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar:\n")
-    expect(Kontena).to receive(:run).with(/vault update.*foo bar/).and_return(0)
-    expect(Kontena).to receive(:run).with(/vault rm.*bar/).and_return(0)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
+    expect(Kontena).to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status).and_return(0)
     subject.run(['--force', '--empty-is-null', 'foo.yml'])
   end
 
   it 'does not run vault rm for kv-pairs with empty value in yaml when no --empty-is-null' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: \"\"\n")
-    expect(Kontena).to receive(:run).with(/vault update.*foo bar/).and_return(0)
-    expect(Kontena).to receive(:run).with(/vault update.*bar ''/).and_return(0)
-    expect(Kontena).not_to receive(:run).with(/vault rm.*bar/)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'bar', ''], returning: :status).and_return(0)
+    expect(Kontena).not_to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status)
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'doesnt vault rm for kv-pairs with null value in yaml when --skip-null used' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: null\n")
-    expect(Kontena).to receive(:run).with(/vault update.*foo bar/).and_return(0)
-    expect(Kontena).not_to receive(:run).with(/vault rm.*bar/)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
+    expect(Kontena).not_to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status)
     subject.run(['--force', '--skip-null', 'foo.yml'])
   end
 

--- a/cli/spec/kontena/cli/vault/import_spec.rb
+++ b/cli/spec/kontena/cli/vault/import_spec.rb
@@ -30,37 +30,37 @@ describe Kontena::Cli::Vault::ImportCommand do
 
   it 'runs vault write for kv-pairs in yaml' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: foo\n")
-    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
-    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'bar', 'foo']).and_return(true)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'bar', 'foo']).and_return(true)
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'runs vault rm for kv-pairs with null value in yaml' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: null\n")
-    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
-    expect(Kontena).to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar']).and_return(true)
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'runs vault rm for kv-pairs with empty value in yaml when --empty-is-null' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar:\n")
-    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
-    expect(Kontena).to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar']).and_return(true)
     subject.run(['--force', '--empty-is-null', 'foo.yml'])
   end
 
   it 'does not run vault rm for kv-pairs with empty value in yaml when no --empty-is-null' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: \"\"\n")
-    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
-    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'bar', '']).and_return(true)
-    expect(Kontena).not_to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar'])
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'bar', '']).and_return(true)
+    expect(Kontena).not_to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'])
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'doesnt vault rm for kv-pairs with null value in yaml when --skip-null used' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: null\n")
-    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
-    expect(Kontena).not_to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar'])
+    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).not_to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'])
     subject.run(['--force', '--skip-null', 'foo.yml'])
   end
 end

--- a/cli/spec/kontena/cli/vault/import_spec.rb
+++ b/cli/spec/kontena/cli/vault/import_spec.rb
@@ -30,39 +30,38 @@ describe Kontena::Cli::Vault::ImportCommand do
 
   it 'runs vault write for kv-pairs in yaml' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: foo\n")
-    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
-    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'bar', 'foo'], returning: :status).and_return(0)
+    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'bar', 'foo']).and_return(true)
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'runs vault rm for kv-pairs with null value in yaml' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: null\n")
-    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
-    expect(Kontena).to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status).and_return(0)
+    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar']).and_return(true)
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'runs vault rm for kv-pairs with empty value in yaml when --empty-is-null' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar:\n")
-    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
-    expect(Kontena).to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status).and_return(0)
+    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar']).and_return(true)
     subject.run(['--force', '--empty-is-null', 'foo.yml'])
   end
 
   it 'does not run vault rm for kv-pairs with empty value in yaml when no --empty-is-null' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: \"\"\n")
-    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
-    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'bar', ''], returning: :status).and_return(0)
-    expect(Kontena).not_to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status)
+    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'bar', '']).and_return(true)
+    expect(Kontena).not_to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar'])
     subject.run(['--force', 'foo.yml'])
   end
 
   it 'doesnt vault rm for kv-pairs with null value in yaml when --skip-null used' do
     expect(File).to receive(:read).with('foo.yml').and_return("foo: bar\nbar: null\n")
-    expect(Kontena).to receive(:run).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar'], returning: :status).and_return(0)
-    expect(Kontena).not_to receive(:run).with(['vault', 'rm', '--silent', '--force', 'bar'], returning: :status)
+    expect(Kontena).to receive(:run?).with(['vault', 'update', '--upsert', '--silent', 'foo', 'bar']).and_return(true)
+    expect(Kontena).not_to receive(:run?).with(['vault', 'rm', '--silent', '--force', 'bar'])
     subject.run(['--force', '--skip-null', 'foo.yml'])
   end
-
 end
 

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -29,19 +29,41 @@ describe Kontena do
 
     before(:each) do
       expect(Kontena::Cli::WhoamiCommand).to receive(:new).and_return(whoami)
-      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
     end
 
     it 'accepts a command line as string' do
+      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
       Kontena.run('whoami --bash-completion-path')
     end
 
     it 'accepts a command line as a list of parameters' do
+      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
       Kontena.run('whoami', '--bash-completion-path')
     end
 
     it 'accepts a command line as an array' do
+      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
       Kontena.run(['whoami', '--bash-completion-path'])
+    end
+
+    it 'Returns the exit status when running with returning: :status when status is 1' do
+      expect(whoami).to receive(:run) { exit 1 }
+      expect(Kontena.run(['whoami'], returning: :status)).to eq 1
+    end
+
+    it 'Returns the exit status when running with returning: :status when status is 0' do
+      expect(whoami).to receive(:run) { exit 0 }
+      expect(Kontena.run(['whoami'], returning: :status)).to be_zero
+    end
+
+    it 'Re-raises the SystemExit without returning: :status when exiting with non-zero status' do
+      expect(whoami).to receive(:run) { exit 1 }
+      expect{Kontena.run(['whoami'])}.to exit_with_error.status(1)
+    end
+
+    it 'Continues as usual without returning: :status when exiting with zero status' do
+      expect(whoami).to receive(:run) { exit 0 }
+      expect{Kontena.run(['whoami'])}.not_to exit_with_error
     end
   end
 end

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -46,24 +46,37 @@ describe Kontena do
       Kontena.run(['whoami', '--bash-completion-path'])
     end
 
-    it 'Returns the exit status when running with returning: :status when status is 1' do
-      expect(whoami).to receive(:run) { exit 1 }
-      expect(Kontena.run(['whoami'], returning: :status)).to eq 1
-    end
-
-    it 'Returns the exit status when running with returning: :status when status is 0' do
+    it 'Returns true if the command exits with SystemExit status 0' do
       expect(whoami).to receive(:run) { exit 0 }
-      expect(Kontena.run(['whoami'], returning: :status)).to be_zero
+      expect(Kontena.run(['whoami'])).to be_truthy
     end
 
-    it 'Re-raises the SystemExit without returning: :status when exiting with non-zero status' do
+    it 'Re-raises the SystemExit when command exits with non-zero status' do
       expect(whoami).to receive(:run) { exit 1 }
       expect{Kontena.run(['whoami'])}.to exit_with_error.status(1)
     end
+  end
 
-    it 'Continues as usual without returning: :status when exiting with zero status' do
+  describe '#run?' do
+    let(:whoami) { double(:whoami) }
+
+    before(:each) do
+      expect(Kontena::Cli::WhoamiCommand).to receive(:new).and_return(whoami)
+    end
+
+    it 'Returns false when status is 1' do
+      expect(whoami).to receive(:run) { exit 1 }
+      expect(Kontena.run?(['whoami'])).to be_falsey
+    end
+
+    it 'Returns true when status is 0' do
       expect(whoami).to receive(:run) { exit 0 }
-      expect{Kontena.run(['whoami'])}.not_to exit_with_error
+      expect(Kontena.run?(['whoami'])).to be_truthy
+    end
+
+    it 'Returns true when nothing was raised' do
+      expect(whoami).to receive(:run).and_return(nil)
+      expect(Kontena.run?(['whoami'])).to be_truthy
     end
   end
 end

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -24,7 +24,7 @@ describe Kontena do
     end
   end
 
-  describe '#run' do
+  describe '#run!' do
     let(:whoami) { double(:whoami) }
 
     before(:each) do
@@ -33,31 +33,31 @@ describe Kontena do
 
     it 'accepts a command line as string' do
       expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
-      Kontena.run('whoami --bash-completion-path')
+      Kontena.run!('whoami --bash-completion-path')
     end
 
     it 'accepts a command line as a list of parameters' do
       expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
-      Kontena.run('whoami', '--bash-completion-path')
+      Kontena.run!('whoami', '--bash-completion-path')
     end
 
     it 'accepts a command line as an array' do
       expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
-      Kontena.run(['whoami', '--bash-completion-path'])
+      Kontena.run!(['whoami', '--bash-completion-path'])
     end
 
     it 'Returns true if the command exits with SystemExit status 0' do
       expect(whoami).to receive(:run) { exit 0 }
-      expect(Kontena.run(['whoami'])).to be_truthy
+      expect(Kontena.run!(['whoami'])).to be_truthy
     end
 
     it 'Re-raises the SystemExit when command exits with non-zero status' do
       expect(whoami).to receive(:run) { exit 1 }
-      expect{Kontena.run(['whoami'])}.to exit_with_error.status(1)
+      expect{Kontena.run!(['whoami'])}.to exit_with_error.status(1)
     end
   end
 
-  describe '#run?' do
+  describe '#run' do
     let(:whoami) { double(:whoami) }
 
     before(:each) do
@@ -66,17 +66,17 @@ describe Kontena do
 
     it 'Returns false when status is 1' do
       expect(whoami).to receive(:run) { exit 1 }
-      expect(Kontena.run?(['whoami'])).to be_falsey
+      expect(Kontena.run(['whoami'])).to be_falsey
     end
 
     it 'Returns true when status is 0' do
       expect(whoami).to receive(:run) { exit 0 }
-      expect(Kontena.run?(['whoami'])).to be_truthy
+      expect(Kontena.run(['whoami'])).to be_truthy
     end
 
     it 'Returns true when nothing was raised' do
       expect(whoami).to receive(:run).and_return(nil)
-      expect(Kontena.run?(['whoami'])).to be_truthy
+      expect(Kontena.run(['whoami'])).to be_truthy
     end
   end
 end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -49,14 +49,16 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each) do
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-  end
+  unless ENV["DEBUG"]
+    config.before(:each) do
+      $stdout = StringIO.new
+      $stderr = StringIO.new
+    end
 
-  config.after(:each) do
-    $stdout = STDOUT
-    $stderr = STDERR
+    config.after(:each) do
+      $stdout = STDOUT
+      $stderr = STDERR
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #1637
Replaces #1702

This PR makes `Kontena.run` re-raise the SystemExit if status is non-zero unless called with `returning: :status` in which case it will return the exit code to caller.

```console
$ kontena stack upgrade redis redis.yml || echo "dang"
[error] Foofoo
dang
```

