### PR TITLE
Support for tracing celluloid actor calls

### DIFF
--- a/server/app/initializers/celluloid.rb
+++ b/server/app/initializers/celluloid.rb
@@ -1,2 +1,4 @@
 Celluloid.logger.level = Logger::ERROR if ENV['RACK_ENV'] == 'production'
 Celluloid.boot
+
+require_relative '../../lib/celluloid_tracer' if ENV['DEBUG']

--- a/server/lib/celluloid_tracer.rb
+++ b/server/lib/celluloid_tracer.rb
@@ -1,0 +1,17 @@
+module CelluloidCallTracer
+  def method_missing(method, *args, &block)
+    t = Time.now
+    $stderr.puts "CELLULOID #{__class__} CALL -> #{__klass__}##{method} @\n\t#{caller.join("\n\t")}"
+
+    ret = super
+    dt = Time.now - t
+
+    $stderr.puts "CELLULOID #{__class__} CALL <- #{__klass__}##{method} => #{ret.class} in #{'%.3fs' % dt}"
+
+    ret
+  end
+end
+
+class Celluloid::Proxy::Sync
+  prepend ::CelluloidCallTracer if ::ENV['TRACE_CELLULOID_CALLS'] == 'sync'
+end

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -34,6 +34,8 @@ require_relative '../server'
 require 'rack/test'
 require 'mongoid-rspec'
 
+require_relative '../lib/celluloid_tracer' # after celluloid require
+
 require_relative '../app/services/mongodb/migrator'
 
 Celluloid.logger = nil


### PR DESCRIPTION
Useful for debugging issues like  #2348

Only loaded in server `DEBUG` mode, or in specs. Activated by using `TRACE_CELLULOID_CALLS=sync`.

Implemented for the server; if the design looks okay, I'll copy-pasta this to the agent as well.

## Example
```
CELLULOID Celluloid::Proxy::Cell CALL -> LeaderElectorJob#leader? @
	/home/kontena/kontena/kontena/server/app/helpers/current_leader.rb:7:in `leader?'
	/home/kontena/kontena/kontena/server/app/jobs/node_cleanup_job.rb:18:in `block in perform'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
	/home/kontena/kontena/kontena/server/vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
CELLULOID Celluloid::Proxy::Cell CALL <- LeaderElectorJob#leader? => FalseClass in 0.002s
```