### PR TITLE
Update JsonPath gem

### DIFF
--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       securecompare
       url_safe_base64
     json-serializer (1.0.0)
-    jsonpath (0.5.8)
+    jsonpath (0.8.3)
       multi_json
     listen (2.8.3)
       celluloid (>= 0.15.2)


### PR DESCRIPTION
Looks like the currently used version contains some (potentially) unsafe evals:

https://skarlso.github.io/2017/05/28/replace-eval-with-object-send-and-a-parser/

