### PR TITLE
Wrap server MongoPubsub subscribe payload in a HashWithIndifferentAccess

### DIFF
--- a/server/app/services/mongo_pubsub.rb
+++ b/server/app/services/mongo_pubsub.rb
@@ -59,7 +59,7 @@ class MongoPubsub
 
     # @param [Hash] data
     def send_message(data)
-      payload = MessagePack.unpack(data.data)
+      payload = HashWithIndifferentAccess.new(MessagePack.unpack(data.data))
       @block.call(payload)
     end
   end

--- a/server/spec/services/mongo_pubsub_spec.rb
+++ b/server/spec/services/mongo_pubsub_spec.rb
@@ -27,6 +27,24 @@ describe MongoPubsub do
       subs.each(&:terminate)
     end
 
+    it 'supports hash keys with mixed symbols and strings' do
+      messages = []
+
+      sub =  described_class.subscribe('test') {|msg|
+        messages << msg
+      }
+
+      described_class.publish('test', {'foo' => 'bar 1'})
+      described_class.publish('test', {foo: 'bar 2'})
+
+      WaitHelper.wait_until!(timeout: 5) { messages.size == 2 }
+
+      expect(messages.map{|m| m[:foo]}).to eq ['bar 1', 'bar 2']
+      expect(messages.map{|m| m['foo']}).to eq ['bar 1', 'bar 2']
+
+      sub.terminate
+    end
+
     it 'quarantees message ordering' do
       expected_mailbox = []
       mailbox1 = []


### PR DESCRIPTION
Fixes #2356 and other incompatibilities (#2353) introduced by the changes in #2342

Previously, the pubsub payloads were loaded as `BSON::Document` objects, which [normalizes hash keys](https://github.com/mongodb/bson-ruby/blob/v3.2.6/lib/bson/document.rb#L53), converting [Symbols to strings](https://github.com/mongodb/bson-ruby/blob/v3.2.6/lib/bson/symbol.rb#L70). Use an [`ActiveSupport::HashWithIndifferentAccess`](http://api.rubyonrails.org/v4.2/classes/ActiveSupport/HashWithIndifferentAccess.html) to provide compatibility with existing code, rather than fixing each use of symbol keys.