### PR TITLE
Enable clearing of statsd, log forwarder and default affinity in "kontena grid update"

### DIFF
--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -66,7 +66,7 @@ module Kontena::Cli::Grids
       opts = {}
       log_opt_list.each do |opt|
         key, value = opt.split('=')
-        opts[key.to_sym] = value
+        opts[key] = value
       end
       opts
     end

--- a/cli/spec/kontena/cli/grids/update_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/update_command_spec.rb
@@ -28,15 +28,35 @@ describe Kontena::Cli::Grids::UpdateCommand do
 
       end
 
-      it 'should send valid options to server' do
+      it 'should send valid full options to server' do
+        expect(client).to receive(:get).with('grids/test').and_return({
+          "id" => "test",
+          "name" => "test",
+          "token" => "abcd",
+          "initial_size" => 1,
+          "stats" => { "statsd" => nil },
+          "default_affinity" => [],
+          "trusted_subnets" => [],
+          "node_count" => 2,
+          "service_count" => 2,
+          "container_count" => 21,
+          "user_count" => 2,
+          "subnet" => "10.81.0.0/16",
+          "supernet" => "10.80.0.0/12"
+        })
+
         expect(client).to receive(:put).with(
           'grids/test', hash_including({
-            logs: {
-              forwarder: 'fluentd',
-              opts: {
-                foo: 'bar'
+            'logs' => {
+              'forwarder' => 'fluentd',
+              'opts' => {
+                'foo' => 'bar'
               }
-            }
+            },
+            'default_affinity' => [],
+            'trusted_subnets' => [],
+            'node_count' => 2,
+            'stats' => { 'statsd' => nil }
           })
         )
         subject.run(['--log-forwarder', 'fluentd', '--log-opt', 'foo=bar', 'test'])

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -77,11 +77,15 @@ module Grids
         attributes[:default_affinity] = self.default_affinity if self.default_affinity
       end
 
-      if self.logs && self.logs[:forwarder] != 'none'
-        self.grid.grid_logs_opts = GridLogsOpts.new(
-          forwarder: self.logs[:forwarder],
-          opts: self.logs[:opts]
-        )
+      if self.logs
+        if self.logs[:forwarder] == 'none'
+          self.grid.grid_logs_opts = nil
+        else
+          self.grid.grid_logs_opts = GridLogsOpts.new(
+            forwarder: self.logs[:forwarder],
+            opts: self.logs[:opts]
+          )
+        end
       elsif self.node_count # full update, 'logs': null
         self.grid.grid_logs_opts = nil
       end

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -72,7 +72,7 @@ module Grids
         attributes[:stats] = self.stats
         attributes[:trusted_subnets] = self.trusted_subnets
         attributes[:default_affinity] = self.default_affinity
-      else # assume this is pre 1.2.1 client that didn't send a full update
+      else # assume this is pre 1.2.2 client that didn't send a full update
         attributes[:stats] = self.stats if self.stats
         attributes[:default_affinity] = self.default_affinity if self.default_affinity
       end

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -31,6 +31,18 @@ module Grids
           model :opts, class: Hash
         end
       end
+
+      # not updatable at the moment, here to accept a full update json
+      string :id
+      string :name
+      string :token
+      integer :initial_size
+      integer :node_count
+      integer :service_count
+      integer :container_count
+      integer :user_count
+      string :subnet
+      string :supernet
     end
 
     def validate
@@ -44,6 +56,7 @@ module Grids
           end
         end
       end
+
       if self.logs
         case self.logs[:forwarder]
         when 'fluentd'
@@ -54,24 +67,27 @@ module Grids
 
     def execute
       attributes = {}
-      if self.stats
+
+      if self.node_count # assume this is a full update
         attributes[:stats] = self.stats
-      end
-      if self.trusted_subnets
         attributes[:trusted_subnets] = self.trusted_subnets
-      end
-      if self.default_affinity
         attributes[:default_affinity] = self.default_affinity
+      else # assume this is pre 1.2.1 client that didn't send a full update
+        attributes[:stats] = self.stats if self.stats
+        attributes[:default_affinity] = self.default_affinity if self.default_affinity
       end
 
-      if self.logs
-        if self.logs[:forwarder] == 'none'
-          self.grid.grid_logs_opts = nil
-        else
-          self.grid.grid_logs_opts = GridLogsOpts.new(forwarder: self.logs[:forwarder], opts: self.logs[:opts])
-        end
+      if self.logs && self.logs[:forwarder] != 'none'
+        self.grid.grid_logs_opts = GridLogsOpts.new(
+          forwarder: self.logs[:forwarder],
+          opts: self.logs[:opts]
+        )
+      elsif self.node_count # full update, 'logs': null
+        self.grid.grid_logs_opts = nil
       end
+
       grid.update_attributes(attributes)
+
       if grid.errors.size > 0
         grid.errors.each do |key, message|
           add_error(key, :invalid, message)


### PR DESCRIPTION
Fixes #2230 by always sending a full update of the grid object by modifying the response of `client.get("grid/#{name}")` (which is a more RESTy approach to PUT requests).

Trickery performed to detect if the request came from a previous version of CLI that does not send a full update (could be done in the controller by snooping on the useragent).

