### PR TITLE
Don't crash StatsWorker actor if statsd config fails

### DIFF
--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -30,6 +30,9 @@ module Kontena::Workers
       else
         @statsd = nil
       end
+    rescue => error
+      warn "statsd configuration failed: #{error.message}"
+      warn error.backtrace.join('\n') if error.backtrace
     end
 
     def start

--- a/agent/lib/kontena/workers/stats_worker.rb
+++ b/agent/lib/kontena/workers/stats_worker.rb
@@ -32,7 +32,7 @@ module Kontena::Workers
       end
     rescue => error
       warn "statsd configuration failed: #{error.message}"
-      warn error.backtrace.join('\n') if error.backtrace
+      warn error.backtrace.join("\n") if error.backtrace
     end
 
     def start

--- a/agent/spec/lib/kontena/workers/stats_workers_spec.rb
+++ b/agent/spec/lib/kontena/workers/stats_workers_spec.rb
@@ -110,6 +110,23 @@ describe Kontena::Workers::StatsWorker do
       subject.configure_statsd(node)
       expect(subject.statsd).to be_nil
     end
+
+    it 'does not crash the worker if statsd config fails' do
+      node = Node.new(
+        'grid' => {
+          'stats' => {
+            'statsd' => {
+              'server' => '192.168.24.33',
+              'port' => 8125
+            }
+          }
+        }
+      )
+      expect(subject.statsd).to be_nil
+      expect(Statsd).to receive(:new).and_raise("Boom")
+      subject.configure_statsd(node)
+      expect(subject.statsd).to be_nil
+    end
   end
 
   describe '#send_statsd_metrics' do


### PR DESCRIPTION
per #2231 fast-crashing actor will start to leak a lot of memory and burns up the CPU.

This PR fixes the case where `StatsWorker` actor gets into crash-restart loop with non-working config.

The idea is that the statsd is tried configure again when the node info is next updated/observed.