### PR TITLE
Fix agent weave restart

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -223,9 +223,11 @@ module Kontena::NetworkAdapters
       wait_until("weave is ready to start") { images_exist? && !starting? }
 
       @starting = true
+      restarting = false
 
       weave = Docker::Container.get('weave') rescue nil
       if weave && config_changed?(weave, node)
+        restarting = true
         weave.delete(force: true)
       end
 
@@ -254,7 +256,12 @@ module Kontena::NetworkAdapters
       info "using trusted subnets: #{trusted_subnets.join(',')}" if trusted_subnets && !already_started?
       post_start(node)
 
-      Celluloid::Notifications.publish('network_adapter:start', node) unless already_started?
+      if !already_started?
+        # only publish once on agent boot, or after a crash and actor restart
+        Celluloid::Notifications.publish('network_adapter:start', node)
+      elsif restarting
+        Celluloid::Notifications.publish('network_adapter:restart', node)
+      end
 
       @started = true
       node

--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -227,6 +227,7 @@ module Kontena::NetworkAdapters
 
       weave = Docker::Container.get('weave') rescue nil
       if weave && config_changed?(weave, node)
+        info "weave image or configuration has been changed, restarting"
         restarting = true
         weave.delete(force: true)
       end

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -28,9 +28,11 @@ module Kontena::Workers
     end
 
     def on_weave_start(topic, data)
+      info "attaching network to existing containers"
       self.start
     end
     def on_weave_restart(topic, data)
+      info "re-attaching network to existing containers after weave restart"
       self.start
     end
 
@@ -40,7 +42,6 @@ module Kontena::Workers
 
       @started = true
 
-      info 'attaching network to existing containers'
       Docker::Container.all(all: false).each do |container|
         self.start_container(container)
       end

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -18,6 +18,8 @@ module Kontena::Workers
 
       @started = false # to prevent handling of container events before migration scan
       subscribe('container:event', :on_container_event)
+      subscribe('network_adapter:restart', :on_weave_restart)
+
       if network_adapter.already_started?
         self.start
       else
@@ -26,6 +28,9 @@ module Kontena::Workers
     end
 
     def on_weave_start(topic, data)
+      self.start
+    end
+    def on_weave_restart(topic, data)
       self.start
     end
 
@@ -39,7 +44,6 @@ module Kontena::Workers
       Docker::Container.all(all: false).each do |container|
         self.start_container(container)
       end
-      
     end
 
     def on_dns_add(topic, event)

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -20,7 +20,13 @@ describe Kontena::Workers::WeaveWorker do
   describe '#on_weave_start' do
     it 'calls start' do
       expect(subject.wrapped_object).to receive(:start)
-      subject.on_weave_start('topic', event)
+      Celluloid::Notifications.publish('network_adapter:start', nil)
+    end
+  end
+  describe '#on_weave_restart' do
+    it 'calls start' do
+      expect(subject.wrapped_object).to receive(:start)
+      Celluloid::Notifications.publish('network_adapter:restart', nil)
     end
   end
 


### PR DESCRIPTION
Hybrid of #2131 and #2173 

Fixes #2158

Adds a new `network_adapter:restart` notification to avoid changing the existing `network_adapter:start` cases ( `Kontena::Launchers::Etcd` and `Kontena::Launchers::IpamPlugin`).

The `WeaveWorker` now runs `start` in both initial agent bootup (or `Weave` actor crash) cases, as well as the `Weave#launch` re-configuration case (changes to `kontena grid trusted-subnet`).

The `start` action with both re-attach any containers, as well as re-add the service DNS names that are missing after a weave restart.