### PR TITLE
Add --use-defaults option to kontena stack upgrade command

### DIFF
--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -16,6 +16,7 @@ module Kontena::Cli::Stacks
     include Common::StackValuesFromOption
 
     option '--[no-]deploy', :flag, 'Trigger deploy after upgrade', default: true
+    option '--use-defaults', :flag, 'Use the default or previous values for all variables instead of prompting'
 
     option '--force', :flag, 'Force upgrade'
 
@@ -26,6 +27,8 @@ module Kontena::Cli::Stacks
       master_data = spinner "Reading stack #{pastel.cyan(name)} metadata from Kontena Master" do |spin|
         read_stack || spin.fail!
       end
+
+      values = values.to_h.merge(master_data.delete('variables').to_h) if use_defaults?
 
       stack = stack_read_and_dump(filename, name: name, values: values, defaults: master_data['variables'])
 

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -13,7 +13,8 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       {
         'name' => 'stack-a',
         'stack' => 'foo/stack-a',
-        'services' => []
+        'services' => [],
+        'variables' => defaults
       }
     end
 
@@ -105,5 +106,16 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
         subject.run(['--no-deploy', 'stack-a', './path/to/kontena.yml'])
       end
     end
+
+    context '--use-defaults option' do
+      it 'uses the values received in master stack response as values instead of defaults for upgrade' do
+        expect(client).to receive(:get).with('stacks/test-grid/stack-a').and_return(stack_response)
+        allow(subject).to receive(:require_config_file).with('./path/to/kontena.yml').and_return(true)
+        expect(subject).to receive(:stack_read_and_dump).with('./path/to/kontena.yml', name: 'stack-a', values: defaults, defaults: nil).and_return(stack)
+        expect(client).to receive(:put).with('stacks/test-grid/stack-a', hash_including('variables' => { 'foo' => 'bar' }))
+        subject.run(['--use-defaults', 'stack-a', './path/to/kontena.yml'])
+      end
+    end
   end
 end
+


### PR DESCRIPTION


With this PR you don't have to hit enter if you want to use the variable values from master metadata.

Currently they are used as defaults and prompted, but with `--use-defaults` they will be used as the final values instead.
