### PR TITLE
Fix service_link resolver spec to use kontena stack validate --online

### DIFF
--- a/test/spec/features/stack/validate_spec.rb
+++ b/test/spec/features/stack/validate_spec.rb
@@ -9,7 +9,7 @@ describe 'stack validate' do
         run 'kontena stack install --no-deploy'
       end
       with_fixture_dir("stack/service_link") do
-        k = kommando 'kontena stack validate', timeout: 5
+        k = kommando 'kontena stack validate --online', timeout: 5
         k.out.on "Select link" do
           k.in << "\r"
         end


### PR DESCRIPTION
Fixes #2117 

The e2e test `kontena stack validate` spec would fail with an error like:

```
 [error] RuntimeError : Variable validation failed: {"lb"=>{:presence=>"Required value missing"}}
```

The `service_link` resolver does not work unless using `kontena stack validate --online` (#2060)