### PR TITLE
Fix agent env validation abort, defaults

### DIFF
--- a/agent/bin/kontena-agent
+++ b/agent/bin/kontena-agent
@@ -13,10 +13,10 @@ api_token = ENV['KONTENA_TOKEN']
 api_uri = ENV['KONTENA_URI'] || 'ws://api.kontena.io'
 
 if !api_token
-  exit('KONTENA_TOKEN is required')
+  abort('Configuration error: The KONTENA_TOKEN env is required')
 end
 if !api_uri
-  exit('KONTENA_URI is required')
+  abort('Configuration error: The KONTENA_URI env is required')
 end
 if api_uri.match(/^http.*/)
   api_uri = api_uri.sub('http', 'ws')

--- a/agent/bin/kontena-agent
+++ b/agent/bin/kontena-agent
@@ -12,10 +12,10 @@ $0 = 'kontena-agent'
 api_token = ENV['KONTENA_TOKEN']
 api_uri = ENV['KONTENA_URI'] || 'ws://api.kontena.io'
 
-if !api_token
+if api_token.nil? || api_token.empty?
   abort('Configuration error: The KONTENA_TOKEN env is required')
 end
-if !api_uri
+if api_uri.nil? || api_uri.empty?
   abort('Configuration error: The KONTENA_URI env is required')
 end
 if api_uri.match(/^http.*/)

--- a/agent/bin/kontena-agent
+++ b/agent/bin/kontena-agent
@@ -10,7 +10,7 @@ $stdout.sync = true
 $0 = 'kontena-agent'
 
 api_token = ENV['KONTENA_TOKEN']
-api_uri = ENV['KONTENA_URI'] || 'ws://api.kontena.io'
+api_uri = ENV['KONTENA_URI']
 
 if api_token.nil? || api_token.empty?
   abort('Configuration error: The KONTENA_TOKEN env is required')


### PR DESCRIPTION
Fixes #2300: The the `kontena-agent` validation of the `KONTENA_TOKEN` and `KONTENA_URI` envs is broken.

Fixes  #2303: The agent also used an implicit `KONTENA_URI=ws://api.kontena.io` default. I have no idea why. That domain does not even resolve?

### Before

```
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock share_agent
/app/bin/kontena-agent:16:in `exit': no implicit conversion of String into Integer (TypeError)
	from /app/bin/kontena-agent:16:in `<main>'
```

```
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e KONTENA_TOKEN= share_agent
I, [2017-05-11T07:05:22.020956 #1]  INFO -- Kontena::Agent: initializing agent (version 1.2.2.dev)
I, [2017-05-11T07:05:22.027609 #1]  INFO -- Kontena::WebsocketClient: initialized with token ...
```

```
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e KONTENA_TOKEN=asdf share_agent
I, [2017-05-11T07:06:28.324155 #1]  INFO -- Kontena::Agent: initializing agent (version 1.2.2.dev)
...
I, [2017-05-11T07:06:28.329320 #1]  INFO -- Kontena::WebsocketClient: initialized with token asdf...
...
I, [2017-05-11T07:06:29.541692 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://api.kontena.io
E, [2017-05-11T07:06:34.698611 #1] ERROR -- Kontena::WebsocketClient: connection error: Network error: ws://api.kontena.io: unable to resolve address: Name does not resolve
```

### After
```
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock share_agent
Configuration error: The KONTENA_TOKEN env is required
```
```
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e KONTENA_TOKEN= share_agent
Configuration error: The KONTENA_TOKEN env is required
```
```
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e KONTENA_TOKEN=asdf share_agent
Configuration error: The KONTENA_URI env is required
```
```
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e KONTENA_TOKEN=asdf -e KONTENA_URI= share_agent
Configuration error: The KONTENA_URI env is required
```
