### PR TITLE
Validate service envs on server, simplify syntax for parsing/validation

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -43,7 +43,7 @@ module Kontena::Cli::Stacks::YAML
               )
             end
           elsif value.is_a?(Array)
-            value.all? { |v| v.kind_of?(String) && v =~ /\A\S+=/ }
+            value.all? { |v| v.kind_of?(String) && v =~ /\A[^=]+=/ }
           else
             false
           end

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -43,7 +43,7 @@ module Kontena::Cli::Stacks::YAML
               )
             end
           elsif value.is_a?(Array)
-            value.all? { |v| v.kind_of?(String) && v =~ /^.+=.*/ }
+            value.all? { |v| v.kind_of?(String) && v =~ /^([^=]+)=(.*)/ }
           else
             false
           end

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -43,7 +43,7 @@ module Kontena::Cli::Stacks::YAML
               )
             end
           elsif value.is_a?(Array)
-            value.all? { |v| v.kind_of?(String) && v =~ /^([^=]+)=(.*)/ }
+            value.all? { |v| v.kind_of?(String) && v =~ /\A\S+=/ }
           else
             false
           end

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -43,7 +43,7 @@ module Kontena::Cli::Stacks::YAML
               )
             end
           elsif value.is_a?(Array)
-            value.all? { |v| v.kind_of?(String) && v =~ /\A\S+(?<!\\)=.*/ }
+            value.all? { |v| v.kind_of?(String) && v =~ /^.+=.*/ }
           else
             false
           end

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -117,6 +117,8 @@ describe Kontena::Cli::Stacks::YAML::ValidatorV3 do
       expect(result.errors.key?('environment')).to be_truthy
       result = subject.validate_options('environment' => ['=VALUE'])
       expect(result.errors.key?('environment')).to be_truthy
+      result = subject.validate_options('environment' => ['=VALUE=VALUE2'])
+      expect(result.errors.key?('environment')).to be_truthy
     end
 
     it 'passes validation if environment array includes items with booleans or nils' do

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -108,16 +108,27 @@ describe Kontena::Cli::Stacks::YAML::ValidatorV3 do
       expect(result.errors.key?('environment')).to be_falsey
       result = subject.validate_options('environment' => { 'KEY' => 'VALUE' })
       expect(result.errors.key?('environment')).to be_falsey
+      result = subject.validate_options('environment' => ['KEY=VALUE', 'KEY2=VALUE2', 'KEY3='])
+      expect(result.errors.key?('environment')).to be_falsey
     end
 
     it 'fails validation if environment array includes items without equals sign' do
-      result = subject.validate_options('environment' => ['KEY=VALUE', 'KEY2=VALUE2', 'KEY3='])
-      expect(result.errors.key?('environment')).to be_falsey
       result = subject.validate_options('environment' => ['KEY=VALUE', 'KEY2 VALUE'])
       expect(result.errors.key?('environment')).to be_truthy
+    end
+
+    it "fails validation if environment has invalid key prefix" do
       result = subject.validate_options('environment' => ['=VALUE'])
       expect(result.errors.key?('environment')).to be_truthy
+    end
+
+    it "fails validation if environemnt has invalid key prefix with valud key prefix in value" do
       result = subject.validate_options('environment' => ['=VALUE=VALUE2'])
+      expect(result.errors.key?('environment')).to be_truthy
+    end
+
+    it "fails validation if environment contains invalid key prefix with valid key prefix in multi-line value" do
+      result = subject.validate_options('environment' => ['=ASDF\nKEY=VALUE'])
       expect(result.errors.key?('environment')).to be_truthy
     end
 

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -111,9 +111,11 @@ describe Kontena::Cli::Stacks::YAML::ValidatorV3 do
     end
 
     it 'fails validation if environment array includes items without equals sign' do
-      result = subject.validate_options('environment' => ['KEY=VALUE', 'KEY2=VALUE2'])
+      result = subject.validate_options('environment' => ['KEY=VALUE', 'KEY2=VALUE2', 'KEY3='])
       expect(result.errors.key?('environment')).to be_falsey
       result = subject.validate_options('environment' => ['KEY=VALUE', 'KEY2 VALUE'])
+      expect(result.errors.key?('environment')).to be_truthy
+      result = subject.validate_options('environment' => ['=VALUE'])
       expect(result.errors.key?('environment')).to be_truthy
     end
 

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -137,6 +137,11 @@ describe Kontena::Cli::Stacks::YAML::ValidatorV3 do
       expect(result.errors.key?('environment')).to be_falsey
     end
 
+    it 'passes validation if environment array includes items with multi-line values' do
+      result = subject.validate_options('environment' => [ "KEY=foo\nbar" ])
+      expect(result.errors.key?('environment')).to be_falsey
+    end
+
     context 'validates secrets' do
       it 'must be array' do
         result = subject.validate_options('secrets' => {})

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -191,7 +191,7 @@ class GridService
   # @return [Hash]
   def env_hash
     if @env_hash.nil?
-      @env_hash = Hash[Array(self.env).map { |kv_pair| kv_pair.split(/(?<!\\)=/, 2) }]
+      @env_hash = Hash[Array(self.env).map { |kv_pair| kv_pair.split('=', 2) }]
     end
 
     @env_hash

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -172,7 +172,7 @@ module GridServices
           end
           string :entrypoint
           array :env do
-            string matches: /\A\S+=/
+            string matches: /\A[^=]+=/
           end
           array :secrets do
             hash do

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -172,7 +172,7 @@ module GridServices
           end
           string :entrypoint
           array :env do
-            string matches: /^([^=]+)=(.*)/
+            string matches: /\A\S+=/
           end
           array :secrets do
             hash do

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -172,7 +172,7 @@ module GridServices
           end
           string :entrypoint
           array :env do
-            string
+            string matches: /^([^=]+)=(.*)/
           end
           array :secrets do
             hash do

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -310,16 +310,16 @@ describe GridService do
       expect(subject).to receive(:env).and_return(
         [
           'FOO=bar',
+          'FOO=BAR=bar',
           'BAR=',
-          'BAZ\=BUZ=foo',
           'DOG'
         ]
       )
       expect(subject.env_hash).to eq(
         {
           'FOO' => 'bar',
+          'FOO' => 'BAR=bar',
           'BAR' => '',
-          'BAZ\=BUZ' => 'foo',
           'DOG' => nil
         }
       )

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -368,6 +368,20 @@ describe GridServices::Create do
       expect(outcome.success?).to be(true)
     end
 
+    it 'validates env syntax' do
+      outcome = described_class.new(
+        grid: grid,
+        name: 'redis',
+        image: 'redis:2.8',
+        stateful: false,
+        env: [
+          'FOO',
+        ],
+      ).run
+      expect(outcome).to_not be_success
+      expect(outcome.errors.message).to eq 'env' => [ "Env[0] isn't in the right format" ]
+    end
+
     context 'volumes' do
       let(:volume) do
         Volume.create!(grid: grid, name: 'foo', scope: 'node')

--- a/server/spec/mutations/stacks/create_spec.rb
+++ b/server/spec/mutations/stacks/create_spec.rb
@@ -300,6 +300,29 @@ describe Stacks::Create do
       expect(outcome.errors.message).to eq 'services' => { 'foo' => {'name' => "Create failed"}, 'bar' => { 'links' => "Service soome-stack/foo does not exist"}}
     end
 
+    pending 'reports service error array outcomes' do
+      services = [
+        {grid: grid, name: 'redis', image: 'redis:2.8', stateful: true,
+          env: [
+            'FOO',
+          ],
+        }
+      ]
+      expect {
+        outcome = described_class.new(
+          grid: grid,
+          name: 'redis',
+          stack: 'foo/bar',
+          version: '0.1.0',
+          registry: 'file://',
+          source: '...',
+          services: services
+        ).run
+        expect(outcome).to_not be_success
+        expect(outcome.errors.message).to eq 'services' => { 'redis' => {'env' => [ "Env[0] isn't in the right format" ]}}
+      }.to_not change{ grid.stacks.count }
+    end
+
     context 'volumes' do
       it 'creates stack with external volumes with name' do
         volume = Volume.create(name: 'someVolume', grid: grid, scope: 'node')


### PR DESCRIPTION
The regexps used to parse/validate service environment variables in #2241 included support for escapes like `FOO\=BAR=bar`, having kontena parse them as `{'FOO\\=BAR' => 'bar'}`. However, I don't think this kind of syntax to escape `=` chars in environment variable names makes a whole lot of sense, because I doubt that other applications are going to parse them the same way?

Remove support for special handling of such escapes, restoring the previous `split('=', 2)` implementation, because any attempt to use them is unlikely to end behave in any sane way. So far, I've only sen ruby interpret `ENV['FOO\\=BAR']`.

This PR also uses the same regexp to validate the service envs on the server side. However, the validation failures will result in HTTP 500 errors for the stacks mutations, pending improved support for handling complex error outcomes in #2058.

#### `kontena.yml`
```yaml
services:
  foo:
    environment:
      - FOO\=BAR=QUUX
```

#### `docker inspect`
```
[
    {
        "Config": {
            "Env": [
                "FOO\\=BAR=QUUX",
            ],
        },
    }
]
```

### `bash`
```
$ echo "${FOO\\}"
bash: ${FOO\\}: bad substitution
$ echo "${FOO\\=BAR}"
bash: ${FOO\\=BAR}: bad substitution
```

### `python`
```
>>> os.environ
{..., 'FOO\\': 'BAR=QUUX', ...}
>>> os.environ['FOO\\']
'BAR=QUUX'
>>> os.environ['FOO\\=BAR']
Traceback (most recent call last):
  ...
KeyError: 'FOO\\=BAR'
```

### `irb`
```
irb(main):001:0> ENV
=> {..., "FOO\"=>"BAR=QUUX", ...}
irb(main):002:0> ENV['FOO\\']
=> "BAR=QUUX"
irb(main):003:0> ENV['FOO\\=BAR']
=> "QUUX"
irb(main):011:0> ENV['FOO=BAR']  
=> nil
```