### PR TITLE
Speed up --bash-completion-path for faster shell loading

### DIFF
--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -11,6 +11,8 @@ STDOUT.sync = true
 if ARGV[0] == 'complete'
   ARGV.delete_at(0)
   require 'kontena/scripts/completer'
+elsif ARGV.last == '--bash-completion-path'
+  puts File.realpath(File.join(__dir__, '../lib/kontena/scripts/init'))
 else
   require 'kontena_cli'
   Kontena::PluginManager.instance.init

--- a/cli/lib/kontena/cli/whoami_command.rb
+++ b/cli/lib/kontena/cli/whoami_command.rb
@@ -5,6 +5,7 @@ class Kontena::Cli::WhoamiCommand < Kontena::Command
 
   def execute
     if self.token?
+      exit 1 unless current_master && current_master.token.access_token
       Kontena.run(%w(master token current --token))
       exit 0
     end

--- a/cli/lib/kontena/cli/whoami_command.rb
+++ b/cli/lib/kontena/cli/whoami_command.rb
@@ -1,22 +1,12 @@
 class Kontena::Cli::WhoamiCommand < Kontena::Command
   include Kontena::Cli::Common
 
-  option '--bash-completion-path', :flag, 'Show bash completion path', hidden: true
   option '--token', :flag, 'Show current master token', hidden: true
 
   def execute
-    if bash_completion_path?
-      puts File.realpath(File.join(__dir__, '../scripts/init'))
-      exit 0
-    end
-
     if self.token?
-      if config.current_master && config.current_master.token
-        puts config.current_master.token.access_token
-        exit 0
-      else
-        exit 1
-      end
+      Kontena.run(%w(master token current --token))
+      exit 0
     end
 
     require_api_url


### PR DESCRIPTION
Fixes #2270 

This PR moves the handling of `--bash-completion-path` to `bin/kontena` to avoid loading so much files for nothing.

Before:

```console
$ time for i in {1..10}; do kontena whoami --bash-completion-path; done
real	0m6.766s
user	0m5.279s
sys	0m1.185s
```

After:

```console
$ time for i in {1..10}; do kontena whoami --bash-completion-path; done
real	0m1.109s
user	0m0.665s
sys	0m0.207s
```
