### PR TITLE
Fix registry create command

### DIFF
--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -1,4 +1,5 @@
 require_relative '../stacks/stacks_helper'
+require 'securerandom'
 
 module Kontena::Cli::Registry
   class CreateCommand < Kontena::Command


### PR DESCRIPTION
When running 1.2.1 version I'm getting 

```
uninitialized constant Kontena::Cli::Registry::CreateCommand::SecureRandom
``` 

Adding `require 'securerandom'` fixed it in my case.