### PR TITLE
Move inclusion of Kontena::Cli::Common to Kontena::Command

### DIFF
--- a/cli/lib/kontena/cli/apps/build_command.rb
+++ b/cli/lib/kontena/cli/apps/build_command.rb
@@ -3,7 +3,6 @@ require_relative 'docker_helper'
 
 module Kontena::Cli::Apps
   class BuildCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
     include DockerHelper
 

--- a/cli/lib/kontena/cli/apps/config_command.rb
+++ b/cli/lib/kontena/cli/apps/config_command.rb
@@ -3,7 +3,6 @@ require 'pp'
 
 module Kontena::Cli::Apps
   class ConfigCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -4,7 +4,6 @@ require_relative 'docker_helper'
 
 module Kontena::Cli::Apps
   class DeployCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
     include DockerHelper

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -7,7 +7,6 @@ require_relative 'kontena_yml_generator'
 
 module Kontena::Cli::Apps
   class InitCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     option ["-f", "--file"], "FILE", "Specify a docker-compose file", attribute_name: :docker_compose_file, default: 'docker-compose.yml'

--- a/cli/lib/kontena/cli/apps/list_command.rb
+++ b/cli/lib/kontena/cli/apps/list_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -3,7 +3,6 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Apps
   class LogsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 

--- a/cli/lib/kontena/cli/apps/monitor_command.rb
+++ b/cli/lib/kontena/cli/apps/monitor_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class MonitorCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/apps/restart_command.rb
+++ b/cli/lib/kontena/cli/apps/restart_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class RestartCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'

--- a/cli/lib/kontena/cli/apps/scale_command.rb
+++ b/cli/lib/kontena/cli/apps/scale_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class ScaleCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/apps/show_command.rb
+++ b/cli/lib/kontena/cli/apps/show_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class ShowCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/apps/start_command.rb
+++ b/cli/lib/kontena/cli/apps/start_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class StartCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/apps/stop_command.rb
+++ b/cli/lib/kontena/cli/apps/stop_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Apps
   class StopCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -1,9 +1,7 @@
 
 module Kontena::Cli::Certificate
   class AuthorizeCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-
 
     parameter "DOMAIN", "Domain to authorize"
 

--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -1,14 +1,11 @@
 
 module Kontena::Cli::Certificate
   class GetCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-
 
     option '--secret-name', 'SECRET_NAME', 'The name for the secret to store the certificate in'
     option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain, chain or cert', default: 'fullchain'
     parameter "DOMAIN ...", "Domain(s) to get certificate for"
-
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/certificate/register_command.rb
+++ b/cli/lib/kontena/cli/certificate/register_command.rb
@@ -1,9 +1,6 @@
-
 module Kontena::Cli::Certificate
   class RegisterCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-
 
     parameter "EMAIL", "Email to register"
 

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -2,7 +2,6 @@ require 'uri'
 
 module Kontena::Cli::Cloud
   class LoginCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     option ['-t', '--token'], '[TOKEN]', 'Use a pre-generated access token', environment_variable: 'KONTENA_ACCOUNT_TOKEN'
     option ['-c', '--code'], '[CODE]', 'Use an authorization code'

--- a/cli/lib/kontena/cli/cloud/logout_command.rb
+++ b/cli/lib/kontena/cli/cloud/logout_command.rb
@@ -1,9 +1,7 @@
 module Kontena::Cli::Cloud
   class LogoutCommand < Kontena::Command
-    include Kontena::Cli::Common
-
     def execute
-      config.accounts.each do |account|        
+      config.accounts.each do |account|
         use_refresh_token(account)
         account.token = nil
       end

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Cloud::Master
   class AddCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     callback_matcher 'cloud-master', 'create'
 
     requires_current_account_token

--- a/cli/lib/kontena/cli/cloud/master/list_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/list_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Cloud::Master
   class ListCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     callback_matcher 'cloud-master', 'list'
 
     option '--return', :flag, 'Return the list', hidden: true

--- a/cli/lib/kontena/cli/cloud/master/remove_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/remove_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Cloud::Master
   class RemoveCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     callback_matcher 'cloud-master', 'delete'
 
     requires_current_account_token

--- a/cli/lib/kontena/cli/cloud/master/show_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/show_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Cloud::Master
   class ShowCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     callback_matcher 'cloud-master', 'show'
 
     requires_current_account_token

--- a/cli/lib/kontena/cli/cloud/master/update_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/update_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Cloud::Master
   class UpdateCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     callback_matcher 'cloud-master', 'update'
 
     requires_current_account_token

--- a/cli/lib/kontena/cli/cloud/master_command.rb
+++ b/cli/lib/kontena/cli/cloud/master_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Cloud
   class MasterCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     subcommand ['list', 'ls'], "List masters in Kontena Cloud", load_subcommand('cloud/master/list_command')
     subcommand "add", "Register a master in Kontena Cloud", load_subcommand('cloud/master/add_command')

--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Containers
   class ExecCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter "CONTAINER_ID", "Container id"

--- a/cli/lib/kontena/cli/containers/inspect_command.rb
+++ b/cli/lib/kontena/cli/containers/inspect_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Containers
   class InspectCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter "CONTAINER_ID", "Container id"

--- a/cli/lib/kontena/cli/containers/list_command.rb
+++ b/cli/lib/kontena/cli/containers/list_command.rb
@@ -1,7 +1,6 @@
 module Kontena::Cli::Containers
   class ListCommand < Kontena::Command
     include Kontena::Util
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     option ['--all', '-a'], :flag, 'Show all containers'

--- a/cli/lib/kontena/cli/containers/logs_command.rb
+++ b/cli/lib/kontena/cli/containers/logs_command.rb
@@ -1,7 +1,7 @@
 require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Containers
-  class LogsCommand < Clamp::Command
+  class LogsCommand < Kontena::Command
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 

--- a/cli/lib/kontena/cli/containers/logs_command.rb
+++ b/cli/lib/kontena/cli/containers/logs_command.rb
@@ -2,7 +2,6 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Containers
   class LogsCommand < Clamp::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 

--- a/cli/lib/kontena/cli/etcd/get_command.rb
+++ b/cli/lib/kontena/cli/etcd/get_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Etcd
   class GetCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/etcd/health_command.rb
+++ b/cli/lib/kontena/cli/etcd/health_command.rb
@@ -3,7 +3,6 @@ require 'kontena/cli/helpers/health_helper'
 
 module Kontena::Cli::Etcd
   class HealthCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::HealthHelper
 

--- a/cli/lib/kontena/cli/etcd/list_command.rb
+++ b/cli/lib/kontena/cli/etcd/list_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Etcd
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/etcd/mkdir_command.rb
+++ b/cli/lib/kontena/cli/etcd/mkdir_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Etcd
   class MkdirCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/etcd/remove_command.rb
+++ b/cli/lib/kontena/cli/etcd/remove_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Etcd
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/etcd/set_command.rb
+++ b/cli/lib/kontena/cli/etcd/set_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Etcd
   class SetCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/external_registries/add_command.rb
+++ b/cli/lib/kontena/cli/external_registries/add_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::ExternalRegistries
   class AddCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter '[URL]', 'Docker Registry url', default: 'https://index.docker.io/v2/'

--- a/cli/lib/kontena/cli/external_registries/list_command.rb
+++ b/cli/lib/kontena/cli/external_registries/list_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::ExternalRegistries
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     def execute

--- a/cli/lib/kontena/cli/external_registries/remove_command.rb
+++ b/cli/lib/kontena/cli/external_registries/remove_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::ExternalRegistries
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NAME", "External registry name to remove"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced

--- a/cli/lib/kontena/cli/grids/audit_log_command.rb
+++ b/cli/lib/kontena/cli/grids/audit_log_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class AuditLogCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     option ["-l", "--lines"], "LINES", "Number of lines"

--- a/cli/lib/kontena/cli/grids/cloud_config_command.rb
+++ b/cli/lib/kontena/cli/grids/cloud_config_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class CloudConfigCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     parameter "NAME", "Grid name"

--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class CreateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     parameter "NAME", "Grid name"
@@ -25,7 +24,7 @@ module Kontena::Cli::Grids
       payload[:default_affinity] = self.default_affinity_list unless self.default_affinity_list.empty?
       payload[:subnet] = subnet if subnet
       payload[:supernet] = supernet if supernet
-      
+
       grid = nil
       if initial_size == 1
         warning "Option --initial-size=1 is only recommended for test/dev usage" unless running_silent?

--- a/cli/lib/kontena/cli/grids/current_command.rb
+++ b/cli/lib/kontena/cli/grids/current_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class CurrentCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     option ["--name"], :flag, "Show name only", default: false

--- a/cli/lib/kontena/cli/grids/env_command.rb
+++ b/cli/lib/kontena/cli/grids/env_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class EnvCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     parameter "[NAME]", "Grid name"

--- a/cli/lib/kontena/cli/grids/events_command.rb
+++ b/cli/lib/kontena/cli/grids/events_command.rb
@@ -2,7 +2,6 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Grids
   class EventsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Helpers::LogHelper
 
     SKIP_TYPES = ['grid']

--- a/cli/lib/kontena/cli/grids/health_command.rb
+++ b/cli/lib/kontena/cli/grids/health_command.rb
@@ -3,7 +3,6 @@ require "kontena/cli/helpers/health_helper"
 
 module Kontena::Cli::Grids
   class HealthCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Helpers::HealthHelper
     include Common
 

--- a/cli/lib/kontena/cli/grids/list_command.rb
+++ b/cli/lib/kontena/cli/grids/list_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     option ['-u', '--use'], :flag, 'Automatically use first available grid sorted by user count', hidden: true

--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -2,8 +2,8 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Grids
   class LogsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Helpers::LogHelper
+
     option "--node", "NODE", "Filter by node name", multivalued: true
     option "--service", "SERVICE", "Filter by service name", multivalued: true
     option ["-c", "--container"], "CONTAINER", "Filter by container", multivalued: true

--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     parameter "NAME", "Grid name"

--- a/cli/lib/kontena/cli/grids/show_command.rb
+++ b/cli/lib/kontena/cli/grids/show_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class ShowCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     parameter "NAME", "Grid name"

--- a/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Grids::TrustedSubnets
   class AddCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NAME", "Grid name"
     parameter "SUBNET", "Trusted subnet"

--- a/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Grids::TrustedSubnets
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NAME", "Grid name"
 

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Grids::TrustedSubnets
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NAME", "Grid name"
     parameter "SUBNET", "Trusted subnet"

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class UpdateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     parameter "NAME", "Grid name"

--- a/cli/lib/kontena/cli/grids/use_command.rb
+++ b/cli/lib/kontena/cli/grids/use_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Grids
   class UseCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     requires_current_master

--- a/cli/lib/kontena/cli/grids/users/add_command.rb
+++ b/cli/lib/kontena/cli/grids/users/add_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Grids::Users
   class AddCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Grids::Common
 

--- a/cli/lib/kontena/cli/grids/users/list_command.rb
+++ b/cli/lib/kontena/cli/grids/users/list_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Grids::Users
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Grids::Common
 
     def execute

--- a/cli/lib/kontena/cli/grids/users/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/users/remove_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Grids::Users
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Grids::Common
 

--- a/cli/lib/kontena/cli/logout_command.rb
+++ b/cli/lib/kontena/cli/logout_command.rb
@@ -1,5 +1,4 @@
 class Kontena::Cli::LogoutCommand < Kontena::Command
-  include Kontena::Cli::Common
 
   banner "Command removed, use 'kontena master logout' to log out of the Kontena Master"
   banner "or 'kontena cloud logout' to log out of the Kontena Cloud", false

--- a/cli/lib/kontena/cli/master/audit_log_command.rb
+++ b/cli/lib/kontena/cli/master/audit_log_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Master
   class AuditLogCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     option ["-l", "--lines"], "LINES", "Number of lines"
 

--- a/cli/lib/kontena/cli/master/config/export_command.rb
+++ b/cli/lib/kontena/cli/master/config/export_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Master::Config
   class ExportCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     requires_current_master
     requires_current_master_token
 

--- a/cli/lib/kontena/cli/master/config/get_command.rb
+++ b/cli/lib/kontena/cli/master/config/get_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Master::Config
   class GetCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     requires_current_master
     requires_current_master_token
 

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Master::Config
   class ImportCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     requires_current_master
     requires_current_master_token
 

--- a/cli/lib/kontena/cli/master/config/set_command.rb
+++ b/cli/lib/kontena/cli/master/config/set_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Master::Config
   class SetCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     requires_current_master
     requires_current_master_token
 

--- a/cli/lib/kontena/cli/master/config/unset_command.rb
+++ b/cli/lib/kontena/cli/master/config/unset_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Master::Config
   class UnsetCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     requires_current_master
     requires_current_master_token
 

--- a/cli/lib/kontena/cli/master/create_command.rb
+++ b/cli/lib/kontena/cli/master/create_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Master
   class CreateCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     callback_matcher :master, :create_with_plugin_select
 

--- a/cli/lib/kontena/cli/master/current_command.rb
+++ b/cli/lib/kontena/cli/master/current_command.rb
@@ -2,8 +2,6 @@ require 'uri'
 
 module Kontena::Cli::Master
   class CurrentCommand < Kontena::Command
-    include Kontena::Cli::Common
-
     option ["--name"], :flag, "Show name only", default: false
     option ["--address"], :flag, "Show IP address or FQDN only", default: false
     option ["--url"], :flag, "Show URL only", default: false

--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Master
   class InitCloudCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     banner "Configures the current Kontena Master to use Kontena Cloud services and authentication"
 
     option '--force',           :flag,       "Don't ask questions"

--- a/cli/lib/kontena/cli/master/list_command.rb
+++ b/cli/lib/kontena/cli/master/list_command.rb
@@ -1,7 +1,5 @@
 module Kontena::Cli::Master
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
-
     def execute
       puts '%-24s %-30s' % ['Name', 'Url']
       current_master = config.current_master

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -2,8 +2,6 @@ require 'uri'
 
 module Kontena::Cli::Master
   class LoginCommand < Kontena::Command
-    include Kontena::Cli::Common
-
     parameter "[URL]", "Kontena Master URL or name"
     option ['-j', '--join'], '[INVITE_CODE]', "Join master using an invitation code"
     option ['-t', '--token'], '[TOKEN]', 'Use a pre-generated access token', environment_variable: 'KONTENA_TOKEN'

--- a/cli/lib/kontena/cli/master/logout_command.rb
+++ b/cli/lib/kontena/cli/master/logout_command.rb
@@ -1,7 +1,5 @@
 module Kontena::Cli::Master
   class LogoutCommand < Kontena::Command
-    include Kontena::Cli::Common
-
     option ['-A', '--all'], :flag, 'Log out from all masters. By default only log out from current master.'
 
     def execute

--- a/cli/lib/kontena/cli/master/remove_command.rb
+++ b/cli/lib/kontena/cli/master/remove_command.rb
@@ -1,7 +1,5 @@
 module Kontena::Cli::Master
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
-
     parameter '[NAME]', "Master name"
 
     banner "Note: This command only removes the master from your local configuration file"

--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -1,8 +1,6 @@
 module Kontena::Cli::Master
   class SshCommand < Kontena::Command
 
-    include Kontena::Cli::Common
-
     parameter "[COMMANDS] ...", "Run command on host"
 
     option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"

--- a/cli/lib/kontena/cli/master/token/create_command.rb
+++ b/cli/lib/kontena/cli/master/token/create_command.rb
@@ -3,7 +3,6 @@ require_relative 'common'
 module Kontena::Cli::Master::Token
   class CreateCommand < Kontena::Command
 
-    include Kontena::Cli::Common
     include Common
 
     requires_current_master

--- a/cli/lib/kontena/cli/master/token/current_command.rb
+++ b/cli/lib/kontena/cli/master/token/current_command.rb
@@ -3,7 +3,6 @@ require_relative 'common'
 module Kontena::Cli::Master::Token
   class CurrentCommand < Kontena::Command
 
-    include Kontena::Cli::Common
     include Common
 
     requires_current_master

--- a/cli/lib/kontena/cli/master/token/list_command.rb
+++ b/cli/lib/kontena/cli/master/token/list_command.rb
@@ -3,7 +3,6 @@ require_relative 'common'
 module Kontena::Cli::Master::Token
   class ListCommand < Kontena::Command
 
-    include Kontena::Cli::Common
     include Common
 
     requires_current_master

--- a/cli/lib/kontena/cli/master/token/remove_command.rb
+++ b/cli/lib/kontena/cli/master/token/remove_command.rb
@@ -5,8 +5,6 @@ module Kontena::Cli::Master::Token
 
     option ['-f', '--force'], :flag, "Don't ask questions"
 
-    include Kontena::Cli::Common
-
     requires_current_master
     requires_current_master_token
 

--- a/cli/lib/kontena/cli/master/token/show_command.rb
+++ b/cli/lib/kontena/cli/master/token/show_command.rb
@@ -5,7 +5,6 @@ module Kontena::Cli::Master::Token
 
     parameter "TOKEN_OR_ID", "Access token or access token id"
 
-    include Kontena::Cli::Common
     include Common
 
     requires_current_master

--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Master
   class UseCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NAME", "Master name to use"
 

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -3,7 +3,6 @@ require_relative 'role/add_command'
 
 module Kontena::Cli::Master::User
   class InviteCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "EMAIL ...", "List of emails"
 

--- a/cli/lib/kontena/cli/master/user/list_command.rb
+++ b/cli/lib/kontena/cli/master/user/list_command.rb
@@ -2,7 +2,6 @@ require_relative '../../common'
 
 module Kontena::Cli::Master::User
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/master/user/remove_command.rb
+++ b/cli/lib/kontena/cli/master/user/remove_command.rb
@@ -2,7 +2,6 @@ require_relative '../../common'
 
 module Kontena::Cli::Master::User
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "EMAIL ...", "List of emails"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced

--- a/cli/lib/kontena/cli/master/user/role/add_command.rb
+++ b/cli/lib/kontena/cli/master/user/role/add_command.rb
@@ -3,7 +3,6 @@ require_relative '../../../common'
 module Kontena::Cli::Master::User
   module Role
     class AddCommand < Kontena::Command
-      include Kontena::Cli::Common
 
       parameter "ROLE", "Role name"
       parameter "USER ...", "List of users"

--- a/cli/lib/kontena/cli/master/user/role/remove_command.rb
+++ b/cli/lib/kontena/cli/master/user/role/remove_command.rb
@@ -2,7 +2,6 @@ require_relative '../../../common'
 
 module Kontena::Cli::Master::User::Role
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "ROLE", "Role name"
     parameter "USER ...", "List of users"

--- a/cli/lib/kontena/cli/nodes/health_command.rb
+++ b/cli/lib/kontena/cli/nodes/health_command.rb
@@ -2,7 +2,6 @@ require 'kontena/cli/helpers/health_helper'
 
 module Kontena::Cli::Nodes
   class HealthCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::HealthHelper
 

--- a/cli/lib/kontena/cli/nodes/labels/add_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/add_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Nodes::Labels
   class AddCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NODE_ID", "Node id"
     parameter "LABEL ...", "Labels"

--- a/cli/lib/kontena/cli/nodes/labels/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/list_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Nodes::Labels
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NODE_ID", "Node id"
 

--- a/cli/lib/kontena/cli/nodes/labels/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/remove_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Nodes::Labels
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     parameter "NODE_ID", "Node id"
     parameter "LABEL ...", "Labels"

--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -2,7 +2,6 @@ require_relative '../helpers/health_helper'
 
 module Kontena::Cli::Nodes
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::HealthHelper
 

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Nodes
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter "NODE_ID", "Node id"

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Nodes
   class ShowCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::BytesHelper
 

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Nodes
   class SshCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter "[NODE_ID]", "SSH to Grid node. Use --any to connect to the first available node"

--- a/cli/lib/kontena/cli/nodes/update_command.rb
+++ b/cli/lib/kontena/cli/nodes/update_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Nodes
   class UpdateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter "NODE_ID", "Node id"

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -3,7 +3,6 @@ require 'open3'
 module Kontena::Cli::Plugins
   class InstallCommand < Kontena::Command
     include Kontena::Util
-    include Kontena::Cli::Common
 
     parameter 'NAME', 'Plugin name'
 

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -3,7 +3,6 @@ require 'open3'
 module Kontena::Cli::Plugins
   class UninstallCommand < Kontena::Command
     include Kontena::Util
-    include Kontena::Cli::Common
 
     parameter 'NAME', 'Plugin name'
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced

--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -2,7 +2,6 @@ require_relative '../stacks/stacks_helper'
 
 module Kontena::Cli::Registry
   class CreateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Stacks::StacksHelper
 

--- a/cli/lib/kontena/cli/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/registry/remove_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Registry
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
 
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 

--- a/cli/lib/kontena/cli/services/containers_command.rb
+++ b/cli/lib/kontena/cli/services/containers_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class ContainersCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -3,7 +3,6 @@ require 'shellwords'
 
 module Kontena::Cli::Services
   class CreateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class DeployCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/envs/add_command.rb
+++ b/cli/lib/kontena/cli/services/envs/add_command.rb
@@ -2,7 +2,6 @@ require_relative '../services_helper'
 
 module Kontena::Cli::Services::Envs
   class AddCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 

--- a/cli/lib/kontena/cli/services/envs/list_command.rb
+++ b/cli/lib/kontena/cli/services/envs/list_command.rb
@@ -2,7 +2,6 @@ require_relative '../services_helper'
 
 module Kontena::Cli::Services::Envs
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 

--- a/cli/lib/kontena/cli/services/envs/remove_command.rb
+++ b/cli/lib/kontena/cli/services/envs/remove_command.rb
@@ -2,7 +2,6 @@ require_relative '../services_helper'
 
 module Kontena::Cli::Services::Envs
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 

--- a/cli/lib/kontena/cli/services/events_command.rb
+++ b/cli/lib/kontena/cli/services/events_command.rb
@@ -3,7 +3,6 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Services
   class EventsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class ExecCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/link_command.rb
+++ b/cli/lib/kontena/cli/services/link_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class LinkCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -3,7 +3,6 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Services
   class LogsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
     include ServicesHelper

--- a/cli/lib/kontena/cli/services/monitor_command.rb
+++ b/cli/lib/kontena/cli/services/monitor_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class MonitorCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include ServicesHelper
 
     parameter "NAME", "Service name"

--- a/cli/lib/kontena/cli/services/restart_command.rb
+++ b/cli/lib/kontena/cli/services/restart_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class RestartCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/scale_command.rb
+++ b/cli/lib/kontena/cli/services/scale_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class ScaleCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/secrets/link_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/link_command.rb
@@ -2,7 +2,6 @@ require_relative '../services_helper'
 
 module Kontena::Cli::Services::Secrets
   class LinkCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 

--- a/cli/lib/kontena/cli/services/secrets/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/unlink_command.rb
@@ -2,7 +2,6 @@ require_relative '../services_helper'
 
 module Kontena::Cli::Services::Secrets
   class UnlinkCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 

--- a/cli/lib/kontena/cli/services/show_command.rb
+++ b/cli/lib/kontena/cli/services/show_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class ShowCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/start_command.rb
+++ b/cli/lib/kontena/cli/services/start_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class StartCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/stats_command.rb
+++ b/cli/lib/kontena/cli/services/stats_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class StatsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/stop_command.rb
+++ b/cli/lib/kontena/cli/services/stop_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class StopCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/unlink_command.rb
@@ -2,7 +2,6 @@ require_relative 'services_helper'
 
 module Kontena::Cli::Services
   class UnlinkCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -3,7 +3,6 @@ require 'shellwords'
 
 module Kontena::Cli::Services
   class UpdateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include ServicesHelper
 

--- a/cli/lib/kontena/cli/stacks/build_command.rb
+++ b/cli/lib/kontena/cli/stacks/build_command.rb
@@ -3,7 +3,6 @@ require 'shellwords'
 
 module Kontena::Cli::Stacks
   class BuildCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Common
 
     banner "Build images listed in a stack file and push them to your image registry"

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -2,7 +2,6 @@ require_relative 'stacks_helper'
 
 module Kontena::Cli::Stacks
   class DeployCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include StacksHelper
 

--- a/cli/lib/kontena/cli/stacks/events_command.rb
+++ b/cli/lib/kontena/cli/stacks/events_command.rb
@@ -2,7 +2,6 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Stacks
   class EventsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Stacks
   class InstallCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Stacks
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/stacks/logs_command.rb
+++ b/cli/lib/kontena/cli/stacks/logs_command.rb
@@ -2,7 +2,6 @@ require_relative '../helpers/log_helper'
 
 module Kontena::Cli::Stacks
   class LogsCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 

--- a/cli/lib/kontena/cli/stacks/monitor_command.rb
+++ b/cli/lib/kontena/cli/stacks/monitor_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Stacks
   class MonitorCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/stacks/registry/pull_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/pull_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Stacks::Registry
   class PullCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
     include Kontena::Cli::Stacks::Common::StackNameParam
 

--- a/cli/lib/kontena/cli/stacks/registry/push_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/push_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Stacks::Registry
   class PushCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
 
     banner "Pushes (uploads) a stack to the stack registry"

--- a/cli/lib/kontena/cli/stacks/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/remove_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Stacks::Registry
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
     include Kontena::Cli::Stacks::Common::StackNameParam
 

--- a/cli/lib/kontena/cli/stacks/registry/search_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/search_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Stacks::Registry
   class SearchCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
 
     banner "Search for stacks on the stack registry"

--- a/cli/lib/kontena/cli/stacks/registry/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/show_command.rb
@@ -2,7 +2,6 @@ require_relative '../common'
 
 module Kontena::Cli::Stacks::Registry
   class ShowCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
     include Kontena::Cli::Stacks::Common::StackNameParam
 

--- a/cli/lib/kontena/cli/stacks/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/remove_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Stacks
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Stacks
   class ShowCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Stacks
   class UpgradeCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Kontena::Cli::Stacks
   class ValidateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Common
 

--- a/cli/lib/kontena/cli/vault/export_command.rb
+++ b/cli/lib/kontena/cli/vault/export_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vault
   class ExportCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     banner "Exports secrets from Vault to STDOUT as YAML or JSON."

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vault
   class ImportCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     banner "Imports secrets to Vault from a YAML file. Secrets with a null value will be deleted from Vault."

--- a/cli/lib/kontena/cli/vault/list_command.rb
+++ b/cli/lib/kontena/cli/vault/list_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vault
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     option '--return', :flag, "Return the keys", hidden: true

--- a/cli/lib/kontena/cli/vault/read_command.rb
+++ b/cli/lib/kontena/cli/vault/read_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vault
   class ReadCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter "NAME", "Secret name"

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vault
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter "NAME", "Secret name"

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vault
   class UpdateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter 'NAME', 'Secret name'

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vault
   class WriteCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     parameter 'NAME', 'Secret name'

--- a/cli/lib/kontena/cli/version_command.rb
+++ b/cli/lib/kontena/cli/version_command.rb
@@ -1,7 +1,6 @@
 require 'kontena/cli/version'
 
 class Kontena::Cli::VersionCommand < Kontena::Command
-  include Kontena::Cli::Common
 
   option "--cli", :flag, "Only CLI version"
 

--- a/cli/lib/kontena/cli/volumes/create_command.rb
+++ b/cli/lib/kontena/cli/volumes/create_command.rb
@@ -1,9 +1,7 @@
 
 module Kontena::Cli::Volumes
   class CreateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-
 
     banner "Creates a volume"
     parameter 'NAME', 'Volume name'

--- a/cli/lib/kontena/cli/volumes/list_command.rb
+++ b/cli/lib/kontena/cli/volumes/list_command.rb
@@ -1,16 +1,14 @@
 
 module Kontena::Cli::Volumes
   class ListCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-
 
     requires_current_master
     requires_current_master_token
 
     def execute
       require 'tty-table'
-      
+
       volumes = client.get("volumes/#{current_grid}")['volumes']
       table = TTY::Table.new ['NAME', 'SCOPE', 'DRIVER', 'CREATED AT'], volumes.map { |volume|
         [volume['name'], volume['scope'], volume['driver'], volume['created_at']]

--- a/cli/lib/kontena/cli/volumes/remove_command.rb
+++ b/cli/lib/kontena/cli/volumes/remove_command.rb
@@ -1,9 +1,7 @@
 
 module Kontena::Cli::Volumes
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
-
 
     banner "Removes a volume"
     parameter 'VOLUME', 'Volume'

--- a/cli/lib/kontena/cli/volumes/show_command.rb
+++ b/cli/lib/kontena/cli/volumes/show_command.rb
@@ -1,7 +1,6 @@
 
 module Kontena::Cli::Volumes
   class ShowCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     banner "Show details of a volume"
@@ -31,7 +30,6 @@ module Kontena::Cli::Volumes
       vol['services'].each do |service|
         puts "    - #{service['id']}"
       end
-
     end
 
   end

--- a/cli/lib/kontena/cli/vpn/config_command.rb
+++ b/cli/lib/kontena/cli/vpn/config_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vpn
   class ConfigCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     def execute

--- a/cli/lib/kontena/cli/vpn/create_command.rb
+++ b/cli/lib/kontena/cli/vpn/create_command.rb
@@ -2,7 +2,6 @@ require_relative '../stacks/stacks_helper'
 
 module Kontena::Cli::Vpn
   class CreateCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Stacks::StacksHelper
 

--- a/cli/lib/kontena/cli/vpn/remove_command.rb
+++ b/cli/lib/kontena/cli/vpn/remove_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Vpn
   class RemoveCommand < Kontena::Command
-    include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced

--- a/cli/lib/kontena/cli/whoami_command.rb
+++ b/cli/lib/kontena/cli/whoami_command.rb
@@ -1,5 +1,4 @@
 class Kontena::Cli::WhoamiCommand < Kontena::Command
-  include Kontena::Cli::Common
 
   option '--bash-completion-path', :flag, 'Show bash completion path', hidden: true
   option '--token', :flag, 'Show current master token', hidden: true

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -7,6 +7,8 @@ require 'kontena/cli/grid_options'
 
 class Kontena::Command < Clamp::Command
 
+  include Kontena::Cli::Common
+
   option ['-D', '--debug'], :flag, "Enable debug", environment_variable: 'DEBUG' do
     ENV['DEBUG'] ||= 'true'
   end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -1,8 +1,6 @@
 require 'kontena/command'
 
 class Kontena::MainCommand < Kontena::Command
-  include Kontena::Util
-  include Kontena::Cli::Common
 
   option ['-v', '--version'], :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
     build_tags = [ 'ruby' + RUBY_VERSION ]


### PR DESCRIPTION
`Kontena::Cli::Common` is included in nearly all of the commands.

..so it can be included in `Kontena::Command` from which all of the commands are inherited from.

This opens up some optimization and refactoring opportunities to further eradicate the Kontena::Cli::Common anti-pattern in the future.
