### PR TITLE
Fix master WWW-Authenticate header

### DIFF
--- a/server/app/middlewares/token_authentication.rb
+++ b/server/app/middlewares/token_authentication.rb
@@ -120,7 +120,7 @@ class TokenAuthentication
     message_parts = ['Bearer realm="kontena_master"']
     message_parts << "error=\"#{error}\"" if error
     message_parts << "error_description=\"#{error_description}\"" if error_description
-    { 'WWW-Authenticate' => message_parts.join(",\n    ") }
+    { 'WWW-Authenticate' => message_parts.join(", ") }
   end
 
   def authenticate_header(error = nil, error_description = nil)


### PR DESCRIPTION
Fixes #2267

Server was splitting the WWW-Authenticate header to multiple lines, which caused rack to send multiple WWW-Authenticate headers, making it kind of invalid or at least hard to parse.
