### PR TITLE
Fix flaky WeaveWorker notification spec

### DIFF
--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -21,12 +21,14 @@ describe Kontena::Workers::WeaveWorker do
     it 'calls start' do
       expect(subject.wrapped_object).to receive(:start)
       Celluloid::Notifications.publish('network_adapter:start', nil)
+      subject.started? # sync ping to wait for async notification task to run
     end
   end
   describe '#on_weave_restart' do
     it 'calls start' do
       expect(subject.wrapped_object).to receive(:start)
       Celluloid::Notifications.publish('network_adapter:restart', nil)
+      subject.started? # sync ping to wait for async notification task to run
     end
   end
 


### PR DESCRIPTION
Introduced in #2278 

Fixes using Celluloid voodoo. It looks like the `Celluloid::Notifications.publish` is entirely sync up to the async call to the subject method. Running a single sync call in the same actor should be enough to ensure that the async notification call has been run.

This fixed spec is better than the original spec, in that it tests that the actor actually subscribes to that notification topic.