### PR TITLE
Fix handling of aborted service deploys

### DIFF
--- a/cli/lib/kontena/cli/stacks/stacks_helper.rb
+++ b/cli/lib/kontena/cli/stacks/stacks_helper.rb
@@ -70,7 +70,6 @@ module Kontena::Cli::Stacks
     end
 
     def wait_for_service_deploy(service_deploy)
-      service_deployed = false
       name = service_deploy['service_id'].split('/')[-1]
       spinner "Deploying service #{pastel.cyan(name)}" do |spin|
         until service_deploy['finished_at']

--- a/server/app/models/grid_service_deploy.rb
+++ b/server/app/models/grid_service_deploy.rb
@@ -86,10 +86,10 @@ class GridServiceDeploy
     !started? && finished?
   end
 
-  # Finish deploy without it necessarily being running.
+  # Finish deploy without it necessarily being running, setting an error state.
   #
   # @param reason [String]
   def abort!(reason = nil)
-    self.set(:finished_at => Time.now.utc, :reason => reason)
+    self.set(:finished_at => Time.now.utc, :deploy_state => :error, :reason => reason)
   end
 end

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -55,7 +55,7 @@ class GridServiceDeployer
       instance_number = i + 1
       self.grid_service_deploy.reload
       unless self.grid_service_deploy.running?
-        raise "halting deploy of #{self.grid_service.to_path}, deploy was aborted: #{self.deploy_state.reason}"
+        raise "halting deploy of #{self.grid_service.to_path}, deploy was aborted: #{self.grid_service_deploy.reason}"
       end
       self.grid_service.reload
       unless self.grid_service.running? || self.grid_service.initialized?

--- a/server/spec/jobs/grid_service_scheduler_worker_spec.rb
+++ b/server/spec/jobs/grid_service_scheduler_worker_spec.rb
@@ -275,6 +275,8 @@ describe GridServiceSchedulerWorker, celluloid: true do
         expect(subject.check_deploy_queue).to be_nil
 
         expect(service_deploy.reload).to be_aborted
+        expect(service_deploy.reload).to be_finished
+        expect(service_deploy.reload).to be_error
       end
     end
   end

--- a/server/spec/models/grid_service_deploy_spec.rb
+++ b/server/spec/models/grid_service_deploy_spec.rb
@@ -75,6 +75,11 @@ describe GridServiceDeploy do
       expect(subject).to_not be_running
       expect(subject).to be_finished
     end
+
+    it "is error" do
+      expect(subject).to be_error
+      expect(subject.reason).to eq "test"
+    end
   end
 
   context "for an aborted deploy after starting" do
@@ -90,6 +95,11 @@ describe GridServiceDeploy do
       expect(subject).to be_started
       expect(subject).to_not be_running
       expect(subject).to be_finished
+    end
+
+    it "is error" do
+      expect(subject).to be_error
+      expect(subject.reason).to eq "test"
     end
   end
 

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -168,7 +168,7 @@ describe GridServiceDeployer do
           expect(grid_service_deploy).to be_error
         end
 
-        it "fails the service deploy if aborted" do
+        it "fails the service deploy if aborted", :celluloid => true do
           expect(subject).to receive(:deploy_service_instance).once.with(2, Array, 1, String) do |total_instances, deploy_futures, instance_number, deploy_rev|
             grid_service_deploy.abort! "testing"
 
@@ -190,6 +190,7 @@ describe GridServiceDeployer do
           grid_service_deploy.reload
 
           expect(grid_service_deploy).to be_error
+          expect(grid_service_deploy.reason).to eq "halting deploy of test-grid/null/redis, deploy was aborted: testing"
         end
       end
     end


### PR DESCRIPTION
Fixes the handling of aborted services deploys that remained TODO in #2221

* Fix the `GridServiceDeployer` deploy abort error handling

    The error message was broken: `undefined method' 'deploy_state' for #<GridServiceDeployer:0x00000004cb1ca0>`

    The spec was also broken, and was actually failing with `Celluloid::NotActive`.

* Fix the `GridServiceDeploy#abort!` to set the `GridServiceDeploy#deploy_state` to `error`
    
    This fixes the `StackDeployWorker` and CLI stack/service deploy helpers to correctly handle aborted deploys as un-succesful cases.

* Fix the CLI `kontena stack deploy` helpers to wait for `finished_at`, instead of the deploy state

    The `kontena stack deploy` command would previously hang on an aborted service deploy, because it expects a `success` or `error` state instead of looking at the `finished_at`. Although this change to set the `error` state fixes this, it's better and more reliable to just wait for `finished_at`. It also matches what the `kontena service deploy` does.