### PR TITLE
Don't crash VolumeManager if volume remove fails

### DIFF
--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -130,7 +130,11 @@ module Kontena::Workers::Volumes
         if volume_instance_id
           unless current_ids.include?(volume_instance_id)
             info "removing volume: #{volume.id}"
-            volume.remove
+            begin
+              volume.remove
+            rescue => exc
+              warn "removing volume failed: #{exc.class} #{exc.message}"
+            end
           end
         end
       end

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -167,6 +167,20 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
       expect(volumes[0]).to receive(:remove)
       subject.terminate_volumes(['456'])
     end
+
+    it 'handles error from volume remove' do
+      volumes = [
+        double(:volume, 'id' => 'foo', 'info' => {
+          'Name' => 'foo',
+          'Labels' => { 'io.kontena.volume_instance.id' => '123'}
+        })
+      ]
+      expect(Docker::Volume).to receive(:all).and_return(volumes)
+      expect(volumes[0]).to receive(:remove).and_raise("BoomBoom")
+      subject.terminate_volumes(['456'])
+      # The actor should be still alive
+      expect(subject).to be_alive
+    end
   end
 
 end


### PR DESCRIPTION
As service/stack and volume removals are now async it is possible that a volume removal lands on the agent before the containers using a volume are actually removed. This causes the `VolumeManager` actor to crash hard during volume removal. When the supervisor boots it again it pretty much crashed immediately again as it syncs up with master and tries to remove some volumes. Vóila, crash-restart-loop until the containers are actually removed.

This PR makes the `VolumeManager` to handle errors in volume remove case. If the remove fails, a `warn` is logged and the remove is re-tried on next sync loop with master.

```
kontena-agent | D, [2017-05-19T11:43:34.500239 #1] DEBUG -- Kontena::Workers::Volumes::VolumeManager: got volumes from master: {"volumes"=>[]}
kontena-agent | I, [2017-05-19T11:43:35.279021 #1]  INFO -- Kontena::Workers::Volumes::VolumeManager: removing volume: redis.testVol-1
kontena-agent | W, [2017-05-19T11:43:35.281974 #1]  WARN -- Kontena::Workers::Volumes::VolumeManager: removing volume failed: Docker::Error::ConflictError Unable to remove volume, volume still in use: remove redis.testVol-1: volume is in use - [ba0f678fb538532b86d7507a86c6562f14be5abf5addc40a3fb4f1222e82c303]
```
Once the container using the volume is removed, volume removal happens as expected:
```
kontena-agent | D, [2017-05-19T11:44:05.295848 #1] DEBUG -- Kontena::Workers::Volumes::VolumeManager: got volumes from master: {"volumes"=>[]}
kontena-agent | I, [2017-05-19T11:44:06.311551 #1]  INFO -- Kontena::Workers::Volumes::VolumeManager: removing volume: redis.testVol-1
```