### PR TITLE
Notify nodes when volumes are removed

### DIFF
--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -132,8 +132,9 @@ module Kontena::Workers::Volumes
             info "removing volume: #{volume.id}"
             begin
               volume.remove
+              info "removed volume: #{volume.id} succesfully"
             rescue => exc
-              warn "removing volume failed: #{exc.class} #{exc.message}"
+              warn "removing volume #{volume.id} failed: #{exc.class} #{exc.message}"
             end
           end
         end

--- a/server/app/mutations/volumes/delete.rb
+++ b/server/app/mutations/volumes/delete.rb
@@ -12,9 +12,17 @@ module Volumes
     end
 
     def execute
+      nodes = self.volume.volume_instances.map { |instance| instance.host_node}.uniq
       self.volume.destroy
+      notify_nodes(nodes)
     end
 
+    def notify_nodes(nodes)
+      nodes.each do |node|
+        RpcClient.new(node.node_id).notify('/volumes/notify_update', 'remove') if node.connected?
+      end
+    end
+    
   end
 
 end


### PR DESCRIPTION
Added notification to needed nodes when volumes are removed. This speeds up the actual volume removal as users don't have to wait the "eventual consistency" of server-agent communication.

On server:
```
api_1      | 172.17.0.1 - - [22/May/2017:17:25:15 +0000] "DELETE /v1/volumes/e2e/testVol HTTP/1.1" 200 2 0.0913
```

And then on the agent:
```
kontena-agent | D, [2017-05-22T17:25:15.491976 #1] DEBUG -- Kontena::RpcServer: rpc notification: Kontena::Rpc::VolumesApi#notify_update ["remove"]
kontena-agent | D, [2017-05-22T17:25:15.505359 #1] DEBUG -- Kontena::RpcClient: waited 0.0s of 30.0s until: request /node_volumes/list has response wth id=1617405855 yielded Array
kontena-agent | D, [2017-05-22T17:25:15.505565 #1] DEBUG -- Kontena::Workers::Volumes::VolumeManager: got volumes from master: {"volumes"=>[]}
kontena-agent | D, [2017-05-22T17:25:15.969008 #1] DEBUG -- Kontena::WebsocketClient: keepalive ping 0.00s of 5.00s timeout
kontena-agent | I, [2017-05-22T17:25:16.828956 #1]  INFO -- Kontena::Workers::Volumes::VolumeManager: removing volume: redis.testVol-1
kontena-agent | I, [2017-05-22T17:25:16.882621 #1]  INFO -- Kontena::Workers::Volumes::VolumeManager: removed volume: redis.testVol-1 succesfully
```

So the removal happens within a sec or so.

fixes #2346 