### PR TITLE
Fix GridServiceSerializer deploy_opts min_health typo

### DIFF
--- a/server/app/serializers/grid_service_serializer.rb
+++ b/server/app/serializers/grid_service_serializer.rb
@@ -59,7 +59,7 @@ class GridServiceSerializer < KontenaJsonSerializer
     deploy_opts = object.deploy_opts
     {
       wait_for_port: deploy_opts.wait_for_port,
-      min_healt: deploy_opts.min_health,
+      min_health: deploy_opts.min_health,
       interval: deploy_opts.interval
     }
   end


### PR DESCRIPTION
Randomly spotted in the cloud websocket events debug output. I think that's the only thing affected?