### PR TITLE
Add spec for kontena registry create with existing registry service

### DIFF
--- a/cli/spec/kontena/cli/registry/create_spec.rb
+++ b/cli/spec/kontena/cli/registry/create_spec.rb
@@ -1,0 +1,22 @@
+require 'kontena/cli/registry/create_command'
+
+describe Kontena::Cli::Registry::CreateCommand do
+  include ClientHelpers
+  include OutputHelpers
+
+  context "with an existing legacy registry service" do
+    let :service do
+      {
+        'name' => 'registry',
+      }
+    end
+
+    before do
+      allow(client).to receive(:get).with('services/test-grid/registry').and_return(service)
+    end
+
+    it "does not create the registry" do
+      expect{subject.run []}.to exit_with_error.and output(/Registry already exists/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1724

I was going to fix this check to use `stacks/#{current_grid}/registry`, but I realized that this check for `services/#{current_grid}/registry` actually serves to prevent `kontena registry create` from creating a new `registry` stack if an existing pre-1.0 `registry` service already exists. AFAIK the server will not validate exposed stack vs service names, so the two would end up colliding via the same `registry.kontena.local` name.

So this PR is just a spec now.