### PR TITLE
Allow stack registry read operations without cloud authentication

### DIFF
--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Cloud
   class LoginCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    option ['-t', '--token'], '[TOKEN]', 'Use a pre-generated access token', environment_variable: 'KONTENA_ACCOUNT_TOKEN'
+    option ['-t', '--token'], '[TOKEN]', 'Use a pre-generated access token', environment_variable: 'KONTENA_CLOUD_TOKEN'
     option ['-c', '--code'], '[CODE]', 'Use an authorization code'
     option ['-v', '--verbose'], :flag, 'Increase output verbosity'
     option ['-f', '--force'], :flag, 'Force reauthentication'

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -161,7 +161,7 @@ module Kontena
       end
 
       def kontena_account
-        @kontena_account ||= config.find_account(ENV['KONTENA_ACCOUNT'] || 'kontena')
+        @kontena_account ||= config.current_account
       end
 
       def cloud_auth?

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -125,7 +125,7 @@ module Kontena
           authorization_endpoint: ENV['AUTH_AUTHORIZE_ENDPOINT'] || 'https://cloud.kontena.io/login/oauth/authorize',
           userinfo_endpoint: ENV['AUTH_USERINFO_ENDPOINT'] || 'https://cloud-api.kontena.io/user',
           token_post_content_type: ENV['AUTH_TOKEN_POST_CONTENT_TYPE'] || 'application/x-www-form-urlencoded',
-          code_requires_basic_auth: ENV['AUTH_CODE_REQUIRES_BASIC_AUTH'].nil? ? false : (ENV['AUTH_CODE_REQUIRES_BASIC_AUTH'].to_s == true),
+          code_requires_basic_auth: ENV['AUTH_CODE_REQUIRES_BASIC_AUTH'].to_s == true,
           token_method: ENV['AUTH_TOKEN_METHOD'] || 'post',
           scope: ENV['AUTH_USERINFO_SCOPE'] || 'user',
           client_id: nil,

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -48,11 +48,9 @@ module Kontena
           parent_type: :master,
           parent_name: 'default'
         )
-        accounts << Account.new(
-          url: ENV['AUTH_API_URL'] || 'https://auth.kontena.io',
-          name: 'kontena',
-          token: Token.new(access_token: ENV['KONTENA_ACCOUNT_TOKEN'], parent_type: :account, parent_name: 'default')
-        )
+        accounts << Account.new(kontena_account_data.merge(
+          token: Token.new(access_token: ENV['KONTENA_CLOUD_TOKEN'], parent_type: :account, parent_name: 'default')
+        ))
 
         self.current_master  = 'default'
         self.current_account = 'kontena'
@@ -115,22 +113,23 @@ module Kontena
         accounts.delete_at(master_index) if master_index
         accounts << Account.new(master_account_data)
 
-        self.current_account = settings['current_account'] || 'kontena'
+        self.current_account = ENV['KONTENA_CLOUD'] || settings['current_account'] || 'kontena'
       end
 
       def kontena_account_data
         {
           name: 'kontena',
-          url: 'https://cloud-api.kontena.io',
-          stacks_url: 'https://stacks.kontena.io',
-          token_endpoint: 'https://cloud-api.kontena.io/oauth2/token',
-          authorization_endpoint: 'https://cloud.kontena.io/login/oauth/authorize',
-          userinfo_endpoint: 'https://cloud-api.kontena.io/user',
-          token_post_content_type: 'application/x-www-form-urlencoded',
-          code_requires_basic_auth: false,
-          token_method: 'post',
-          scope: 'user',
-          client_id: nil
+          url: ENV['KONTENA_CLOUD_URL'] || 'https://cloud-api.kontena.io',
+          stacks_url: ENV['KONTENA_STACK_REGISTRY_URL'] || 'https://stacks.kontena.io',
+          token_endpoint: ENV['AUTH_TOKEN_ENDPOINT'] || 'https://cloud-api.kontena.io/oauth2/token',
+          authorization_endpoint: ENV['AUTH_AUTHORIZE_ENDPOINT'] || 'https://cloud.kontena.io/login/oauth/authorize',
+          userinfo_endpoint: ENV['AUTH_USERINFO_ENDPOINT'] || 'https://cloud-api.kontena.io/user',
+          token_post_content_type: ENV['AUTH_TOKEN_POST_CONTENT_TYPE'] || 'application/x-www-form-urlencoded',
+          code_requires_basic_auth: ENV['AUTH_CODE_REQUIRES_BASIC_AUTH'].nil? ? false : (ENV['AUTH_CODE_REQUIRES_BASIC_AUTH'].to_s == true),
+          token_method: ENV['AUTH_TOKEN_METHOD'] || 'post',
+          scope: ENV['AUTH_USERINFO_SCOPE'] || 'user',
+          client_id: nil,
+          stacks_read_authentication: ENV['KONTENA_STACK_REGISTRY_READ_AUTHENTICATION'].to_s == 'true'
         }
       end
 

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -153,10 +153,7 @@ module Kontena::Cli::Stacks
     end
 
     def stacks_client
-      return @stacks_client if @stacks_client
-      Kontena.run('cloud login') unless cloud_auth?
-      config.reset_instance
-      @stacks_client = Kontena::StacksClient.new(kontena_account.stacks_url, kontena_account.token)
+      @stacks_client ||= Kontena::StacksClient.new(current_account.stacks_url, current_account.token, read_requires_token: current_account.stacks_read_authentication)
     end
   end
 end

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -88,7 +88,6 @@ module Kontena
         else
           @token = token
         end
-        @default_headers.merge!('Authorization' => "Bearer #{@token['access_token']}")
       end
 
       @api_url = api_url

--- a/cli/lib/kontena/stacks_client.rb
+++ b/cli/lib/kontena/stacks_client.rb
@@ -7,6 +7,19 @@ module Kontena
     ACCEPT_YAML = { 'Accept' => 'application/yaml' }
     CT_YAML     = { 'Content-Type' => 'application/yaml' }
 
+    def raise_unless_token
+      unless token && token['access_token']
+        raise Kontena::Errors::StandardError.new(401, "Stack registry write operations require authentication")
+      end
+    end
+
+    def raise_unless_read_token
+      return false unless options[:read_requires_token]
+      unless token && token['access_token']
+        raise Kontena::Errors::StandardError.new(401, "Stack registry requires authentication")
+      end
+    end
+
     def full_uri(stack_name, version = nil)
       URI.join(api_url, path_to(stack_name, version)).to_s
     end
@@ -16,29 +29,35 @@ module Kontena
     end
 
     def push(stack_name, version, data)
-      post('/stack/', data, {}, CT_YAML)
+      raise_unless_token
+      post('/stack/', data, {}, CT_YAML, true)
     end
 
     def show(stack_name, stack_version = nil)
-      get("#{path_to(stack_name, stack_version)}", {}, ACCEPT_JSON)
+      raise_unless_read_token
+      get("#{path_to(stack_name, stack_version)}", ACCEPT_JSON, options[:read_requires_token])
     end
 
     def versions(stack_name)
-      get("#{path_to(stack_name, nil)}/versions", {}, ACCEPT_JSON)['versions']
+      raise_unless_read_token
+      get("#{path_to(stack_name, nil)}/versions", ACCEPT_JSON, options[:read_requires_token])['versions']
     end
 
     def pull(stack_name, version = nil)
-      get(path_to(stack_name, version), {}, ACCEPT_YAML)
+      raise_unless_read_token
+      get(path_to(stack_name, version), ACCEPT_YAML, options[:read_requires_token])
     rescue StandardError => ex
       ex.message << " : #{path_to(stack_name, version)}"
       raise ex, ex.message
     end
 
     def search(query)
-      get('/search', { q: query }, {}, ACCEPT_JSON)['stacks']
+      raise_unless_read_token
+      get('/search', { q: query }, ACCEPT_JSON, options[:read_requires_token])['stacks']
     end
 
     def destroy(stack_name, version = nil)
+      raise_unless_token
       delete(path_to(stack_name, version), {})
     end
   end

--- a/cli/lib/kontena/stacks_client.rb
+++ b/cli/lib/kontena/stacks_client.rb
@@ -35,17 +35,17 @@ module Kontena
 
     def show(stack_name, stack_version = nil)
       raise_unless_read_token
-      get("#{path_to(stack_name, stack_version)}", ACCEPT_JSON, options[:read_requires_token])
+      get("#{path_to(stack_name, stack_version)}", nil, ACCEPT_JSON, options[:read_requires_token])
     end
 
     def versions(stack_name)
       raise_unless_read_token
-      get("#{path_to(stack_name, nil)}/versions", ACCEPT_JSON, options[:read_requires_token])['versions']
+      get("#{path_to(stack_name, nil)}/versions", nil, ACCEPT_JSON, options[:read_requires_token])['versions']
     end
 
     def pull(stack_name, version = nil)
       raise_unless_read_token
-      get(path_to(stack_name, version), ACCEPT_YAML, options[:read_requires_token])
+      get(path_to(stack_name, version), nil, ACCEPT_YAML, options[:read_requires_token])
     rescue StandardError => ex
       ex.message << " : #{path_to(stack_name, version)}"
       raise ex, ex.message


### PR DESCRIPTION
Fixes #2317
Fixes #2318

Also removes a bug where the client would always send a bearer token, even when a request without authentication was attempted with the `auth = false` option.

Also renames all KONTENA_ACCOUNT_X env vars to KONTENA_CLOUD_X.

Also makes the kontena account auth details configurable via env (the env variable names are copied from master auth config for uniformity.)

