### PR TITLE
Support capturing STDOUT in Kontena.run

### DIFF
--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -14,13 +14,17 @@ module Kontena
       command = cmdline
     end
     ENV["DEBUG"] && puts("Running Kontena.run(#{command.inspect}")
+    result = nil
     if capture
       orig_stdout = $stdout
       stdout = StringIO.new
       $stdout = stdout
-      Kontena::MainCommand.new(File.basename(__FILE__)).run(command)
-      $stdout = orig_stdout
-      result = stdout.string.split(/[\r\n]/)
+      begin
+        Kontena::MainCommand.new(File.basename(__FILE__)).run(command)
+      ensure
+        result = stdout.string.split(/[\r\n]/)
+        $stdout = orig_stdout
+      end
     else
       result = Kontena::MainCommand.new(File.basename(__FILE__)).run(command)
     end
@@ -28,6 +32,7 @@ module Kontena
     result
   rescue SystemExit => ex
     ENV["DEBUG"] && $stderr.puts("Command caused SystemExit, result: #{result.inspect} status: #{ex.status}")
+    return result if ex.status.zero? && capture
     return true if ex.status.zero?
     raise ex
   rescue => ex

--- a/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/master/add_command_spec.rb
@@ -95,8 +95,8 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
       subject.provider = 'provider'
       subject.version  = '10.10.10'
 
-      expect(Kontena).to receive(:run!).with(%w(master config import --force --preset kontena_auth_provider))
-      expect(Kontena).to receive(:run!).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true))
+      expect(Kontena).to receive(:run!).with(%w(master config import --force --preset kontena_auth_provider), capture: false)
+      expect(Kontena).to receive(:run!).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true), capture: false)
 
       subject.register_current
     end
@@ -108,9 +108,9 @@ describe Kontena::Cli::Cloud::Master::AddCommand do
       subject.version  = '10.10.10'
       subject.cloud_master_id = 'abcd'
 
-      expect(Kontena).to receive(:run!).with(%w(cloud master update --provider provider --version 10.10.10 abcd)).and_return(true)
-      expect(Kontena).to receive(:run!).with(%w(master config import --force --preset kontena_auth_provider)).and_return(true)
-      expect(Kontena).to receive(:run!).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true)).and_return(true)
+      expect(Kontena).to receive(:run!).with(%w(cloud master update --provider provider --version 10.10.10 abcd), capture: false).and_return(true)
+      expect(Kontena).to receive(:run!).with(%w(master config import --force --preset kontena_auth_provider), capture: false).and_return(true)
+      expect(Kontena).to receive(:run!).with(%w(master config set oauth2.client_id=123 oauth2.client_secret=345 server.root_url=foofoofoo server.name=foofoo cloud.provider_is_kontena=true), capture: false).and_return(true)
 
       subject.register_current
     end

--- a/cli/spec/kontena/kontena_cli_spec.rb
+++ b/cli/spec/kontena/kontena_cli_spec.rb
@@ -31,35 +31,44 @@ describe Kontena do
   end
 
   describe '#run!' do
-    let(:whoami) { double(:whoami) }
-
-    before(:each) do
-      expect(Kontena::Cli::WhoamiCommand).to receive(:new).and_return(whoami)
+    context 'capture' do
+      it 'captures command output' do
+        STDOUT.puts Kontena.run!(['--version'], capture:true).inspect
+        expect(Kontena.run!(['--version'], capture: true).join(' ')).to match /kontena\-cli \d+\.\d+.\d+/
+      end
     end
 
-    it 'accepts a command line as string' do
-      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
-      Kontena.run!('whoami --bash-completion-path')
-    end
+    context 'without capture' do
+      let(:whoami) { double(:whoami) }
 
-    it 'accepts a command line as a list of parameters' do
-      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
-      Kontena.run!('whoami', '--bash-completion-path')
-    end
+      before(:each) do
+        expect(Kontena::Cli::WhoamiCommand).to receive(:new).and_return(whoami)
+      end
 
-    it 'accepts a command line as an array' do
-      expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
-      Kontena.run!(['whoami', '--bash-completion-path'])
-    end
+      it 'accepts a command line as string' do
+        expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
+        Kontena.run!('whoami --bash-completion-path')
+      end
 
-    it 'Returns true if the command exits with SystemExit status 0' do
-      expect(whoami).to receive(:run) { exit 0 }
-      expect(Kontena.run!(['whoami'])).to be_truthy
-    end
+      it 'accepts a command line as a list of parameters' do
+        expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
+        Kontena.run!('whoami', '--bash-completion-path')
+      end
 
-    it 'Re-raises the SystemExit when command exits with non-zero status' do
-      expect(whoami).to receive(:run) { exit 1 }
-      expect{Kontena.run!(['whoami'])}.to exit_with_error.status(1)
+      it 'accepts a command line as an array' do
+        expect(whoami).to receive(:run).with(['--bash-completion-path']).and_return(true)
+        Kontena.run!(['whoami', '--bash-completion-path'])
+      end
+
+      it 'Returns true if the command exits with SystemExit status 0' do
+        expect(whoami).to receive(:run) { exit 0 }
+        expect(Kontena.run!(['whoami'])).to be_truthy
+      end
+
+      it 'Re-raises the SystemExit when command exits with non-zero status' do
+        expect(whoami).to receive(:run) { exit 1 }
+        expect{Kontena.run!(['whoami'])}.to exit_with_error.status(1)
+      end
     end
   end
 


### PR DESCRIPTION
In addendum to #2209 

Captures command STDOUT output and returns it as an array of strings.

```ruby
result = Kontena.run(%w(node ls -q), capture: true)
result.each do |node_name|
  puts node_name
end
```
