### PR TITLE
Fix GridService#deploy_pending? to consider all unfinished deploys as pending

### DIFF
--- a/server/app/jobs/grid_service_health_monitor_job.rb
+++ b/server/app/jobs/grid_service_health_monitor_job.rb
@@ -30,7 +30,7 @@ class GridServiceHealthMonitorJob
     min_health = service.deploy_opts.min_health || 0.8
     expected_health = 1 - min_health
     if health_percent < expected_health
-      service.running? && !service.deploy_pending?
+      service.running? && !service.deploy_outstanding?
     else
       false
     end

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -147,7 +147,7 @@ class GridService
   end
 
   def deploy_pending?
-    self.grid_service_deploys.where(started_at: nil).count > 0
+    self.grid_service_deploys.where(finished_at: nil).count > 0
   end
 
   # @return [Boolean]

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -146,8 +146,17 @@ class GridService
     self.stack.exposed_service?(self)
   end
 
+  # Are there any deploys in queue for this service
+  # @return [Boolean]
   def deploy_pending?
-    self.grid_service_deploys.where(finished_at: nil).count > 0
+    self.grid_service_deploys.where(started_at: nil).count > 0
+  end
+
+  # Are there any deploys in queue or in progress for this service
+  # Ignores any possibly stale deploys that have been started but never finished
+  # @return [Boolean]
+  def deploy_outstanding?
+    self.grid_service_deploys.any_of({:started_at => nil, :finished_at => nil}, {:started_at.gt => 30.minutes.ago , finished_at: nil}).count > 0
   end
 
   # @return [Boolean]

--- a/server/spec/jobs/grid_service_health_monitor_job_spec.rb
+++ b/server/spec/jobs/grid_service_health_monitor_job_spec.rb
@@ -49,7 +49,7 @@ describe GridServiceHealthMonitorJob, celluloid: true do
           health_status: {healthy: 1, total: 6},
           deploy_opts: double({min_health: 0.8}),
           running?: true,
-          deploy_pending?: false
+          deploy_outstanding?: false
         })
       expect(subject.deploy_needed?(service)).to be_truthy
     end
@@ -60,7 +60,7 @@ describe GridServiceHealthMonitorJob, celluloid: true do
           health_status: {healthy: 1, total: 6},
           deploy_opts: double({min_health: 0.8}),
           running?: true,
-          deploy_pending?: true
+          deploy_outstanding?: true
         })
       expect(subject.deploy_needed?(service)).to be_falsey
     end

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -305,4 +305,20 @@ describe GridService do
       expect(subject.affinity).to eq(['label!=type=ssd'])
     end
   end
+
+  describe '#deploy_pending?' do
+    it 'returns false when no deployments' do
+      expect(subject.deploy_pending?).to be_falsey
+    end
+
+    it 'returns true when queued deployments' do
+      GridServiceDeploy.create!(grid_service: subject, started_at: nil, finished_at: nil)
+      expect(subject.deploy_pending?).to be_truthy
+    end
+
+    it 'returns true when un-finished deployments' do
+      GridServiceDeploy.create!(grid_service: subject, started_at: Time.now, finished_at: nil)
+      expect(subject.deploy_pending?).to be_truthy
+    end
+  end
 end

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -306,19 +306,24 @@ describe GridService do
     end
   end
 
-  describe '#deploy_pending?' do
+  describe '#deploy_outstanding?' do
     it 'returns false when no deployments' do
-      expect(subject.deploy_pending?).to be_falsey
+      expect(subject.deploy_outstanding?).to be_falsey
     end
 
     it 'returns true when queued deployments' do
       GridServiceDeploy.create!(grid_service: subject, started_at: nil, finished_at: nil)
-      expect(subject.deploy_pending?).to be_truthy
+      expect(subject.deploy_outstanding?).to be_truthy
     end
 
     it 'returns true when un-finished deployments' do
-      GridServiceDeploy.create!(grid_service: subject, started_at: Time.now, finished_at: nil)
-      expect(subject.deploy_pending?).to be_truthy
+      GridServiceDeploy.create!(grid_service: subject, started_at: 10.minutes.ago, finished_at: nil)
+      expect(subject.deploy_outstanding?).to be_truthy
+    end
+
+    it 'returns true when un-finished stale deployments' do
+      GridServiceDeploy.create!(grid_service: subject, started_at: 32.minutes.ago, finished_at: nil)
+      expect(subject.deploy_outstanding?).to be_falsey
     end
   end
 end

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -321,8 +321,18 @@ describe GridService do
       expect(subject.deploy_outstanding?).to be_truthy
     end
 
-    it 'returns true when un-finished stale deployments' do
+    it 'returns false when un-finished stale deployments' do
       GridServiceDeploy.create!(grid_service: subject, started_at: 32.minutes.ago, finished_at: nil)
+      expect(subject.deploy_outstanding?).to be_falsey
+    end
+
+    it 'returns false when finished deployments' do
+      GridServiceDeploy.create!(grid_service: subject, started_at: 32.minutes.ago, finished_at: 26.minutes.ago)
+      expect(subject.deploy_outstanding?).to be_falsey
+    end
+
+    it 'returns false when finished deployments with no started_at' do
+      GridServiceDeploy.create!(grid_service: subject, started_at: nil, finished_at: 26.minutes.ago)
       expect(subject.deploy_outstanding?).to be_falsey
     end
   end


### PR DESCRIPTION
fixes #2208 

There was a racey condition when the GridServiceSchedulerWorker check the deploy "queue", it marks deploys with some timestamp for started_at when it picks them up from the queue and only after a 30 "wait" marks them back at not started if there were previous ongoing deploys. This leaves a window where the previous logic (`started_at != nil`) would allow to create multiple deploys from e.g. failing health check that would pile up.