### PR TITLE
Add yaml loading to error handling

### DIFF
--- a/cli/lib/kontena/errors.rb
+++ b/cli/lib/kontena/errors.rb
@@ -24,6 +24,7 @@ module Kontena
 
       # Render as indented YAML
       def errors_message(indent: "\t")
+        require 'yaml'
         @errors.to_yaml.lines[1..-1].map{|line| "#{indent}#{line}" }.join
       end
 


### PR DESCRIPTION
CLI load time optimizations removed global yaml require and forgot to add it to all needed places. This resulted into `to_yaml` errors on CLI error handling:
```
k service create nginx nginx
 [fail] Creating nginx service      
 [error] NoMethodError : undefined method `to_yaml' for {"name"=>"is already taken"}:Hash
Did you mean?  to_a
```

This PR adds needed yaml require to `StandardErrorHash` which yamlifies the errors.

```
$ k service create nginx nginx
 [fail] Creating nginx service      
 [error] 422 : Unprocessable Entity:
	name: is already taken
```