### PR TITLE
Add --no-statsd-server and --no-default-affinity to "kontena grid update"

### DIFF
--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::Grids
     option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
     option "--no-statsd-server", :flag, "Unset statsd server setting"
     option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
-    option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder"
+    option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
     option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
 
     def execute
@@ -28,7 +28,7 @@ module Kontena::Cli::Grids
       end
 
       if no_statsd_server?
-        payload[:stats] = { statsd: { server: 'none', port: 0 } }
+        payload[:stats] = { statsd:  nil }
       end
 
       if log_forwarder
@@ -38,9 +38,10 @@ module Kontena::Cli::Grids
         }
       end
 
-      if default_affinity_list
+      unless default_affinity_list.empty?
         payload[:default_affinity] = default_affinity_list
       end
+
       client(token).put("grids/#{name}", payload)
     end
 

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -7,6 +7,7 @@ module Kontena::Cli::Grids
 
     parameter "NAME", "Grid name"
     option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
+    option "--no-statsd-server", :flag, "Unset statsd server setting"
     option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
     option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder"
     option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
@@ -24,6 +25,10 @@ module Kontena::Cli::Grids
             port: port || 8125
           }
         }
+      end
+
+      if no_statsd_server?
+        payload[:stats] = { statsd: { server: 'none', port: 0 } }
       end
 
       if log_forwarder

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -9,6 +9,7 @@ module Kontena::Cli::Grids
     option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
     option "--no-statsd-server", :flag, "Unset statsd server setting"
     option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
+    option "--no-default-affinity", :flag, "Unset grid default affinity"
     option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
     option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
 
@@ -40,6 +41,10 @@ module Kontena::Cli::Grids
 
       unless default_affinity_list.empty?
         payload[:default_affinity] = default_affinity_list
+      end
+
+      if no_default_affinity?
+        payload[:default_affinity] = []
       end
 
       client(token).put("grids/#{name}", payload)

--- a/cli/spec/kontena/cli/grids/update_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/update_command_spec.rb
@@ -50,6 +50,15 @@ describe Kontena::Cli::Grids::UpdateCommand do
         )
         subject.run(['--no-statsd-server', 'test'])
       end
+
+      it 'should send empty default_affinity when --no-default-affinity given' do
+        expect(client).to receive(:put).with(
+          'grids/test', hash_including({
+            default_affinity: []
+          })
+        )
+        subject.run(['--no-default-affinity', 'test'])
+      end
     end
   end
 end

--- a/cli/spec/kontena/cli/grids/update_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/update_command_spec.rb
@@ -41,6 +41,15 @@ describe Kontena::Cli::Grids::UpdateCommand do
         )
         subject.run(['--log-forwarder', 'fluentd', '--log-opt', 'foo=bar', 'test'])
       end
+
+      it 'should send empty statsd when --no-statsd-server given' do
+        expect(client).to receive(:put).with(
+          'grids/test', hash_including({
+            stats: { statsd: nil }
+          })
+        )
+        subject.run(['--no-statsd-server', 'test'])
+      end
     end
   end
 end

--- a/docs/using-kontena/grids.md
+++ b/docs/using-kontena/grids.md
@@ -53,15 +53,21 @@ See the [Deployment Strategies](deploy.md#affinity) documentation for the affini
 This option can be changed using `kontena grid update --default-affinity ...`.
 This will re-schedule the grid services, and may cause service instances to be moved to different nodes.
 
+To disable any previously set grid default affinity use `kontena grid update --no-default-affinity grid_name`.
+
 ### `statsd` Server
 
 The `kontena grid update --statsd-server HOST:PORT` option configures each host node to send stats metrics for each host node and service container to a remote statsd receiver using the UDP StatsD protocol.
+
+To disable previously set statsd setting use `kontena grid update --no-statsd-server grid_name`.
 
 See the [Statistics](stats.md#exporting-stats) documentation for further details.
 
 ### Logging options
 
 The `kontena grid update --log-forwarder fluentd --log-opt fluentd-server=xyz:22445` options configures each host node to send container logs to a remote log collection service.
+
+Use `kontena grid update --log-forwarder none` to disable log forwarding.
 
 See the [Logs](logs.md) documentation for further details.
 
@@ -176,8 +182,13 @@ Parameters:
 
 Options:
     --statsd-server STATSD_SERVER Statsd server address (host:port)
+    --no-statsd-server            Unset statsd server setting
     --default-affinity [AFFINITY] Default affinity rule for the grid
+    --no-default-affinity         Unset grid default affinity
+    --log-forwarder LOG_FORWARDER Set grid wide log forwarder (set to 'none' to disable)
+    --log-opt [LOG_OPT]           Set log options (key=value)
     -h, --help                    print help
+    -D, --debug                   Enable debug (default: $DEBUG)
 ```
 
 #### Remove a Grid

--- a/docs/using-kontena/stats.md
+++ b/docs/using-kontena/stats.md
@@ -7,11 +7,11 @@ Kontena collects statistics about running Services with the help of [cAdvisor](h
 
 ```
 $ kontena service stats loadbalancer
-CONTAINER                      CPU %           MEM USAGE/LIMIT      MEM %           NET I/O        
-loadbalancer-3                 1.67%           208.64M / N/A        N/A             61.53G/16.17G  
-loadbalancer-5                 1.73%           213.72M / N/A        N/A             61.7G/16.28G   
-loadbalancer-2                 1.59%           198.91M / N/A        N/A             61.45G/16.1G   
-loadbalancer-1                 1.65%           219.86M / N/A        N/A             61.57G/16.52G  
+CONTAINER                      CPU %           MEM USAGE/LIMIT      MEM %           NET I/O
+loadbalancer-3                 1.67%           208.64M / N/A        N/A             61.53G/16.17G
+loadbalancer-5                 1.73%           213.72M / N/A        N/A             61.7G/16.28G
+loadbalancer-2                 1.59%           198.91M / N/A        N/A             61.45G/16.1G
+loadbalancer-1                 1.65%           219.86M / N/A        N/A             61.57G/16.52G
 loadbalancer-4                 2.05%           220.73M / N/A        N/A             61.7G/16.42G
 ```
 
@@ -25,6 +25,12 @@ Statistics exporting can be activated on a Grid by updating it:
 
 ```
 $ kontena grid update --statsd-server influx.example.com:8125
+```
+
+To disable stats exporting use:
+
+```
+$ kontena grid update --no-statsd-server grid_name
 ```
 
 

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -10,7 +10,7 @@ module Grids
       hash :stats do
         optional do
           hash :statsd do
-            optional do
+            required do
               string :server
               integer :port
             end

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -8,9 +8,9 @@ module Grids
 
     optional do
       hash :stats do
-        required do
+        optional do
           hash :statsd do
-            required do
+            optional do
               string :server
               integer :port
             end
@@ -54,15 +54,9 @@ module Grids
 
     def execute
       attributes = {}
-      if self.stats
-        attributes[:stats] = self.stats['statsd']['server'] == 'none' ? {} : self.stats
-      end
-      if self.trusted_subnets
-        attributes[:trusted_subnets] = self.trusted_subnets
-      end
-      if self.default_affinity
-        attributes[:default_affinity] = self.default_affinity
-      end
+      attributes[:stats] = self.stats if self.stats
+      attributes[:trusted_subnets] = self.trusted_subnets if self.trusted_subnets
+      attributes[:default_affinity] = self.default_affinity if self.default_affinity
 
       if self.logs
         if self.logs[:forwarder] == 'none'

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -55,7 +55,7 @@ module Grids
     def execute
       attributes = {}
       if self.stats
-        attributes[:stats] = self.stats
+        attributes[:stats] = self.stats['statsd']['server'] == 'none' ? {} : self.stats
       end
       if self.trusted_subnets
         attributes[:trusted_subnets] = self.trusted_subnets

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -31,7 +31,7 @@ describe Grids::Update, celluloid: true do
         }
       }
       grid.update_attributes stats: stats
-      described_class.new(user: user, grid: grid, stats: { statsd: { server: 'none', port: 0 } }).run
+      described_class.new(user: user, grid: grid, stats: { statsd: nil }).run
       expect(grid.reload.stats['statsd']).to be_nil
     end
 

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -23,6 +23,18 @@ describe Grids::Update, celluloid: true do
       expect(grid.reload.stats['statsd']['server']).to eq('127.0.0.1')
     end
 
+    it 'clears statsd settings' do
+      stats = {
+        statsd: {
+          server: '127.0.0.1',
+          port: 8125
+        }
+      }
+      grid.update_attributes stats: stats
+      described_class.new(user: user, grid: grid, stats: { statsd: { server: 'none', port: 0 } }).run
+      expect(grid.reload.stats['statsd']).to be_nil
+    end
+
     it 'returns error if grid has errors' do
       outcome = described_class.new(user: user, grid: grid, stats: 'foo').run
       expect(outcome.success?).to be_falsey


### PR DESCRIPTION
Fixes #2230 by adding `--no-statsd-server` to `kontena grid update`.
Also:
Fixes #2252 (default_affinity was always cleared when you ran `kontena grid update` without `--default-affinity` option.

