### PR TITLE
Support basic authentication in auth provider userinfo request

### DIFF
--- a/docs/using-kontena/authentication.md
+++ b/docs/using-kontena/authentication.md
@@ -133,6 +133,14 @@ Some providers may provide user information through a token info endpoint that t
 
 **Example:** `https://api.example.com/tokeninfo/:access_token`
 
+#### `oauth2.userinfo_requires_basic_auth`
+
+When false (default) the obtained access token is used as bearer token authentication when requesting userinfo from the authentication provider.
+
+Some providers require you to use the client_id and client_secret as basic authentication username and password. Usually this also means that you must use the `:access_token` url interpolation in `oauth2.userinfo_endpoint` to supply the access token.
+
+**Example:** `false`
+
 #### `oauth2.token_method`
 
 The HTTP method to use when requesting access tokens from the token endpoint. Normally it's `POST`; however, some providers only support `GET` with an authorization code as a query parameter in the URL.

--- a/server/config/seed.yml
+++ b/server/config/seed.yml
@@ -11,6 +11,7 @@ default: &default
   oauth2.token_method: <%= ENV['AUTH_TOKEN_METHOD'] %>
   oauth2.token_post_content_type: <%= ENV['AUTH_TOKEN_POST_CONTENT_TYPE'] %>
   oauth2.code_requires_basic_auth: <%= ENV['AUTH_CODE_REQUIRES_BASIC_AUTH'].to_s == "true" %>
+  oauth2.userinfo_requires_basic_auth: <%= ENV['USERINFO_REQUIRES_BASIC_AUTH'].to_s == "true" %>
   oauth2.userinfo_scope: <%= ENV['AUTH_USERINFO_SCOPE'] %>
   oauth2.userinfo_username_jsonpath: <%= ENV['AUTH_USERINFO_USERNAME_JSONPATH'] %>
   oauth2.userinfo_email_jsonpath: <%= ENV['AUTH_USERINFO_EMAIL_JSONPATH'] %>

--- a/server/spec/services/auth_provider_spec.rb
+++ b/server/spec/services/auth_provider_spec.rb
@@ -223,6 +223,7 @@ describe AuthProvider do
   context "userinfo" do
     before(:each) do
       allow(client).to receive(:set_auth)
+      allow(client).to receive(:force_basic_auth=)
     end
 
     let(:client) { double }

--- a/server/spec/services/auth_provider_spec.rb
+++ b/server/spec/services/auth_provider_spec.rb
@@ -221,6 +221,10 @@ describe AuthProvider do
   end
 
   context "userinfo" do
+    before(:each) do
+      allow(client).to receive(:set_auth)
+    end
+
     let(:client) { double }
     let(:success_response) {
       OpenStruct.new(headers: OpenStruct.new("Content-Type" => "application/json"), body: '{"user": { "id" : "userid", "email" : "email", "username" : "username" } }')


### PR DESCRIPTION
Fixes #2248

If the config `oauth2.userinfo_requires_basic_auth` is true, the auth provider client will send client_id + client_secret as basic auth credentials when performing the userinfo/token introspection request.

The default behavior when the config value is false is to use the obtained access token as bearer authentication header.
