### PR TITLE
Serialize all pubsub payloads to avoid issues with dotted fields

### DIFF
--- a/server/app/models/pubsub_channel.rb
+++ b/server/app/models/pubsub_channel.rb
@@ -3,5 +3,5 @@ class PubsubChannel
 
   field :created_at, type: DateTime
   field :channel, type: String
-  field :data, type: Hash
+  field :data, type: BSON::Binary
 end

--- a/server/app/services/mongo_pubsub.rb
+++ b/server/app/services/mongo_pubsub.rb
@@ -59,14 +59,7 @@ class MongoPubsub
 
     # @param [Hash] data
     def send_message(data)
-      payload = Marshal::load(data.data)
-      if payload.is_a?(Hash)
-        # Serialization preserves symbol keys opposed to old un-serialized hash storing which automatically converted
-        # symbol keys into strings.
-        # There's lot of code paths where stringified keys are expected
-        payload = payload.stringify_keys
-      end
-      
+      payload = MessagePack.unpack(data.data)
       @block.call(payload)
     end
   end
@@ -101,7 +94,7 @@ class MongoPubsub
   def publish(channel, data)
     self.collection.insert_one(
       channel: channel,
-      data: BSON::Binary.new(Marshal::dump(data)),
+      data: BSON::Binary.new(MessagePack.pack(data)),
       created_at: Time.now.utc
     )
   end

--- a/server/spec/services/rpc_client_spec.rb
+++ b/server/spec/services/rpc_client_spec.rb
@@ -28,7 +28,8 @@ describe RpcClient, celluloid: true do
         publish_response(resp['message'][1], response)
       }
       resp = subject.request('/hello/service', :foo, :bar)
-      expect(resp).to eq(['/hello/service', :foo, :bar])
+      # Msgpack serializes symbols into strings
+      expect(resp).to eq(['/hello/service', 'foo', 'bar'])
 
       server.terminate
     end
@@ -117,7 +118,8 @@ describe RpcClient, celluloid: true do
       server = fake_server('notify') {|resp|
         receiver.handle(resp['message'][2])
       }
-      expect(receiver).to receive(:handle).with([:foo, :bar])
+      # Msgpack serializes symbols into strings
+      expect(receiver).to receive(:handle).with(['foo', 'bar'])
       subject.notify('/hello/service', :foo, :bar)
       sleep 0.05
       server.terminate


### PR DESCRIPTION
fixes #2340 

Newer mongoid doesn't allow dotted fields in hashes. There are multiple RPC cases where the hash payload has dotted fields.

This PR adds generic payload serialization on pubsub messages to avoid any such issues.