### PR TITLE
Fix agent ServicePodWorker to log complete apply error

### DIFF
--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -76,6 +76,7 @@ module Kontena::Workers
           ensure_desired_state
         rescue => error
           warn "failed to sync #{service_pod.name} at #{service_pod.deploy_rev}: #{error}"
+          warn error
           sync_state_to_master(current_state, error)
         else
           @container_state_changed = false


### PR DESCRIPTION
The logging was missing the complete backtrace.

```
W, [2017-05-10T11:56:07.223977 #1]  WARN -- Kontena::Workers::ServicePodWorker: failed to sync redis-3 at 2017-05-10 11:56:00 UTC: pretend start failed
W, [2017-05-10T11:56:07.224204 #1]  WARN -- Kontena::Workers::ServicePodWorker: pretend start failed (RuntimeError)
/app/lib/kontena/service_pods/creator.rb:61:in `perform'
/app/lib/kontena/workers/service_pod_worker.rb:120:in `ensure_running'
/app/lib/kontena/workers/service_pod_worker.rb:97:in `ensure_desired_state'
/app/lib/kontena/workers/service_pod_worker.rb:76:in `block in apply'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:97:in `exclusive'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid.rb:421:in `exclusive'
/app/lib/kontena/workers/service_pod_worker.rb:74:in `apply'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/call/async.rb:7:in `dispatch'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```