### PR TITLE
Speed up CLI startup by loading SecureRandom only when needed

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -1,4 +1,3 @@
-require 'securerandom'
 
 module Kontena
   module Callbacks
@@ -9,6 +8,7 @@ module Kontena
       matches_commands 'master create'
 
       def after
+        require 'securerandom'
         ENV["DEBUG"] && $stderr.puts("Command result: #{command.result.inspect}")
         ENV["DEBUG"] && $stderr.puts("Command exit code: #{command.exit_code.inspect}")
         return unless command.exit_code == 0


### PR DESCRIPTION
SecureRandom loads OpenSSL and takes 20ms+

```
rb(main):001:0> require 'securerandom'
require 'digest.so' in 0ms
require 'openssl.so' in 5ms
require 'openssl/bn' in 0ms
require 'openssl/pkey' in 0ms
require 'openssl/cipher' in 1ms
require 'stringio' in 0ms
require 'openssl/config' in 1ms
require 'openssl/digest' in 0ms
require 'openssl/x509' in 1ms
require 'openssl/buffering' in 1ms
require 'io/nonblock' in 0ms
require 'openssl/ssl' in 12ms
require 'openssl' in 24ms
require 'securerandom' in 24ms
```

The `authenticate_after_deploy` hook was loading it preemptively, slowing any CLI spin up by said 20ms+.
