### PR TITLE
Fixing subcommand loading bug when running init-cloud

### DIFF
--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -1,6 +1,3 @@
-require 'kontena/cli/cloud_command'
-require 'kontena/cli/cloud/master_command'
-
 module Kontena::Cli::Cloud::Master
   class AddCommand < Kontena::Command
 

--- a/cli/lib/kontena/cli/master/user_command.rb
+++ b/cli/lib/kontena/cli/master/user_command.rb
@@ -1,5 +1,3 @@
-require 'kontena/cli/master/user_command'
-
 module Kontena::Cli::Master
   class UserCommand < Kontena::Command
     subcommand "invite", "Invite user to Kontena Master", load_subcommand('master/user/invite_command')


### PR DESCRIPTION
This fixes issue #2347 .  Unnecessary `require`-ing of commands.