### PR TITLE
Improve platform identification on the Kontena Cloud

### DIFF
--- a/server/app/services/auth_provider.rb
+++ b/server/app/services/auth_provider.rb
@@ -98,7 +98,7 @@ class AuthProvider
 
     body = {
       data: {
-        attributes: {          
+        attributes: {
           'redirect-uri' => callback_url,
           'url'          => self.root_url,
           'uuid'         => self.uuid

--- a/server/app/services/auth_provider.rb
+++ b/server/app/services/auth_provider.rb
@@ -46,6 +46,7 @@ class AuthProvider
   attr_accessor :cloud_api_url
   attr_accessor :ignore_invalid_ssl
   attr_accessor :provider_is_kontena
+  attr_accessor :uuid
 
   def self.instance
     new(Configuration.decrypt_all)
@@ -69,6 +70,7 @@ class AuthProvider
     @cloud_api_url = config['cloud.api_url'] || 'https://cloud-api.kontena.io'
     @ignore_invalid_ssl = config['cloud.ignore_invalid_ssl'].to_s == 'true'
     @provider_is_kontena = config['cloud.provider_is_kontena'].to_s == "true"
+    @uuid = config['server.uuid']
   end
 
   def is_kontena?
@@ -96,9 +98,10 @@ class AuthProvider
 
     body = {
       data: {
-        attributes: {
+        attributes: {          
           'redirect-uri' => callback_url,
-          'url'          => self.root_url
+          'url'          => self.root_url,
+          'uuid'         => self.uuid
         }
       }
     }

--- a/server/spec/services/auth_provider_spec.rb
+++ b/server/spec/services/auth_provider_spec.rb
@@ -140,6 +140,7 @@ describe AuthProvider do
     end
 
     it "should update kontena cloud information when valid" do
+      uuid = SecureRandom.uuid
       Configuration['oauth2.client_id'] = "foo"
       Configuration['oauth2.client_secret'] = "foo"
       Configuration['oauth2.authorize_endpoint'] = "https://foo.kontena.io/foo"
@@ -147,6 +148,7 @@ describe AuthProvider do
       Configuration['oauth2.userinfo_endpoint'] = "foo"
       Configuration['oauth2.userinfo_scope'] = "foo"
       Configuration['server.root_url'] = "https://example.com:8181"
+      Configuration['server.uuid'] = uuid
       allow(subject).to receive(:master_access_token).and_return('foobar')
       expect(client).to receive(:request) do |httpmethod, url, options|
         expect(httpmethod).to eq :put
@@ -154,7 +156,11 @@ describe AuthProvider do
         expect(options[:header]['Content-Type']).to eq "application/json"
         expect(options[:header]['Authorization']).to eq "Bearer foobar"
         body = JSON.parse(options[:body])
-        expect(body["data"]["attributes"]["redirect-uri"]).to eq "https://example.com:8181/cb"
+        expect(body["data"]["attributes"]).to eq({
+          'redirect-uri' => 'https://example.com:8181/cb',
+          'url' => 'https://example.com:8181',
+          'uuid' => uuid
+        })
       end.and_return(success_response)
       subject.update_kontena
     end


### PR DESCRIPTION
This PR will send `uuid` field among other master information to Kontena Cloud to improve Platform identification. We can display this information on the Kontena Cloud and user can identify and verify Kontena Platform better.