### PR TITLE
Add tty as separation option in container/service exec

### DIFF
--- a/agent/lib/kontena/actors/container_exec.rb
+++ b/agent/lib/kontena/actors/container_exec.rb
@@ -30,8 +30,12 @@ module Kontena::Actors
 
     # @param [String] input
     def input(input)
-      @last_input = Time.now.to_i
-      @write_pipe.write(input)
+      if input.nil?
+        @write_pipe.close
+      else
+        @last_input = Time.now.to_i
+        @write_pipe.write(input)
+      end
     end
 
     # @param [String] cmd

--- a/agent/lib/kontena/rpc/docker_container_api.rb
+++ b/agent/lib/kontena/rpc/docker_container_api.rb
@@ -128,15 +128,12 @@ module Kontena
       # @param [String] session_id
       # @param [Array<String>] cmd
       # @param [Boolean] tty
-      def run_exec(session_id, cmd, tty = false)
+      # @param [Boolean] stdin
+      def run_exec(session_id, cmd, tty = false, stdin = false)
         actor_id = "container_exec_#{session_id}"
         executor = Celluloid::Actor[actor_id]
         if executor
-          if tty
-            executor.async.interactive(cmd)
-          else
-            executor.async.run(cmd)
-          end
+          executor.async.run(cmd, tty, stdin)
         else
           raise RpcServer::Error.new(404, "Exec session (#{session_id}) not found")
         end
@@ -144,6 +141,8 @@ module Kontena
         {}
       end
 
+      # @param [String] id
+      # @param [String] input
       def tty_input(id, input)
         actor_id = "container_exec_#{id}"
         executor = Celluloid::Actor[actor_id]
@@ -152,6 +151,7 @@ module Kontena
         end
       end
 
+      # @param [String] id
       def terminate_exec(id)
         actor_id = "container_exec_#{id}"
         executor = Celluloid::Actor[actor_id]

--- a/agent/lib/kontena/rpc/docker_container_api.rb
+++ b/agent/lib/kontena/rpc/docker_container_api.rb
@@ -147,7 +147,7 @@ module Kontena
         actor_id = "container_exec_#{id}"
         executor = Celluloid::Actor[actor_id]
         if executor
-          executor.async.input(input)
+          executor.input(input)
         end
       end
 

--- a/agent/lib/kontena/rpc_server.rb
+++ b/agent/lib/kontena/rpc_server.rb
@@ -29,6 +29,8 @@ module Kontena
       end
     end
 
+    exclusive :handle_notification
+
     ##
     # @param [Array] message msgpack-rpc request array
     # @return [Array]

--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -19,28 +19,40 @@ module Kontena::Cli::Containers
       require_api_url
       token = require_token
       cmd = JSON.dump({cmd: cmd_list})
-      url = ws_url("#{current_grid}/#{container_id}")
-      url << 'interactive=true&' if interactive?
-      url << 'tty=true&' if tty?
-      url << 'shell=true' if shell?
+      queue = Queue.new
+      stdin_reader = nil
       ws = connect(url, token)
-
       ws.on :message do |msg|
-        self.handle_message(msg)
+        data = parse_message(msg)
+        queue << data if data.is_a?(Hash)
       end
       ws.on :open do
         ws.text(cmd)
-        self.stream_stdin_to_ws(ws) if interactive?
+        stdin_reader = self.stream_stdin_to_ws(ws) if self.interactive?
       end
       ws.on :close do |e|
         if e.reason.include?('code: 404')
-          exit_with_error('Not found')
+          queue << {'exit' => 1, 'message' => 'Not found'}
         else
-          exit 1
+          queue << {'exit' => 1}
         end
       end
       ws.connect
-      sleep
+      while msg = queue.pop
+        self.handle_message(msg)
+      end
+    rescue SystemExit
+      stdin_reader.kill if stdin_reader
+      raise
+    end
+
+    # @return [String]
+    def url
+      url = ws_url("#{current_grid}/#{container_id}")
+      url = url + 'interactive=true&' if interactive?
+      url = url + 'tty=true&' if tty?
+      url = url + 'shell=true' if shell?
+      url
     end
   end
 end

--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -10,7 +10,8 @@ module Kontena::Cli::Containers
     parameter "CMD ...", "Command"
 
     option ["--shell"], :flag, "Execute as a shell command"
-    option ["--interactive"], :flag, "Keep stdin open"
+    option ["-i", "--interactive"], :flag, "Keep stdin open"
+    option ["-t", "--tty"], :flag, "Allocate a pseudo-TTY"
 
     def execute
       require_api_url
@@ -18,6 +19,7 @@ module Kontena::Cli::Containers
       cmd = JSON.dump({cmd: cmd_list})
       url = ws_url("#{current_grid}/#{container_id}")
       url << 'interactive=true&' if interactive?
+      url << 'tty=true&' if tty?
       url << 'shell=true' if shell?
       ws = connect(url, token)
 

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -23,22 +23,21 @@ module Kontena::Cli::Helpers
       }
     end
 
-    # @param [Websocket::Frame::Incoming] msg
+    # @param [Hash] msg
     def handle_message(msg)
-      data = parse_message(msg)
-      if data.is_a?(Hash)
-        if data.has_key?('exit')
-          exit data['exit'].to_i
-        elsif data.has_key?('stream')
-          if data['stream'] == 'stdout'
-            $stdout << data['chunk']
-          else 
-            $stderr << data['chunk']
-          end
+      if msg.has_key?('exit')
+        if msg['message']
+          exit_with_error(msg['message'])
+        else
+          exit msg['exit'].to_i
+        end
+      elsif msg.has_key?('stream')
+        if msg['stream'] == 'stdout'
+          $stdout << msg['chunk']
+        else
+          $stderr << msg['chunk']
         end
       end
-    rescue => exc
-      $stderr << "#{exc.class.name}: #{exc.message}"
     end
 
     # @param [Websocket::Frame::Incoming] msg

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -12,10 +12,11 @@ module Kontena::Cli::Services
     parameter "NAME", "Service name"
     parameter "CMD ...", "Command"
 
-    option ["-i", "--instance"], "INSTANCE", "Exec on given numbered instance, default first running" do |value| Integer(value) end
+    option ["--instance"], "INSTANCE", "Exec on given numbered instance, default first running" do |value| Integer(value) end
     option ["-a", "--all"], :flag, "Exec on all running instances"
     option ["--shell"], :flag, "Execute as a shell command"
-    option ["--interactive"], :flag, "Keep stdin open"
+    option ["-i", "--interactive"], :flag, "Keep stdin open"
+    option ["-t", "--tty"], :flag, "Allocate a pseudo-TTY"
     option ["--skip"], :flag, "Skip failed instances when executing --all"
     option ["--silent"], :flag, "Do not show exec status"
     option ["--verbose"], :flag, "Show exec status"
@@ -91,6 +92,7 @@ module Kontena::Cli::Services
       token = require_token
       url = ws_url(container['id'])
       url << 'shell=true' if shell?
+      url << 'tty=true' if tty?
       ws = connect(url, token)
       ws.on :message do |msg|
         data = base.parse_message(msg)
@@ -124,6 +126,7 @@ module Kontena::Cli::Services
       base = self
       url = ws_url(container['id']) << 'interactive=true'
       url << '&shell=true' if shell?
+      url << '&tty=true' if tty?
       ws = connect(url, token)
       ws.on :message do |msg|
         base.handle_message(msg)        

--- a/cli/lib/kontena/websocket/client/connection.rb
+++ b/cli/lib/kontena/websocket/client/connection.rb
@@ -46,7 +46,7 @@ module Kontena
         def_delegators :@client, :text, :binary, :ping, :close, :protocol, :on
 
         def write(buffer)
-          @socket.write buffer
+          @socket.write(buffer)
         end
 
         def read_socket

--- a/docs/using-kontena/services.md
+++ b/docs/using-kontena/services.md
@@ -376,10 +376,11 @@ $ kontena service exec <name>
 
 ```
 --grid GRID                   Specify grid to use
--i, --instance INSTANCE       Exec on given numbered instance, default first running
+--instance INSTANCE           Exec on given numbered instance, default first running
 -a, --all                     Exec on all running instances
 --shell                       Execute as a shell command
---interactive                 Keep stdin open
+-i, --interactive             Keep stdin open
+-t, --tty                     Allocate a pseudo-TTY
 --skip                        Skip failed instances when executing --all
 --silent                      Do not show exec status
 --verbose                     Show exec status

--- a/server/app/routes/v1/containers_api.rb
+++ b/server/app/routes/v1/containers_api.rb
@@ -57,12 +57,12 @@ module V1
           r.on 'exec' do
             r.websocket do |ws|
               executor = Docker::StreamingExecutor.new(container, ws)
-              if r['interactive']
-                audit_event(r, container.grid, container, 'exec_tty')
-                executor.start_tty(r['shell'].to_s == 'true')
+              if r['interactive'].to_s == 'true'
+                audit_event(r, container.grid, container, 'exec_interactive')
+                executor.start(r['shell'].to_s == 'true', true, r['tty'].to_s == 'true')
               else
                 audit_event(r, container.grid, container, 'exec')
-                executor.start(r['shell'].to_s == 'true')
+                executor.start(r['shell'].to_s == 'true', false, r['tty'].to_s == 'true')
               end
             end
           end

--- a/test/spec/features/container/exec_spec.rb
+++ b/test/spec/features/container/exec_spec.rb
@@ -1,7 +1,7 @@
 describe 'container exec' do
   def container_id
     k = run("kontena container list")
-    k.out.match(/^.* (.+\/kontena-agent) .*/)[1]
+    k.out.match(/.* (.+\/kontena-agent).*/)[1]
   end
 
   it 'executes command in a given container' do 

--- a/test/spec/features/container/exec_spec.rb
+++ b/test/spec/features/container/exec_spec.rb
@@ -20,7 +20,7 @@ describe 'container exec' do
 
   it 'runs a command inside a container with tty' do
     id = container_id
-    k = kommando("kontena container exec --interactive #{id} sh")
+    k = kommando("kontena container exec -it #{id} sh")
     
     k.out.on("#") do
       k.in << "ls -la \r"

--- a/test/spec/features/container/inspect_spec.rb
+++ b/test/spec/features/container/inspect_spec.rb
@@ -1,0 +1,19 @@
+describe 'container inspect' do
+  def container_id
+    k = run("kontena container list")
+    k.out.match(/^.* (.+\/kontena-agent) .*/)[1]
+  end
+
+  it 'inspects a given container' do 
+    id = container_id
+    expect(id).not_to be_nil
+
+    k = kommando("kontena container inspect #{id}")
+    expect(k.run).to be_truthy
+  end
+
+  it 'returns error if container does not exist' do 
+    k = run("kontena container inspect invalid-id")
+    expect(k.code).to eq(1)
+  end
+end

--- a/test/spec/features/container/logs_spec.rb
+++ b/test/spec/features/container/logs_spec.rb
@@ -1,0 +1,19 @@
+describe 'container logs' do
+  def container_id
+    k = run("kontena container list")
+    k.out.match(/^.* (.+\/kontena-agent) .*/)[1]
+  end
+
+  it 'inspects a given container' do 
+    id = container_id
+    expect(id).not_to be_nil
+
+    k = kommando("kontena container logs #{id}")
+    expect(k.run).to be_truthy
+  end
+
+  it 'returns error if container does not exist' do 
+    k = run("kontena container logs invalid-id")
+    expect(k.code).to eq(1)
+  end
+end

--- a/test/spec/features/service/exec_spec.rb
+++ b/test/spec/features/service/exec_spec.rb
@@ -32,7 +32,7 @@ describe 'service exec' do
   end
 
   it 'runs a command inside a service with tty' do
-    k = kommando("kontena service exec --interactive test-1 sh")
+    k = kommando("kontena service exec -it test-1 sh")
     
     k.out.on("#") do
       k.in << "ls -la /\r"

--- a/test/spec/features/service/exec_spec.rb
+++ b/test/spec/features/service/exec_spec.rb
@@ -43,6 +43,12 @@ describe 'service exec' do
     expect(k.run).to be_truthy
   end
 
+  it 'runs a command with piped stdin' do
+    k = kommando("$ echo beer | kontena service exec -i test-1 rev")
+    expect(k.run).to be_truthy
+    expect(k.out).to eq('reeb')
+  end
+
   it 'runs a command on every instance with --all' do 
     run("kontena service scale test-1 2")
     k = kommando("kontena service exec --all --silent test-1 hostname -s")


### PR DESCRIPTION
This has one breaking change, now `-i` option means `--interactive` in `service exec` (to match docker etc tools behaviour).