### PR TITLE
Do not run workers in server tests or utilities

### DIFF
--- a/server/app/boot_jobs.rb
+++ b/server/app/boot_jobs.rb
@@ -5,6 +5,5 @@ require_relative 'services/mongodb/migrator'
 unless ENV['RACK_ENV'] == 'test' || ENV['NO_MONGO_PUBSUB']
   MongoPubsub.start!(PubsubChannel)
   JobSupervisor.run!
+  WorkerSupervisor.run!
 end
-
-WorkerSupervisor.run!


### PR DESCRIPTION
The server `GridServiceSchedulerWorker`, `StackDeployWorker` and `StaackRemoveWorker` actors were running during the server specs. This caused flaky specs when creating `GridServiceDeploy` objects in specs, because they might get modified by the `GridServiceSchedulerWorker` between the create and the expect:

```
  1) GridServiceSchedulerWorker#check_deploy_queue fails if fetch_deploy_item returns a non-pending deploy
     Failure/Error: expect{subject.check_deploy_queue}.to raise_error(RuntimeError, "deploy not pending")
       expected RuntimeError with "deploy not pending" but nothing was raised
     # ./spec/jobs/grid_service_scheduler_worker_spec.rb:49:in `block (3 levels) in <top (required)>'
```

```
  2) GridServices::Scale#run sets state to deploy_pending
     Failure/Error: expect {
       expected result to have changed from false to true, but did not change

     # ./spec/mutations/grid_services/scale_spec.rb:35:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:88:in `block (2 levels) in <top (required)>'
```

This extends the same `ENV['RACK_ENV'] == 'test'` logic used to not run the server jobs to also prevent running the workers. The `Stacks::Remove` and `Stacks::Deploy` specs already mocked out the corresponding workers, so the specs still pass without those workers running.