### PR TITLE
Fix master join command option forwarding to master login

### DIFF
--- a/cli/lib/kontena/cli/master/join_command.rb
+++ b/cli/lib/kontena/cli/master/join_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::Master
 
     def execute
       params = []
-      params += ["--join", self.invite_code.shellescape]
+      params += ["--join", self.invite_code]
       params << "--remote" if self.remote?
       params += ["--name", self.name.shellescape] if self.name
       params << "--verbose" if self.verbose?

--- a/cli/lib/kontena/cli/master/join_command.rb
+++ b/cli/lib/kontena/cli/master/join_command.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Master
       params = []
       params += ["--join", self.invite_code]
       params << "--remote" if self.remote?
-      params += ["--name", self.name.shellescape] if self.name
+      params += ["--name", self.name] if self.name
       params << "--verbose" if self.verbose?
 
       cmd = ['master', 'login'] + params

--- a/cli/lib/kontena/cli/master/join_command.rb
+++ b/cli/lib/kontena/cli/master/join_command.rb
@@ -9,9 +9,9 @@ module Kontena::Cli::Master
 
     def execute
       params = []
-      params << "--join #{self.invite_code.shellescape}"
+      params += ["--join", self.invite_code.shellescape]
       params << "--remote" if self.remote?
-      params << "--name #{self.name.shellescape}" if self.name
+      params += ["--name", self.name.shellescape] if self.name
       params << "--verbose" if self.verbose?
 
       cmd = ['master', 'login'] + params

--- a/cli/spec/kontena/cli/master/join_command_spec.rb
+++ b/cli/spec/kontena/cli/master/join_command_spec.rb
@@ -1,0 +1,33 @@
+require 'kontena/cli/master/join_command'
+require 'kontena/cli/localhost_web_server'
+require 'launchy'
+require 'ostruct'
+
+describe Kontena::Cli::Master::JoinCommand do
+
+  include ClientHelpers
+
+  let(:subject) do
+    described_class.new(File.basename($0))
+  end
+
+  it 'calls master login with proper join options' do
+    expect(Kontena).to receive(:run!).with(%w(master login --join xyz someurl))
+    subject.run(%w(someurl xyz))
+  end
+
+  it 'calls master login with remote option' do
+    expect(Kontena).to receive(:run!).with(%w(master login --join xyz --remote someurl))
+    subject.run(%w(--remote someurl xyz))
+  end
+
+  it 'calls master login with name option' do
+    expect(Kontena).to receive(:run!).with(%w(master login --join xyz --name somename someurl))
+    subject.run(%w(--name somename someurl xyz))
+  end
+
+  it 'calls master login with verbose option' do
+    expect(Kontena).to receive(:run!).with(%w(master login --join xyz --verbose someurl))
+    subject.run(%w(--verbose someurl xyz))
+  end
+end


### PR DESCRIPTION
`kontena master join ...` command "forwarded" some of the options and their values as single string in the command array. That broke down `Kontena.run` since when the commands are executed through that Clamp expects to get options and their values as separate array items.

```
$ k master join https://somemaster code

ERROR: Unrecognised option '--join code'

```

This PR fixes that by putting the options and their values as separate items in the command array.