### PR TITLE
Add v4auth to create registry with s3 driver

### DIFF
--- a/docs/using-kontena/image-registry.md
+++ b/docs/using-kontena/image-registry.md
@@ -44,7 +44,7 @@ $ kontena vault write REGISTRY_STORAGE_S3_SECRETKEY <secret_key>
 Create registry service:
 
 ```
-$ kontena registry create --s3-bucket=<bucket_name> --s3-region=<optional_aws_region>
+$ kontena registry create --s3-bucket=<bucket_name> --s3-region=<optional_aws_region> --s3-v4auth
 ```
 
 #### Azure storage backend


### PR DESCRIPTION
Since registry 2.6.0 auth v4 is required. This could be mentioned in docs (also default value could be changed in cli).