### PR TITLE
Stack stop and restart commands

### DIFF
--- a/cli/lib/kontena/cli/stack_command.rb
+++ b/cli/lib/kontena/cli/stack_command.rb
@@ -11,6 +11,8 @@ class Kontena::Cli::StackCommand < Kontena::Command
   subcommand "build", "Build images listed in a stack file and push them to an image registry", load_subcommand('stacks/build_command')
   subcommand ["reg", "registry"], "Stack registry related commands", load_subcommand('stacks/registry_command')
   subcommand "validate", "Process and validate a stack file", load_subcommand('stacks/validate_command')
+  subcommand "stop", "Stop stacks services", load_subcommand('stacks/stop_command')
+  subcommand "restart", "Restart stacks services", load_subcommand('stacks/restart_command')
 
   def execute
   end

--- a/cli/lib/kontena/cli/stacks/restart_command.rb
+++ b/cli/lib/kontena/cli/stacks/restart_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Stacks
     requires_current_master_token
 
     def execute
-      spinner "Sending stop signal for stack services" do
+      spinner "Sending restart signal for stack services" do
         client.post("stacks/#{current_grid}/#{name}/restart", {})
       end
     end

--- a/cli/lib/kontena/cli/stacks/restart_command.rb
+++ b/cli/lib/kontena/cli/stacks/restart_command.rb
@@ -1,0 +1,23 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class RestartCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    banner "Restarts all services of a stack that has been installed in a grid on Kontena Master"
+
+    parameter "NAME", "Stack name"
+
+    requires_current_master
+    requires_current_master_token
+
+    def execute
+      spinner "Sending stop signal for stack services" do
+        client.post("stacks/#{current_grid}/#{name}/restart", {})
+      end
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/stacks/stop_command.rb
+++ b/cli/lib/kontena/cli/stacks/stop_command.rb
@@ -1,0 +1,23 @@
+require_relative 'common'
+
+module Kontena::Cli::Stacks
+  class StopCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Common
+
+    banner "Stops all services of a stack that has been installed in a grid on Kontena Master"
+
+    parameter "NAME", "Stack name"
+
+    requires_current_master
+    requires_current_master_token
+
+    def execute
+      spinner "Sending stop signal for stack services" do
+        client.post("stacks/#{current_grid}/#{name}/stop", {})
+      end
+    end
+
+  end
+end

--- a/cli/spec/kontena/cli/stacks/restart_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/restart_command_spec.rb
@@ -1,0 +1,16 @@
+require "kontena/cli/stacks/restart_command"
+
+describe Kontena::Cli::Stacks::RestartCommand do
+  include ClientHelpers
+  include RequirementsHelper
+
+  expect_to_require_current_master
+  expect_to_require_current_master_token
+
+  describe '#execute' do
+    it 'sends stop request to server' do
+      expect(client).to receive(:post).with('stacks/test-grid/foo/restart', {})
+      subject.run(['foo'])
+    end
+  end
+end

--- a/cli/spec/kontena/cli/stacks/stop_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/stop_command_spec.rb
@@ -1,0 +1,16 @@
+require "kontena/cli/stacks/stop_command"
+
+describe Kontena::Cli::Stacks::StopCommand do
+  include ClientHelpers
+  include RequirementsHelper
+
+  expect_to_require_current_master
+  expect_to_require_current_master_token
+
+  describe '#execute' do
+    it 'sends stop request to server' do
+      expect(client).to receive(:post).with('stacks/test-grid/foo/stop', {})
+      subject.run(['foo'])
+    end
+  end
+end

--- a/server/app/mutations/stacks/restart.rb
+++ b/server/app/mutations/stacks/restart.rb
@@ -1,0 +1,14 @@
+module Stacks
+  class Restart < Mutations::Command
+
+    required do
+      model :stack, class: Stack
+    end
+
+    def execute
+      self.stack.grid_services.each do |service|
+        GridServices::Restart.run(grid_service: service)
+      end
+    end
+  end
+end

--- a/server/app/mutations/stacks/restart.rb
+++ b/server/app/mutations/stacks/restart.rb
@@ -7,7 +7,10 @@ module Stacks
 
     def execute
       self.stack.grid_services.each do |service|
-        GridServices::Restart.run(grid_service: service)
+        outcome = GridServices::Restart.run(grid_service: service)
+        unless outcome.success?
+          add_error(service.to_path, :stop_failed, outcome.errors.message)
+        end
       end
     end
   end

--- a/server/app/mutations/stacks/restart.rb
+++ b/server/app/mutations/stacks/restart.rb
@@ -1,5 +1,6 @@
 module Stacks
   class Restart < Mutations::Command
+    include Common
 
     required do
       model :stack, class: Stack
@@ -9,7 +10,7 @@ module Stacks
       self.stack.grid_services.each do |service|
         outcome = GridServices::Restart.run(grid_service: service)
         unless outcome.success?
-          add_error(service.to_path, :stop_failed, outcome.errors.message)
+          handle_service_outcome_errors(service.name, outcome.errors)
         end
       end
     end

--- a/server/app/mutations/stacks/stop.rb
+++ b/server/app/mutations/stacks/stop.rb
@@ -9,7 +9,7 @@ module Stacks
       self.stack.grid_services.each do |service|
         outcome = GridServices::Stop.run(grid_service: service)
         unless outcome.success?
-          add_error(service.to_path, :stop_failed, outcome.errors.message)
+          handle_service_outcome_errors(service.name, outcome.errors)
         end
       end
     end

--- a/server/app/mutations/stacks/stop.rb
+++ b/server/app/mutations/stacks/stop.rb
@@ -7,7 +7,10 @@ module Stacks
 
     def execute
       self.stack.grid_services.each do |service|
-        GridServices::Stop.run(grid_service: service)
+        outcome = GridServices::Stop.run(grid_service: service)
+        unless outcome.success?
+          add_error(service.to_path, :stop_failed, outcome.errors.message)
+        end
       end
     end
   end

--- a/server/app/mutations/stacks/stop.rb
+++ b/server/app/mutations/stacks/stop.rb
@@ -1,0 +1,14 @@
+module Stacks
+  class Stop < Mutations::Command
+
+    required do
+      model :stack, class: Stack
+    end
+
+    def execute
+      self.stack.grid_services.each do |service|
+        GridServices::Stop.run(grid_service: service)
+      end
+    end
+  end
+end

--- a/server/app/mutations/stacks/stop.rb
+++ b/server/app/mutations/stacks/stop.rb
@@ -1,6 +1,7 @@
 module Stacks
   class Stop < Mutations::Command
-
+    include Common
+    
     required do
       model :stack, class: Stack
     end

--- a/server/app/routes/v1/stacks_api.rb
+++ b/server/app/routes/v1/stacks_api.rb
@@ -65,11 +65,9 @@ module V1
       # @param [Stack] stack
       def stop_stack(stack)
         outcome = Stacks::Stop.run(stack: stack)
-
         if outcome.success?
           audit_event(request, @grid, @stack, 'stop')
           response.status = 200
-          @stack_deploy = outcome.result
           {}
         else
           response.status = 422

--- a/server/app/routes/v1/stacks_api.rb
+++ b/server/app/routes/v1/stacks_api.rb
@@ -82,7 +82,6 @@ module V1
         if outcome.success?
           audit_event(request, @grid, @stack, 'restart')
           response.status = 200
-          @stack_deploy = outcome.result
           {}
         else
           response.status = 422

--- a/server/app/routes/v1/stacks_api.rb
+++ b/server/app/routes/v1/stacks_api.rb
@@ -62,6 +62,36 @@ module V1
         end
       end
 
+      # @param [Stack] stack
+      def stop_stack(stack)
+        outcome = Stacks::Stop.run(stack: stack)
+
+        if outcome.success?
+          audit_event(request, @grid, @stack, 'stop')
+          response.status = 200
+          @stack_deploy = outcome.result
+          {}
+        else
+          response.status = 422
+          {error: outcome.errors.message}
+        end
+      end
+
+      # @param [Stack] stack
+      def restart_stack(stack)
+        outcome = Stacks::Restart.run(stack: stack)
+
+        if outcome.success?
+          audit_event(request, @grid, @stack, 'restart')
+          response.status = 200
+          @stack_deploy = outcome.result
+          {}
+        else
+          response.status = 422
+          {error: outcome.errors.message}
+        end
+      end
+
       # /v1/stacks/:grid/
       r.on ':grid/:name' do |grid, name|
 
@@ -72,8 +102,16 @@ module V1
         end
 
         r.post do
-          r.on ':deploy' do
+          r.on 'deploy' do
             deploy_stack(@stack)
+          end
+
+          r.on 'stop' do
+            stop_stack(@stack)
+          end
+
+          r.on 'restart' do
+            restart_stack(@stack)
           end
         end
 

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -648,6 +648,34 @@ Deploy a stack. Returns a stack deploy object that can be used for deploy tracki
 
 `POST /v1/stacks/{stack_id}/deploy`
 
+## Stop all stack services
+
+```http
+POST /v1/stacks/my-grid/redis/stop HTTP/1.1
+Authorization: bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Accept: application/json
+```
+
+Stops all services in the stack.
+
+### Endpoint
+
+`POST /v1/stacks/{stack_id}/stop`
+
+## Restart all stack services
+
+```http
+POST /v1/stacks/my-grid/redis/restart HTTP/1.1
+Authorization: bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Accept: application/json
+```
+
+Restart all services in the stack.
+
+### Endpoint
+
+`POST /v1/stacks/{stack_id}/restart`
+
 ## Delete a stack
 
 ```http

--- a/server/spec/api/v1/stacks_spec.rb
+++ b/server/spec/api/v1/stacks_spec.rb
@@ -202,4 +202,40 @@ describe '/v1/stacks', celluloid: true do
       expect(response.status).to eq(404)
     end
   end
+
+  describe 'POST /:id/stop' do
+    it 'returns 200 when stop successful' do
+      expect(GridServices::Stop).to receive(:run).twice.and_return(double({:success? => true}))
+      expect {
+        post "/v1/stacks/#{stack.to_path}/stop", nil, request_headers
+        expect(response.status).to eq(200)
+      }.to change{AuditLog.count}.by(1)
+    end
+    it 'returns 422 when stop fails' do
+      expect(GridServices::Stop).to receive(:run).twice.and_return(
+        double({:success? => false, :errors => double({:message => 'error'})}))
+      expect {
+        post "/v1/stacks/#{stack.to_path}/stop", nil, request_headers
+        expect(response.status).to eq(422)
+      }.to change{AuditLog.count}.by(0)
+    end
+  end
+  
+  describe 'POST /:id/restart' do
+    it 'returns 200 when restart successful' do
+      expect(GridServices::Restart).to receive(:run).twice.and_return(double({:success? => true}))
+      expect {
+        post "/v1/stacks/#{stack.to_path}/restart", nil, request_headers
+        expect(response.status).to eq(200)
+      }.to change{AuditLog.count}.by(1)
+    end
+    it 'returns 422 when restart fails' do
+      expect(GridServices::Restart).to receive(:run).twice.and_return(
+        double({:success? => false, :errors => double({:message => 'error'})}))
+      expect {
+        post "/v1/stacks/#{stack.to_path}/restart", nil, request_headers
+        expect(response.status).to eq(422)
+      }.to change{AuditLog.count}.by(0)
+    end
+  end
 end

--- a/server/spec/api/v1/stacks_spec.rb
+++ b/server/spec/api/v1/stacks_spec.rb
@@ -205,15 +205,15 @@ describe '/v1/stacks', celluloid: true do
 
   describe 'POST /:id/stop' do
     it 'returns 200 when stop successful' do
-      expect(GridServices::Stop).to receive(:run).twice.and_return(double({:success? => true}))
+      expect(Stacks::Stop).to receive(:run).once.and_return(double({:success? => true}))
       expect {
         post "/v1/stacks/#{stack.to_path}/stop", nil, request_headers
         expect(response.status).to eq(200)
       }.to change{AuditLog.count}.by(1)
     end
     it 'returns 422 when stop fails' do
-      expect(GridServices::Stop).to receive(:run).twice.and_return(
-        double({:success? => false, :errors => double({:message => 'error'})}))
+      expect(Stacks::Stop).to receive(:run).once.and_return(
+        double({:success? => false, :errors => double({:message => 'boom'})}))
       expect {
         post "/v1/stacks/#{stack.to_path}/stop", nil, request_headers
         expect(response.status).to eq(422)
@@ -223,14 +223,14 @@ describe '/v1/stacks', celluloid: true do
   
   describe 'POST /:id/restart' do
     it 'returns 200 when restart successful' do
-      expect(GridServices::Restart).to receive(:run).twice.and_return(double({:success? => true}))
+      expect(Stacks::Restart).to receive(:run).once.and_return(double({:success? => true}))
       expect {
         post "/v1/stacks/#{stack.to_path}/restart", nil, request_headers
         expect(response.status).to eq(200)
       }.to change{AuditLog.count}.by(1)
     end
     it 'returns 422 when restart fails' do
-      expect(GridServices::Restart).to receive(:run).twice.and_return(
+      expect(Stacks::Restart).to receive(:run).once.and_return(
         double({:success? => false, :errors => double({:message => 'error'})}))
       expect {
         post "/v1/stacks/#{stack.to_path}/restart", nil, request_headers

--- a/server/spec/mutations/stacks/restart_spec.rb
+++ b/server/spec/mutations/stacks/restart_spec.rb
@@ -1,0 +1,24 @@
+describe Stacks::Restart do
+  let(:grid) { Grid.create!(name: 'test-grid') }
+
+  let(:stack) {
+    Stacks::Create.run(
+      grid: grid,
+      name: 'stack',
+      stack: 'foo/bar',
+      version: '0.1.0',
+      registry: 'file://',
+      source: '...',
+      services: [{name: 'redis', image: 'redis:2.8', stateful: true }, {name: 'redis2', image: 'redis:2.8', stateful: true }]
+    ).result
+  }
+
+  describe '#run' do
+    it 'stops all services in stack' do
+      expect(GridServices::Restart).to receive(:run).twice
+
+      described_class.run(stack: stack)
+    end
+  end
+
+end

--- a/server/spec/mutations/stacks/restart_spec.rb
+++ b/server/spec/mutations/stacks/restart_spec.rb
@@ -15,7 +15,7 @@ describe Stacks::Restart do
 
   describe '#run' do
     it 'stops all services in stack' do
-      expect(GridServices::Restart).to receive(:run).twice
+      expect(GridServices::Restart).to receive(:run).twice.and_return(double({:success? => true}))
 
       described_class.run(stack: stack)
     end

--- a/server/spec/mutations/stacks/stop_spec.rb
+++ b/server/spec/mutations/stacks/stop_spec.rb
@@ -15,7 +15,7 @@ describe Stacks::Stop do
 
   describe '#run' do
     it 'stops all services in stack' do
-      expect(GridServices::Stop).to receive(:run).twice
+      expect(GridServices::Stop).to receive(:run).twice.and_return(double({:success? => true}))
 
       described_class.run(stack: stack)
     end

--- a/server/spec/mutations/stacks/stop_spec.rb
+++ b/server/spec/mutations/stacks/stop_spec.rb
@@ -1,0 +1,24 @@
+describe Stacks::Stop do
+  let(:grid) { Grid.create!(name: 'test-grid') }
+
+  let(:stack) {
+    Stacks::Create.run(
+      grid: grid,
+      name: 'stack',
+      stack: 'foo/bar',
+      version: '0.1.0',
+      registry: 'file://',
+      source: '...',
+      services: [{name: 'redis', image: 'redis:2.8', stateful: true }, {name: 'redis2', image: 'redis:2.8', stateful: true }]
+    ).result
+  }
+
+  describe '#run' do
+    it 'stops all services in stack' do
+      expect(GridServices::Stop).to receive(:run).twice
+
+      described_class.run(stack: stack)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds `stop` and `restart` commands for stacks.

fixes #1899 and #1707 

This does now create bit inconsistency as `kontena stack start` command is actually an alias for `deploy`

## TODO

API docs