### PR TITLE
Abort deploy gracefully in exceptional cases

### DIFF
--- a/server/app/jobs/grid_service_scheduler_worker.rb
+++ b/server/app/jobs/grid_service_scheduler_worker.rb
@@ -41,6 +41,12 @@ class GridServiceSchedulerWorker
         return nil
       end
     end
+  rescue => exc
+    error "aborting deploy on un-handled error: #{exc.message}"
+    error exc.backtrace.join("\n") if exc.backtrace
+    service_deploy.abort! "service deploy aborted: #{exc.message}" if service_deploy
+    
+    nil
   end
 
   # Pick up the oldest pending un-queued deploy, mark it as queued, and return for processing.

--- a/server/spec/jobs/grid_service_scheduler_worker_spec.rb
+++ b/server/spec/jobs/grid_service_scheduler_worker_spec.rb
@@ -45,9 +45,22 @@ describe GridServiceSchedulerWorker, celluloid: true do
 
     it "fails if fetch_deploy_item returns a non-pending deploy" do
       service_deploy = GridServiceDeploy.create(grid_service: service, created_at: 1.hour.ago, started_at: 1.hour.ago)
-
-      expect{subject.check_deploy_queue}.to raise_error(RuntimeError, "deploy not pending")
+      
+      expect(subject.check_deploy_queue).to be_nil
+      expect(service_deploy.reload).to be_finished
+      expect(service_deploy.reason).to eq "service deploy aborted: deploy not pending"
     end
+
+    it "aborts deploy when un-handled error occurs" do
+      service_deploy = GridServiceDeploy.create(grid_service: nil, created_at: 1.hour.ago)
+      expect(subject.wrapped_object).to receive(:fetch_deploy_item).and_return(service_deploy)
+      
+      expect(subject.check_deploy_queue).to be_nil
+      expect(service_deploy.reload).to be_aborted
+      expect(service_deploy.deploy_state).to eq :error
+      expect(service_deploy.reason).not_to be_nil
+    end
+    
   end
 
   context "without any deploys" do


### PR DESCRIPTION
Fixes `GridServiceSchedulerWorker#check_deploy_queue` to "gracefully" abort deploys in case of unhandled errors.


### TODO
- Should there be a specific check for removed service as happened in #2275? It would be probably nicer in logs instead of:
```
NoMethodError: undefined method `deploy_running?' for nil:NilClass
...
```

fixes #2275 