### PR TITLE
Use current grid or --grid in all "kontena grid trusted-subnet" subcommands

### DIFF
--- a/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
@@ -1,17 +1,17 @@
 module Kontena::Cli::Grids::TrustedSubnets
   class AddCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
-    parameter "NAME", "Grid name"
     parameter "SUBNET", "Trusted subnet"
 
+    requires_current_master
+
     def execute
-      require_api_url
-      token = require_token
-      grid = client(token).get("grids/#{name}")
+      grid = client.get("grids/#{current_grid}")
       data = {trusted_subnets: grid['trusted_subnets'] + [self.subnet]}
-      spinner "Adding #{subnet.colorize(:cyan)} as a trusted subnet in #{name.colorize(:cyan)} grid " do
-        client(token).put("grids/#{name}", data)
+      spinner "Adding #{subnet.colorize(:cyan)} as a trusted subnet in #{current_grid.colorize(:cyan)} grid " do
+        client.put("grids/#{current_grid}", data)
       end
     end
   end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
@@ -1,13 +1,12 @@
 module Kontena::Cli::Grids::TrustedSubnets
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
-    parameter "NAME", "Grid name"
+    requires_current_master
 
     def execute
-      require_api_url
-      token = require_token
-      grid = client(token).get("grids/#{current_grid}")
+      grid = client.get("grids/#{current_grid}")
       trusted_subnets = grid['trusted_subnets'] || []
       trusted_subnets.each do |subnet|
         puts subnet

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -1,23 +1,23 @@
 module Kontena::Cli::Grids::TrustedSubnets
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
 
-    parameter "NAME", "Grid name"
     parameter "SUBNET", "Trusted subnet"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
+    requires_current_master
+
     def execute
-      require_api_url
-      token = require_token
-      grid = client(token).get("grids/#{name}")
+      grid = client.get("grids/#{current_grid}")
       confirm_command(subnet) unless forced?
       trusted_subnets = grid['trusted_subnets'] || []
       unless trusted_subnets.delete(self.subnet)
-        exit_with_error("Grid #{name.colorize(:cyan)} does not have trusted subnet #{subnet.colorize(:cyan)}")
+        exit_with_error("Grid #{current_grid.colorize(:cyan)} does not have trusted subnet #{subnet.colorize(:cyan)}")
       end
       data = {trusted_subnets: trusted_subnets}
-      spinner "Removing trusted subnet #{subnet.colorize(:cyan)} from #{name.colorize(:cyan)} grid " do
-        client(token).put("grids/#{name}", data)
+      spinner "Removing trusted subnet #{subnet.colorize(:cyan)} from #{current_grid.colorize(:cyan)} grid " do
+        client.put("grids/#{current_grid}", data)
       end
     end
   end

--- a/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/add_command_spec.rb
@@ -4,24 +4,40 @@ require "kontena/cli/grids/trusted_subnets/add_command"
 describe Kontena::Cli::Grids::TrustedSubnets::AddCommand do
 
   include ClientHelpers
+  include RequirementsHelper
+
+  expect_to_require_current_master
 
   describe '#execute' do
-    it 'requires grid as param' do
+    it 'requires subnet as param' do
       expect {
         subject.run([])
       }.to raise_error(Clamp::UsageError)
     end
 
     it 'adds subnet to grid' do
-      allow(client).to receive(:get).with("grids/my-grid").and_return(
+      allow(client).to receive(:get).with("grids/test-grid").and_return(
         'trusted_subnets' => ['192.168.12.0/24']
       )
       expect(client).to receive(:put).with(
-        'grids/my-grid', hash_including({trusted_subnets: [
+        'grids/test-grid', hash_including({trusted_subnets: [
           '192.168.12.0/24', '10.12.0.0/19'
         ]})
       )
-      subject.run(['my-grid', '10.12.0.0/19'])
+      subject.run(['10.12.0.0/19'])
+    end
+
+    it 'supports the --grid option' do
+      allow(subject).to receive(:current_grid).and_call_original
+      allow(client).to receive(:get).with("grids/ingrid").and_return(
+        'trusted_subnets' => ['192.168.12.0/24']
+      )
+      expect(client).to receive(:put).with(
+        'grids/ingrid', hash_including({trusted_subnets: [
+          '192.168.12.0/24', '10.12.0.0/19'
+        ]})
+      )
+      subject.run(['--grid', 'ingrid', '10.12.0.0/19'])
     end
   end
 end

--- a/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/list_command_spec.rb
@@ -4,19 +4,24 @@ require "kontena/cli/grids/trusted_subnets/list_command"
 describe Kontena::Cli::Grids::TrustedSubnets::ListCommand do
 
   include ClientHelpers
+  include RequirementsHelper
+
+  expect_to_require_current_master
 
   describe '#execute' do
-    it 'requires grid as param' do
-      expect {
-        subject.run([])
-      }.to raise_error(Clamp::UsageError)
-    end
-
     it 'requests grid details from master' do
       expect(client).to receive(:get).with("grids/test-grid").and_return('trusted_subnets' => [
           '192.168.0.1/24',
       ])
-      expect{subject.run(['test-grid'])}.to output("192.168.0.1/24\n").to_stdout
+      expect{subject.run([])}.to output("192.168.0.1/24\n").to_stdout
+    end
+
+    it 'supports the --grid option' do
+      allow(subject).to receive(:current_grid).and_call_original
+      expect(client).to receive(:get).with("grids/ingrid").and_return('trusted_subnets' => [
+          '192.168.0.1/24',
+      ])
+      expect{subject.run(['--grid', 'ingrid'])}.to output("192.168.0.1/24\n").to_stdout
     end
   end
 end

--- a/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/trusted_subnets/remove_command_spec.rb
@@ -4,24 +4,40 @@ require "kontena/cli/grids/trusted_subnets/remove_command"
 describe Kontena::Cli::Grids::TrustedSubnets::RemoveCommand do
 
   include ClientHelpers
+  include RequirementsHelper
+
+  expect_to_require_current_master
 
   describe '#execute' do
-    it 'requires grid as param' do
+    it 'requires subnet as param' do
       expect {
         subject.run([])
       }.to raise_error(Clamp::UsageError)
     end
 
     it 'removes subnet from grid' do
-      allow(client).to receive(:get).with("grids/my-grid").and_return(
+      allow(client).to receive(:get).with("grids/test-grid").and_return(
         'trusted_subnets' => ['192.168.12.0/24', '192.168.50.0/24']
       )
       expect(client).to receive(:put).with(
-        'grids/my-grid', hash_including({trusted_subnets: [
+        'grids/test-grid', hash_including({trusted_subnets: [
           '192.168.12.0/24'
         ]})
       )
-      subject.run(['--force', 'my-grid', '192.168.50.0/24'])
+      subject.run(['--force', '192.168.50.0/24'])
+    end
+
+    it 'supports the --grid option' do
+      allow(subject).to receive(:current_grid).and_call_original
+      allow(client).to receive(:get).with("grids/ingrid").and_return(
+        'trusted_subnets' => ['192.168.12.0/24', '192.168.50.0/24']
+      )
+      expect(client).to receive(:put).with(
+        'grids/ingrid', hash_including({trusted_subnets: [
+          '192.168.12.0/24'
+        ]})
+      )
+      subject.run(['--force', '--grid', 'ingrid', '192.168.50.0/24'])
     end
   end
 end


### PR DESCRIPTION
Replaces #1148

The `kontena grid trusted-subnet [add|remove|ls]` commands were expecting the grid name as the first parameter.

Also the `kontena grid trusted-subnet ls` command currently requires the grid name as a parameter but doesn't use it for anything and uses the `current_grid` instead.

The user is probably already using a grid and has a working `current_grid` when running these commands. 

The only commands to require a grid name as param should be `kontena grid [create|show|use|remove]`

This PR makes the subcommands use the "standard" `include Kontena::Cli::GridOptions` way of using `current_grid` / `--grid` / `KONTENA_GRID`.

If a user has written some scripts that utilize any of these  subcommands, after this PR they will simply fail due to `ERROR: too many arguments` and not corrupt any data until the extra grid parameter is removed from said scripts.
