### PR TITLE
Add tracking if service embedded docs changes

### DIFF
--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -75,34 +75,34 @@ module GridServices
       attributes[:health_check] = self.health_check if self.health_check
       attributes[:volumes_from] = self.volumes_from if self.volumes_from
 
-      embeds_dirrty = false
+      embeds_changed = false
 
       if self.links
         attributes[:grid_service_links] = build_grid_service_links(
           self.grid_service.grid_service_links.to_a,
           self.grid_service.grid, grid_service.stack, self.links
         )
-        embeds_dirrty = attributes[:grid_service_links] != self.grid_service.grid_service_links.to_a
+        embeds_changed ||= attributes[:grid_service_links] != self.grid_service.grid_service_links.to_a
       end
 
       if self.hooks
         attributes[:hooks] = self.build_grid_service_hooks(self.grid_service.hooks.to_a)
-        embeds_dirrty = attributes[:hooks] != self.grid_service.hooks.to_a
+        embeds_changed ||= attributes[:hooks] != self.grid_service.hooks.to_a
       end
 
       if self.secrets
         attributes[:secrets] = self.build_grid_service_secrets(self.grid_service.secrets.to_a)
-        embeds_dirrty = attributes[:secrets] != self.grid_service.secrets.to_a
+        embeds_changed ||= attributes[:secrets] != self.grid_service.secrets.to_a
       end
       if self.volumes
         attributes[:service_volumes] = self.build_service_volumes(self.grid_service.service_volumes.to_a,
           self.grid_service.grid, self.grid_service.stack
         )
-        embeds_dirrty = attributes[:service_volumes] != self.grid_service.service_volumes.to_a
+        embeds_changed ||= attributes[:service_volumes] != self.grid_service.service_volumes.to_a
       end
       grid_service.attributes = attributes
 
-      if grid_service.changed? || embeds_dirrty
+      if grid_service.changed? || embeds_changed
         info "updating service #{grid_service.to_path} with changes: #{changed(grid_service)}"
         grid_service.revision += 1
       else

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -75,28 +75,34 @@ module GridServices
       attributes[:health_check] = self.health_check if self.health_check
       attributes[:volumes_from] = self.volumes_from if self.volumes_from
 
+      embeds_dirrty = false
+
       if self.links
         attributes[:grid_service_links] = build_grid_service_links(
           self.grid_service.grid_service_links.to_a,
           self.grid_service.grid, grid_service.stack, self.links
         )
+        embeds_dirrty = attributes[:grid_service_links] != self.grid_service.grid_service_links.to_a
       end
 
       if self.hooks
         attributes[:hooks] = self.build_grid_service_hooks(self.grid_service.hooks.to_a)
+        embeds_dirrty = attributes[:hooks] != self.grid_service.hooks.to_a
       end
 
       if self.secrets
         attributes[:secrets] = self.build_grid_service_secrets(self.grid_service.secrets.to_a)
+        embeds_dirrty = attributes[:secrets] != self.grid_service.secrets.to_a
       end
       if self.volumes
         attributes[:service_volumes] = self.build_service_volumes(self.grid_service.service_volumes.to_a,
           self.grid_service.grid, self.grid_service.stack
         )
+        embeds_dirrty = attributes[:service_volumes] != self.grid_service.service_volumes.to_a
       end
       grid_service.attributes = attributes
 
-      if grid_service.changed?
+      if grid_service.changed? || embeds_dirrty
         info "updating service #{grid_service.to_path} with changes: #{changed(grid_service)}"
         grid_service.revision += 1
       else

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -195,7 +195,7 @@ describe GridServices::Update do
           }.to change{service.reload.revision}.and change{service.reload.updated_at}
         end
 
-        skip 'removes secrets' do
+        it 'removes secrets' do
           subject = described_class.new(
               grid_service: service,
               secrets: [
@@ -316,7 +316,7 @@ describe GridServices::Update do
           expect(service.service_volumes.map{|sv| sv.to_s}).to eq ['/foo:/foo', '/foo2:/foo2']
         end
 
-        skip 'deletes volumes' do
+        it 'deletes volumes' do
           subject = described_class.new(
               grid_service: service,
               volumes: [
@@ -467,7 +467,7 @@ describe GridServices::Update do
           }.to not_change{service.reload.revision}.and not_change{service.reload.updated_at}
         end
 
-        skip 'clears links' do
+        it 'clears links' do
           subject = described_class.new(
               grid_service: service,
               links: [ ],
@@ -477,7 +477,7 @@ describe GridServices::Update do
           }.to change{service.reload.revision}.and change{service.reload.updated_at}.and change{service.reload.grid_service_links.count}.from(1).to(0)
         end
 
-        skip 'deletes links' do
+        it 'deletes links' do
           service.link_to(linked_service3)
           expect(service.grid_service_links.count).to eq 2
 


### PR DESCRIPTION
Removing embedded models (secrets, links, hooks, volumes) from `GridService` didn't bump up the `revision` or `created_at`and thus did not deploy the changes without `--force` flag.



fixes #2109 
