### PR TITLE
Add a "Getting started" banner to main command

### DIFF
--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -9,25 +9,31 @@ class Kontena::MainCommand < Kontena::Command
     exit 0
   end
 
+  banner Kontena.pastel.green("Getting started:"), false
+  banner ' - Create a Kontena Master (see "kontena plugin search" for a list of', false
+  banner '   provisioning plugins)', false
+  banner ' - Or log into an existing master, use: "kontena master login <master url>"', false
+  banner ' - Read more about Kontena at https://www.kontena.io/docs/', false
+
+  subcommand "master", "Kontena Master specific commands", load_subcommand('master_command')
   subcommand "cloud", "Kontena Cloud specific commands", load_subcommand('cloud_command')
-  subcommand "logout", "Logout from Kontena Masters or Kontena Cloud accounts", load_subcommand('logout_command')
+  subcommand "node", "Node specific commands", load_subcommand('node_command')
   subcommand "grid", "Grid specific commands", load_subcommand('grid_command')
-  subcommand "app", "App specific commands", load_subcommand('app_command')
   subcommand "stack", "Stack specific commands", load_subcommand('stack_command')
   subcommand "service", "Service specific commands", load_subcommand('service_command')
-  subcommand "vault", "Vault specific commands", load_subcommand('vault_command')
-  subcommand "certificate", "LE Certificate specific commands", load_subcommand('certificate_command')
-  subcommand "node", "Node specific commands", load_subcommand('node_command')
-  subcommand "master", "Master specific commands", load_subcommand('master_command')
-  subcommand "vpn", "VPN specific commands", load_subcommand('vpn_command')
-  subcommand "registry", "Registry specific commands", load_subcommand('registry_command')
   subcommand "container", "Container specific commands", load_subcommand('container_command')
+  subcommand "vault", "Vault specific commands", load_subcommand('vault_command')
+  subcommand "vpn", "VPN specific commands", load_subcommand('vpn_command')
   subcommand "etcd", "Etcd specific commands", load_subcommand('etcd_command')
+  subcommand "certificate", "LE Certificate specific commands", load_subcommand('certificate_command')
+  subcommand "registry", "Registry specific commands", load_subcommand('registry_command')
   subcommand "external-registry", "External registry specific commands", load_subcommand('external_registry_command')
-  subcommand "whoami", "Shows current logged in user", load_subcommand('whoami_command')
-  subcommand "plugin", "Plugin related commands", load_subcommand('plugin_command')
-  subcommand "version", "Show CLI and current master version", load_subcommand('version_command')
   subcommand "volume", "Volume specific commands [EXPERIMENTAL]", load_subcommand('volume_command')
+  subcommand "app", "App specific commands", load_subcommand('app_command')
+  subcommand "plugin", "Plugin specific commands", load_subcommand('plugin_command')
+  subcommand "whoami", "Shows current logged in user", load_subcommand('whoami_command')
+  subcommand "logout", "Logout from Kontena Masters or Kontena Cloud accounts", load_subcommand('logout_command')
+  subcommand "version", "Show CLI and current master version", load_subcommand('version_command')
 
   def execute
   end
@@ -40,12 +46,14 @@ class Kontena::MainCommand < Kontena::Command
   end
 
   def subcommand_missing(name)
+    extend Kontena::Cli::Common
     if known_plugin_subcommand?(name)
-      extend Kontena::Cli::Common
       exit_with_error "The '#{name}' plugin has not been installed. Use: kontena plugin install #{name}"
-    else
-      super(name)
+    elsif name == 'login'
+      exit_with_error "Use 'kontena master login' to log into a Kontena Master\n"+
+             "         or 'kontena cloud login' for logging into your Kontena Cloud account"
     end
+    super
   end
 
   def known_plugin_subcommand?(name)

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -32,7 +32,6 @@ class Kontena::MainCommand < Kontena::Command
   subcommand "app", "App specific commands", load_subcommand('app_command')
   subcommand "plugin", "Plugin specific commands", load_subcommand('plugin_command')
   subcommand "whoami", "Shows current logged in user", load_subcommand('whoami_command')
-  subcommand "logout", "Logout from Kontena Masters or Kontena Cloud accounts", load_subcommand('logout_command')
   subcommand "version", "Show CLI and current master version", load_subcommand('version_command')
 
   def execute
@@ -52,6 +51,9 @@ class Kontena::MainCommand < Kontena::Command
     elsif name == 'login'
       exit_with_error "Use 'kontena master login' to log into a Kontena Master\n"+
              "         or 'kontena cloud login' for logging into your Kontena Cloud account"
+    elsif name == 'logout'
+      exit_with_error "Use 'kontena master logout' to log out from a Kontena Master\n"+
+             "         or 'kontena cloud logout' for logging out from your Kontena Cloud account"
     end
     super
   end

--- a/cli/lib/kontena/scripts/completer.rb
+++ b/cli/lib/kontena/scripts/completer.rb
@@ -139,7 +139,7 @@ helper.logger.debug { "Completing #{words.inspect}" }
 
 begin
   completion = []
-  completion.push %w(cloud logout grid app service stack vault certificate node master vpn registry container etcd external-registry whoami plugin version) if words.size < 2
+  completion.push %w(cloud grid app service stack vault certificate node master vpn registry container etcd external-registry whoami plugin version) if words.size < 2
   if words.size > 0
     case words[0]
       when 'plugin'


### PR DESCRIPTION
Replaces #2250

Also adds a hint about logging in and reorders the command list (which makes the diff hard to review)

Banner:
![image](https://cloud.githubusercontent.com/assets/224971/26618773/423c4010-45e4-11e7-86a6-c572db243dd5.png)

Login hint:
![image](https://cloud.githubusercontent.com/assets/224971/26618786/50c04f64-45e4-11e7-89dc-d75a0e93f640.png)
