### PR TITLE
Fix flaky vpn E2E specs

### DIFF
--- a/test/spec/features/vpn/config_spec.rb
+++ b/test/spec/features/vpn/config_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe 'vpn config' do
+  before(:each) do
+    # Due to async nature of stack/service removals, need to wait until possible previous vpn containers have gone
+    wait_until_container_gone('vpn.server-1')
+  end
+
   after(:each) do
     run 'kontena stack rm --force vpn'
   end

--- a/test/spec/features/vpn/create_spec.rb
+++ b/test/spec/features/vpn/create_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
 
 describe 'vpn create' do
+  before(:each) do
+    # Due to async nature of stack/service removals, need to wait until possible previous vpn containers have gone
+    wait_until_container_gone('vpn.server-1')
+  end
+
+  after(:each) do
+    run 'kontena stack rm --force vpn'
+  end
+
   it 'creates a vpn stack' do
     k = run 'kontena vpn create'
     expect(k.code).to eq(0)

--- a/test/spec/features/vpn/remove_spec.rb
+++ b/test/spec/features/vpn/remove_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
 
 describe 'vpn remove' do
+  before(:each) do
+    # Due to async nature of stack/service removals, need to wait until possible previous vpn containers have gone
+    wait_until_container_gone('vpn.server-1')
+  end
+
+  after(:each) do
+    run 'kontena stack rm --force vpn'
+  end
+
   it 'removes the vpn stack' do
     run 'kontena vpn create'
     k = run 'kontena stack rm --force vpn'

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   include Shell
+  include ContainerHelper
 
   config.before :each do
     k = Kommando.run "kontena grid use e2e"

--- a/test/spec/support/container_helper.rb
+++ b/test/spec/support/container_helper.rb
@@ -1,0 +1,19 @@
+module ContainerHelper
+
+  # Checks if a deployed container exists with given name
+  # @param [String] name of the container to check
+  def container_exist?(name)
+    k = run "kontena container ls"
+    k.out.include?(name)
+  end
+
+  # Waits until no container exists with the name
+  # @param [String] name of the container to check
+  def wait_until_container_gone(name)
+    loop do
+      return unless container_exist?(name)
+      sleep 1
+    end
+  end
+
+end

--- a/test/spec/support/container_helper.rb
+++ b/test/spec/support/container_helper.rb
@@ -3,7 +3,7 @@ module ContainerHelper
   # Checks if a deployed container exists with given name
   # @param [String] name of the container to check
   def container_exist?(name)
-    k = run "kontena container ls"
+    k = run "kontena container ls -q"
     fail "kontena container ls command failed: #{k.out}" if k.code != 0
     k.out.include?(name)
   end

--- a/test/spec/support/container_helper.rb
+++ b/test/spec/support/container_helper.rb
@@ -4,6 +4,7 @@ module ContainerHelper
   # @param [String] name of the container to check
   def container_exist?(name)
     k = run "kontena container ls"
+    fail "kontena container ls command failed: #{k.out}" if k.code != 0
     k.out.include?(name)
   end
 


### PR DESCRIPTION
E2E VPN specs were a bit flaky and the problem was seen on server logs:
```
StackDeployWorker: service e2e/vpn/server deploy failed: Cannot find applicable node for service instance e2e/vpn/server-1: Did not find any nodes with unused ports: [1194]
```

This is due to the "eventually consistent" nature of service/stack removal. Even though specs "cleaned" after running by doing `kontena stack rm --force vpn` it does not guarantee that actual VPN containers are really gone before the next spec starts.

Added generic helper to check container existence and to wait until container is gone.

Fixes #2118