### PR TITLE
Remove broken/dead code for cli ssh command parameter handling 

### DIFF
--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -20,9 +20,6 @@ module Kontena::Cli::Master
     end
 
     def execute
-
-      commands_list.insert('--') unless commands_list.empty?
-
       if master_provider == 'vagrant'
         unless Kontena::PluginManager.instance.plugins.find { |plugin| plugin.name == 'kontena-plugin-vagrant' }
           exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'
@@ -40,4 +37,3 @@ module Kontena::Cli::Master
     end
   end
 end
-

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -28,8 +28,6 @@ module Kontena::Cli::Nodes
 
       provider = Array(node["labels"]).find{ |l| l.start_with?('provider=')}.to_s.split('=').last
 
-      commands_list.insert('--') unless commands_list.empty?
-
       if provider == 'vagrant'
         unless Kontena::PluginManager.instance.plugins.find { |plugin| plugin.name == 'kontena-plugin-vagrant' }
           exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'

--- a/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
@@ -1,0 +1,38 @@
+require 'kontena/cli/nodes/ssh_command'
+
+describe Kontena::Cli::Nodes::SshCommand do
+  include ClientHelpers
+
+  let :node do
+    {
+      'labels' => [],
+      'public_ip' => '192.0.2.10',
+      'private_ip' => '10.0.8.10',
+      'overlay_ip' => '10.81.0.1',
+    }
+  end
+
+  before do
+    allow(client).to receive(:get).with('nodes/test-grid/test-node').and_return(node)
+  end
+
+  it "uses the public IP by default" do
+    expect(subject).to receive(:exec).with('ssh', 'core@192.0.2.10')
+    subject.run ['test-node']
+  end
+
+  it "uses the private IP" do
+    expect(subject).to receive(:exec).with('ssh', 'core@10.0.8.10')
+    subject.run ['--private-ip', 'test-node']
+  end
+
+  it "uses the overlay IP" do
+    expect(subject).to receive(:exec).with('ssh', 'core@10.81.0.1')
+    subject.run ['--internal-ip', 'test-node']
+  end
+
+  it "passes through the command to SSH" do
+    expect(subject).to receive(:exec).with('ssh', 'core@192.0.2.10', 'ls', '-l')
+    subject.run ['test-node', 'ls', '-l']
+  end
+end

--- a/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
@@ -35,4 +35,9 @@ describe Kontena::Cli::Nodes::SshCommand do
     expect(subject).to receive(:exec).with('ssh', 'core@192.0.2.10', 'ls', '-l')
     subject.run ['test-node', 'ls', '-l']
   end
+
+  it "passes through arguments to SSH" do
+    expect(subject).to receive(:exec).with('ssh', 'core@192.0.2.10', '-F', 'ssh/config' 'ls', '-l')
+    subject.run ['test-node', '-F', 'ssh/config' 'ls', '-l']
+  end
 end


### PR DESCRIPTION
Fixes #1972

The CLI `kontena node ssh` and `kontena master ssh` commands contain code that is intended to prevent SSH from interpreting the parameters given:

```ruby
      commands_list.insert('--') unless commands_list.empty?
```

However, the call to `Array#insert` with a single parameter is broken, and does nothing:

```ruby
irb(main):004:0> l = ['foo']
=> ["foo"]
irb(main):005:0> l.insert('--')
=> ["foo"]
irb(main):006:0> l
=> ["foo"]
```

Removing this as dead code, since in terms of #1972 passing through the parameters to SSH without `--` is a feature.

Also adds some basic specs for `kontena node ssh`.