### PR TITLE
Make kontena master ssh work without server.provider set

### DIFF
--- a/cli/lib/kontena/cli/master/config/get_command.rb
+++ b/cli/lib/kontena/cli/master/config/get_command.rb
@@ -12,16 +12,14 @@ module Kontena::Cli::Master::Config
 
     option ['-p', '--pair'], :flag, "Print key=value instead of only value"
 
-    option '--return', :flag, "Return the value", hidden: true
+    def response
+      client.get("config/#{key}")
+    end
 
     def execute
-      if self.pair?
-        puts client.get("config/#{self.key}").inspect
-      elsif self.return?
-        return client.get("config/#{self.key}")[self.key]
-      else
-        puts client.get("config/#{self.key}")[self.key]
-      end
+      value = response[key]
+      print(key + '=') if pair?
+      puts value
     end
   end
 end

--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -31,7 +31,7 @@ module Kontena::Cli::Master
     def master_is_vagrant?
       if master_provider_vagrant?
         unless vagrant_plugin_installed?
-          exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'
+          exit_with_error 'You need to install vagrant plugin to ssh into this master. Use: kontena plugin install vagrant'
         end
         logger.debug { "Master config server.provider is vagrant" }
         true

--- a/cli/lib/kontena/cli/master/ssh_command.rb
+++ b/cli/lib/kontena/cli/master/ssh_command.rb
@@ -15,25 +15,50 @@ module Kontena::Cli::Master
       URI.parse(current_master.url).host
     end
 
-    def master_provider
-      Kontena.run!(%w(master config get --return server.provider))
+    def master_provider_vagrant?
+      require 'kontena/cli/master/config/get_command'
+      cmd = Kontena::Cli::Master::Config::GetCommand.new([])
+      cmd.parse(['server.provider'])
+      cmd.response['server.provider'] == 'vagrant'
+    rescue => ex
+      false
+    end
+
+    def vagrant_plugin_installed?
+      Kontena::PluginManager.instance.plugins.any? { |plugin| plugin.name == 'kontena-plugin-vagrant' }
+    end
+
+    def master_is_vagrant?
+      if master_provider_vagrant?
+        unless vagrant_plugin_installed?
+          exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'
+        end
+        logger.debug { "Master config server.provider is vagrant" }
+        true
+      elsif vagrant_plugin_installed? && current_master.url.include?('192.168.66.')
+        logger.debug { "Vagrant plugin installed and current_master url looks like vagrant" }
+        true
+      else
+        logger.debug { "Assuming non-vagrant master host" }
+        false
+      end
+    end
+
+    def run_ssh
+      cmd = ['ssh']
+      cmd << "#{user}@#{master_host}"
+      cmd += ["-i", identity_file] if identity_file
+      cmd += commands_list
+      logger.debug { "Executing #{cmd.inspect}" }
+      exec(*cmd)
+    end
+
+    def run_vagrant_ssh
+      Kontena.run!(['vagrant', 'master', 'ssh'] + commands_list)
     end
 
     def execute
-      if master_provider == 'vagrant'
-        unless Kontena::PluginManager.instance.plugins.find { |plugin| plugin.name == 'kontena-plugin-vagrant' }
-          exit_with_error 'You need to install vagrant plugin to ssh into this node. Use kontena plugin install vagrant'
-        end
-        cmd = ['vagrant', 'master', 'ssh']
-        cmd += commands_list
-        Kontena.run!(cmd)
-      else
-        cmd = ['ssh']
-        cmd << "#{user}@#{master_host}"
-        cmd += ["-i", identity_file] if identity_file
-        cmd += commands_list
-        exec(*cmd)
-      end
+      master_is_vagrant? ? run_vagrant_ssh : run_ssh
     end
   end
 end

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -34,7 +34,7 @@ module Kontena
     else
       command = cmdline
     end
-    logger.debug { "Running Kontena.run(#{command.inspect}" }
+    logger.debug { "Running Kontena.run(#{command.inspect})" }
     result = Kontena::MainCommand.new(File.basename(__FILE__)).run(command)
     logger.debug { "Command completed, result: #{result.inspect} status: 0" }
     result


### PR DESCRIPTION
Fixes #2373

Uses fuzzy logic to use vagrant  anyway (vagrant plugin is installed and master url has '192.168.66').
