### PR TITLE
Make all "kontena XX list" commands accept -q (or --quiet) to only output the id column without header

### DIFF
--- a/cli/lib/kontena/cli/cloud/master/list_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/list_command.rb
@@ -2,6 +2,7 @@ module Kontena::Cli::Cloud::Master
   class ListCommand < Kontena::Command
 
     include Kontena::Cli::Common
+    include Kontena::Cli::TableGenerator::Helper
 
     callback_matcher 'cloud-master', 'list'
 
@@ -9,22 +10,24 @@ module Kontena::Cli::Cloud::Master
 
     requires_current_account_token
 
+    def fields
+      quiet? ? ['id'] : %w(id name owner url connected)
+    end
+
     def execute
-      response = cloud_client.get('user/masters')
+      response = spin_if(!quiet?, "Retrieving Master list from Kontena Cloud") do
+        cloud_client.get('user/masters')
+      end
+
       unless response && response.kind_of?(Hash) && response['data'].kind_of?(Array)
         abort "Listing masters failed".colorize(:red)
       end
 
-      if response['data'].empty?
-        return [] if self.return?
-        puts "No masters registered"
-      else
-        return response['data'] if self.return?
-        puts '%-26.26s %-24s %-12s %s' % ['ID', 'NAME', 'OWNER', 'URL']
-        response['data'].each do |data|
-          attr = data['attributes']
-          puts '%-26.26s %-24s %-12s %s' % [data['id'], attr['name'], attr['owner'], attr['url']]
-        end
+      return Array(response['data']) if self.return?
+
+      print_table(response['data']) do |row|
+        row.merge!(row['attributes'])
+        row['connected'] = !!row['connected'] ? pastel.green('yes') : pastel.red('no')
       end
     end
   end

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -13,6 +13,18 @@ module Kontena
     class Config < OpenStruct
       include Singleton
 
+      module Fields
+        def keys
+          @table.keys
+        end
+
+        def values_at(*fields)
+          (fields.first.is_a?(Array) ? fields.first : fields).map { |field| self[field] }
+        end
+      end
+
+      include Fields
+
       attr_accessor :logger
       attr_accessor :current_server
       attr_reader :current_account
@@ -468,6 +480,7 @@ module Kontena
       end
 
       class Account < OpenStruct
+        include Fields
         include TokenSerializer
         include ConfigurationInstance
 
@@ -484,6 +497,7 @@ module Kontena
       end
 
       class Server < OpenStruct
+        include Fields
         include TokenSerializer
         include ConfigurationInstance
 
@@ -494,6 +508,7 @@ module Kontena
       end
 
       class Token < OpenStruct
+        include Fields
         include ConfigurationInstance
 
         # Hash representation of token data

--- a/cli/lib/kontena/cli/external_registries/list_command.rb
+++ b/cli/lib/kontena/cli/external_registries/list_command.rb
@@ -1,5 +1,3 @@
-require 'tty-table'
-
 module Kontena::Cli::ExternalRegistries
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common

--- a/cli/lib/kontena/cli/external_registries/list_command.rb
+++ b/cli/lib/kontena/cli/external_registries/list_command.rb
@@ -1,17 +1,25 @@
+require 'tty-table'
+
 module Kontena::Cli::ExternalRegistries
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
+    include Kontena::Cli::TableGenerator::Helper
+
+    requires_current_master
+    requires_current_master_token
+    requires_current_grid
+
+    def fields
+      quiet? ? %(name) : %w(name username email)
+    end
+
+    def external_registries
+      client.get("grids/#{current_grid}/external_registries")['external_registries']
+    end
 
     def execute
-      require_api_url
-      require_current_grid
-      token = require_token
-      result = client(token).get("grids/#{current_grid}/external_registries")
-      puts "%-30s %-20s %-30s" % ['Name', 'Username', 'Email']
-      result['external_registries'].each { |r|
-        puts "%-30.30s %-20.20s %-30.30s" % [r['name'], r['username'], r['email']]
-      }
+      print_table(external_registries)
     end
   end
 end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
@@ -1,16 +1,18 @@
+require 'kontena/cli/grids/common'
+
 module Kontena::Cli::Grids::TrustedSubnets
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
+    include Kontena::Cli::Grids::Common
+
+    # the command outputs id info only anyway, this is here strictly for ignoring purposes
+    option ['-q', '--quiet'], :flag, "Output the identifying column only", hidden: true
 
     requires_current_master
 
     def execute
-      grid = client.get("grids/#{current_grid}")
-      trusted_subnets = grid['trusted_subnets'] || []
-      trusted_subnets.each do |subnet|
-        puts subnet
-      end
+      Array(get_grid['trusted_subnets']).map(&method(:puts))
     end
   end
 end

--- a/cli/lib/kontena/cli/grids/users/list_command.rb
+++ b/cli/lib/kontena/cli/grids/users/list_command.rb
@@ -4,15 +4,17 @@ module Kontena::Cli::Grids::Users
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::Grids::Common
+    include Kontena::Cli::TableGenerator::Helper
+    include Kontena::Cli::GridOptions
+
+    requires_current_master
+
+    def fields
+      quiet? ? %w(email) : %w(email name)
+    end
 
     def execute
-      require_api_url
-      token = require_token
-      result = client(token).get("grids/#{current_grid}/users")
-      puts "%-40s %-40s" % ['Email', 'Name']
-      result['users'].each { |user|
-        puts "%-40.40s %-40.40s" % [user['email'], user['name']]
-      }
+      print_table(client.get("grids/#{current_grid}/users")['users'])
     end
   end
 end

--- a/cli/lib/kontena/cli/master/list_command.rb
+++ b/cli/lib/kontena/cli/master/list_command.rb
@@ -1,18 +1,24 @@
 module Kontena::Cli::Master
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::TableGenerator::Helper
+
+    def fields
+      @fields ||= quiet? ? %w(name) : %w(name url)
+    end
+
+    def current_master_name
+      @current_master_name ||= current_master.nil? ? nil : current_master.name
+    end
+
+    def mark_if_current(row)
+      unless quiet?
+        row.name.insert(0, pastel.yellow('* ')) if row.name == current_master_name
+      end
+    end
 
     def execute
-      puts '%-24s %-30s' % ['Name', 'Url']
-      current_master = config.current_master
-      config.servers.each do |server|
-        if current_master && server['name'] == current_master.name
-          name = "* #{server['name']}"
-        else
-          name = server['name']
-        end
-        puts '%-24s %-30s' % [name, server['url']]
-      end
+      print_table(config.servers, fields, &method(:mark_if_current))
     end
   end
 end

--- a/cli/lib/kontena/cli/master/token/list_command.rb
+++ b/cli/lib/kontena/cli/master/token/list_command.rb
@@ -2,25 +2,36 @@ require_relative 'common'
 
 module Kontena::Cli::Master::Token
   class ListCommand < Kontena::Command
-
+    include Kontena::Util
     include Kontena::Cli::Common
+    include Kontena::Cli::TableGenerator::Helper
     include Common
 
     requires_current_master
     requires_current_master_token
 
+    def fields
+      return ['id'] if quiet?
+      { id: 'id', token_type: 'token_type', token_last4: 'access_token_last_four', expires_in: 'expires_in', scopes: 'scopes' }
+    end
+
     def execute
-      rows = []
-      puts "%-26s %-18s %-11s %-10s %-20s" % ["ID", "TOKEN_TYPE", "TOKEN_LAST4", "EXPIRES_IN", "SCOPES"]
-      client.get("/oauth2/tokens")["tokens"].each do |row_data|
-        data = token_data_to_hash(row_data)
-        puts "%-26s %-18s %-11s %-10s %-20s" % [
-          data[:id],
-          data[:token_type],
-          data[:access_token_last_four],
-          data[:expires_in],
-          data[:scopes]
-        ]
+      data = Array(client.get("/oauth2/tokens")["tokens"])
+      print_table(data) do |row|
+        next if quiet?
+        row['expires_in'] = colorize(row['expires_in'].to_i)
+        row['token_type'] ||= row['grant_type']
+      end
+    end
+
+    def colorize(expires_in)
+      return expires_in.to_s unless $stdout.tty?
+      if expires_in.zero?
+        pastel.yellow('never')
+      elsif expires_in < 0
+        pastel.red(time_ago(Time.now.to_i + expires_in))
+      else
+        pastel.green(time_until(expires_in))
       end
     end
   end

--- a/cli/lib/kontena/cli/master/user/list_command.rb
+++ b/cli/lib/kontena/cli/master/user/list_command.rb
@@ -3,15 +3,26 @@ require_relative '../../common'
 module Kontena::Cli::Master::User
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
+    include Kontena::Cli::TableGenerator::Helper
+
+    requires_current_master
+    requires_current_master_token
+
+    def fields
+      quiet? ? ['id'] : { email: 'email', roles: 'role_list' }
+    end
 
     def execute
-      require_api_url
-      token = require_token
-      response = client(token).get('users')
+      response = spin_if(!quiet? && $stdout.tty?, "Retrieving user list from Kontena Master") do
+        client.get('users')['users']
+      end
 
-      response['users'].each do |user|
-        roles = user['roles'].map{|r| r['name']}
-        puts "#{user['email']} - #{roles.join(', ')}"
+      print_table(response) do |row|
+        if row['roles'].empty?
+          row['role_list'] = ''
+        else
+          row['role_list'] = row['roles'].map { |r| r['name'] }.join(',')
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/nodes/labels/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/list_command.rb
@@ -4,6 +4,9 @@ module Kontena::Cli::Nodes::Labels
 
     parameter "NODE_ID", "Node id"
 
+    # the command outputs id info only anyway, this is here strictly for ignoring purposes
+    option ['-q', '--quiet'], :flag, "Output the identifying column only", hidden: true
+
     requires_current_master
     requires_current_master_token
     requires_current_grid

--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -5,57 +5,74 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::HealthHelper
+    include Kontena::Cli::TableGenerator::Helper
 
-    option ["--all"], :flag, "List nodes for all grids", default: false
+    option ['-a', '--all'], :flag, 'List nodes for all grids', default: false
+
+    requires_current_master
+    requires_current_master_token
+    requires_current_grid
+
+    def node_name(node, grid)
+      return node['name'] unless all?
+      "#{grid['name']}/#{node['name']}"
+    end
+
+    def node_status(node)
+      node['connected'] ? pastel.green('online') : pastel.red('offline')
+    end
 
     def node_initial(node, grid)
-      if node['initial_member']
-        return "#{node['node_number']} / #{grid['initial_size']}"
-      else
-        return "-"
-      end
+      return '-' unless node['initial_member']
+      "#{node['node_number']} / #{grid['initial_size']}"
     end
 
     def node_labels(node)
-      (node['labels'] || ['-']).join(",")
+      (node['labels'] || ['-']).join(',')
     end
 
-    def show_grid_nodes(grid, nodes, multi: false)
-      grid_health = grid_health(grid, nodes)
+    def fields
+      return ['name'] if quiet?
+      {
+        ' ' =>   'health_icon',
+        name:    'name',
+        version: 'agent_version',
+        status:  'status',
+        initial: 'initial',
+        labels:  'labels'
+      }
+    end
 
-      nodes = nodes.sort_by{|n| n['node_number'] }
-      nodes.each do |node|
-        puts [
-          "%s" % health_icon(node_health(node, grid_health)),
-          "%-70.70s" % [multi ? "#{grid['name']}/#{node['name']}" : node['name']],
-          "%-10s" % node['agent_version'],
-          "%-10s" % (node['connected'] ? "online" : "offline"),
-          "%-10s" % node_initial(node, grid),
-          "%s" % [node_labels(node)],
-        ].join ' '
+    def grids
+      all? ? client.get("grids")['grids'] : [client.get("grids/#{current_grid}")]
+    end
+
+    def node_data
+      grids.flat_map do |grid|
+        grid_nodes = []
+
+        client.get("grids/#{grid['id']}/nodes")['nodes'].each do |node|
+          node['name'] = node_name(node, grid)
+          next if quiet?
+          node['initial'] = node_initial(node, grid)
+          node['status'] = node_status(node)
+          node['labels'] = node_labels(node)
+          grid_nodes << node
+        end
+
+        unless quiet?
+          grid_health = grid_health(grid, grid_nodes)
+          grid_nodes.each do |node|
+            node['health_icon'] = health_icon(node_health(node, grid_health))
+          end
+        end
+
+        grid_nodes
       end
     end
 
     def execute
-      require_api_url
-      require_current_grid
-      token = require_token
-
-      puts "%s %-70s %-10s %-10s %-10s %-s" % [health_icon(nil), "Name", "Version", "Status", "Initial", "Labels"]
-
-      if all?
-        grids = client(token).get("grids")
-        grids['grids'].each do |grid|
-          nodes = client(require_token).get("grids/#{grid['id']}/nodes")['nodes']
-
-          show_grid_nodes(grid, nodes, multi: true)
-        end
-      else
-        grid = client(token).get("grids/#{current_grid}")
-        nodes = client(require_token).get("grids/#{current_grid}/nodes")['nodes']
-
-        show_grid_nodes(grid, nodes)
-      end
+      print_table(node_data)
     end
   end
 end

--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -47,17 +47,21 @@ module Kontena::Cli::Nodes
       all? ? client.get("grids")['grids'] : [client.get("grids/#{current_grid}")]
     end
 
+    def grid_nodes(grid_name)
+      client.get("grids/#{grid_name}/nodes")['nodes']
+    end
+
     def node_data
       grids.flat_map do |grid|
         grid_nodes = []
 
-        client.get("grids/#{grid['id']}/nodes")['nodes'].each do |node|
+        grid_nodes(grid['id']).each do |node|
           node['name'] = node_name(node, grid)
+          grid_nodes << node
           next if quiet?
           node['initial'] = node_initial(node, grid)
           node['status'] = node_status(node)
           node['labels'] = node_labels(node)
-          grid_nodes << node
         end
 
         unless quiet?
@@ -67,7 +71,7 @@ module Kontena::Cli::Nodes
           end
         end
 
-        grid_nodes
+        grid_nodes.sort { |n| n['node_number'] }
       end
     end
 

--- a/cli/lib/kontena/cli/plugins/list_command.rb
+++ b/cli/lib/kontena/cli/plugins/list_command.rb
@@ -2,14 +2,28 @@ require_relative 'common'
 
 module Kontena::Cli::Plugins
   class ListCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::TableGenerator::Helper
     include Common
 
-    def execute
-      titles = ['NAME', 'VERSION', 'DESCRIPTION']
-      puts "%-40s %-10s %-40s" % titles
-      Kontena::PluginManager.instance.plugins.each do |plugin|
-        puts "%-40s %-10s %-40s" % [short_name(plugin.name), plugin.version, plugin.description]
+    banner "List installed plugins"
+
+    def fields
+      quiet? ? [:name] : %i(name version description)
+    end
+
+    def plugins
+      Kontena::PluginManager.instance.plugins.map do |plugin|
+        {
+          name: short_name(plugin.name),
+          version: plugin.version,
+          description: plugin.description
+        }
       end
+    end
+
+    def execute
+      print_table(plugins)
     end
   end
 end

--- a/cli/lib/kontena/cli/services/containers_command.rb
+++ b/cli/lib/kontena/cli/services/containers_command.rb
@@ -7,12 +7,19 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
+    option ['-q', '--quiet'], :flag, "Output the identifying column only"
 
     def execute
       require_api_url
       token = require_token
 
       result = client(token).get("services/#{parse_service_id(name)}/containers")
+
+      if quiet?
+        puts result['containers'].map { |c| "#{c['node']['name']}/#{c['name']}" }.join("\n")
+        exit 0
+      end
+
       result['containers'].each do |container|
         puts "#{container['name']}:"
         puts "  rev: #{container['deploy_rev']}"

--- a/cli/lib/kontena/cli/services/envs/list_command.rb
+++ b/cli/lib/kontena/cli/services/envs/list_command.rb
@@ -5,15 +5,17 @@ module Kontena::Cli::Services::Envs
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
+    include Kontena::Cli::TableGenerator::Helper
 
     parameter "NAME", "Service name"
 
+    requires_current_master
+    requires_current_master_token
+
     def execute
-      require_api_url
-      token = require_token
-      service = client(token).get("services/#{parse_service_id(name)}")
+      service = client.get("services/#{parse_service_id(name)}")
       service["env"].sort.each do |env|
-        puts env
+        puts quiet? ? env.split('=', 2).first : env
       end
     end
   end

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -58,7 +58,7 @@ module Kontena::Cli::Services
 
         instances = [row['instance_counts']['running'], row['instances']]
         if instances.first < instances.last
-          instances.first = pastel.cyan(instances.first.to_s)
+          instances[0] = pastel.cyan(instances[0].to_s)
         end
         row['instances'] = instances.join(' / ')
       end

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -33,6 +33,8 @@ module Kontena::Cli::Services
     end
 
     def service_name(service)
+      stack_id = stack_id(service)
+      return service['name'] if stack_id == 'null'
       [ stack_id(service), service['name'] ].compact.join('/')
     end
 

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -4,53 +4,62 @@ module Kontena::Cli::Services
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
+    include Kontena::Cli::TableGenerator::Helper
     include ServicesHelper
 
-    option ["-q", "--quiet"], :flag, "Show only service names"
     option '--stack', 'STACK', 'Stack name'
 
-    def execute
-      require_api_url
-      token = require_token
+    requires_current_master
+    requires_current_master_token
 
-      grids = client(token).get("grids/#{current_grid}/services?stack=#{stack}")
-      services = grids['services'].sort_by{|s| s['updated_at'] }.reverse
+    def services
+      client.get("grids/#{current_grid}/services#{"?stack=#{stack}" if stack}")['services'].sort_by{|s| s['updated_at'] }.reverse
+    end
+
+    def fields
+      quiet? ? ['name'] : {'  ' => 'health_icon', name: 'name', instances: 'instances', stateful: 'stateful', state: 'state', "exposed ports" => 'ports' }
+    end
+
+    def service_port(port)
+      "#{port['ip']}:#{port['node_port']}->#{port['container_port']}/#{port['protocol']}"
+    end
+
+    def stack_id(service)
       if quiet?
-        services.each do |service|
-          puts "#{service.dig('stack', 'id')}/#{service['name']}"
-        end
+        service.fetch('stack', {}).fetch('id', 'null')
       else
-        titles = ['NAME', 'INSTANCES', 'STATEFUL', 'STATE', 'EXPOSED PORTS']
-        puts "%-60s %-10s %-8s %-10s %-50s" % titles
-        services.each do |service|
-          print_service_row(service)
-        end
+        service.fetch('stack', {}).fetch('name', nil)
       end
     end
 
-    def print_service_row(service)
-      stateful = service['stateful'] ? 'yes' : 'no'
-      running = service['instance_counts']['running']
-      desired = service['instances']
-      instances = "#{running} / #{desired}"
-      ports = service['ports'].map{|p|
-        "#{p['ip']}:#{p['node_port']}->#{p['container_port']}/#{p['protocol']}"
-      }.join(", ")
-      health = health_status(service)
-      if service.dig('stack', 'name').to_s == 'null'.freeze
-        name = service['name']
-      else
-        name = "#{service.dig('stack', 'name')}/#{service['name']}"
+    def service_name(service)
+      [ stack_id(service), service['name'] ].compact.join('/')
+    end
+
+    def state_color(state)
+      case state
+      when 'running' then :green
+      when 'initialized' then :cyan
+      when 'stopped' then :red
+      else :blue
       end
-      vars = [
-        health_status_icon(health),
-        name,
-        instances,
-        stateful,
-        service['state'],
-        ports
-      ]
-      puts "%s %-58s %-10.10s %-8s %-10s %-50s" % vars
+    end
+
+    def execute
+      print_table(services) do |row|
+        row['name'] = service_name(row)
+        next if quiet?
+        row['health_icon'] = health_status_icon(health_status(row))
+        row['stateful'] = row['stateful'] ? pastel.green('yes') : 'no'
+        row['ports'] = row['ports'].map(&method(:service_port)).join(',')
+        row['state'] = pastel.send(state_color(row['state']), row['state'])
+
+        instances = [row['instance_counts']['running'], row['instances']]
+        if instances.first < instances.last
+          instances.first = pastel.cyan(instances.first.to_s)
+        end
+        row['instances'] = instances.join(' / ')
+      end
     end
   end
 end

--- a/cli/lib/kontena/cli/stacks/registry/search_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/search_command.rb
@@ -9,8 +9,14 @@ module Kontena::Cli::Stacks::Registry
 
     parameter "[QUERY]", "Query string"
 
+    option ['-q', '--quiet'], :flag, "Output the identifying column only"
+
     def execute
       results = stacks_client.search(query.to_s)
+      if quiet?
+        puts results.map { |s| s['stack'] }.join("\n")
+        exit 0
+      end
       exit_with_error 'Nothing found' if results.empty?
       titles = ['NAME', 'VERSION', 'DESCRIPTION']
       columns = "%-40s %-10s %-40s"

--- a/cli/lib/kontena/cli/stacks/registry_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry_command.rb
@@ -1,9 +1,8 @@
 module Kontena::Cli::Stacks
   class RegistryCommand < Kontena::Command
-
     subcommand "push", "Push a stack into the stacks registry", load_subcommand('stacks/registry/push_command')
     subcommand "pull", "Pull a stack from the stacks registry", load_subcommand('stacks/registry/pull_command')
-    subcommand ["search", "list", "ls"], "Search for stacks in the stacks registry", load_subcommand('stacks/registry/search_command')
+    subcommand ["search"], "Search for stacks in the stacks registry", load_subcommand('stacks/registry/search_command')
     subcommand "show", "Show info about a stack in the stacks registry", load_subcommand('stacks/registry/show_command')
     subcommand ["remove", "rm"], "Remove a stack (or version) from the stacks registry", load_subcommand('stacks/registry/remove_command')
   end

--- a/cli/lib/kontena/cli/stacks/registry_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Stacks
 
     subcommand "push", "Push a stack into the stacks registry", load_subcommand('stacks/registry/push_command')
     subcommand "pull", "Pull a stack from the stacks registry", load_subcommand('stacks/registry/pull_command')
-    subcommand "search", "Search for stacks in the stacks registry", load_subcommand('stacks/registry/search_command')
+    subcommand ["search", "list", "ls"], "Search for stacks in the stacks registry", load_subcommand('stacks/registry/search_command')
     subcommand "show", "Show info about a stack in the stacks registry", load_subcommand('stacks/registry/show_command')
     subcommand ["remove", "rm"], "Remove a stack (or version) from the stacks registry", load_subcommand('stacks/registry/remove_command')
   end

--- a/cli/lib/kontena/cli/table_generator.rb
+++ b/cli/lib/kontena/cli/table_generator.rb
@@ -1,0 +1,103 @@
+require 'tty-table'
+
+module Kontena
+  module Cli
+    class TableGenerator
+
+      attr_reader :data
+      attr_reader :fields
+      attr_reader :header
+      attr_reader :row_format_proc, :header_format_proc, :render_options
+
+      DEFAULT_HEADER_FORMAT_PROC = lambda { |header| header.to_s.capitalize }
+
+      module Helper
+        def self.included(base)
+          if base.respond_to?(:option)
+            base.option ['-q', '--quiet'], :flag, "Output the identifying column only"
+          end
+        end
+
+        def generate_table(array, fields = nil, &block)
+          fields ||= self.fields if self.respond_to?(:fields)
+          Kontena::Cli::TableGenerator.new(
+            array,
+            fields,
+            row_format_proc: block_given? ? block.to_proc : nil,
+            header_format_proc: lambda { |item| pastel.blue(item.to_s.capitalize) },
+            render_options: self.respond_to?(:render_options) ? self.render_options : nil
+          ).render
+        end
+
+        def print_table(array, fields = nil, &block)
+          puts generate_table(array, fields, &block)
+        end
+      end
+
+      # @param data [Array<Hash>,Array<Array>] an array of hashes or arrays
+      # @param fields [Array] an array of field names found in the data hashes.
+      # @param fields [Hash] a hash of field_title => field_name_in_the_data_hash, for example 'Users' => 'user_count'
+      # @param fields [NilClass] try to auto detect fields (all fields!) from the data hashes
+      # @return [TTY::Table]
+      def initialize(data, fields = nil, row_format_proc: nil, header_format_proc: nil, render_options: nil)
+        @data = data
+        @render_options = render_options || {}
+        @row_format_proc = row_format_proc
+        @header_format_proc = header_format_proc || DEFAULT_HEADER_FORMAT_PROC
+        @fields = parse_fields(fields)
+        @header = generate_header(fields)
+      end
+
+      def table
+        TTY::Table.new(
+          header: header,
+          rows: rows
+        )
+      end
+
+      def render
+        table.render(:basic, render_options || {})
+      end
+
+      def format_row(row)
+        return row if row_format_proc.nil?
+        row_clone = row.dup
+        row_format_proc.call(row_clone)
+        row_clone
+      end
+
+      def format_header_item(field_name)
+        header_format_proc.call(field_name)
+      end
+
+      def rows
+        fields.empty? ? data.map { |row| format_row(row).map(&:values) } : data.map { |row| format_row(row).values_at(*fields) }
+      end
+
+      # Collect all the unique keys from the hashes if the data
+      # is an array of hashes.
+      def detect_fields
+        if data.first.respond_to?(:keys)
+          data.flat_map(&:keys).uniq
+        else
+          []
+        end
+      end
+
+      def parse_fields(fields)
+        if fields.nil? || fields.empty?
+          detect_fields
+        elsif fields.kind_of?(Hash)
+          fields.values
+        else
+          fields
+        end
+      end
+
+      def generate_header(fields)
+        header = Array(fields.kind_of?(Hash) ? fields.keys : fields)
+        header.size < 2 ? nil : header.map { |head| format_header_item(head) }
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/table_generator.rb
+++ b/cli/lib/kontena/cli/table_generator.rb
@@ -65,7 +65,11 @@ module Kontena
       end
 
       def render
-        table.render(render_mode, render_options)
+        if data.empty?
+          fields.map(&method(:format_header_item)).join('  ')
+        else
+          table.render(render_mode, render_options)
+        end
       end
 
       def format_row(row)

--- a/cli/lib/kontena/cli/volumes/create_command.rb
+++ b/cli/lib/kontena/cli/volumes/create_command.rb
@@ -4,13 +4,17 @@ module Kontena::Cli::Volumes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
     banner "Creates a volume"
     parameter 'NAME', 'Volume name'
 
-    option '--driver', 'DRIVER', 'Volume driver to be used'
+    SCOPES = %w(grid stack instance)
+
+    option '--driver', 'DRIVER', 'Volume driver to be used', required: true
     option '--driver-opt', 'DRIVER_OPT', 'Volume driver options', multivalued: true
-    option '--scope', 'SCOPE', 'Volume scope'
+    option '--scope', 'SCOPE', "Volume scope (#{SCOPES.join(',')})", required: true do |scope|
+      exit_with_error "Unknown scope '#{scope}, must be one of #{SCOPES.join(',')}" unless SCOPES.include?(scope)
+      scope
+    end
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/util.rb
+++ b/cli/lib/kontena/util.rb
@@ -30,26 +30,30 @@ module Kontena
 
     def time_ago(time)
       now = Time.now.to_i
-      time = DateTime.parse(time).to_time.to_i
+      time = time.kind_of?(Integer) ? time : DateTime.parse(time).to_time.to_i
       diff = now - time
-      if diff > 60 * 60 * 24
-        "#{diff / 60 / 60 / 24} days"
-      elsif diff > 60 * 60
-        "#{diff / 60 / 60} hours"
-      elsif diff > 60
-        "#{diff / 60} minutes"
+      seconds_to_human(diff) + ' ago'
+    end
+
+    def time_until(seconds)
+      'in ' + seconds_to_human(seconds)
+    end
+
+    def seconds_to_human(seconds)
+      if seconds > 60 * 60 * 24
+        result = "#{seconds / 60 / 60 / 24} days"
+      elsif seconds > 60 * 60
+        result = "#{seconds / 60 / 60} hours"
+      elsif seconds > 60
+        result = "#{seconds / 60} minutes"
       else
-        "#{diff} seconds"
+        result = "#{seconds} seconds"
       end
+      result.start_with?('1 ') ? result[0..-2] : result
     end
 
     def longest_string_in_array(array)
-      longest = 0
-      array.each do |item|
-        longest = item.length if item.length > longest
-      end
-
-      longest
+      array.max_by(&:length).length
     end
 
     module_function(:which)

--- a/cli/spec/kontena/cli/containers/list_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/list_command_spec.rb
@@ -6,8 +6,7 @@ describe Kontena::Cli::Containers::ListCommand do
   context "for a single container with logs" do
 
     it "fetches containers" do
-      expect(client).to receive(:get).with('containers/test-grid?').and_return({'containers' => []})
-
+      expect(client).to receive(:get).with('containers/test-grid').and_return({'containers' => []})
       subject.run([])
     end
   end

--- a/cli/spec/kontena/cli/containers/list_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/list_command_spec.rb
@@ -11,8 +11,4 @@ describe Kontena::Cli::Containers::ListCommand do
       subject.run([])
     end
   end
-
-  context '#longest_string_in_array' do
-    expect(described_class.new('').longest_string_in_array(['a', 'bcd', 'ef'])).to eq 'bcd'
-  end
 end

--- a/cli/spec/kontena/cli/containers/list_command_spec.rb
+++ b/cli/spec/kontena/cli/containers/list_command_spec.rb
@@ -11,4 +11,8 @@ describe Kontena::Cli::Containers::ListCommand do
       subject.run([])
     end
   end
+
+  context '#longest_string_in_array' do
+    expect(described_class.new('').longest_string_in_array(['a', 'bcd', 'ef'])).to eq 'bcd'
+  end
 end

--- a/cli/spec/kontena/cli/nodes/list_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/list_command_spec.rb
@@ -4,63 +4,78 @@ describe Kontena::Cli::Nodes::ListCommand do
   include ClientHelpers
   include OutputHelpers
 
+  let(:subject) { described_class.new("kontena") }
+
+  let(:client) { double }
+
   before do
     allow(subject).to receive(:health_icon) {|health| health.inspect }
+    allow(subject).to receive(:client).and_return(client)
   end
 
   describe '#show_grid_nodes' do
     context "For a initial_size=3 grid" do
-      let :grid do
-        {
-          "id" => "test",
-          "name" => "test",
-          "initial_size" => 3,
-          "node_count" => 1,
-        }
+      before do
+        allow(client).to receive(:get).with('grids/test-grid').and_return(
+          {
+            "id" => "test-grid",
+            "name" => "test-grid",
+            "initial_size" => 3,
+            "node_count" => 1,
+          }
+        )
       end
 
       context "with a single node" do
-        let :grid_nodes do
-          { "nodes" => [
+
+        before do
+          allow(client).to receive(:get).with('grids/test-grid/nodes').and_return(
             {
-              "connected" => true,
-              "name" => "node-1",
-              "node_number" => 1,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-          ] }
+              'nodes' => [
+                {
+                  "connected" => true,
+                  "name" => "node-1",
+                  "node_number" => 1,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                }
+              ]
+            }
+          )
         end
 
         it "outputs node with error" do
-          expect{subject.show_grid_nodes(grid, grid_nodes['nodes'])}.to output_table [
+          expect{subject.run([])}.to output_table [
             [':error node-1', '1.1-dev', 'online', '1 / 3', '-'],
           ]
         end
       end
 
       context "with a single online node" do
-        let :grid_nodes do
-          { "nodes" => [
-            {
-              "connected" => true,
-              "name" => "node-1",
-              "node_number" => 1,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => false,
-              "name" => "node-2",
-              "node_number" => 2,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-          ] }
+        before do
+          allow(client).to receive(:get).with('grids/test-grid/nodes').and_return(
+            { "nodes" => [
+                {
+                  "connected" => true,
+                  "name" => "node-1",
+                  "node_number" => 1,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => false,
+                  "name" => "node-2",
+                  "node_number" => 2,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+              ]
+            }
+          )
         end
 
         it "outputs online node with error" do
-          expect{subject.show_grid_nodes(grid, grid_nodes['nodes'])}.to output_table [
+          expect{subject.run([])}.to output_table [
             [':error node-1', '1.1-dev', 'online', '1 / 3', '-'],
             [':offline node-2', '1.1-dev', 'offline', '2 / 3', '-'],
           ]
@@ -68,27 +83,30 @@ describe Kontena::Cli::Nodes::ListCommand do
       end
 
       context "with two online nodes" do
-        let :grid_nodes do
-          { "nodes" => [
-            {
-              "connected" => true,
-              "name" => "node-1",
-              "node_number" => 1,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => true,
-              "name" => "node-2",
-              "node_number" => 2,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-          ] }
+        before do
+          allow(client).to receive(:get).with('grids/test-grid/nodes').and_return(
+            { "nodes" => [
+                {
+                  "connected" => true,
+                  "name" => "node-1",
+                  "node_number" => 1,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => true,
+                  "name" => "node-2",
+                  "node_number" => 2,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+              ]
+            }
+          )
         end
 
         it "outputs both nodes with warning" do
-          expect{subject.show_grid_nodes(grid, grid_nodes['nodes'])}.to output_table [
+          expect{subject.run([])}.to output_table [
             [':warning node-1', '1.1-dev', 'online', '1 / 3', '-'],
             [':warning node-2', '1.1-dev', 'online', '2 / 3', '-'],
           ]
@@ -96,34 +114,37 @@ describe Kontena::Cli::Nodes::ListCommand do
       end
 
       context "with two online nodes and one offline node" do
-        let :grid_nodes do
-          { "nodes" => [
-            {
-              "connected" => true,
-              "name" => "node-1",
-              "node_number" => 1,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => true,
-              "name" => "node-2",
-              "node_number" => 2,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => false,
-              "name" => "node-3",
-              "node_number" => 3,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-          ] }
+        before do
+          allow(client).to receive(:get).with('grids/test-grid/nodes').and_return(
+            { "nodes" => [
+                {
+                  "connected" => true,
+                  "name" => "node-1",
+                  "node_number" => 1,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => true,
+                  "name" => "node-2",
+                  "node_number" => 2,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => false,
+                  "name" => "node-3",
+                  "node_number" => 3,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+              ]
+            }
+          )
         end
 
         it "outputs two nodes with warning and one offline" do
-          expect{subject.show_grid_nodes(grid, grid_nodes['nodes'])}.to output_table [
+          expect{subject.run([])}.to output_table [
             [':warning node-1', '1.1-dev', 'online',  '1 / 3', '-'],
             [':warning node-2', '1.1-dev', 'online',  '2 / 3', '-'],
             [':offline node-3', '1.1-dev', 'offline', '3 / 3', '-'],
@@ -132,34 +153,38 @@ describe Kontena::Cli::Nodes::ListCommand do
       end
 
       context "with two online initial nodes and one non-initial node" do
-        let :grid_nodes do
-          { "nodes" => [
+        before do
+          allow(client).to receive(:get).with('grids/test-grid/nodes').and_return(
             {
-              "connected" => true,
-              "name" => "node-1",
-              "node_number" => 1,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => true,
-              "name" => "node-2",
-              "node_number" => 2,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => true,
-              "name" => "node-4",
-              "node_number" => 4,
-              "initial_member" => false,
-              'agent_version' => '1.1-dev',
-            },
-          ] }
+              "nodes" => [
+                {
+                  "connected" => true,
+                  "name" => "node-1",
+                  "node_number" => 1,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => true,
+                  "name" => "node-2",
+                  "node_number" => 2,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => true,
+                  "name" => "node-4",
+                  "node_number" => 4,
+                  "initial_member" => false,
+                  'agent_version' => '1.1-dev',
+                },
+              ]
+            }
+          )
         end
 
         it "outputs two nodes with warning and one online" do
-          expect{subject.show_grid_nodes(grid, grid_nodes['nodes'])}.to output_table [
+          expect{subject.run([])}.to output_table [
             [':warning node-1', '1.1-dev', 'online',  '1 / 3', '-'],
             [':warning node-2', '1.1-dev', 'online',  '2 / 3', '-'],
             [':ok node-4', '1.1-dev', 'online', '-', '-'],
@@ -168,34 +193,38 @@ describe Kontena::Cli::Nodes::ListCommand do
       end
 
       context "with three online initial nodes" do
-        let :grid_nodes do
-          { "nodes" => [
+        before do
+          allow(client).to receive(:get).with('grids/test-grid/nodes').and_return(
             {
-              "connected" => true,
-              "name" => "node-1",
-              "node_number" => 1,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => true,
-              "name" => "node-2",
-              "node_number" => 2,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-            {
-              "connected" => true,
-              "name" => "node-3",
-              "node_number" => 3,
-              "initial_member" => true,
-              'agent_version' => '1.1-dev',
-            },
-          ] }
+              "nodes" => [
+                {
+                  "connected" => true,
+                  "name" => "node-1",
+                  "node_number" => 1,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => true,
+                  "name" => "node-2",
+                  "node_number" => 2,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+                {
+                  "connected" => true,
+                  "name" => "node-3",
+                  "node_number" => 3,
+                  "initial_member" => true,
+                  'agent_version' => '1.1-dev',
+                },
+              ]
+            }
+          )
         end
 
         it "outputs three nodes with ok" do
-          expect{subject.show_grid_nodes(grid, grid_nodes['nodes'])}.to output_table [
+          expect{subject.run([])}.to output_table [
             [':ok node-1', '1.1-dev', 'online', '1 / 3', '-'],
             [':ok node-2', '1.1-dev', 'online', '2 / 3', '-'],
             [':ok node-3', '1.1-dev', 'online', '3 / 3', '-'],

--- a/cli/spec/kontena/cli/table_generator_spec.rb
+++ b/cli/spec/kontena/cli/table_generator_spec.rb
@@ -1,0 +1,118 @@
+require 'kontena/cli/table_generator'
+require 'kontena/command'
+require 'kontena/cli/common'
+
+describe Kontena::Cli::TableGenerator do
+  let(:data) { [{'a' => 'a1', 'b' => 'b1', 'c' => 'c1'}, {'a' => 'a2', 'b' => 'b2', 'c' => 'c2'}] }
+
+  context Kontena::Cli::TableGenerator::Helper do
+    let(:klass) { Class.new(Kontena::Command) }
+
+    it 'adds the quiet option' do
+      klass.include(described_class)
+      expect(klass.recognised_options.first.flag?).to be_truthy
+      expect(klass.recognised_options.first.long_switch).to eq '--quiet'
+      expect(klass.recognised_options.first.switches).to include '-q'
+      expect(klass.recognised_options.first.description).to match (/identifying column/)
+    end
+
+    context 'with the helper included' do
+
+      let(:subject) { klass.new([]) }
+
+      before(:each) do
+        klass.include(Kontena::Cli::Common)
+        klass.include(described_class)
+      end
+
+      it 'responds to print_table' do
+        expect(subject).to respond_to(:print_table)
+      end
+
+      it 'responds to generate_table' do
+        expect(subject).to respond_to(:print_table)
+      end
+
+      context '#print_table' do
+
+        include OutputHelpers
+
+        it 'outputs a table from an array and a list of fields' do
+          expect{subject.print_table(data, ['a', 'b'])}.to output_table([
+            ['a1', 'b1'],
+            ['a2', 'b2']
+          ]).with_header(['A', 'B'])
+        end
+
+        it 'outputs a table without a header when only one field' do
+          expect{subject.print_table(data, ['a'])}.to output_table([
+            ['a1'],
+            ['a2']
+          ]).without_header
+        end
+
+        it 'tries to read the fields from #fields method when none given' do
+          expect(subject).to receive(:fields).and_return(['a', 'b'])
+          expect{subject.print_table(data)}.to output_table([
+            ['a1', 'b1'],
+            ['a2', 'b2']
+          ]).with_header(['A', 'B'])
+        end
+
+        it 'tries to read render options from #render_options method' do
+          expect(subject).to receive(:render_options).and_return(mode: :ascii, border: { separator: '|' })
+          expect{subject.print_table(data)}.to output(/\|/).to_stdout
+        end
+      end
+    end
+  end
+
+  let(:klass) { described_class }
+
+  context 'with an array of hashes' do
+    context 'given a list of fields' do
+      it 'collects the fields listed from the hashes and capitalizes the field names' do
+        subject = klass.new(data, ['a', 'b'])
+        expect(subject).to receive(:create_table).with(['A', 'B'], [['a1', 'b1'], ['a2', 'b2']]).and_return(true)
+        subject.table
+      end
+    end
+
+    context 'given no list of fields' do
+      it 'uses all fields found in the data and creates field names for the header' do
+        data.each { |hash| expect(hash).to receive(:keys).and_call_original }
+        subject = klass.new(data)
+        expect(subject).to receive(:create_table).with(['A', 'B', 'C'], [['a1', 'b1', 'c1'], ['a2', 'b2', 'c2']]).and_return(true)
+        subject.table
+      end
+    end
+
+    context 'given one field' do
+      it 'creates a table of one column without a header (quiet mode)' do
+        subject = klass.new(data, 'a')
+        expect(subject).to receive(:create_table).with(nil, [['a1'], ['a2']]).and_return(true)
+        subject.table
+      end
+    end
+
+    context 'given a field mapping' do
+      it 'uses the field keys as header titles and values as data field keys' do
+        subject = klass.new(data, { 'First' => 'a', 'Third' => 'c' })
+        expect(subject).to receive(:create_table).with(['First', 'Third'], [['a1', 'c1'], ['a2', 'c2']]).and_return(true)
+        subject.table
+      end
+    end
+
+    context 'row formatting' do
+      it 'calls the format proc for all rows of data' do
+        format_proc = proc do |row|
+          row['d'] = [row['b'], row['c']].join('/')
+        end
+        expect(format_proc).to receive(:call).exactly(2).times.and_call_original
+        subject = klass.new(data, ['a', 'd'], row_format_proc: format_proc)
+        expect(subject).to receive(:create_table).with(['A', 'D'], [['a1', 'b1/c1'], ['a2', 'b2/c2']]).and_return(true)
+        subject.table
+      end
+    end
+  end
+end

--- a/cli/spec/support/output_helpers.rb
+++ b/cli/spec/support/output_helpers.rb
@@ -41,6 +41,8 @@ module OutputHelpers
 
       if @expected_header
         @expected.unshift(@expected_header)
+      elsif @no_header
+        nil
       else
         @real.shift
       end
@@ -68,6 +70,10 @@ module OutputHelpers
 
     chain :with_header do |header|
       @expected_header = header
+    end
+
+    chain :without_header do
+      @no_header = true
     end
 
     failure_message do |block|


### PR DESCRIPTION
Fixes #2291

This helps a lot in scripting. Instead of `kontena service ls | tail -n +2 | cut -d" " -f 1` you can now just do `kontena service ls -q`.

The `-q` is also used in docker cli for similar function.

This PR also replaces all `puts "%20s %10s %40s" % vars` style table rendering in the list views with tty-table.

Included is a fancy `TableGenerator` frontend for tty-table and a helper that allows row modification like this:

```ruby
def execute
  print_table(rows) do |row|
    row['name'].insert(0, '* ') if row['name'] == current_master.name
  end
end
```

Some of the refactorings use a shortcut for calling methods with the iterator value that may be confusing if you haven't seen it before:

```ruby
['foo', 'bar'].map(&:to_sym) # the usual symbol to proc, calls .to_sym on each value
['foo', 'bar'].map(&method(:puts)) # like above, but calls puts('foo) and puts('bar')
['foo', 'bar'].map(&pastel.method(:green)) # pastel.green('foo') and pastel.green('bar')
```

The deal with the `def fields` in each command is that in the future you could switch that to something like `--fields x,y,z` easily by adding something like:

```ruby
option '--fields', 'FIELDS', "Output fields", default: %w(id name foo) do |fields|
  Array(fields.split(','))
end
```

..and then removing the `fields` method.

Some list views were heavily refactored.

Some list views already generated `-q` like output, for those the option is added as `hidden: true` to accept and ignore the option.

The `time_ago` method in `Kontena::Util` now returns the string with `"  ago"`  appended and a new method `time_until returns `in XX minutes`. The methods now also say `1 day` instead of `1 days`.

Some of the list views now include fancy coloring and some lists show `time_ago`/`time_until` instead of a monstrous `2017-04-07T07:24:35.938Z` timestamp (which can be seen when piping or using `--long`).
