### PR TITLE
Render service links with qualified name

### DIFF
--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -34,7 +34,7 @@ json.stack do
   json.name grid_service.stack.name
 end
 json.links grid_service.grid_service_links.map { |s|
-  { id: s.linked_grid_service.to_path, alias: s.alias, name: s.alias } if s.linked_grid_service
+  { id: s.linked_grid_service.to_path, alias: s.alias, name: s.linked_grid_service.qualified_name } if s.linked_grid_service
 }.compact
 json.log_driver grid_service.log_driver
 json.log_opts grid_service.log_opts

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -34,7 +34,7 @@ json.stack do
   json.name grid_service.stack.name
 end
 json.links grid_service.grid_service_links.map { |s|
-  { id: s.linked_grid_service.to_path, alias: s.alias, name: s.linked_grid_service.name } if s.linked_grid_service
+  { id: s.linked_grid_service.to_path, alias: s.alias, name: s.alias } if s.linked_grid_service
 }.compact
 json.log_driver grid_service.log_driver
 json.log_opts grid_service.log_opts

--- a/test/spec/features/service/link_spec.rb
+++ b/test/spec/features/service/link_spec.rb
@@ -26,6 +26,17 @@ describe 'service link' do
     expect(k.out.match(/^\s+\- simple\/redis\s*$/)).to be_truthy
   end
 
+  it 'links stack service with existing links to service' do
+    with_fixture_dir("stack/links") do
+      run 'kontena stack install --no-deploy links.yml'
+    end
+    run "kontena service create test-1 redis:3.0"
+    k = run "kontena service link simple/bar test-1"
+    expect(k.code).to eq(0)
+    k = run "kontena service show simple/bar"
+    expect(k.out.match(/^\s+\- test-1\s*$/)).to be_truthy
+  end
+
   it 'returns error if target does not exist' do
     run "kontena service create test-1 redis:3.0"
     k = run "kontena service link test-1 foo"

--- a/test/spec/features/service/unlink_spec.rb
+++ b/test/spec/features/service/unlink_spec.rb
@@ -5,7 +5,7 @@ describe 'service unlink' do
     end
   end
 
-  it 'links service to target' do
+  it 'unlinks service to target' do
     run "kontena service create test-1 redis:3.0"
     run "kontena service create test-2 redis:3.0"
     run "kontena service link test-1 test-2"
@@ -13,6 +13,19 @@ describe 'service unlink' do
     expect(k.code).to eq(0)
     k = run "kontena service show test-1"
     expect(k.out.match(/^\s+- test-2\s*$/)).to be_falsey
+  end
+
+  it 'unlinks service from stack with existing links' do
+    with_fixture_dir("stack/links") do
+      run 'kontena stack install --no-deploy links.yml'
+    end
+    run "kontena service create test-1 redis:3.0"
+    k = run "kontena service link simple/bar test-1"
+    expect(k.code).to eq(0)
+    k = run "kontena service show simple/bar"
+    expect(k.out.match(/^\s+\- test-1\s*$/)).to be_truthy
+    k = run "kontena service unlink simple/bar test-1"
+    expect(k.out.match(/^\s+\- test-1\s*$/)).to be_falsey
   end
 
   it 'returns error if target does not exist' do

--- a/test/spec/fixtures/stack/links/links.yml
+++ b/test/spec/fixtures/stack/links/links.yml
@@ -1,0 +1,9 @@
+stack: test/simple
+services:
+  foo:
+    image: redis
+
+  bar:
+    image: redis
+    links:
+      - foo


### PR DESCRIPTION
Both `kontena service link` and `kontena service unlink` commands were slightly broken.

The commands first get the service details (including links) and then send back modified links. The problem is that server sends the `name` attribute of the link as plain service name without stack prefix. Naturally CLI just posts those back as is for existing and un-touched links. This breaks things like:
```
$ kontena service show todo-app/web 
test/todo-app/web:
  created: 2017-06-02T09:18:56.304Z
  updated: 2017-06-02T12:32:22.773Z
  stack: test/todo-app
  desired_state: running
  image: jnummelin/todo-example:latest
  revision: 2
  stack_revision: 1
  stateful: no
  scaling: 3
  strategy: ha
  deploy_opts:
    min_health: 0.8
    wait_for_port: 9292
  dns: web.todo-app.test.kontena.local
  cmd: bundle exec puma -p 9292 -e production
  env: 
    - MONGODB_URI=mongodb://mongo-1:27017,mongo-2:27017,mongo-3:27017/todo_production
    - KONTENA_LB_VIRTUAL_HOSTS=todo-demo.kontena.io
    - KONTENA_LB_INTERNAL_PORT=9292
  links: 
    - infra/lb-external
    - mongo
    - redis
  instances:
        …
$ kontena service unlink todo-app/web redis
 [fail] Unlinking todo-app/web from redis      
 [error] 422 : Unprocessable Entity:
    links:
    - Service todo-app/lb-external does not exist
```

As the `infra/lb-external` link is posted back with name `lb-external` server assumes we're trying to link to another service within the same stack.

This PR changes the server to send name with the stack prefix which is actually same as the `alias` field. Or are there cases where they would be different?

This does slightly alter the API, but IMO to better direction as we mention in the API docs that the name should be prefixed with stack name:
> name: The linked service. Within stack use <service_name>, otherwise use <stack_name>/<service_name>


fixes #2416 