### PR TITLE
Fix cloud master update endpoint

### DIFF
--- a/cli/lib/kontena/cli/cloud/master/update_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/update_command.rb
@@ -37,7 +37,7 @@ module Kontena::Cli::Cloud::Master
       attrs["owner"]        = self.owner        if self.owner
 
       response = cloud_client.put(
-        "master",
+        "user/masters/#{master_id}",
         { data: { attributes: attrs.reject{ |k, _| ['client-id', 'client-secret'].include?(k) } } }
       )
 


### PR DESCRIPTION
`kontena cloud master update xyz` command was using the wrong API endpoint on cloud.

Not adding any specs since we're probably anyway getting rid of this as the management happens on cloud web UI side. (< "quote" from @nevalla :D)

fixes #2419 