### PR TITLE
Destroy cloud access_token only if not nil

### DIFF
--- a/server/app/services/cloud/rpc/server_api.rb
+++ b/server/app/services/cloud/rpc/server_api.rb
@@ -73,7 +73,7 @@ module Cloud
         info "\"#{opts[:method].to_s.upcase} #{path}\" #{status} #{headers['Content-Length']} #{(end_time-start_time).round(4)}"
         result
       ensure
-        @access_token.destroy
+        @access_token.destroy if @access_token
       end
     end
   end


### PR DESCRIPTION
There's some indication that Cloud RPC API handler might trigger celluloid/EM thread locks by raising un-handled `NoMethodError`, similarly as seen in #2348.
```
W, [2017-05-27T12:50:40.717530 #7]  WARN -- Watchdog<WebsocketBackend>: watchdog delayed by 5.922s @
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `sleep'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `wait'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `block in check'
	/usr/lib/ruby/gems/2.3.0/gems/timers-4.1.2/lib/timers/wait.rb:15:in `block in for'
	/usr/lib/ruby/gems/2.3.0/gems/timers-4.1.2/lib/timers/wait.rb:14:in `loop'
	/usr/lib/ruby/gems/2.3.0/gems/timers-4.1.2/lib/timers/wait.rb:14:in `for'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:58:in `check'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:77:in `block in receive'
	/usr/lib/ruby/gems/2.3.0/gems/timers-4.1.2/lib/timers/wait.rb:15:in `block in for'
	/usr/lib/ruby/gems/2.3.0/gems/timers-4.1.2/lib/timers/wait.rb:14:in `loop'
	/usr/lib/ruby/gems/2.3.0/gems/timers-4.1.2/lib/timers/wait.rb:14:in `for'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:76:in `receive'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:50:in `wait'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid.rb:141:in `suspend'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:41:in `response'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:45:in `value'
	/usr/lib/ruby/gems/2.3.0/gems/celluloid-0.17.3/lib/celluloid/proxy/sync.rb:22:in `method_missing'
	/app/app/helpers/current_leader.rb:7:in `leader?'
	/app/app/services/cloud/websocket_client.rb:148:in `on_message'
	/app/app/services/cloud/websocket_client.rb:111:in `block in connect'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:39:in `block in emit'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:38:in `each'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:38:in `emit'
	/usr/lib/ruby/gems/2.3.0/gems/faye-websocket-0.10.7/lib/faye/websocket/api/event_target.rb:44:in `dispatch_event'
	/usr/lib/ruby/gems/2.3.0/gems/faye-websocket-0.10.7/lib/faye/websocket/api.rb:113:in `receive_message'
	/usr/lib/ruby/gems/2.3.0/gems/faye-websocket-0.10.7/lib/faye/websocket/api.rb:45:in `block in initialize'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:39:in `block in emit'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:38:in `each'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/event_emitter.rb:38:in `emit'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:396:in `emit_message'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:379:in `emit_frame'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:123:in `parse'
	/usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/client.rb:63:in `parse'
	/usr/lib/ruby/gems/2.3.0/gems/faye-websocket-0.10.7/lib/faye/websocket/api.rb:153:in `parse'
	/usr/lib/ruby/gems/2.3.0/gems/faye-websocket-0.10.7/lib/faye/websocket/client.rb:80:in `receive_data'
	/usr/lib/ruby/gems/2.3.0/gems/eventmachine-1.2.3/lib/eventmachine.rb:194:in `run_machine'
	/usr/lib/ruby/gems/2.3.0/gems/eventmachine-1.2.3/lib/eventmachine.rb:194:in `run'
```
This itself does not tell much, but later on when `Watchdog` tries to abort the stuck worker reports:
```
E, [2017-05-27T12:51:57.557786 #7] ERROR -- Cloud::RpcServer: NoMethodError: undefined method `destroy' for nil:NilClass
E, [2017-05-27T12:51:57.616563 #7] ERROR -- Cloud::RpcServer: /app/app/services/cloud/rpc/server_api.rb:76:in `ensure in request'
/app/app/services/cloud/rpc/server_api.rb:76:in `request'
/app/app/services/cloud/rpc/server_api.rb:25:in `get'
/app/app/services/cloud/rpc_server.rb:26:in `handle_request'
/app/app/services/cloud/websocket_client.rb:153:in `block in on_message'
/usr/lib/ruby/gems/2.3.0/gems/eventmachine-1.2.3/lib/eventmachine.rb:1076:in `block in spawn_threadpool'
```

Clearly the `Cloud::Rpc::ServerApi` is trying to destroy a `nil` `@access_token`.