### PR TITLE
Fix error in exec commands when master url does not have a trailing slash

### DIFF
--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -21,6 +21,7 @@ module Kontena::Cli::Containers
       cmd = JSON.dump({cmd: cmd_list})
       queue = Queue.new
       stdin_reader = nil
+      url = ws_url("#{current_grid}/#{container_id}", interactive: interactive?, shell: shell?, tty: tty?)
       ws = connect(url, token)
       ws.on :message do |msg|
         data = parse_message(msg)
@@ -44,15 +45,6 @@ module Kontena::Cli::Containers
     rescue SystemExit
       stdin_reader.kill if stdin_reader
       raise
-    end
-
-    # @return [String]
-    def url
-      url = ws_url("#{current_grid}/#{container_id}")
-      url = url + 'interactive=true&' if interactive?
-      url = url + 'tty=true&' if tty?
-      url = url + 'shell=true' if shell?
-      url
     end
   end
 end

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -3,7 +3,7 @@ require_relative '../../websocket/client'
 module Kontena::Cli::Helpers
   module ExecHelper
 
-    # @param [WebSocket::Client::Simple] ws 
+    # @param [WebSocket::Client::Simple] ws
     # @return [Thread]
     def stream_stdin_to_ws(ws)
       require 'io/console'
@@ -50,9 +50,12 @@ module Kontena::Cli::Helpers
     # @param [String] container_id
     # @return [String]
     def ws_url(container_id)
-      url = require_current_master.url
-      url << '/' unless url.end_with?('/')
-      "#{url.sub('http', 'ws')}v1/containers/#{container_id}/exec?"
+      require 'uri' unless Object.const_defined?(:URI)
+      url = URI.parse(require_current_master.url)
+      url.scheme = url.scheme.sub('http', 'ws')
+      url.path = "/v1/containers/#{container_id}/exec"
+      url.query = {}
+      url.to_s
     end
 
     # @param [String] url

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -50,6 +50,7 @@ module Kontena::Cli::Helpers
     # @param container_id [String] The container id
     # @param interactive [Boolean] Interactive TTY on/off
     # @param shell [Boolean] Shell on/of
+    # @param tty [Boolean] TTY on/of
     # @return [String]
     def ws_url(container_id, interactive: false, shell: false, tty: false)
       require 'uri' unless Object.const_defined?(:URI)

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -51,17 +51,18 @@ module Kontena::Cli::Helpers
     # @param interactive [Boolean] Interactive TTY on/off
     # @param shell [Boolean] Shell on/of
     # @return [String]
-    def ws_url(container_id, interactive: false, shell: false)
+    def ws_url(container_id, interactive: false, shell: false, tty: false)
       require 'uri' unless Object.const_defined?(:URI)
       extend Kontena::Cli::Common unless self.respond_to?(:require_current_master)
 
       url = URI.parse(require_current_master.url)
       url.scheme = url.scheme.sub('http', 'ws')
       url.path = "/v1/containers/#{container_id}/exec"
-      if shell || interactive
+      if shell || interactive || tty
         query = {}
         query.merge!(interactive: true) if interactive
         query.merge!(shell: true) if shell
+        query.merge!(tty: true) if tty
         url.query = URI.encode_www_form(query)
       end
       url.to_s

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -47,14 +47,23 @@ module Kontena::Cli::Helpers
       nil
     end
 
-    # @param [String] container_id
+    # @param container_id [String] The container id
+    # @param interactive [Boolean] Interactive TTY on/off
+    # @param shell [Boolean] Shell on/of
     # @return [String]
-    def ws_url(container_id)
+    def ws_url(container_id, interactive: false, shell: false)
       require 'uri' unless Object.const_defined?(:URI)
+      extend Kontena::Cli::Common unless self.respond_to?(:require_current_master)
+
       url = URI.parse(require_current_master.url)
       url.scheme = url.scheme.sub('http', 'ws')
       url.path = "/v1/containers/#{container_id}/exec"
-      url.query = {}
+      if shell || interactive
+        query = {}
+        query.merge!(interactive: true) if interactive
+        query.merge!(shell: true) if shell
+        url.query = URI.encode_www_form(query)
+      end
       url.to_s
     end
 

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -92,7 +92,7 @@ module Kontena::Cli::Services
       cmd = JSON.dump({ cmd: cmd_list })
       exit_status = nil
       token = require_token
-      ws = connect(ws_url(container['id'], shell: shell?), token)
+      ws = connect(url(container['id']), token)
       ws.on :message do |msg|
         data = base.parse_message(msg)
         if data
@@ -124,7 +124,7 @@ module Kontena::Cli::Services
       cmd = JSON.dump({ cmd: cmd_list })
       queue = Queue.new
       stdin_stream = nil
-      ws = connect(ws_url(container['id'], interactive: true, shell: shell?, tty: tty?), token)
+      ws = connect(url(container['id']), token)
       ws.on :message do |msg|
         data = self.parse_message(msg)
         queue << data if data.is_a?(Hash)
@@ -147,6 +147,10 @@ module Kontena::Cli::Services
     rescue SystemExit
       stdin_stream.kill if stdin_stream
       raise
+    end
+
+    def url(container_id)
+      ws_url(container_id, shell: shell?, interactive: interactive?, tty: tty?)
     end
   end
 end

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -1,6 +1,5 @@
 require 'shellwords'
 require 'json'
-require 'uri'
 require_relative 'services_helper'
 require_relative '../helpers/exec_helper'
 

--- a/cli/spec/kontena/cli/helpers/exec_helper_spec.rb
+++ b/cli/spec/kontena/cli/helpers/exec_helper_spec.rb
@@ -1,0 +1,44 @@
+require "kontena/cli/helpers/exec_helper"
+
+describe Kontena::Cli::Helpers::ExecHelper do
+
+  include ClientHelpers
+
+  let(:described_class) do
+    Class.new do
+      include Kontena::Cli::Helpers::ExecHelper
+      def initialize(*args)
+      end
+    end
+  end
+
+  describe '#ws_url' do
+    it 'returns an exec url for a container id' do
+      expect(subject).to receive(:require_current_master).and_return(double(url: 'http://someurl/'))
+      expect(subject.ws_url('abcd1234')).to eq 'ws://someurl/v1/containers/abcd1234/exec'
+    end
+
+    it 'also works when the url does not have a trailing slash' do
+      expect(subject).to receive(:require_current_master).and_return(double(url: 'http://someurl'))
+      expect(subject.ws_url('abcd1234')).to eq 'ws://someurl/v1/containers/abcd1234/exec'
+    end
+
+    context 'query params' do
+      before(:each) do
+        allow(subject).to receive(:require_current_master).and_return(double(url: 'http://someurl'))
+      end
+
+      it 'can add the interactive query param' do
+        expect(subject.ws_url('abcd1234', interactive: true)).to eq 'ws://someurl/v1/containers/abcd1234/exec?interactive=true'
+      end
+
+      it 'can add the shell query param' do
+        expect(subject.ws_url('abcd1234', shell: true)).to eq 'ws://someurl/v1/containers/abcd1234/exec?shell=true'
+      end
+
+      it 'can add both query params' do
+        expect(subject.ws_url('abcd1234', shell: true, interactive: true)).to eq 'ws://someurl/v1/containers/abcd1234/exec?interactive=true&shell=true'
+      end
+    end
+  end
+end

--- a/cli/spec/kontena/cli/services/exec_command_spec.rb
+++ b/cli/spec/kontena/cli/services/exec_command_spec.rb
@@ -17,9 +17,9 @@ describe Kontena::Cli::Services::ExecCommand do
       def on(callback, &block)
         @callbacks[callback] = block
         if callback == :open
-          Thread.new { 
-            sleep 0.01 
-            @callbacks[:open].call 
+          Thread.new {
+            sleep 0.01
+            @callbacks[:open].call
           }
         end
       end
@@ -28,7 +28,7 @@ describe Kontena::Cli::Services::ExecCommand do
 
       def receive_message(msg)
         @callbacks[:message].call(Event.new(JSON.dump(msg)))
-      rescue => exc 
+      rescue => exc
         STDERR.puts exc.message
       end
     end
@@ -69,12 +69,12 @@ describe Kontena::Cli::Services::ExecCommand do
     end
 
     it "Executes on the running container by default" do
-      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec?", anything).and_return(ws_client)
+      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec", anything).and_return(ws_client)
       expect(ws_client).to receive(:text) do |foo|
         ws_client.receive_message({'stream' => 'stdout', 'chunk' => "ok\n"})
         ws_client.receive_message({'exit' => 0})
       end
-      
+
       expect {
         subject.run(['test-service', 'test'])
       }.to output("ok\n").to_stdout
@@ -107,7 +107,7 @@ describe Kontena::Cli::Services::ExecCommand do
 
     it "Executes on the first running container by default" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec?", anything).and_return(ws_client)
+      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec", anything).and_return(ws_client)
       expect(ws_client).to receive(:text) do
         respond_ok(ws_client)
       end
@@ -118,7 +118,7 @@ describe Kontena::Cli::Services::ExecCommand do
 
     it "Executes on the first running container, even if they are ordered differently" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return({'containers' => service_containers['containers'].reverse })
-      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec?", anything).and_return(ws_client)
+      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec", anything).and_return(ws_client)
       expect(ws_client).to receive(:text) do
         respond_ok(ws_client)
       end
@@ -129,7 +129,7 @@ describe Kontena::Cli::Services::ExecCommand do
 
     it "Executes on the first running container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec?", anything).and_return(ws_client)
+      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec", anything).and_return(ws_client)
       expect(ws_client).to receive(:text) do
         respond_ok(ws_client)
       end
@@ -140,7 +140,7 @@ describe Kontena::Cli::Services::ExecCommand do
 
     it "Executes on the second running container if given" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-2/exec?", anything).and_return(ws_client)
+      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-2/exec", anything).and_return(ws_client)
       expect(ws_client).to receive(:text) do
         respond_ok(ws_client)
       end
@@ -160,13 +160,13 @@ describe Kontena::Cli::Services::ExecCommand do
 
       3.times do |i|
         ws_client = ws_client_class.new
-        expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-#{i + 1}/exec?", anything).and_return(ws_client)
+        expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-#{i + 1}/exec", anything).and_return(ws_client)
         expect(ws_client).to receive(:text) do
           ws_client.receive_message({'stream' => 'stdout', 'chunk' => "test#{i + 1}\n"})
           ws_client.receive_message({'exit' => 0})
         end
       end
-      
+
       expect {
         subject.run(['--silent', '--all', 'test-service', 'test'])
       }.to output("test1\ntest2\ntest3\n").to_stdout
@@ -174,7 +174,7 @@ describe Kontena::Cli::Services::ExecCommand do
 
     it "Stops if the first container fails" do
       expect(client).to receive(:get).with('services/test-grid/null/test-service/containers').and_return(service_containers)
-      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec?", anything).and_return(ws_client)
+      expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-1/exec", anything).and_return(ws_client)
       expect(ws_client).to receive(:text) do
         respond_error(ws_client)
       end
@@ -188,11 +188,11 @@ describe Kontena::Cli::Services::ExecCommand do
       i = 1
       [:ok, :err].each do |status|
         ws_client = ws_client_class.new
-        expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-#{i}/exec?", anything).and_return(ws_client)
+        expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-#{i}/exec", anything).and_return(ws_client)
         expect(ws_client).to receive(:text) do
           if status == :ok
             respond_ok(ws_client)
-          else 
+          else
             respond_error(ws_client)
           end
         end
@@ -209,11 +209,11 @@ describe Kontena::Cli::Services::ExecCommand do
       i = 1
       [:ok, :err, :ok].each do |status|
         ws_client = ws_client_class.new
-        expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-#{i}/exec?", anything).and_return(ws_client)
+        expect(Kontena::Websocket::Client).to receive(:new).with("#{master_url}v1/containers/test-grid/host/test-service.container-#{i}/exec", anything).and_return(ws_client)
         expect(ws_client).to receive(:text) do
           if status == :ok
             respond_ok(ws_client)
-          else 
+          else
             respond_error(ws_client)
           end
         end


### PR DESCRIPTION
Fixes #2414