### PR TITLE
Add --values option to kontena stack show command

### DIFF
--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -46,7 +46,6 @@ module Kontena::Cli::Stacks
         cmd = ['stack', 'install', '-n', target_name, '--parent-name', stack_name]
 
         dependency['variables'].merge(dependency_values_from_options(dependency['name'])).each do |key, value|
-          next if key == 'PARENT_STACK'
           cmd.concat ['-v', "#{key}=#{value}"]
         end
 

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -13,7 +13,7 @@ module Kontena::Cli::Stacks
     requires_current_master
     requires_current_master_token
 
-    option '--variables', :flag, 'Output the variable-value pairs as YAML'
+    option '--values', :flag, 'Output the variable-value pairs as YAML'
 
     def execute
       variables? ? show_variables : show_stack

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -13,16 +13,24 @@ module Kontena::Cli::Stacks
     requires_current_master
     requires_current_master_token
 
+    option '--variables', :flag, 'Output the variable-value pairs as YAML'
+
     def execute
-      show_stack(name)
+      variables? ? show_variables : show_stack
     end
 
-    def fetch_stack(name)
+    def fetch_stack
       client.get("stacks/#{current_grid}/#{name}")
     end
 
-    def show_stack(name)
-      stack = fetch_stack(name)
+    def show_variables
+      require 'yaml'
+      stack = fetch_stack
+      puts stack['variables'].to_yaml
+    end
+
+    def show_stack
+      stack = fetch_stack
 
       puts "#{stack['name']}:"
       puts "  created: #{stack['created_at']}"

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -19,18 +19,18 @@ module Kontena::Cli::Stacks
       variables? ? show_variables : show_stack
     end
 
-    def fetch_stack
+    def fetch_stack(name)
       client.get("stacks/#{current_grid}/#{name}")
     end
 
     def show_variables
       require 'yaml'
-      stack = fetch_stack
+      stack = fetch_stack(name)
       puts stack['variables'].to_yaml
     end
 
     def show_stack
-      stack = fetch_stack
+      stack = fetch_stack(name)
 
       puts "#{stack['name']}:"
       puts "  created: #{stack['created_at']}"

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -53,6 +53,10 @@ module Kontena::Cli::Stacks
       puts "  version: #{stack['version']}"
       puts "  revision: #{stack['revision']}"
       puts "  expose: #{stack['expose'] || '-'}"
+      puts "  variables:#{' -' if stack['variables'].nil? || stack['variables'].empty?}"
+      stack['variables'].each do |var, val|
+        puts "    #{var}: #{val}"
+      end
       puts "  parent: #{stack['parent'] ? stack['parent']['name'] : '-'}"
       if stack['children'] && !stack['children'].empty?
         puts "  children:"

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -18,6 +18,7 @@ module Kontena::Cli::Stacks
     include Common::StackValuesToOption
 
     def execute
+      write_variables if values_to
       values? ? show_variables : show_stack
     end
 
@@ -29,22 +30,15 @@ module Kontena::Cli::Stacks
       puts variable_yaml
     end
 
-    def clean_variables
-      rejected_keys = Set.new(%w(GRID STACK PARENT_STACK PLATFORM))
-      stack['variables'].reject do |key, _|
-        rejected_keys.include?(key)
-      end
-    end
-
     def variable_yaml
-      ::YAML.dump(clean_variables)
+      ::YAML.dump(stack['variables'])
     end
 
+    def write_variables
+      File.write(values_to, variable_yaml)
+    end
+      
     def show_stack
-      if values_to
-        File.write(values_to, variable_yaml)
-      end
-
       puts "#{stack['name']}:"
       puts "  created: #{stack['created_at']}"
       puts "  updated: #{stack['updated_at']}"

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Stacks
     option '--values', :flag, 'Output the variable-value pairs as YAML'
 
     def execute
-      variables? ? show_variables : show_stack
+      values? ? show_variables : show_stack
     end
 
     def fetch_stack(name)

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -22,6 +22,10 @@ module Kontena::Cli::Stacks
       values? ? show_variables : show_stack
     end
 
+    def variables
+      @variables ||= stack['variables'] || {}
+    end
+
     def stack
       @stack ||= client.get("stacks/#{current_grid}/#{name}")
     end
@@ -31,7 +35,7 @@ module Kontena::Cli::Stacks
     end
 
     def variable_yaml
-      ::YAML.dump(stack['variables'])
+      ::YAML.dump(variables)
     end
 
     def write_variables
@@ -47,8 +51,8 @@ module Kontena::Cli::Stacks
       puts "  version: #{stack['version']}"
       puts "  revision: #{stack['revision']}"
       puts "  expose: #{stack['expose'] || '-'}"
-      puts "  variables:#{' -' if stack['variables'].nil? || stack['variables'].empty?}"
-      stack['variables'].each do |var, val|
+      puts "  variables:#{' -' if variables.empty?}"
+      variables.each do |var, val|
         puts "    #{var}: #{val}"
       end
       puts "  parent: #{stack['parent'] ? stack['parent']['name'] : '-'}"

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -140,7 +140,6 @@ module Kontena::Cli::Stacks
           cmd = ['stack', 'install', '--name', stackname]
           cmd.concat ['--parent-name', stack['parent_name']] if stack['parent_name']
           stack['variables'].merge(dependency_values_from_options(stackname)).each do |k, v|
-            next if k == 'PARENT_STACK'
             cmd.concat ['-v', "#{k}=#{v}"]
           end
           cmd << '--no-deploy'

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -52,7 +52,7 @@ module Kontena::Cli::Stacks
       def variable_values(without_defaults: false, without_vault: false)
         result = variables.to_h(values_only: true)
         if without_defaults
-          result.delete_if { |k, _| default_envs.key?(k.to_s) }
+          result.delete_if { |k, _| default_envs.key?(k.to_s) || k.to_s == 'PARENT_STACK' }
         end
         if without_vault
           result.delete_if { |k, _| variables.option(k).from.include?('vault') || variables.option(k).to.include?('vault') }

--- a/cli/spec/kontena/cli/stacks/show_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/show_command_spec.rb
@@ -9,5 +9,21 @@ describe Kontena::Cli::Stacks::ShowCommand do
       expect(client).to receive(:get).with('stacks/test-grid/test-stack').and_return(spy())
       subject.run(['test-stack'])
     end
+
+    context '--variables option' do
+      let(:stack_response) do
+        {
+          'name' => 'stack-a',
+          'stack' => 'foo/stack-a',
+          'services' => [],
+          'variables' => { 'foo' => 'bar' }
+        }
+      end
+
+      it 'outputs a yaml of the stack variables and values' do
+        expect(client).to receive(:get).with('stacks/test-grid/test-stack').and_return(stack_response)
+        expect{subject.run(['--variables', 'test-stack'])}.to output(/^foo: bar$/).to_stdout
+      end
+    end
   end
 end

--- a/cli/spec/kontena/cli/stacks/show_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/show_command_spec.rb
@@ -22,7 +22,7 @@ describe Kontena::Cli::Stacks::ShowCommand do
 
       it 'outputs a yaml of the stack variables and values' do
         expect(client).to receive(:get).with('stacks/test-grid/test-stack').and_return(stack_response)
-        expect{subject.run(['--variables', 'test-stack'])}.to output(/^foo: bar$/).to_stdout
+        expect{subject.run(['--values', 'test-stack'])}.to output(/^foo: bar$/).to_stdout
       end
     end
   end

--- a/cli/spec/kontena/cli/stacks/show_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/show_command_spec.rb
@@ -10,7 +10,7 @@ describe Kontena::Cli::Stacks::ShowCommand do
       subject.run(['test-stack'])
     end
 
-    context '--variables option' do
+    context '--values option' do
       let(:stack_response) do
         {
           'name' => 'stack-a',


### PR DESCRIPTION
Fixes #2408

This PR adds `--values` and `--values-to` options to `kontena stack show` command.

Variable names and values are also displayed in normal `stack show` output.

```
$ kontena stack show --values somestack > somestack-vars.yml
$ kontena stack show --values-to foo.yml somestack
```

```
$ kontena stack show twemproxy-redis1
```

![image](https://user-images.githubusercontent.com/224971/30481050-62f2a1e2-9a25-11e7-99c9-8472f69a6914.png)
