### PR TITLE
Better error handling for ServicePodWorker#image_outdated?

### DIFF
--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -195,10 +195,13 @@ module Kontena::Workers
     # @param [Docker::Container] service_container
     # @return [Boolean]
     def image_outdated?(service_container)
-      image = Docker::Image.get(service_pod.image_name) rescue nil
-      return true unless image
-      return true if image.id != service_container.info['Image']
-
+      begin
+        image = Docker::Image.get(service_pod.image_name)
+        return true if image.id != service_container.info['Image']
+      rescue Docker::Error::NotFoundError
+        info "failed to get image: #{service_pod.image_name}"
+        return true
+      end
       false
     end
 

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -197,7 +197,10 @@ module Kontena::Workers
     def image_outdated?(service_container)
       begin
         image = Docker::Image.get(service_pod.image_name)
-        return true if image.id != service_container.info['Image']
+        if image.id != service_container.info['Image']
+          info "containers image(#{service_container.info['Image']} does not match images id(#{image.id})}"
+          return true
+        end
       rescue Docker::Error::NotFoundError
         info "failed to get image: #{service_pod.image_name}"
         return true

--- a/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
@@ -291,6 +291,20 @@ describe Kontena::Workers::ServicePodWorker do
       allow(Docker::Image).to receive(:get).with(service_pod.image_name).and_return(image)
       expect(subject.image_outdated?(service_container)).to be_falsey
     end
+
+    it 'returns true if Docker::Error::NotFoundError raised' do
+      service_container = double(:service_container)
+      allow(Docker::Image).to receive(:get).with(service_pod.image_name).and_raise(Docker::Error::NotFoundError)
+      expect(subject.image_outdated?(service_container)).to be_truthy
+    end
+
+    it 'lets un-expected errors fall through'  do
+      service_container = double(:service_container)
+      allow(Docker::Image).to receive(:get).with(service_pod.image_name).and_raise(StandardError)
+      # call through wrapped_object to prevent actor crash logs during spec runs
+      expect {subject.wrapped_object.image_outdated?(service_container)}.to raise_error(StandardError)
+    end
+    
   end
 
   describe '#labels_outdated?' do


### PR DESCRIPTION
In case of `Docker::Image.get` raised some error the `image_outdated?` would just return true with no indication why it failed. `rescue nil` strikes-again. :)

With the fix any un-expected errors are just let through and eventually seen on cli and event logs:
```
$ k service deploy nginx
 [fail] Deploying service nginx      
 [error] Kontena::Errors::StandardErrorArray : halting deploy of e2e/null/nginx, one or more instances failed:
	⊗ Failed to deploy instance e2e/null/nginx-1 to node moby: GridServiceInstanceDeployer::ServiceError: RuntimeError: BoomBoom
```
```
$ k service events nginx
TIME                      TYPE                 MESSAGE
2017-05-09T12:29:51.492Z  deploy               service e2e/null/nginx deploy started
2017-05-09T12:29:54.682Z  deploy               Failed to deploy service instance e2e/null/nginx-1 to node moby: GridServiceInstanceDeployer::ServiceError: RuntimeError: BoomBoom
2017-05-09T12:29:54.688Z  deploy               deploy of e2e/null/nginx errored: halting deploy of e2e/null/nginx, one or more instances failed
```