### PR TITLE
Avoid missing constants by using autoload

### DIFF
--- a/cli/lib/kontena/autoload_core.rb
+++ b/cli/lib/kontena/autoload_core.rb
@@ -1,0 +1,18 @@
+# stdlib
+autoload :JSON, 'json'
+autoload :YAML, 'safe_yaml'
+autoload :URI, 'uri'
+autoload :Logger, 'logger'
+autoload :FileUtils, 'fileutils'
+autoload :Forwardable, 'forwardable'
+autoload :Singleton, 'singleton'
+autoload :Observable, 'observer'
+autoload :Pathname, 'pathname'
+autoload :DateTime, 'date'
+autoload :Date, 'date'
+autoload :Base64, 'base64'
+autoload :SecureRandom, 'securerandom'
+
+# dependencies
+autoload :Excon, 'excon'
+autoload :Opto, 'opto'

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -6,6 +6,7 @@ module Kontena
 
   module Cli
     autoload :ShellSpinner, 'kontena/cli/spinner'
+    autoload :Spinner, 'kontena/cli/spinner'
     autoload :Config, 'kontena/cli/config'
 
     module Common

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -2,7 +2,12 @@ require 'forwardable'
 require 'kontena_cli'
 
 module Kontena
+  autoload :Client, 'kontena/client'
+
   module Cli
+    autoload :ShellSpinner, 'kontena/cli/spinner'
+    autoload :Config, 'kontena/cli/config'
+
     module Common
       extend Forwardable
 
@@ -27,12 +32,10 @@ module Kontena
       end
 
       def spinner(msg, &block)
-        require 'kontena/cli/spinner' unless Kontena::Cli.const_defined?(:Spinner)
          Kontena::Cli::Spinner.spin(msg, &block)
       end
 
       def config
-        require 'kontena/cli/config' unless Kontena::Cli.const_defined?(:Config)
         Kontena::Cli::Config.instance
       end
 

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -9,6 +9,7 @@ end
 module Kontena
   module Cli
     autoload :Config, 'kontena/cli/config'
+    autoload :ShellSpinner, 'kontena/cli/spinner'
     autoload :Spinner, 'kontena/cli/spinner'
     autoload :Common, 'kontena/cli/common'
     autoload :TableGenerator, 'kontena/cli/table_generator'

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require 'kontena/autoload_core'
 
 $KONTENA_START_TIME = Time.now.to_f
 at_exit do

--- a/test/spec/features/plugin/run_spec.rb
+++ b/test/spec/features/plugin/run_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'plugin support' do
+  context 'spinner' do
+    it 'is available by including Kontena::Cli::ShellSpinner' do
+      k = run('bundle exec ruby ' + fixture_dir('plugins') + 'spinner_test.rb')
+      expect(k.code).to be_zero
+      expect(k.out).to match /Testing spinner/
+    end
+
+    it 'is available by including Kontena::Cli::Common' do
+      k = run('bundle exec ruby ' + fixture_dir('plugins') + 'spinner_test_2.rb')
+      expect(k.code).to be_zero
+      expect(k.out).to match /Testing spinner/
+    end
+
+    it 'is available without including anything' do
+      k = run('bundle exec ruby ' + fixture_dir('plugins') + 'spinner_test_3.rb')
+      expect(k.code).to be_zero
+      expect(k.out).to match /Testing spinner/
+    end
+  end
+
+  context 'client' do
+    it 'does not need be required' do
+      k = run('bundle exec ruby ' + fixture_dir('plugins') + 'client_test.rb')
+      expect(k.code).to be_zero
+      expect(k.out).to match(/^example\.com/)
+    end
+  end
+
+  context 'config' do
+    it 'does not need to be required' do
+      k = run('bundle exec ruby ' + fixture_dir('plugins') + 'config_test.rb')
+      expect(k.code).to be_zero
+      expect(k.out).to match(/kontena_client/)
+    end
+  end
+
+  context 'common' do
+    it 'has access to the essentials' do
+      k = run('bundle exec ruby ' + fixture_dir('plugins') + 'common_test.rb')
+      expect(k.code).to be_zero
+    end
+  end
+end

--- a/test/spec/fixtures/plugins/client_test.rb
+++ b/test/spec/fixtures/plugins/client_test.rb
@@ -1,0 +1,3 @@
+require 'kontena_cli'
+
+puts Kontena::Client.new('https://example.com').host

--- a/test/spec/fixtures/plugins/common_test.rb
+++ b/test/spec/fixtures/plugins/common_test.rb
@@ -1,0 +1,16 @@
+require 'kontena_cli'
+
+include Kontena::Cli::Common
+
+spinner "test" do
+  sleep 0.1
+end
+
+puts current_master
+puts current_grid
+puts config.servers.size
+puts pastel.green('hello')
+puts prompt.help_color
+logger.info "hello"
+raise "foo" unless respond_to?(:ask)
+raise "foo" unless respond_to?(:yes?)

--- a/test/spec/fixtures/plugins/config_test.rb
+++ b/test/spec/fixtures/plugins/config_test.rb
@@ -1,0 +1,3 @@
+require 'kontena_cli'
+
+puts Kontena::Cli::Config.instance.config_filename

--- a/test/spec/fixtures/plugins/spinner_test.rb
+++ b/test/spec/fixtures/plugins/spinner_test.rb
@@ -1,0 +1,7 @@
+require 'kontena_cli'
+
+include Kontena::Cli::ShellSpinner
+
+spinner 'Testing spinner' do
+  sleep 0.1
+end

--- a/test/spec/fixtures/plugins/spinner_test_2.rb
+++ b/test/spec/fixtures/plugins/spinner_test_2.rb
@@ -1,0 +1,7 @@
+require 'kontena_cli'
+
+include Kontena::Cli::Common
+
+spinner 'Testing spinner' do
+  sleep 0.1
+end

--- a/test/spec/fixtures/plugins/spinner_test_3.rb
+++ b/test/spec/fixtures/plugins/spinner_test_3.rb
@@ -1,0 +1,5 @@
+require 'kontena_cli'
+
+Kontena::Cli::Spinner.spin 'Testing spinner' do
+  sleep 0.1
+end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -59,7 +59,10 @@ RSpec.configure do |config|
 
   config.before :each do
     k = Kommando.run "kontena grid use e2e"
-    abort "e2e grid does not exist" unless k.code == 0
+    unless k.code == 0
+      STDERR.puts(k.out)
+      abort "e2e grid does not exist"
+    end
   end
 
 # The settings below are suggested to provide a good initial experience

--- a/test/spec/support/shell.rb
+++ b/test/spec/support/shell.rb
@@ -24,8 +24,12 @@ module Shell
     "\x03".freeze
   end
 
+  def fixture_dir(dir)
+    "./spec/fixtures/#{dir}/"
+  end
+
   def with_fixture_dir(dir)
-    Dir.chdir("./spec/fixtures/#{dir}/") do
+    Dir.chdir(fixture_dir(dir)) do
       yield
     end
   end


### PR DESCRIPTION
Needed to make current versions of plugins run with 1.3.0

Before:
```
$ bin/kontena master ssh
 [error] NameError : uninitialized constant Kontena::Cli::ShellSpinner
```

After:
```
$ bin/kontena master ssh
Works
```

