### PR TITLE
Add deprecation flag for app commands

### DIFF
--- a/cli/lib/kontena/cli/app_command.rb
+++ b/cli/lib/kontena/cli/app_command.rb
@@ -1,6 +1,8 @@
 
 class Kontena::Cli::AppCommand < Kontena::Command
 
+  warn Kontena.pastel.yellow("[DEPRECATED] The `kontena app` commands are deprecated in favor of `kontena stack` commands and will be removed in future releases")
+
   subcommand "init", "Init Kontena application", load_subcommand('apps/init_command')
   subcommand "build", "Build Kontena services", load_subcommand('apps/build_command')
   subcommand "config", "View service configurations", load_subcommand('apps/config_command')


### PR DESCRIPTION
Kontena app commands are superseded by stacks. So makes sense to direct people to start moving from apps to stacks.
```
 k app
[DEPRECATED] The `kontena app` commands are deprecated in favor of `kontena stack` commands and will be removed in future releases
Usage:
    kontena app [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    init                          Init Kontena application
    build                         Build Kontena services
    config                        View service configurations
    deploy                        Deploy Kontena services
    scale                         Scale services
    start                         Start services
    stop                          Stop services
    restart                       Restart services
    show                          Show service details
    ps, list, ls                  List services
    logs                          Show service logs
    monitor                       Monitor services
    remove, rm                    Remove services

Options:
    -h, --help                    print help
    -D, --debug                   Enable debug (default: $DEBUG)


```

fixes #2319 