### PR TITLE
Restore "kontena login" and "logout" commands

### DIFF
--- a/cli/lib/kontena/cli/login_command.rb
+++ b/cli/lib/kontena/cli/login_command.rb
@@ -1,0 +1,6 @@
+module Kontena::Cli
+  class LoginCommand < Kontena::Command
+    subcommand "master", "Login to a Kontena Master", load_subcommand('master/login_command')
+    subcommand "cloud", "Login to a Kontena Cloud account", load_subcommand('cloud/login_command')
+  end
+end

--- a/cli/lib/kontena/cli/logout_command.rb
+++ b/cli/lib/kontena/cli/logout_command.rb
@@ -1,10 +1,4 @@
 class Kontena::Cli::LogoutCommand < Kontena::Command
-  include Kontena::Cli::Common
-
-  banner "Command removed, use 'kontena master logout' to log out of the Kontena Master"
-  banner "or 'kontena cloud logout' to log out of the Kontena Cloud", false
-
-  def execute
-    exit_with_error("Command removed. Use #{"kontena master logout".colorize(:yellow)} to log out of the Kontena Master")
-  end
+  subcommand "master", "Logout from Kontena Masters", load_subcommand('master/logout_command')
+  subcommand "cloud", "Logout from Kontena Cloud account", load_subcommand('cloud/logout_command')
 end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -13,6 +13,7 @@ class Kontena::MainCommand < Kontena::Command
   end
 
   subcommand "cloud", "Kontena Cloud specific commands", load_subcommand('cloud_command')
+  subcommand "login", "Login to Kontena Masters or Kontena Cloud accounts", load_subcommand('login_command')
   subcommand "logout", "Logout from Kontena Masters or Kontena Cloud accounts", load_subcommand('logout_command')
   subcommand "grid", "Grid specific commands", load_subcommand('grid_command')
   subcommand "app", "App specific commands", load_subcommand('app_command')


### PR DESCRIPTION
From community Slack:

![image](https://cloud.githubusercontent.com/assets/224971/25653227/b058ddde-2ff4-11e7-80eb-86a58767f454.png)

This PR restores the good old "kontena login", but with a twist:

`kontena login master` is exactly the same as `kontena master login`
`kontena login cloud` is exactly the same as `kontena cloud login`

And therefore:
`kontena login` gives you the subcommand list:

```
Usage:
    kontena login [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    master                        Login to a Kontena Master
    cloud                         Login to a Kontena Cloud account
```

Same goes with `kontena logout`.
