### PR TITLE
Finetune header formatting on list commands

### DIFF
--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -34,7 +34,6 @@ module Kontena::Cli::Nodes
     def fields
       return ['name'] if quiet?
       {
-        ' ' =>   'health_icon',
         name:    'name',
         version: 'agent_version',
         status:  'status',
@@ -67,7 +66,7 @@ module Kontena::Cli::Nodes
         unless quiet?
           grid_health = grid_health(grid, grid_nodes)
           grid_nodes.each do |node|
-            node['health_icon'] = health_icon(node_health(node, grid_health))
+            node['name'] = health_icon(node_health(node, grid_health)) + " " + node['name']
           end
         end
 

--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::Services
     end
 
     def fields
-      quiet? ? ['name'] : {'  ' => 'health_icon', name: 'name', instances: 'instances', stateful: 'stateful', state: 'state', "exposed ports" => 'ports' }
+      quiet? ? ['name'] : {name: 'name', instances: 'instances', stateful: 'stateful', state: 'state', "exposed ports" => 'ports' }
     end
 
     def service_port(port)
@@ -49,9 +49,8 @@ module Kontena::Cli::Services
 
     def execute
       print_table(services) do |row|
-        row['name'] = service_name(row)
+        row['name'] = quiet? ? service_name(row) :  health_status_icon(health_status(row)) + " " + service_name(row)
         next if quiet?
-        row['health_icon'] = health_status_icon(health_status(row))
         row['stateful'] = row['stateful'] ? pastel.green('yes') : 'no'
         row['ports'] = row['ports'].map(&method(:service_port)).join(',')
         row['state'] = pastel.send(state_color(row['state']), row['state'])

--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -26,7 +26,6 @@ module Kontena::Cli::Stacks
     def fields
       return ['name'] if quiet?
       {
-        '  ' => 'health_icon',
         name: 'name',
         stack: 'stack',
         services: 'services_count',
@@ -38,7 +37,7 @@ module Kontena::Cli::Stacks
     def execute
       print_table(stacks) do |row|
         next if quiet?
-        row['health_icon'] = health_icon(stack_health(row))
+        row['name'] = health_icon(stack_health(row)) + " " + row['name']
         row['stack'] = "#{row['stack']}:#{row['version']}"
         row['services_count'] = row['services'].size
         row['ports'] = stack_ports(row).join(',')

--- a/cli/lib/kontena/cli/table_generator.rb
+++ b/cli/lib/kontena/cli/table_generator.rb
@@ -11,6 +11,8 @@ module Kontena
 
       DEFAULT_HEADER_FORMAT_PROC = lambda { |header| header.to_s.capitalize }
 
+      DEFAULT_RENDER_OPTS = {padding: [0,2,0,0]}
+
       module Helper
         def self.included(base)
           if base.respond_to?(:option)
@@ -29,7 +31,7 @@ module Kontena
             fields,
             row_format_proc: block_given? ? block.to_proc : nil,
             header_format_proc: lambda { |item| pastel.bold(item.to_s.upcase) },
-            render_options: self.respond_to?(:render_options) ? self.render_options : {padding: [0,2,0,0]}
+            render_options: self.respond_to?(:render_options) ? DEFAULT_RENDER_OPTS.merge(self.render_options) : DEFAULT_RENDER_OPTS
           ).render
         end
 

--- a/cli/lib/kontena/cli/table_generator.rb
+++ b/cli/lib/kontena/cli/table_generator.rb
@@ -28,8 +28,8 @@ module Kontena
             array,
             fields,
             row_format_proc: block_given? ? block.to_proc : nil,
-            header_format_proc: lambda { |item| pastel.blue(item.to_s.capitalize) },
-            render_options: self.respond_to?(:render_options) ? self.render_options : nil
+            header_format_proc: lambda { |item| pastel.bold(item.to_s.upcase) },
+            render_options: self.respond_to?(:render_options) ? self.render_options : {padding: [0,2,0,0]}
           ).render
         end
 


### PR DESCRIPTION
The change to `tty-table` usage for most `kontena xyz ls` commands also changed the table headers to be always blue in colour. Quite many are using black backgrounds on their terminals, including Kontena cloud, and blue-on-black is just not too readable.

This PR "reverts" the formatting closer to original upcase'd format, only by bolding the headers. As there's no colours used, the font colour is selected automatically based on the terminal.

Also the health icons were moved into their own column. Now when slight padding is added, the icons drifted a bit so I moved them to the same column with the service/node/stack names.

After the changes applied the outputs look like:
![image](https://cloud.githubusercontent.com/assets/3205505/26675712/a597d4aa-46cd-11e7-9a0d-8ebde1609474.png)

![image](https://cloud.githubusercontent.com/assets/3205505/26675755/c7f69860-46cd-11e7-8144-a1a605cb1b1b.png)

On black(ish) background the bolded white table headers seems to slightly blur, but is it too bad? IMO they are still quite readable.
