### PR TITLE
Speed up CLI loading by reducing the number of explicitly loaded files

### DIFF
--- a/cli/bin/kontena
+++ b/cli/bin/kontena
@@ -14,6 +14,6 @@ if ARGV[0] == 'complete'
 else
   ENV['DEBUG'] ||= "true" if ARGV.any? { |arg| arg == '-D' || arg == '--debug'}
   require 'kontena_cli'
-  Kontena::PluginManager.instance.init
+  Kontena::PluginManager.instance.init unless ENV['NO_PLUGINS']
   Kontena::MainCommand.run
 end

--- a/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
+++ b/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
@@ -2,8 +2,6 @@ module Kontena
   module Callbacks
     class ListAndSelectGrid < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master login'
 
       def after_load
@@ -15,6 +13,7 @@ module Kontena
       # Runs kontena grids list --use which will auto join the first available
       # grid
       def after
+        extend Kontena::Cli::Common
         return if command.skip_grid_auto_select?
         return unless current_master
         return unless command.exit_code == 0

--- a/cli/lib/kontena/callbacks/master/01_clear_current_master_after_terminate.rb
+++ b/cli/lib/kontena/callbacks/master/01_clear_current_master_after_terminate.rb
@@ -2,11 +2,10 @@ module Kontena
   module Callbacks
     class ClearCurrentMasterAfterTerminate < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master terminate'
 
       def after
+        extend Kontena::Cli::Common
         return unless command.exit_code == 0
         return unless config.current_master
 

--- a/cli/lib/kontena/callbacks/master/deploy/01_show_logo_before_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/01_show_logo_before_deploy.rb
@@ -2,11 +2,10 @@ module Kontena
   module Callbacks
     class DisplayLogoBeforeMasterDeploy < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def before
+        extend Kontena::Cli::Common
         display_logo
       end
     end

--- a/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
@@ -2,11 +2,11 @@ module Kontena
   module Callbacks
     class BeforeDeployConfigurationWizard < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def after_load
+        extend Kontena::Cli::Common
+
         command.class_eval do
           option ['--no-prompt'], :flag, "Don't ask questions"
           option ['--skip-auth-provider'], :flag, "Skip auth provider configuration (single user mode)"

--- a/cli/lib/kontena/callbacks/master/deploy/40_install_ssl_certificate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/40_install_ssl_certificate_after_deploy.rb
@@ -2,11 +2,11 @@ module Kontena
   module Callbacks
     class InstallSslCertificateAfterDeploy < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def after
+        extend Kontena::Cli::Common
+
         return unless command.exit_code == 0
         return unless command.result.kind_of?(Hash)
         return unless command.result.has_key?(:ssl_certificate)

--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -5,6 +5,8 @@ module Kontena
       matches_commands 'master create'
 
       def after
+        extend Kontena::Cli::Common
+
         require 'securerandom'
         extend Kontena::Cli::Common
         logger.debug { "Command result: #{command.result.inspect}" }

--- a/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
@@ -1,14 +1,12 @@
-require 'securerandom'
-
 module Kontena
   module Callbacks
     class AuthenticateAfterDeploy < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def after
+        require 'securerandom'
+        extend Kontena::Cli::Common
         logger.debug { "Command result: #{command.result.inspect}" }
         logger.debug { "Command exit code: #{command.exit_code.inspect}" }
         return unless command.exit_code == 0

--- a/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
@@ -2,11 +2,11 @@ module Kontena
   module Callbacks
     class CreateInitialGridAfterDeploy < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def after
+        extend Kontena::Cli::Common
+
         return unless command.exit_code == 0
         return unless config.current_master
         return unless config.current_master.name == command.result[:name]

--- a/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
@@ -2,11 +2,10 @@ module Kontena
   module Callbacks
     class SetServerProviderAfterDeploy < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def after
+        extend Kontena::Cli::Common
         return unless command.exit_code == 0
         return unless config.current_master
         return unless config.current_master.name == command.result[:name]

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -2,8 +2,6 @@ module Kontena
   module Callbacks
     class ConfigureAuthProviderAfterDeploy < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def init_cloud_args
@@ -16,6 +14,7 @@ module Kontena
       end
 
       def after
+        extend Kontena::Cli::Common
         return unless command.exit_code == 0
         return unless command.result.kind_of?(Hash)
         return unless command.result.has_key?(:name)

--- a/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
@@ -2,8 +2,6 @@ module Kontena
   module Callbacks
     class InviteSelfAfterDeploy < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create', 'master init_cloud'
 
       def cloud_user_data
@@ -25,6 +23,7 @@ module Kontena
       end
 
       def after
+        extend Kontena::Cli::Common
         return unless current_master
         return unless command.exit_code == 0
         return nil if command.respond_to?(:skip_auth_provider?) && command.skip_auth_provider?

--- a/cli/lib/kontena/callbacks/master/deploy/90_proptip_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/90_proptip_after_deploy.rb
@@ -2,11 +2,11 @@ module Kontena
   module Callbacks
     class SuggestInvitingYourself < Kontena::Callback
 
-      include Kontena::Cli::Common
-
       matches_commands 'master create'
 
       def after
+        extend Kontena::Cli::Common
+
         return unless current_master
         return unless command.exit_code == 0
         return if current_master.username.to_s == 'admin'

--- a/cli/lib/kontena/cli/apps/common.rb
+++ b/cli/lib/kontena/cli/apps/common.rb
@@ -1,4 +1,3 @@
-require 'yaml'
 require_relative '../services/services_helper'
 require_relative './service_generator'
 require_relative './service_generator_v2'

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -4,6 +4,8 @@ require_relative 'dockerfile_generator'
 require_relative 'docker_compose_generator'
 require_relative 'kontena_yml_generator'
 
+require "safe_yaml"
+SafeYAML::OPTIONS[:default_mode] = :safe
 
 module Kontena::Cli::Apps
   class InitCommand < Kontena::Command

--- a/cli/lib/kontena/cli/apps/kontena_yml_generator.rb
+++ b/cli/lib/kontena/cli/apps/kontena_yml_generator.rb
@@ -1,5 +1,6 @@
-require 'yaml'
 require_relative 'common'
+require "safe_yaml"
+SafeYAML::OPTIONS[:default_mode] = :safe
 
 module Kontena::Cli::Apps
   class KontenaYmlGenerator

--- a/cli/lib/kontena/cli/apps/yaml/reader.rb
+++ b/cli/lib/kontena/cli/apps/yaml/reader.rb
@@ -1,4 +1,5 @@
-require 'yaml'
+require "safe_yaml"
+SafeYAML::OPTIONS[:default_mode] = :safe
 require_relative 'service_extender'
 require_relative 'validator'
 require_relative 'validator_v2'

--- a/cli/lib/kontena/cli/apps/yaml/service_extender.rb
+++ b/cli/lib/kontena/cli/apps/yaml/service_extender.rb
@@ -1,4 +1,3 @@
-require 'yaml'
 require_relative '../../../util'
 
 module Kontena::Cli::Apps

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -1,10 +1,3 @@
-require 'pastel'
-require 'uri'
-require 'io/console'
-
-require 'kontena/cli/config'
-require 'kontena/cli/spinner'
-require 'kontena/cli/table_generator'
 require 'forwardable'
 
 module Kontena
@@ -13,7 +6,16 @@ module Kontena
       extend Forwardable
 
       def_delegators :Kontena, :pastel, :prompt, :logger
+      def_delegators :prompt, :ask, :yes?
+      def_delegators :config,
+        :current_grid=, :require_current_grid, :current_master,
+        :current_master=, :require_current_master, :require_current_account,
+        :current_account
       def_delegator Kontena::Cli::Spinner, :spin, :spinner
+      def_delegator Kontena::Cli::Config, :instance, :config
+      def_delegator Kontena::Cli::Config, :instance, :settings
+      def_delegator :config, :config_filename, :settings_filename
+      def_delegator :client, :server_version, :api_url_version
 
       # Read from STDIN. If stdin is a console, use prompt to ask.
       # @param [String] message
@@ -120,10 +122,7 @@ module Kontena
         $stderr.puts " [#{error}] #{msg}"
         exit code
       end
-
-      def config
-        Kontena::Cli::Config.instance
-      end
+      module_function :exit_with_error
 
       def require_api_url
         config.require_current_master.url
@@ -155,18 +154,6 @@ module Kontena
         logger.debug "Refreshing failed: #{ex.class.name} : #{ex.message}"
       end
 
-      def require_current_master
-        config.require_current_master
-      end
-
-      def require_current_account
-        config.require_current_account
-      end
-
-      def current_account
-        config.current_account
-      end
-
       def kontena_account
         @kontena_account ||= config.current_account
       end
@@ -176,10 +163,6 @@ module Kontena
         return false unless kontena_account.token
         return false unless kontena_account.token.access_token
         true
-      end
-
-      def api_url_version
-        client.server_version
       end
 
       def cloud_client
@@ -205,24 +188,8 @@ module Kontena
         @client = nil
       end
 
-      def settings_filename
-        config.config_filename
-      end
-
-      def settings
-        config
-      end
-
       def api_url
         config.require_current_master.url
-      end
-
-      def current_grid=(grid)
-        config.current_grid=(grid)
-      end
-
-      def require_current_grid
-        config.require_current_grid
       end
 
       def clear_current_grid
@@ -238,25 +205,9 @@ module Kontena
         config.find_server_index(require_current_master.name)
       end
 
-      def current_master
-        config.current_master
-      end
-
-      def current_master=(master_alias)
-        config.current_master = master_alias
-      end
-
       def error(message = "Error")
         prompt.error(message)
         exit(1)
-      end
-
-      def ask(question = "")
-        prompt.ask(question)
-      end
-
-      def yes?(question = "")
-        prompt.yes?(question)
       end
 
       def confirm_command(name, message = nil)
@@ -351,6 +302,7 @@ module Kontena
       def display_logo
         puts File.read(File.expand_path('../../../../LOGO', __FILE__))
       end
+      module_function :display_logo
     end
   end
 end

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -174,11 +174,13 @@ module Kontena
       end
 
       def client(token = nil, api_url = nil)
+        return @client if @client
+
         if token.kind_of?(String)
           token = Kontena::Cli::Config::Token.new(access_token: token)
         end
 
-        @client ||= Kontena::Client.new(
+        @client = Kontena::Client.new(
           api_url || require_current_master.url,
           token || require_current_master.token
         )

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -1,8 +1,8 @@
 require 'ostruct'
 require 'singleton'
 require 'forwardable'
-require 'json'
 require 'logger'
+autoload :JSON, 'json'
 
 module Kontena
   module Cli
@@ -28,6 +28,7 @@ module Kontena
       attr_accessor :logger
       attr_accessor :current_server
       attr_reader :current_account
+
 
       def self.reset_instance
         Singleton.send :__init__, self

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -40,7 +40,8 @@ module Kontena::Cli::Master::Config
         require 'json'
         JSON.parse(data)
       when 'yaml', 'yml'
-        require 'yaml'
+        require "safe_yaml"
+        SafeYAML::OPTIONS[:default_mode] = :safe
         YAML.safe_load(data)
       else
         exit_with_error "Unknown input format '#{self.format}'"

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -3,6 +3,9 @@ require_relative '../services/services_helper'
 require_relative 'service_generator_v2'
 require_relative '../../stacks_client'
 
+require "safe_yaml"
+SafeYAML::OPTIONS[:default_mode] = :safe
+
 module Kontena::Cli::Stacks
   module Common
     include Kontena::Cli::Services::ServicesHelper

--- a/cli/lib/kontena/cli/stacks/registry/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/show_command.rb
@@ -14,6 +14,8 @@ module Kontena::Cli::Stacks::Registry
 
     def execute
       require 'semantic'
+      require "safe_yaml"
+      SafeYAML::OPTIONS[:default_mode] = :safe
       unless versions?
         stack = ::YAML.safe_load(stacks_client.show(stack_name, stack_version))
         puts "#{stack['stack']}:"

--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -1,4 +1,5 @@
 require_relative 'common'
+require 'yaml'
 
 module Kontena::Cli::Stacks
   class ValidateCommand < Kontena::Command

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -25,7 +25,8 @@ module Kontena::Cli::Stacks
       attr_reader :file, :raw_content, :errors, :notifications, :defaults, :values, :registry
 
       def initialize(file, skip_validation: false, skip_variables: false, variables: nil, values: nil, defaults: nil)
-        require 'yaml'
+        require "safe_yaml"
+        SafeYAML::OPTIONS[:default_mode] = :safe
         require_relative 'service_extender'
         require_relative 'validator_v3'
         require_relative 'opto'

--- a/cli/lib/kontena/cli/stacks/yaml/service_extender.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/service_extender.rb
@@ -1,4 +1,3 @@
-require 'yaml'
 require_relative '../../../util'
 
 module Kontena::Cli::Stacks

--- a/cli/lib/kontena/cli/vault/export_command.rb
+++ b/cli/lib/kontena/cli/vault/export_command.rb
@@ -11,6 +11,9 @@ module Kontena::Cli::Vault
 
     def execute
       require 'shellwords'
+      require 'json'
+      require "safe_yaml"
+      SafeYAML::OPTIONS[:default_mode] = :safe
       meth = json? ? :to_json : :to_yaml
       puts(
         Kontena.run!(['vault', 'ls', '--return']).sort.map do |secret|

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -15,6 +15,9 @@ module Kontena::Cli::Vault
     requires_current_master
 
     def parsed_input
+      require "json"
+      require "safe_yaml"
+      SafeYAML::OPTIONS[:default_mode] = :safe
       json? ? JSON.load(input) : YAML.safe_load(input)
     end
 

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -1,16 +1,3 @@
-require 'json'
-require 'excon'
-require 'uri'
-require 'base64'
-require 'socket'
-require 'openssl'
-require 'uri'
-require 'time'
-require 'logger'
-require 'kontena/errors'
-require 'kontena/cli/version'
-require 'kontena/cli/config'
-
 module Kontena
   class Client
 
@@ -41,6 +28,18 @@ module Kontena
     # @param [Kontena::Cli::Config::Token,Hash] access_token
     # @param [Hash] options
     def initialize(api_url, token = nil, options = {})
+      require 'json'
+      require 'excon'
+      require 'uri'
+      require 'base64'
+      require 'socket'
+      require 'openssl'
+      require 'uri'
+      require 'time'
+      require 'kontena/errors'
+      require 'kontena/cli/version'
+      require 'kontena/cli/config'
+
       @api_url, @token, @options = api_url, token, options
       uri = URI.parse(@api_url)
       @host = uri.host

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -1,9 +1,9 @@
 require 'clamp'
 require 'kontena/cli/subcommand_loader'
-require 'kontena/cli/common'
 require 'kontena/util'
 require 'kontena/cli/bytes_helper'
 require 'kontena/cli/grid_options'
+require 'excon/errors'
 
 class Kontena::Command < Clamp::Command
 

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -1,9 +1,6 @@
 require 'kontena/command'
 
 class Kontena::MainCommand < Kontena::Command
-  include Kontena::Util
-  include Kontena::Cli::Common
-
   option ['-v', '--version'], :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
     build_tags = [ 'ruby' + RUBY_VERSION ]
     build_tags << RUBY_PLATFORM
@@ -44,7 +41,7 @@ class Kontena::MainCommand < Kontena::Command
 
   def subcommand_missing(name)
     if known_plugin_subcommand?(name)
-      exit_with_error "The '#{name}' plugin has not been installed. Use: kontena plugin install #{name}"
+      abort "The '#{name}' plugin has not been installed. Use: kontena plugin install #{name}"
     else
       super(name)
     end

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -41,7 +41,8 @@ class Kontena::MainCommand < Kontena::Command
 
   def subcommand_missing(name)
     if known_plugin_subcommand?(name)
-      abort "The '#{name}' plugin has not been installed. Use: kontena plugin install #{name}"
+      extend Kontena::Cli::Common
+      exit_with_error "The '#{name}' plugin has not been installed. Use: kontena plugin install #{name}"
     else
       super(name)
     end

--- a/cli/lib/kontena/stacks_cache.rb
+++ b/cli/lib/kontena/stacks_cache.rb
@@ -1,10 +1,6 @@
-require_relative 'stacks_client'
-require_relative 'cli/common'
-require_relative 'cli/stacks/common'
-require 'yaml'
-require 'uri'
-
 module Kontena
+  autoload :StacksClient, 'kontena/stacks_client'
+
   class StacksCache
     class CachedStack
 
@@ -12,6 +8,8 @@ module Kontena
       attr_accessor :version
 
       def initialize(stack, version = nil)
+        require "safe_yaml"
+        SafeYAML::OPTIONS[:default_mode] = :safe
         unless version
           stack, version = stack.split(':', 2)
         end
@@ -59,6 +57,8 @@ module Kontena
     end
 
     class RegistryClientFactory
+      require 'kontena/cli/common'
+      require 'kontena/cli/stacks/common'
       include Kontena::Cli::Common
       include Kontena::Cli::Stacks::Common
     end

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -7,6 +7,19 @@ at_exit do
 end
 
 module Kontena
+  module Cli
+    autoload :Config, 'kontena/cli/config'
+    autoload :Spinner, 'kontena/cli/spinner'
+    autoload :Common, 'kontena/cli/common'
+  end
+
+  autoload :Command, 'kontena/command'
+  autoload :Client, 'kontena/client'
+  autoload :StacksCache, 'kontena/stacks_cache'
+  autoload :PluginManager, 'kontena/plugin_manager'
+  autoload :MainCommand, 'kontena/main_command'
+  autoload :Errors, 'kontena/errors'
+
   # Run a kontena command like it was launched from the command line. Re-raises any exceptions,
   # except a SystemExit with status 0, which is considered a success.
   #
@@ -166,14 +179,5 @@ end
 
 require 'ruby_dig'
 require 'shellwords'
-require "safe_yaml"
-SafeYAML::OPTIONS[:default_mode] = :safe
 require 'kontena/cli/version'
 Kontena.logger.debug { "Kontena CLI #{Kontena::Cli::VERSION} (ruby-#{RUBY_VERSION}+#{RUBY_PLATFORM})" }
-require 'kontena/cli/common'
-require 'kontena/command'
-require 'kontena/client'
-require 'kontena/stacks_cache'
-require 'kontena/plugin_manager'
-require 'kontena/main_command'
-require 'kontena/cli/spinner'

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -11,6 +11,7 @@ module Kontena
     autoload :Config, 'kontena/cli/config'
     autoload :Spinner, 'kontena/cli/spinner'
     autoload :Common, 'kontena/cli/common'
+    autoload :TableGenerator, 'kontena/cli/table_generator'
   end
 
   autoload :Command, 'kontena/command'

--- a/cli/spec/kontena/cli/nodes/list_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/list_command_spec.rb
@@ -6,8 +6,6 @@ describe Kontena::Cli::Nodes::ListCommand do
 
   let(:subject) { described_class.new("kontena") }
 
-  let(:client) { double }
-
   before do
     allow(subject).to receive(:health_icon) {|health| health.inspect }
     allow(subject).to receive(:client).and_return(client)

--- a/cli/spec/kontena/cli/version_command_spec.rb
+++ b/cli/spec/kontena/cli/version_command_spec.rb
@@ -3,7 +3,7 @@ require "kontena/cli/version_command"
 describe Kontena::Cli::VersionCommand do
 
   include ClientHelpers
-  
+
   let :http_client do
     double(:http_client)
   end
@@ -13,7 +13,7 @@ describe Kontena::Cli::VersionCommand do
       expect(client).to receive(:http_client).and_return(http_client)
       expect(http_client).to receive(:get).with(path: '/').and_return(double(body: '{"version": "0.1"}'))
 
-      expect { subject.run([]) }.to output("cli: #{Kontena::Cli::VERSION}\nmaster: 0.1 (someurl)\n").to_stdout
+      expect { subject.run([]) }.to output("cli: #{Kontena::Cli::VERSION}\nmaster: 0.1 (#{subject.current_master.url})\n").to_stdout
     end
   end
 end

--- a/cli/spec/support/client_helpers.rb
+++ b/cli/spec/support/client_helpers.rb
@@ -21,8 +21,8 @@ module ClientHelpers
       {'current_server' => 'alias',
        'current_account' => 'kontena',
        'servers' => [
-           {'name' => 'some_master', 'url' => 'some_master'},
-           {'name' => 'alias', 'url' => 'someurl', 'token' => token, 'account' => 'master', 'grid' => current_grid},
+           {'name' => 'some_master', 'url' => 'http://someurl.example.com'},
+           {'name' => 'alias', 'url' => 'http://someurl.example.com/', 'token' => token, 'account' => 'master', 'grid' => current_grid},
        ]
       }
     end
@@ -31,7 +31,7 @@ module ClientHelpers
       RSpec::Mocks.space.proxy_for(File).reset
       allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:current_grid).and_return(current_grid)
-      allow(File).to receive(:exist?).with(File.join(Dir.home, '.kontena/certs/.pem')).and_return(false)
+      allow(File).to receive(:exist?).with(File.join(Dir.home, '.kontena/certs/someurl.example.com.pem')).and_return(false)
       allow(File).to receive(:exist?).with(File.join(Dir.home, '.kontena_client.json')).and_return(true)
       allow(File).to receive(:readable?).with(File.join(Dir.home, '.kontena_client.json')).and_return(true)
       allow(File).to receive(:read).and_call_original

--- a/cli/spec/support/output_helpers.rb
+++ b/cli/spec/support/output_helpers.rb
@@ -5,6 +5,7 @@ module OutputHelpers
     supports_block_expectations
 
     match do |block|
+      @expected = expected
       stdout = lines.flatten.join("\n") + "\n"
 
       begin
@@ -14,7 +15,7 @@ module OutputHelpers
 
         return false
       else
-        return values_match? expected, @return
+        return values_match? @expected, @return
       end
     end
 
@@ -22,7 +23,7 @@ module OutputHelpers
       if @error
         return @error
       else
-        return "expected #{block} to return #{expected}, but returned #{@return}"
+        return "expected #{block} to return #{@expected}, but returned #{@return}"
       end
     end
   end
@@ -59,7 +60,9 @@ module OutputHelpers
           end
         end
       else
-        @error = "expected #{@expected.size} lines but got #{@lines.size} lines instead"
+        @error = "expected #{@expected.size} lines but got #{@real.size} lines instead:\n"
+        @error += "Expected:\n#{@expected.map(&:inspect).join("\n")}"
+        @error += "Received:\n#{@real.map(&:inspect).join("\n")}"
       end
       @error.nil?
     end


### PR DESCRIPTION
Before: (with #2334 and the plugin disabler from this PR)

```
$ time NO_PLUGINS=true bin/kontena whoami --help
0.26s user 0.06s system 92% cpu 0.342 total
```

After:
```
$ time NO_PLUGINS=true bin/kontena whoami --help
0.09s user 0.04s system 84% cpu 0.161 total
```
