### PR TITLE
Fixing key type in cloud websocket notifications

### DIFF
--- a/server/app/services/cloud/websocket_client.rb
+++ b/server/app/services/cloud/websocket_client.rb
@@ -180,18 +180,20 @@ module Cloud
 
     # @param [Hash] msg
     def send_notification_message(msg)
-      invalidate_users_cache if msg[:type] == 'User' # clear cache if users are modified
+      invalidate_users_cache if msg['type'] == 'User' # clear cache if users are modified
       grid_id = resolve_grid_id(msg)
       users = resolve_users(grid_id)
-      params = [grid_id, users, msg[:object]]
-      message = [2, "#{msg[:type]}##{msg[:event]}", params]
+      params = [grid_id, users, msg['object']]
+      message = [2, "#{msg['type']}##{msg['event']}", params]
       debug "Sending notification message: #{message}"
       send_message(MessagePack.dump(message).bytes)
+    rescue => exc
+      error exc.message
     end
 
     def resolve_grid_id(msg)
-      object = msg[:object]
-      if msg[:type] == "Grid"
+      object = msg['object']
+      if msg['type'] == "Grid"
         object['id']
       else
         object.dig('grid', 'id')

--- a/server/spec/services/cloud/websocket_client_spec.rb
+++ b/server/spec/services/cloud/websocket_client_spec.rb
@@ -153,9 +153,9 @@ describe Cloud::WebsocketClient do
     it 'sends notification message' do
       grid  #create
       message = {
-        type: 'GridService',
-        event: 'create',
-        object: { name: "test-service", grid: { id: "test"} }
+        'type' => 'GridService',
+        'event' => 'create',
+        'object' => { name: "test-service", grid: { id: "test"} }
       }
       expect(ws).to receive(:send).once do
           EM.stop
@@ -171,9 +171,9 @@ describe Cloud::WebsocketClient do
       it 'is right formatted' do
         grid  #create
         message = {
-          type: 'GridService',
-          event: 'create',
-          object: {"name": "test-service", "grid": {"id": "test"}}
+          'type' => 'GridService',
+          'event' => 'create',
+          'object' => {"name": "test-service", "grid": {"id": "test"}}
         }
 
         expect(ws).to receive(:send).once do |param|
@@ -195,9 +195,9 @@ describe Cloud::WebsocketClient do
         it 'contains grid as first entry' do
           grid  #create
           message = {
-            type: 'GridService',
-            event: 'create',
-            object: { "name" => "test-service", "grid" => { "id" => "test" }}
+            'type' => 'GridService',
+            'event' => 'create',
+            'object' => { "name" => "test-service", "grid" => { "id" => "test" }}
           }
 
           expect(ws).to receive(:send).once do |param|
@@ -216,9 +216,9 @@ describe Cloud::WebsocketClient do
         it 'contains users as second entry' do
           grid  #create
           message = {
-            type: 'GridService',
-            event: 'create',
-            object: { "name" => "test-service", "grid" => { "id" => "test" }}
+            'type' => 'GridService',
+            'event' => 'create',
+            'object' => { "name" => "test-service", "grid" => { "id" => "test" }}
           }
 
           expect(ws).to receive(:send).once do |param|
@@ -238,9 +238,9 @@ describe Cloud::WebsocketClient do
         it 'contains object as third entry' do
           grid  #create
           message = {
-            type: 'GridService',
-            event: 'create',
-            object: { "name" => "test-service", "grid" => { "id" => "test" }}
+            'type' => 'GridService',
+            'event' => 'create',
+            'object' => { "name" => "test-service", "grid" => { "id" => "test" }}
           }
 
           expect(ws).to receive(:send).once do |param|


### PR DESCRIPTION
Fixes issue where notification events coming from master nodes were not being published over websocket.

Since we are only publishing data that comes from mongo pubsub (whose data is serialized) I don't think we ever need to support symbols as keys.