### PR TITLE
Prevent WeaveWorker from doing duplicate subscription for container:event

### DIFF
--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -16,6 +16,8 @@ module Kontena::Workers
 
       @migrate_containers = nil # initialized by #start
 
+      @subscribed_container_event = false
+
       if network_adapter.already_started?
         self.start
       else
@@ -32,7 +34,9 @@ module Kontena::Workers
       debug "Scanned #{@migrate_containers.size} existing containers for potential migration: #{@migrate_containers}"
 
       # ready to start handling container events
-      subscribe('container:event', :on_container_event)
+      # #start can be called multiple times, subscribe only if not done already as we don't want duplicate events
+      subscribe('container:event', :on_container_event) unless @subscribed_container_event
+      @subscribed_container_event = true
 
       info 'attaching network to existing containers'
       Docker::Container.all(all: false).each do |container|

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -50,6 +50,7 @@ module Kontena::Workers
     # @param [String] topic
     # @param [Docker::Event] event
     def on_container_event(topic, event)
+      # cannot run start_container before start has populated @migrate_containers
       return unless started?
 
       if event.status == 'start'

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -17,6 +17,16 @@ describe Kontena::Workers::WeaveWorker do
     subject
   end
 
+  describe '#start' do
+    it 'subscribes container:event only once' do
+      allow(network_adapter).to receive(:get_containers).and_return([])
+      allow(Docker::Container).to receive(:all).and_return([])
+      expect(subject.wrapped_object).to receive(:subscribe).with('container:event', :on_container_event).once
+      subject.start
+      subject.start
+    end
+  end
+
   describe '#on_weave_start' do
     it 'calls start' do
       expect(subject.wrapped_object).to receive(:start)


### PR DESCRIPTION
As WeaveWorker#start can be called multiple times for different cases (weave restart for example) it does subscribe to `container:event` each time. This leads to exponential handling of the events as seen in #2225.


fixes #2225 

