### PR TITLE
Normalize parameter names in command help output

### DIFF
--- a/cli/lib/kontena/cli/apps/build_command.rb
+++ b/cli/lib/kontena/cli/apps/build_command.rb
@@ -8,10 +8,10 @@ module Kontena::Cli::Apps
     include DockerHelper
 
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['--no-cache'], :flag, 'Do not use cache when building the image', default: false
     option '--skip-validation', :flag, 'Skip YAML file validation', default: false
-    parameter "[SERVICE] ...", "Services to build"
+    parameter "[SERVICE] ...", "Services to build", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/apps/config_command.rb
+++ b/cli/lib/kontena/cli/apps/config_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::Common
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
     option '--skip-validation', :flag, 'Skip YAML file validation', default: false
-    parameter "[SERVICE] ...", "Services to view"
+    parameter "[SERVICE] ...", "Services to view", completion: :yaml_services
 
     def execute
       require_config_file(filename)

--- a/cli/lib/kontena/cli/apps/deploy_command.rb
+++ b/cli/lib/kontena/cli/apps/deploy_command.rb
@@ -9,14 +9,14 @@ module Kontena::Cli::Apps
     include Common
     include DockerHelper
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['--no-build'], :flag, 'Don\'t build an image, even if it\'s missing', default: false
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
     option '--async', :flag, 'Run deploys async/parallel'
     option '--force', :flag, 'Force deploy even if service does not have any changes'
 
     option '--skip-validation', :flag, 'Skip YAML file validation', default: false
-    parameter "[SERVICE] ...", "Services to start"
+    parameter "[SERVICE] ...", "Services to start", completion: :yaml_services
 
     attr_reader :services, :deploy_queue
 

--- a/cli/lib/kontena/cli/apps/init_command.rb
+++ b/cli/lib/kontena/cli/apps/init_command.rb
@@ -10,11 +10,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::Common
     include Common
 
-    option ["-f", "--file"], "FILE", "Specify a docker-compose file", attribute_name: :docker_compose_file, default: 'docker-compose.yml'
+    option ["-f", "--file"], "YAML_FILE", "Specify a docker-compose file", attribute_name: :docker_compose_file, default: 'docker-compose.yml'
     option ["-i", "--image-name"], "IMAGE_NAME", "Specify a docker image name"
     option ["-b", "--base-image"], "BASE_IMAGE_NAME", "Specify a docker base image name", default: "kontena/buildstep"
     option ["-p", "--project-name"], "NAME", "Specify an alternate project name (default: directory name)"
-
 
     def execute
       if File.exist?('Dockerfile')

--- a/cli/lib/kontena/cli/apps/list_command.rb
+++ b/cli/lib/kontena/cli/apps/list_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::GridOptions
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
 
-    parameter "[SERVICE] ...", "Services to start"
+    parameter "[SERVICE] ...", "Services to start", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/apps/logs_command.rb
+++ b/cli/lib/kontena/cli/apps/logs_command.rb
@@ -9,9 +9,9 @@ module Kontena::Cli::Apps
 
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
-    parameter "[SERVICE] ...", "Show only specified service logs"
+    parameter "[SERVICE] ...", "Show only specified service logs", completion: :yaml_services
 
     def execute
       require_config_file(filename)

--- a/cli/lib/kontena/cli/apps/monitor_command.rb
+++ b/cli/lib/kontena/cli/apps/monitor_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::GridOptions
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
 
-    parameter "[SERVICE] ...", "Services to start"
+    parameter "[SERVICE] ...", "Services to start", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/apps/remove_command.rb
+++ b/cli/lib/kontena/cli/apps/remove_command.rb
@@ -6,11 +6,11 @@ module Kontena::Cli::Apps
     include Kontena::Cli::GridOptions
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
     option '--force', :flag, 'Force remove', default: false, attribute_name: :forced
 
-    parameter "[SERVICE] ...", "Remove services"
+    parameter "[SERVICE] ...", "Remove services", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/apps/restart_command.rb
+++ b/cli/lib/kontena/cli/apps/restart_command.rb
@@ -5,10 +5,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::Common
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
 
-    parameter "[SERVICE] ...", "Services to start"
+    parameter "[SERVICE] ...", "Services to start", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/apps/scale_command.rb
+++ b/cli/lib/kontena/cli/apps/scale_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::GridOptions
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
 
-    parameter "SERVICE", "Service to show"
+    parameter "SERVICE", "Service to show", completion: :yaml_services
     parameter "INSTANCES", "Scales service to given number of instances"
 
     attr_reader :services

--- a/cli/lib/kontena/cli/apps/show_command.rb
+++ b/cli/lib/kontena/cli/apps/show_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::GridOptions
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
 
-    parameter "SERVICE", "Service to show"
+    parameter "SERVICE", "Service to show", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/apps/start_command.rb
+++ b/cli/lib/kontena/cli/apps/start_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::GridOptions
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
 
-    parameter "[SERVICE] ...", "Services to start"
+    parameter "[SERVICE] ...", "Services to start", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/apps/stop_command.rb
+++ b/cli/lib/kontena/cli/apps/stop_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Apps
     include Kontena::Cli::GridOptions
     include Common
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
     option ['-p', '--project-name'], 'NAME', 'Specify an alternate project name (default: directory name)'
 
-    parameter "[SERVICE] ...", "Services to stop"
+    parameter "[SERVICE] ...", "Services to stop", completion: :yaml_services
 
     attr_reader :services
 

--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -4,7 +4,6 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
     parameter "DOMAIN", "Domain to authorize"
 
     def execute

--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -4,11 +4,9 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
     option '--secret-name', 'SECRET_NAME', 'The name for the secret to store the certificate in'
-    option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain, chain or cert', default: 'fullchain'
+    option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain, chain or cert', default: 'fullchain', completion: %w(fullchain chain cert)
     parameter "DOMAIN ...", "Domain(s) to get certificate for"
-
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/certificate/register_command.rb
+++ b/cli/lib/kontena/cli/certificate/register_command.rb
@@ -4,7 +4,6 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
     parameter "EMAIL", "Email to register"
 
     def execute

--- a/cli/lib/kontena/cli/certificate_command.rb
+++ b/cli/lib/kontena/cli/certificate_command.rb
@@ -1,7 +1,5 @@
 
 class Kontena::Cli::CertificateCommand < Kontena::Command
-
-
   subcommand "register", "Register to LetsEncrypt", load_subcommand('certificate/register_command')
   subcommand "authorize", "Create DNS authorization for domain", load_subcommand('certificate/authorize_command')
   subcommand "get", "Get certificate for domain", load_subcommand('certificate/get_command')

--- a/cli/lib/kontena/cli/cloud/logout_command.rb
+++ b/cli/lib/kontena/cli/cloud/logout_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Cloud
     include Kontena::Cli::Common
 
     def execute
-      config.accounts.each do |account|        
+      config.accounts.each do |account|
         use_refresh_token(account)
         account.token = nil
       end

--- a/cli/lib/kontena/cli/cloud/master/remove_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/remove_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Cloud::Master
 
     requires_current_account_token
 
-    parameter "[MASTER_ID]", "Master ID"
+    parameter "[CLOUD_MASTER_ID]", "Master ID", attribute_name: :master_id
 
     option ['-f', '--force'], :flag, "Don't ask for confirmation"
 

--- a/cli/lib/kontena/cli/cloud/master/show_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/show_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Cloud::Master
 
     requires_current_account_token
 
-    parameter "MASTER_ID", "Master ID"
+    parameter "CLOUD_MASTER_ID", "Master ID", attribute_name: :master_id
 
     def execute
       response = cloud_client.get("user/masters/#{master_id}")

--- a/cli/lib/kontena/cli/cloud/master/update_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/update_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Cloud::Master
 
     requires_current_account_token
 
-    parameter "MASTER_ID", "Master ID"
+    parameter "CLOUD_MASTER_ID", "Master ID", attribute_name: :master_id
 
     option ['--redirect-uri'], '[URL]',      'Set master redirect URL'
     option ['--url'],          '[URL]',      'Set master URL'

--- a/cli/lib/kontena/cli/etcd/get_command.rb
+++ b/cli/lib/kontena/cli/etcd/get_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Etcd
     include Kontena::Cli::GridOptions
     include Common
 
-    parameter "KEY", "Etcd key"
+    parameter "ETCD_KEY", "Etcd key", attribute_name: :key
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/etcd/health_command.rb
+++ b/cli/lib/kontena/cli/etcd/health_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Etcd
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::HealthHelper
 
-    parameter "[NODE]", "Show health for specific node"
+    parameter "[NODE_NAME]", "Show health for specific node", attribute_name: :node
 
     requires_current_master
     requires_current_grid

--- a/cli/lib/kontena/cli/etcd/list_command.rb
+++ b/cli/lib/kontena/cli/etcd/list_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Etcd
     include Kontena::Cli::GridOptions
     include Common
 
-    parameter "KEY", "Etcd key"
+    parameter "ETCD_KEY", "Etcd key", attribute_name: :key
 
     option "--recursive", :flag, "List keys recursively", default: false
 

--- a/cli/lib/kontena/cli/etcd/mkdir_command.rb
+++ b/cli/lib/kontena/cli/etcd/mkdir_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Etcd
     include Kontena::Cli::GridOptions
     include Common
 
-    parameter "KEY", "Etcd key"
+    parameter "ETCD_KEY", "Etcd key", attribute_name: :key
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/etcd/remove_command.rb
+++ b/cli/lib/kontena/cli/etcd/remove_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Etcd
     include Kontena::Cli::GridOptions
     include Common
 
-    parameter "KEY", "Etcd key"
+    parameter "ETCD_KEY", "Etcd key", attribute_name: :key
 
     option "--recursive", :flag, "Remove keys recursively"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced

--- a/cli/lib/kontena/cli/etcd/set_command.rb
+++ b/cli/lib/kontena/cli/etcd/set_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Etcd
     include Kontena::Cli::GridOptions
     include Common
 
-    parameter "KEY", "Etcd key"
+    parameter "ETCD_KEY", "Etcd key", attribute_name: :key
     parameter "VALUE", "Etcd value"
 
     def execute

--- a/cli/lib/kontena/cli/external_registries/remove_command.rb
+++ b/cli/lib/kontena/cli/external_registries/remove_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::ExternalRegistries
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "NAME", "External registry name to remove"
+    parameter "EXTERNAL_REGISTRY_NAME", "External registry name to remove", attribute_name: :name
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute

--- a/cli/lib/kontena/cli/grids/cloud_config_command.rb
+++ b/cli/lib/kontena/cli/grids/cloud_config_command.rb
@@ -5,12 +5,12 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
     include Common
 
-    parameter "NAME", "Grid name"
+    parameter "GRID_NAME", "Grid name"
     option "--dns", "DNS",  "DNS server", multivalued: true
     option "--peer-interface", "IFACE", "Peer (private) network interface", default: "eth1"
     option "--default-interface-match", "IFACE-GLOB", "Match default network interfaces", default: nil
     option "--docker-bip", "BIP", "Docker bridge ip", default: "172.17.43.1/16"
-    option "--version", "VERSION", "Agent version", default: "latest"
+    option "--version", "VERSION", "Agent version", default: "latest", completion: %w(latest edge)
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/grids/env_command.rb
+++ b/cli/lib/kontena/cli/grids/env_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
     include Common
 
-    parameter "[NAME]", "Grid name"
+    parameter "[GRID_NAME]", "Grid name", attribute_name: :name
     option ["-e", "--export"], :flag, "Add export", default: false
 
     def execute

--- a/cli/lib/kontena/cli/grids/events_command.rb
+++ b/cli/lib/kontena/cli/grids/events_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Grids
 
     SKIP_TYPES = ['grid']
 
-    option "--node", "NODE", "Filter by node name", multivalued: true
+    option "--node", "NODE_NAME", "Filter by node name", multivalued: true, attribute_name: :node_list
     option "--service", "SERVICE", "Filter by service name", multivalued: true
 
     def execute

--- a/cli/lib/kontena/cli/grids/health_command.rb
+++ b/cli/lib/kontena/cli/grids/health_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Helpers::HealthHelper
     include Common
 
-    parameter "[NAME]", "Grid name"
+    parameter "[GRID_NAME]", "Grid name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -4,9 +4,10 @@ module Kontena::Cli::Grids
   class LogsCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::Helpers::LogHelper
-    option "--node", "NODE", "Filter by node name", multivalued: true
+
+    option "--node", "NODE_NAME", "Filter by node name", multivalued: true, attribute_name: :node_list
     option "--service", "SERVICE", "Filter by service name", multivalued: true
-    option ["-c", "--container"], "CONTAINER", "Filter by container", multivalued: true
+    option ["-c", "--container"], "CONTAINER_ID", "Filter by container", multivalued: true, attribute_name: :container_list
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
     include Common
 
-    parameter "NAME", "Grid name"
+    parameter "GRID_NAME", "Grid name", attribute_name: :name
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute

--- a/cli/lib/kontena/cli/grids/show_command.rb
+++ b/cli/lib/kontena/cli/grids/show_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
     include Common
 
-    parameter "NAME", "Grid name"
+    parameter "GRID_NAME", "Grid name", attribute_name: :name
 
     option '--token', :flag, 'Just output grid token'
 

--- a/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/list_command.rb
@@ -3,7 +3,11 @@ module Kontena::Cli::Grids::TrustedSubnets
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
+<<<<<<< Updated upstream
     requires_current_master
+=======
+    parameter "GRID_NAME", "Grid name", attribute_name: :name
+>>>>>>> Stashed changes
 
     def execute
       grid = client.get("grids/#{current_grid}")

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Grids::TrustedSubnets
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "SUBNET", "Trusted subnet"
+    parameter "TRUSTED_SUBNET", "Trusted subnet", attribute_name: :subnet
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     requires_current_master

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -5,12 +5,12 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
     include Common
 
-    parameter "NAME", "Grid name"
+    parameter "GRID_NAME", "Grid name", attribute_name: :name
     option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
     option "--no-statsd-server", :flag, "Unset statsd server setting"
     option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
     option "--no-default-affinity", :flag, "Unset grid default affinity"
-    option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
+    option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)", completion: %w(none fluentd)
     option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
 
     def execute

--- a/cli/lib/kontena/cli/grids/use_command.rb
+++ b/cli/lib/kontena/cli/grids/use_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Grids
 
     requires_current_master
 
-    parameter "NAME", "Grid name to use"
+    parameter "GRID_NAME", "Grid name to use", attribute_name: :name
 
     option ['--silent'], :flag, 'Reduce output verbosity'
 

--- a/cli/lib/kontena/cli/grids/user_command.rb
+++ b/cli/lib/kontena/cli/grids/user_command.rb
@@ -1,6 +1,4 @@
 module Kontena::Cli::Grids
-
-
   class UserCommand < Kontena::Command
     subcommand ["list", "ls"], "List grid users", load_subcommand('grids/users/list_command')
     subcommand "add", "Add user to grid", load_subcommand('grids/users/add_command')

--- a/cli/lib/kontena/cli/master/config/export_command.rb
+++ b/cli/lib/kontena/cli/master/config/export_command.rb
@@ -8,10 +8,10 @@ module Kontena::Cli::Master::Config
 
     banner "Reads configuration from master"
 
-    parameter '[PATH]', "Output to file in PATH, default: STDOUT", required: false
-    option ['-f', '--format'], '[FORMAT]', "Specify output format (json, yaml) (default: guess from PATH or json)"
+    parameter '[FILE]', "Output to file in PATH, default: STDOUT", required: false, attribute_name: :path, completion: %w(*.yml *.json)
+    option ['-f', '--format'], '[FORMAT]', "Specify output format (json, yaml) (default: guess from PATH or json)", completion: %(yaml json)
 
-    option ['--filter'], "[FILTER]", "Filter keys, example: oauth2.*"
+    option ['--filter'], "[KEY]", "Filter keys, example: oauth2.*"
 
     def decorate(data)
       case self.format.downcase

--- a/cli/lib/kontena/cli/master/config/get_command.rb
+++ b/cli/lib/kontena/cli/master/config/get_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Master::Config
 
     banner "Reads a configuration value from master"
 
-    parameter "KEY", "Configuration key to read from master", required: true
+    parameter "CONFIG_KEY", "Configuration key to read from master", required: true
 
     option ['-p', '--pair'], :flag, "Print key=value instead of only value"
 

--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -8,14 +8,13 @@ module Kontena::Cli::Master::Config
 
     banner "Updates configuration from a file into Master"
 
-    parameter '[PATH]', "Input from file in PATH (default: STDIN)", required: false
+    parameter '[FILE]', "Input from file in PATH (default: STDIN)", required: false, attribute_name: :path, completion: %w(*.yml *.json)
 
     option ['--preset'], '[NAME]', 'Load preset', hidden: true
 
-    option ['--format'], '[FORMAT]', "Specify input format (json, yaml) (default: guess from PATH or json)"
+    option ['--format'], '[FORMAT]', "Specify input format (json, yaml) (default: guess from PATH or json)", completion: %w(yaml json)
     option ['--full'], :flag, "Perform full update, keys that are not present in the input are cleared"
     option ['-f', '--force'], :flag, "Don't ask for confirmation"
-
 
     def input_as_hash
       if self.path && self.preset

--- a/cli/lib/kontena/cli/master/config/set_command.rb
+++ b/cli/lib/kontena/cli/master/config/set_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Master::Config
 
     banner "Sets a configuration value to Master"
 
-    parameter "KEY_VALUE_PAIR ...", "Key/value pair, for example server.root_url=http://example.com", required: true
+    parameter "KEY_VALUE_PAIR ...", "Key/value pair, for example server.root_url=http://example.com", required: true, completion: "CONFIG_KEY"
 
     def execute
       data = Hash[*self.key_value_pair_list.flat_map{ |p| p.split('=') }]

--- a/cli/lib/kontena/cli/master/config/unset_command.rb
+++ b/cli/lib/kontena/cli/master/config/unset_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Master::Config
     requires_current_master
     requires_current_master_token
 
-    parameter "KEY ...", "Key(s) to unset", required: true
+    parameter "CONFIG_KEY ...", "Key(s) to unset", required: true, attribute_name: :key_list
 
     banner "Clears a configuration value from Master"
 

--- a/cli/lib/kontena/cli/master/config_command.rb
+++ b/cli/lib/kontena/cli/master/config_command.rb
@@ -1,4 +1,3 @@
-
 module Kontena
   module Cli
     module Master

--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -5,10 +5,10 @@ module Kontena::Cli::Master
 
     banner "Configures the current Kontena Master to use Kontena Cloud services and authentication"
 
-    option '--force',           :flag,       "Don't ask questions"
-    option '--cloud-master-id', '[ID]',      "Use existing cloud master ID"
-    option '--provider',        '[NAME]',    "Set master provider name"
-    option '--version',         '[VERSION]', "Set master version"
+    option '--force', :flag, "Don't ask questions"
+    option '--cloud-master-id', '[CLOUD_MASTER_ID]', "Use existing cloud master ID"
+    option '--provider', '[NAME]', "Set master provider name", completion: "PLUGIN_NAME"
+    option '--version', '[VERSION]', "Set master version", completion: %w(latest edge)
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Master
   class LoginCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "[URL]", "Kontena Master URL or name"
+    parameter "[MASTER_URL]", "Kontena Master URL or name", attribute_name: :url
     option ['-j', '--join'], '[INVITE_CODE]', "Join master using an invitation code"
     option ['-t', '--token'], '[TOKEN]', 'Use a pre-generated access token', environment_variable: 'KONTENA_TOKEN'
     option ['-n', '--name'], '[NAME]', 'Set server name', environment_variable: 'KONTENA_MASTER'

--- a/cli/lib/kontena/cli/master/remove_command.rb
+++ b/cli/lib/kontena/cli/master/remove_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Master
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter '[NAME]', "Master name"
+    parameter '[MASTER_NAME]', "Master name"
 
     banner "Note: This command only removes the master from your local configuration file"
 

--- a/cli/lib/kontena/cli/master/token/remove_command.rb
+++ b/cli/lib/kontena/cli/master/token/remove_command.rb
@@ -1,7 +1,7 @@
 module Kontena::Cli::Master::Token
   class RemoveCommand < Kontena::Command
 
-    parameter "TOKEN_OR_ID", "Access token or access token id"
+    parameter "TOKEN_OR_ID", "Access token or access token id", completion: "MASTER_TOKEN"
 
     option ['-f', '--force'], :flag, "Don't ask questions"
 

--- a/cli/lib/kontena/cli/master/token/show_command.rb
+++ b/cli/lib/kontena/cli/master/token/show_command.rb
@@ -3,7 +3,7 @@ require_relative 'common'
 module Kontena::Cli::Master::Token
   class ShowCommand < Kontena::Command
 
-    parameter "TOKEN_OR_ID", "Access token or access token id"
+    parameter "TOKEN_OR_ID", "Access token or access token id", completion: "MASTER_TOKEN"
 
     include Kontena::Cli::Common
     include Common

--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -2,7 +2,7 @@ module Kontena::Cli::Master
   class UseCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "NAME", "Master name to use"
+    parameter "MASTER_NAME", "Master name to use", attribute_name: :name
 
     def execute
       master = config.find_server(name)

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -7,9 +7,9 @@ module Kontena::Cli::Master::User
 
     parameter "EMAIL ...", "List of emails"
 
-    option ['-r', '--roles'], '[ROLES]', 'Comma separated list of roles to assign to the invited users'
+    option ['-r', '--roles'], '[ROLES]', 'Comma separated list of roles to assign to the invited users', completion: %w(master_admin grid_admin)
     option ['-c', '--code'], :flag, 'Only output the invite code'
-    option '--external-id', '[EXTERNAL ID]', 'Assign external id to user', hidden: true
+    option '--external-id', '[EXTERNAL_ID]', 'Assign external id to user', hidden: true
     option '--return', :flag, 'Return the code', hidden: true
 
     requires_current_master

--- a/cli/lib/kontena/cli/master/user/remove_command.rb
+++ b/cli/lib/kontena/cli/master/user/remove_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Master::User
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "EMAIL ...", "List of emails"
+    parameter "EMAIL ...", "List of emails", completion: "MASTER_USER"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute

--- a/cli/lib/kontena/cli/master/user/role/add_command.rb
+++ b/cli/lib/kontena/cli/master/user/role/add_command.rb
@@ -5,8 +5,8 @@ module Kontena::Cli::Master::User
     class AddCommand < Kontena::Command
       include Kontena::Cli::Common
 
-      parameter "ROLE", "Role name"
-      parameter "USER ...", "List of users"
+      parameter "ROLE", "Role name", completion: %w(master_admin grid_admin)
+      parameter "EMAIL ...", "List of users", completion: "MASTER_USER", attribute_name: :user_list
 
       option '--silent', :flag, 'Reduce output verbosity'
 

--- a/cli/lib/kontena/cli/master/user/role/remove_command.rb
+++ b/cli/lib/kontena/cli/master/user/role/remove_command.rb
@@ -4,10 +4,9 @@ module Kontena::Cli::Master::User::Role
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "ROLE", "Role name"
-    parameter "USER ...", "List of users"
+    parameter "ROLE", "Role name", completion: %w(grid_admin master_admin)
+    parameter "EMAIL ...", "List of users", completion: "MASTER_USER", attribute_name: :user_list
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
-
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/master/users_command.rb
+++ b/cli/lib/kontena/cli/master/users_command.rb
@@ -8,6 +8,5 @@ module Kontena::Cli::Master
     subcommand ["list", "ls"], "List users", load_subcommand('master/user/list_command')
     subcommand "role", "User role specific commands", load_subcommand('master/user/role_command')
 
-
   end
 end

--- a/cli/lib/kontena/cli/nodes/health_command.rb
+++ b/cli/lib/kontena/cli/nodes/health_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::HealthHelper
 
-    parameter "NODE_ID", "Node id"
+    parameter "NODE_NAME", "Node name", attribute_name: :node_id
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/nodes/labels/add_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/add_command.rb
@@ -2,8 +2,8 @@ module Kontena::Cli::Nodes::Labels
   class AddCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "NODE_ID", "Node id"
-    parameter "LABEL ...", "Labels"
+    parameter "NODE_NAME", "Node name", attribute_name: :node_id
+    parameter "LABEL ...", "Labels", completion: "NODE_LABEL"
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/nodes/labels/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/list_command.rb
@@ -2,15 +2,23 @@ module Kontena::Cli::Nodes::Labels
   class ListCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "NODE_ID", "Node id"
+    parameter "[NODE_NAME]", "Node name", attribute_name: :node_id
+
+    option ['-a', '--all'], :flag, "List labels on all nodes in the grid"
 
     requires_current_master
     requires_current_master_token
     requires_current_grid
 
     def execute
-      node = client.get("nodes/#{current_grid}/#{node_id}")
-      puts Array(node['labels']).join("\n")
+      if node_id.nil? && !all?
+        exit_with_error "NODE_NAME or --all missing"
+      elsif node_id && all?
+        exit_with_error "NODE_NAME and --all can't be used together"
+      end
+
+      nodes = all? ? client.get("grids/#{current_grid}/nodes")['nodes'] : [client.get("nodes/#{current_grid}/#{node_id}")]
+      puts nodes.flat_map { |n| n['labels'] }.uniq.join("\n")
     end
   end
 end

--- a/cli/lib/kontena/cli/nodes/labels/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/remove_command.rb
@@ -2,8 +2,8 @@ module Kontena::Cli::Nodes::Labels
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
 
-    parameter "NODE_ID", "Node id"
-    parameter "LABEL ...", "Labels"
+    parameter "NODE_NAME", "Node name", attribute_name: :node_id
+    parameter "LABEL ...", "Labels", completion: "NODE_LABEL"
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::HealthHelper
 
-    option ["--all"], :flag, "List nodes for all grids", default: false
+    option ["-a", "--all"], :flag, "List nodes for all grids", default: false, attribute_name: :all
 
     def node_initial(node, grid)
       if node['initial_member']

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "NODE_ID", "Node id"
+    parameter "NODE_NAME", "Node name", attribute_name: :node_id
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -4,7 +4,9 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::GridOptions
     include Kontena::Cli::BytesHelper
 
-    parameter "NODE_ID", "Node id"
+    parameter "NODE_NAME", "Node name", attribute_name: :node_id
+
+    option '--ip', '[FIELD]', "Show public/private/overlay IP only or use 'all' for all IPs", completion: %w(public private overlay all), attribute_name: :ip_field
 
     def execute
       require_api_url
@@ -12,6 +14,17 @@ module Kontena::Cli::Nodes
       token = require_token
 
       node = client(token).get("nodes/#{current_grid}/#{node_id}")
+
+      if ip_field
+        if ip_field == 'all'
+          puts %w(public_ip private_ip overlay_ip).map { |field| node[field] }.join("\n")
+        else
+          puts node[ip_field + "_ip"]
+        end
+
+        exit 0
+      end
+
       puts "#{node['name']}:"
       puts "  id: #{node['id']}"
       puts "  agent version: #{node['agent_version']}"

--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -3,11 +3,11 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "[NODE_ID]", "SSH to Grid node. Use --any to connect to the first available node"
+    parameter "[NODE_NAME]", "SSH to Grid node. Use --any to connect to the first available node", attribute_name: :node_id
     parameter "[COMMANDS] ...", "Run command on host"
     option ["-a", "--any"], :flag, "Connect to first available node"
-    option ["-i", "--identity-file"], "IDENTITY_FILE", "Path to ssh private key"
-    option ["-u", "--user"], "USER", "Login as a user", default: "core"
+    option ["-i", "--identity-file"], "FILE", "Path to ssh private key"
+    option ["-u", "--user"], "USER", "Login as a user", default: "core", completion: %w(core root)
     option "--private-ip", :flag, "Connect to node's private IP address"
     option "--internal-ip", :flag, "Connect to node's internal IP address (requires VPN connection)"
 

--- a/cli/lib/kontena/cli/nodes/update_command.rb
+++ b/cli/lib/kontena/cli/nodes/update_command.rb
@@ -3,8 +3,8 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "NODE_ID", "Node id"
-    option ["-l", "--label"], "LABEL", "Node label", multivalued: true
+    parameter "NODE_NAME", "Node name", attribute_name: :node_id
+    option ["-l", "--label"], "LABEL", "Node label", multivalued: true, completion: "NODE_LABEL"
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Plugins
     include Kontena::Util
     include Kontena::Cli::Common
 
-    parameter 'NAME', 'Plugin name'
+    parameter 'NAME', 'Plugin name', completion: "PLUGIN_SEARCH"
 
     option ['-v', '--version'], 'VERSION', 'Specify version of plugin to install'
     option '--pre', :flag, 'Allow pre-release of a plugin to be installed', default: false

--- a/cli/lib/kontena/cli/plugins/search_command.rb
+++ b/cli/lib/kontena/cli/plugins/search_command.rb
@@ -4,19 +4,25 @@ module Kontena::Cli::Plugins
   class SearchCommand < Kontena::Command
     include Common
 
-    parameter '[NAME]', 'Search text'
+    parameter '[NAME]', 'Search text', completion: "PLUGIN_SEARCH"
     option '--pre', :flag, 'Include pre-release versions'
+
+    option ['-q', '--quiet'], :flag, "Only list the identifying column", attribute_name: :quiet
 
     def execute
       results = Kontena::PluginManager.instance.search_plugins(name)
       exit_with_error("Cannot access plugin server") unless results
-      puts "%-50s %-10s %-60s" % ['NAME', 'VERSION', 'DESCRIPTION']
+      puts "%-50s %-10s %-60s" % ['NAME', 'VERSION', 'DESCRIPTION'] unless quiet?
       results.each do |item|
         if pre?
           latest = Kontena::PluginManager.instance.latest_version(item['name'], pre: true)
           item['version'] = latest.version.to_s
         end
-        puts "%-50s %-10s %-60s" % [short_name(item['name']), item['version'], item['info']]
+        if quiet?
+          puts short_name(item['name'])
+        else
+          puts "%-50s %-10s %-60s" % [short_name(item['name']), item['version'], item['info']]
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Plugins
     include Kontena::Util
     include Kontena::Cli::Common
 
-    parameter 'NAME', 'Plugin name'
+    parameter 'PLUGIN_NAME', 'Plugin name', attribute_name: :name
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute

--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::Registry
 
     REGISTRY_VERSION = '2.6.0'
 
-    option '--node', 'NODE', 'Node name'
+    option '--node', 'NODE_NAME', 'Node name', attribute_name: :node
     option '--s3-bucket', 'S3_BUCKET', 'S3 bucket'
     option '--s3-region', 'S3_REGION', 'S3 region', default: 'eu-west-1'
     option '--s3-encrypt', :flag, 'Encrypt S3 objects', default: false

--- a/cli/lib/kontena/cli/service_command.rb
+++ b/cli/lib/kontena/cli/service_command.rb
@@ -14,11 +14,8 @@ class Kontena::Cli::ServiceCommand < Kontena::Command
   subcommand "events", "Show service events", load_subcommand('services/events_command')
   subcommand "stats", "Show service statistics", load_subcommand('services/stats_command')
   subcommand "monitor", "Monitor", load_subcommand('services/monitor_command')
-
   subcommand "env", "Environment variable specific commands", load_subcommand('services/env_command')
-
   subcommand "secret", "Secret specific commands", load_subcommand('services/secret_command')
-
   subcommand "link", "Link service to another service", load_subcommand('services/link_command')
   subcommand "unlink", "Unlink service from another service", load_subcommand('services/unlink_command')
   subcommand "exec", "Execute commands in service containers", load_subcommand('services/exec_command')

--- a/cli/lib/kontena/cli/services/containers_command.rb
+++ b/cli/lib/kontena/cli/services/containers_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     option '--force', :flag, 'Force deploy even if service does not have any changes'
 
     def execute

--- a/cli/lib/kontena/cli/services/env_command.rb
+++ b/cli/lib/kontena/cli/services/env_command.rb
@@ -1,6 +1,4 @@
 module Kontena::Cli::Services
-
-
   class EnvCommand < Kontena::Command
     subcommand ["list", "ls"], "List service environment variables", load_subcommand('services/envs/list_command')
     subcommand "add", "Add environment variable", load_subcommand('services/envs/add_command')

--- a/cli/lib/kontena/cli/services/envs/add_command.rb
+++ b/cli/lib/kontena/cli/services/envs/add_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services::Envs
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     parameter "ENV", "Environment variable"
 
     def execute

--- a/cli/lib/kontena/cli/services/envs/list_command.rb
+++ b/cli/lib/kontena/cli/services/envs/list_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services::Envs
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/envs/remove_command.rb
+++ b/cli/lib/kontena/cli/services/envs/remove_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services::Envs
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     parameter "ENV", "Environment variable name"
 
     def execute

--- a/cli/lib/kontena/cli/services/events_command.rb
+++ b/cli/lib/kontena/cli/services/events_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::Helpers::LogHelper
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     parameter "CMD ...", "Command"
 
     option ["-i", "--instance"], "INSTANCE", "Exec on given numbered instance, default first running" do |value| Integer(value) end

--- a/cli/lib/kontena/cli/services/link_command.rb
+++ b/cli/lib/kontena/cli/services/link_command.rb
@@ -6,8 +6,8 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
-    parameter "TARGET", "Link target service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
+    parameter "TARGET_SERVICE_NAME", "Link target service name", completion: "SERVICE_NAME", attribute_name: :target
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     option ["-q", "--quiet"], :flag, "Show only service names"
-    option '--stack', 'STACK', 'Stack name'
+    option '--stack', 'STACK_NAME', 'Stack name'
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::Helpers::LogHelper
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     option ["-i", "--instance"], "INSTANCE", "Show only given instance specific logs"
 
     def execute

--- a/cli/lib/kontena/cli/services/monitor_command.rb
+++ b/cli/lib/kontena/cli/services/monitor_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     option "--interval", "SECONDS", "How often view is refreshed", default: 2
 
     def execute

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::Common
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     option "--instance", "INSTANCE", "Remove only given instance"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 

--- a/cli/lib/kontena/cli/services/restart_command.rb
+++ b/cli/lib/kontena/cli/services/restart_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/scale_command.rb
+++ b/cli/lib/kontena/cli/services/scale_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     parameter "INSTANCES", "Scales service to given number of instances"
 
     def execute

--- a/cli/lib/kontena/cli/services/secret_command.rb
+++ b/cli/lib/kontena/cli/services/secret_command.rb
@@ -1,6 +1,4 @@
 module Kontena::Cli::Services
-
-
   class SecretCommand < Kontena::Command
     subcommand "link", "Link secret from Vault", load_subcommand('services/secrets/link_command')
     subcommand "unlink", "Unlink secret from Vault", load_subcommand('services/secrets/unlink_command')

--- a/cli/lib/kontena/cli/services/secrets/link_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/link_command.rb
@@ -6,8 +6,8 @@ module Kontena::Cli::Services::Secrets
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 
-    parameter "NAME", "Service name"
-    parameter "SECRET", "Secret to be added from Vault (format: secret:name:type)"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
+    parameter "SECRET", "Secret to be added from Vault (format: secret:name:type)", completion: "SECRET_NAME" # at least you get to complete something
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/secrets/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/unlink_command.rb
@@ -6,8 +6,8 @@ module Kontena::Cli::Services::Secrets
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Services::ServicesHelper
 
-    parameter "NAME", "Service name"
-    parameter "SECRET", "Secret to be removed (format: secret:name:type)"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
+    parameter "SECRET", "Secret to be removed (format: secret:name:type)", completion: "SECRET_NAME" # at least you get to complete something
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/show_command.rb
+++ b/cli/lib/kontena/cli/services/show_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/start_command.rb
+++ b/cli/lib/kontena/cli/services/start_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/stats_command.rb
+++ b/cli/lib/kontena/cli/services/stats_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Services
       1.8446744073709552e+19, 9.223372036854772e+18
     ]
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
     option ["-t", "--tail"], :flag, "Tail (follow) stats in real time", default: false
 
     def execute

--- a/cli/lib/kontena/cli/services/stop_command.rb
+++ b/cli/lib/kontena/cli/services/stop_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/unlink_command.rb
@@ -6,8 +6,8 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
-    parameter "TARGET", "Link target service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
+    parameter "TARGET_SERVICE_NAME", "Link target service name", completion: "SERVICE_NAME", attribute_name: :target
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "SERVICE_NAME", "Service name", attribute_name: :name
 
     option "--image", "IMAGE", "Docker image to use"
     option ["-p", "--ports"], "PORT", "Publish a service's port to the host", multivalued: true

--- a/cli/lib/kontena/cli/stacks/build_command.rb
+++ b/cli/lib/kontena/cli/stacks/build_command.rb
@@ -8,19 +8,19 @@ module Kontena::Cli::Stacks
 
     banner "Build images listed in a stack file and push them to your image registry"
 
-    option ['-f', '--file'], 'FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
+    option ['-f', '--file'], 'YAML_FILE', 'Specify an alternate Kontena compose file', attribute_name: :filename, default: 'kontena.yml'
 
     option ['--no-cache'], :flag, 'Do not use cache when building the image', default: false
     option ['--no-push'], :flag, 'Do not push images to registry', default: false
     option ['--no-pull'], :flag, 'Do not attempt to pull a newer version of the image', default: false
     option ['--[no-]sudo'], :flag, 'Run docker using sudo', hidden: Kontena.on_windows?, environment_variable: 'KONTENA_SUDO', default: false
 
-    option ['-n', '--name'], 'NAME', 'Define stack name (by default comes from stack file)'
+    option ['-n', '--name'], 'STACK_NAME', 'Define stack name (by default comes from stack file)', attribute_name: :name
 
     include Common::StackValuesToOption
     include Common::StackValuesFromOption
 
-    parameter "[SERVICE] ...", "Services to build"
+    parameter "[SERVICE_NAME] ...", "Services to build", completion: :yaml_services, attribute_name: :service_list
 
     requires_current_master # the stack may use a vault resolver
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -20,15 +20,28 @@ module Kontena::Cli::Stacks
       end
     end
 
+    module RegistryStackNameParam
+      attr_accessor :stack_version
+
+      def self.included(where)
+        where.parameter "STACK_NAME", "Stack name, for example user/stackname or user/stackname:version", completion: "REGISTRY_STACK_NAME" do |name|
+          if name.include?(':')
+            name, @stack_version = name.split(':',2 )
+          end
+          name
+        end
+      end
+    end
+
     module StackFileOrNameParam
       def self.included(where)
-        where.parameter "[FILE]", "Kontena stack file, registry stack name (user/stack or user/stack:version) or URL", default: "kontena.yml", attribute_name: :filename
+        where.parameter "[YAML_FILE]", "Kontena stack file, registry stack name (user/stack or user/stack:version) or URL", default: "kontena.yml", attribute_name: :filename
       end
     end
 
     module StackNameOption
       def self.included(where)
-        where.option ['-n', '--name'], 'NAME', 'Define stack name (by default comes from stack file)'
+        where.option ['-n', '--name'], 'STACK_NAME', 'Define stack name (by default comes from stack file)', attribute_name: :name
       end
     end
 
@@ -47,7 +60,7 @@ module Kontena::Cli::Stacks
     module StackValuesFromOption
       attr_accessor :values
       def self.included(where)
-        where.option '--values-from', '[FILE]', 'Read variable values from YAML' do |filename|
+        where.option '--values-from', '[YAML_FILE]', 'Read variable values from YAML', attribute_name: :values_file do |filename|
           if filename
             require_config_file(filename)
             @values = ::YAML.safe_load(File.read(filename))

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Stacks
 
     banner "Deploys all services of a stack that has been installed in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    parameter "STACK_NAME", "Stack name", attribute_name: :name
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/events_command.rb
+++ b/cli/lib/kontena/cli/stacks/events_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Stacks
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Helpers::LogHelper
 
-    parameter "NAME", "Service name"
+    parameter "STACK_NAME", "Stack name", attribute_name: :name
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/stacks/logs_command.rb
+++ b/cli/lib/kontena/cli/stacks/logs_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Stacks
 
     banner "Shows logs from services in a stack"
 
-    parameter "NAME", "Stack name"
+    parameter "STACK_NAME", "Stack name", attribute_name: :name
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/monitor_command.rb
+++ b/cli/lib/kontena/cli/stacks/monitor_command.rb
@@ -8,8 +8,8 @@ module Kontena::Cli::Stacks
 
     banner "Monitor services in a stack"
 
-    parameter "NAME", "Stack name"
-    parameter "[SERVICES] ...", "Stack services to monitor", attribute_name: 'selected_services'
+    parameter "STACK_NAME", "Stack name", attribute_name: :name
+    parameter "[SERVICE_NAME] ...", "Stack services to monitor", attribute_name: 'selected_services', completion: :stack_services
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/registry/pull_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/pull_command.rb
@@ -4,11 +4,13 @@ module Kontena::Cli::Stacks::Registry
   class PullCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
-    include Kontena::Cli::Stacks::Common::StackNameParam
+    include Kontena::Cli::Stacks::Common::RegistryStackNameParam
 
     banner "Pulls / downloads a stack from the stack registry"
 
-    option ['-F', '--file'], '[FILENAME]', "Write to file (default STDOUT)"
+    attr_accessor :stack_version
+
+    option ['-F', '--file'], 'FILE', "Write to file (default STDOUT)", required: false
     option '--no-cache', :flag, "Don't use local cache"
     option '--return', :flag, 'Return the result', hidden: true
 

--- a/cli/lib/kontena/cli/stacks/registry/push_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/push_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Stacks::Registry
 
     banner "Pushes (uploads) a stack to the stack registry"
 
-    parameter "FILENAME", "Stack file path"
+    parameter "YAML_FILE", "Stack file path", attribute_name: :filename
 
     requires_current_account_token
 

--- a/cli/lib/kontena/cli/stacks/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/remove_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Stacks::Registry
   class RemoveCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
-    include Kontena::Cli::Stacks::Common::StackNameParam
+    include Kontena::Cli::Stacks::Common::RegistryStackNameParam
 
     banner "Removes a stack (or version) from the stack registry. Use user/stack_name or user/stack_name:version."
 

--- a/cli/lib/kontena/cli/stacks/registry/search_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/search_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Stacks::Registry
 
     banner "Search for stacks on the stack registry"
 
-    parameter "[QUERY]", "Query string"
+    parameter "[QUERY]", "Query string", completion: "REGISTRY_STACK_NAME"
 
     def execute
       results = stacks_client.search(query.to_s)

--- a/cli/lib/kontena/cli/stacks/registry/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/show_command.rb
@@ -4,7 +4,7 @@ module Kontena::Cli::Stacks::Registry
   class ShowCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::Stacks::Common
-    include Kontena::Cli::Stacks::Common::StackNameParam
+    include Kontena::Cli::Stacks::Common::RegistryStackNameParam
 
     banner "Shows information about a stack on the stacks registry"
 

--- a/cli/lib/kontena/cli/stacks/registry_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry_command.rb
@@ -1,6 +1,5 @@
 module Kontena::Cli::Stacks
   class RegistryCommand < Kontena::Command
-
     subcommand "push", "Push a stack into the stacks registry", load_subcommand('stacks/registry/push_command')
     subcommand "pull", "Pull a stack from the stacks registry", load_subcommand('stacks/registry/pull_command')
     subcommand "search", "Search for stacks in the stacks registry", load_subcommand('stacks/registry/search_command')

--- a/cli/lib/kontena/cli/stacks/remove_command.rb
+++ b/cli/lib/kontena/cli/stacks/remove_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Stacks
 
     banner "Removes a stack in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    parameter "STACK_NAME", "Stack name", attribute_name: :name
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     requires_current_master

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Stacks
 
     banner "Show information and status of a stack in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    parameter "STACK_NAME", "Stack name", attribute_name: :name
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -8,7 +8,7 @@ module Kontena::Cli::Stacks
 
     banner "Upgrades a stack in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    parameter "STACK_NAME", "Stack name", attribute_name: :name
 
     include Common::StackFileOrNameParam
 

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Vault
     option '--skip-null', :flag, "Do not remove keys with null values"
     option '--empty-is-null', :flag, "Treat empty values as null"
 
-    parameter '[PATH]', "Input from file in PATH (default: STDIN)"
+    parameter '[YAML_FILE]', "Input from file in PATH (default: STDIN)", attribute_name: :path
 
     requires_current_master
 

--- a/cli/lib/kontena/cli/vault/read_command.rb
+++ b/cli/lib/kontena/cli/vault/read_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Vault
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "NAME", "Secret name"
+    parameter "SECRET_NAME", "Secret name", attribute_name: :name
 
     option '--value', :flag, 'Just output the value'
     option '--return', :flag, 'Return the value', hidden: true

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Vault
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "NAME", "Secret name"
+    parameter "SECRET_NAME", "Secret name", attribute_name: :name
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
     option "--silent", :flag, "Reduce output verbosity"
 

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Vault
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter 'NAME', 'Secret name'
+    parameter 'SECRET_NAME', 'Secret name', attribute_name: :name
     parameter '[VALUE]', 'Secret value (default: STDIN)'
 
     option ['-u', '--upsert'], :flag, 'Create secret unless already exists', default: false

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Vault
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter 'NAME', 'Secret name'
+    parameter 'SECRET_NAME', 'Secret name', attribute_name: :name
     parameter '[VALUE]', 'Secret value (default: STDIN)'
 
     option '--silent', :flag, "Reduce output verbosity"

--- a/cli/lib/kontena/cli/version_command.rb
+++ b/cli/lib/kontena/cli/version_command.rb
@@ -3,7 +3,7 @@ require 'kontena/cli/version'
 class Kontena::Cli::VersionCommand < Kontena::Command
   include Kontena::Cli::Common
 
-  option "--cli", :flag, "Only CLI version"
+  option "--cli", :flag, "Show CLI version only"
 
   def execute
     puts "cli: #{Kontena::Cli::VERSION}"

--- a/cli/lib/kontena/cli/volumes/create_command.rb
+++ b/cli/lib/kontena/cli/volumes/create_command.rb
@@ -4,13 +4,12 @@ module Kontena::Cli::Volumes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
     banner "Creates a volume"
-    parameter 'NAME', 'Volume name'
+    parameter 'VOLUME_NAME', 'Volume name', attribute_name: :name
 
     option '--driver', 'DRIVER', 'Volume driver to be used'
     option '--driver-opt', 'DRIVER_OPT', 'Volume driver options', multivalued: true
-    option '--scope', 'SCOPE', 'Volume scope'
+    option '--scope', 'SCOPE', 'Volume scope', completion: %w(grid stack instance)
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/volumes/list_command.rb
+++ b/cli/lib/kontena/cli/volumes/list_command.rb
@@ -4,13 +4,12 @@ module Kontena::Cli::Volumes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
     requires_current_master
     requires_current_master_token
 
     def execute
       require 'tty-table'
-      
+
       volumes = client.get("volumes/#{current_grid}")['volumes']
       table = TTY::Table.new ['NAME', 'SCOPE', 'DRIVER', 'CREATED AT'], volumes.map { |volume|
         [volume['name'], volume['scope'], volume['driver'], volume['created_at']]

--- a/cli/lib/kontena/cli/volumes/remove_command.rb
+++ b/cli/lib/kontena/cli/volumes/remove_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Volumes
 
 
     banner "Removes a volume"
-    parameter 'VOLUME', 'Volume'
+    parameter 'VOLUME_NAME', 'Volume', attribute_name: :volume
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     requires_current_master

--- a/cli/lib/kontena/cli/volumes/show_command.rb
+++ b/cli/lib/kontena/cli/volumes/show_command.rb
@@ -6,7 +6,7 @@ module Kontena::Cli::Volumes
 
     banner "Show details of a volume"
 
-    parameter 'VOLUME', 'Volume'
+    parameter 'VOLUME_NAME', 'Volume', attribute_name: :volume
 
     requires_current_master
     requires_current_master_token

--- a/cli/lib/kontena/cli/vpn/create_command.rb
+++ b/cli/lib/kontena/cli/vpn/create_command.rb
@@ -6,8 +6,8 @@ module Kontena::Cli::Vpn
     include Kontena::Cli::GridOptions
     include Kontena::Cli::Stacks::StacksHelper
 
-    option '--node', 'NODE', 'Node name where VPN is deployed'
-    option '--ip', 'IP', 'Node ip-address to use in VPN service configuration'
+    option '--node', 'NODE_NAME', 'Node name where VPN is deployed', attribute_name: :node
+    option '--ip', 'NODE_IP', 'Node ip-address to use in VPN service configuration', attribute_name: :ip
 
     def execute
       require_api_url

--- a/cli/spec/kontena/cli/master/user/role/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/master/user/role/remove_command_spec.rb
@@ -1,4 +1,5 @@
 require 'kontena/cli/master/user_command'
+require 'kontena/cli/master/user/role_command'
 require 'kontena/cli/master/user/role/remove_command'
 
 describe Kontena::Cli::Master::User::Role::RemoveCommand do


### PR DESCRIPTION
In preparation of the automated completion generation, all of the parameter/option value names, such as `parameter "NAME"` have been changed to be a bit more specific, for example: `parameter "STACK_NAME"`.

This aids in the automatic generation of completion functions, as the generator can look for the parameter name and figure out how to generate completions for that argument.

Clamp doesn't seem to mind if an option declaration includes any unknown keywords, in this case `completion`. The upcoming generator can utilize these hints.

In some cases there's an array:
```
completion: %w(fullchain chain cert)
```

The completer will return those values as completion candidates.

In some cases there's a symbol:

```
completion: :yaml_services
```

These require a bit more logic to them, in this case for example, it has to look if the command line contains any YAML_FILE arguments and output the service names in that yaml.

In some cases there's a string:

```
parameter "TARGET_SERVICE_NAME", "Link target service name", completion: "SERVICE_NAME", attribute_name: :target
```

in this case it makes more sense to show something else in help than what the completion for that argument should be.

This PR also adds a couple of completion supporting features:
`kontena node labels ls` : `option ['-a', '--all'], :flag, "List labels on all nodes in the grid"`
`kontena node show`: `option '--ip', '[FIELD]', "Show public/private/overlay IP only or use 'all' for all IPs", completion: %w(public private overlay all), attribute_name: :ip_field`
`kontena plugin search -q` (only show names)

--
To keep the PR minimal, the `attribute_name:` option from clamp is used instead of changing references in code.

