### PR TITLE
Fix variable value defaulting from master during stack upgrade

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -97,7 +97,7 @@ module Kontena::Cli::Stacks
     end
 
     def stack_read_and_dump(filename, name: nil, values: nil, defaults: nil)
-      reader = reader_from_yaml(filename, name: name, values: values)
+      reader = reader_from_yaml(filename, name: name, values: values, defaults: defaults)
       stack = stack_from_reader(reader)
       dump_variables(reader) if values_to
       stack

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -66,10 +66,9 @@ module Kontena::Cli::Stacks
       if reader.stack_name.nil?
         exit_with_error "Stack MUST have stack name in YAML top level field 'stack'! Aborting."
       end
-      set_env_variables(name || reader.stack_name, self.respond_to?(:current_grid) ? current_grid : nil)
+      set_env_variables(name || reader.stack_name, current_grid)
       reader
     end
-    module_function :reader_from_yaml
 
     def stack_from_reader(reader)
       outcome = reader.execute
@@ -91,21 +90,18 @@ module Kontena::Cli::Stacks
       }
       stack
     end
-    module_function :stack_from_reader
 
     def stack_from_yaml(filename, name: nil, values: nil, defaults: nil)
       reader = reader_from_yaml(filename, name: name, values: values, defaults: defaults)
       stack_from_reader(reader)
     end
-    module_function :stack_from_yaml
 
     def stack_read_and_dump(filename, name: nil, values: nil, defaults: nil)
       reader = reader_from_yaml(filename, name: name, values: values, defaults: defaults)
       stack = stack_from_reader(reader)
-      dump_variables(reader) if self.respond_to?(:values_to) && values_to
+      dump_variables(reader) if values_to
       stack
     end
-    module_function :stack_read_and_dump
 
     def require_config_file(filename)
       exit_with_error("File #{filename} does not exist") unless File.exists?(filename)
@@ -122,7 +118,6 @@ module Kontena::Cli::Stacks
         config.merge('name' => name)
       end
     end
-    module_function :generate_volumes
 
     def generate_services(yaml_services)
       return [] unless yaml_services
@@ -131,13 +126,11 @@ module Kontena::Cli::Stacks
         ServiceGeneratorV2.new(config).generate.merge('name' => name)
       end
     end
-    module_function :generate_services
 
     def set_env_variables(stack, grid)
       ENV['STACK'] = stack
       ENV['GRID'] = grid
     end
-    module_function :set_env_variables
 
     # @return [String]
     def current_dir

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -66,9 +66,10 @@ module Kontena::Cli::Stacks
       if reader.stack_name.nil?
         exit_with_error "Stack MUST have stack name in YAML top level field 'stack'! Aborting."
       end
-      set_env_variables(name || reader.stack_name, current_grid)
+      set_env_variables(name || reader.stack_name, self.respond_to?(:current_grid) ? current_grid : nil)
       reader
     end
+    module_function :reader_from_yaml
 
     def stack_from_reader(reader)
       outcome = reader.execute
@@ -90,18 +91,21 @@ module Kontena::Cli::Stacks
       }
       stack
     end
+    module_function :stack_from_reader
 
     def stack_from_yaml(filename, name: nil, values: nil, defaults: nil)
       reader = reader_from_yaml(filename, name: name, values: values, defaults: defaults)
       stack_from_reader(reader)
     end
+    module_function :stack_from_yaml
 
     def stack_read_and_dump(filename, name: nil, values: nil, defaults: nil)
       reader = reader_from_yaml(filename, name: name, values: values, defaults: defaults)
       stack = stack_from_reader(reader)
-      dump_variables(reader) if values_to
+      dump_variables(reader) if self.respond_to?(:values_to) && values_to
       stack
     end
+    module_function :stack_read_and_dump
 
     def require_config_file(filename)
       exit_with_error("File #{filename} does not exist") unless File.exists?(filename)
@@ -118,6 +122,7 @@ module Kontena::Cli::Stacks
         config.merge('name' => name)
       end
     end
+    module_function :generate_volumes
 
     def generate_services(yaml_services)
       return [] unless yaml_services
@@ -126,11 +131,13 @@ module Kontena::Cli::Stacks
         ServiceGeneratorV2.new(config).generate.merge('name' => name)
       end
     end
+    module_function :generate_services
 
     def set_env_variables(stack, grid)
       ENV['STACK'] = stack
       ENV['GRID'] = grid
     end
+    module_function :set_env_variables
 
     # @return [String]
     def current_dir

--- a/cli/spec/kontena/cli/stacks/common_spec.rb
+++ b/cli/spec/kontena/cli/stacks/common_spec.rb
@@ -3,7 +3,19 @@ require "kontena/cli/stacks/yaml/reader"
 
 describe Kontena::Cli::Stacks::Common do
 
-  let(:subject) { described_class }
+  let(:klass) do
+    Class.new(Kontena::Command) do
+      include Kontena::Cli::Stacks::Common
+      include Kontena::Cli::Common
+      include Kontena::Cli::Stacks::Common::StackNameParam
+      include Kontena::Cli::Stacks::Common::StackFileOrNameParam
+      include Kontena::Cli::Stacks::Common::StackNameOption
+      include Kontena::Cli::Stacks::Common::StackValuesToOption
+      include Kontena::Cli::Stacks::Common::StackValuesFromOption
+    end
+  end
+
+  let(:subject) { klass.new('') }
 
   context 'stack yaml reader methods' do
     let(:reader) { double(:reader) }

--- a/cli/spec/kontena/cli/stacks/common_spec.rb
+++ b/cli/spec/kontena/cli/stacks/common_spec.rb
@@ -1,0 +1,90 @@
+require "kontena/cli/stacks/common"
+require "kontena/cli/stacks/yaml/reader"
+
+describe Kontena::Cli::Stacks::Common do
+
+  let(:subject) { described_class }
+
+  context 'stack yaml reader methods' do
+    let(:reader) { double(:reader) }
+
+    before(:each) do
+      allow(reader).to receive(:execute).and_return({ errors: [], notifications: [] })
+      allow(reader).to receive(:raw_content).and_return("")
+      allow(reader).to receive(:stack_name).and_return('foo')
+      allow(subject).to receive(:set_env_variables).and_return(true)
+    end
+
+    describe '#stack_read_and_dump' do
+      it 'passes args to reader' do
+        expect(Kontena::Cli::Stacks::YAML::Reader).to receive(:new).with('foo', values: { 'value' => 'value' }, defaults: { 'default' => 'default' }).and_return(reader)
+        subject.stack_read_and_dump('foo', name: 'name', values: { 'value' => 'value' }, defaults: { 'default' => 'default' })
+      end
+
+      it 'returns a stack hash' do
+        expect(Kontena::Cli::Stacks::YAML::Reader).to receive(:new).and_return(reader)
+        expect(subject.stack_read_and_dump('foo')).to be_kind_of Hash
+      end
+    end
+
+    describe '#stack_from_yaml' do
+      it 'passes args to reader' do
+        expect(Kontena::Cli::Stacks::YAML::Reader).to receive(:new).with('foo', values: { 'value' => 'value' }, defaults: { 'default' => 'default' }).and_return(reader)
+        subject.stack_from_yaml('foo', name: 'name', values: { 'value' => 'value' }, defaults: { 'default' => 'default' })
+      end
+
+      it 'returns a stack hash' do
+        expect(Kontena::Cli::Stacks::YAML::Reader).to receive(:new).and_return(reader)
+        expect(subject.stack_from_yaml('foo')).to be_kind_of Hash
+      end
+    end
+
+    describe '#reader_from_yaml' do
+      it 'passes args to reader' do
+        expect(Kontena::Cli::Stacks::YAML::Reader).to receive(:new).with('foo', values: { 'value' => 'value' }, defaults: { 'default' => 'default' }).and_return(reader)
+        subject.reader_from_yaml('foo', name: 'name', values: { 'value' => 'value' }, defaults: { 'default' => 'default' })
+      end
+
+      it 'returns a reader' do
+        expect(Kontena::Cli::Stacks::YAML::Reader).to receive(:new).and_return(reader)
+        expect(subject.reader_from_yaml('foo')).to eq reader
+      end
+    end
+  end
+
+  describe '#stack_name' do
+  end
+
+  describe '#stack_from_reader' do
+  end
+
+  describe '#stack_from_yaml' do
+  end
+
+  describe '#require_config_file' do
+  end
+
+  describe '#generate_volumes' do
+  end
+
+  describe '#generate_services' do
+  end
+
+  describe '#set_env_variables' do
+  end
+
+  describe '#current_dir' do
+  end
+
+  describe '#display_notifications' do
+  end
+
+  describe '#hint_on_validation_notifications' do
+  end
+
+  describe '#abort_on_validation_errors' do
+  end
+
+  describe '#stacks_client' do
+  end
+end


### PR DESCRIPTION
Fixes #2216 

Stack variable answer defaults were not used from master when running stack upgrade in release 1.2.0.

This PR fixes that.

Before:

```console
$ kontena stack install redis.yml
Enter stuff: asdasdasd
$ kontena stack upgrade redis redis.yml
Enter stuff: 
```

After:

```console
$ kontena stack install redis.yml
Enter stuff: asdasdasd
$ kontena stack upgrade redis redis.yml
Enter stuff (asdasdasd):
```

