### PR TITLE
Terminate ContainerHealthCheckWorker less brutally

### DIFF
--- a/agent/lib/kontena/workers/container_health_check_worker.rb
+++ b/agent/lib/kontena/workers/container_health_check_worker.rb
@@ -55,9 +55,8 @@ module Kontena::Workers
         # Restart the container, master will handle re-scheduling logic
         info "About to restart container #{name} as it's reported to be unhealthy"
         emit_service_pod_event("service:health_check", "restarting #{name} because it's reported as unhealthy", Logger::WARN)
-        defer {
-          restart_container
-        }
+        
+        restart_container
       end
     end
 

--- a/agent/lib/kontena/workers/health_check_worker.rb
+++ b/agent/lib/kontena/workers/health_check_worker.rb
@@ -56,8 +56,7 @@ module Kontena::Workers
     def stop_container_check(container_id)
       worker = workers.delete(container_id)
       if worker
-        # we have to use kill because worker is blocked by log stream
-        Celluloid::Actor.kill(worker) if worker.alive?
+        worker.terminate if worker.alive?
       end
     end
 

--- a/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
@@ -55,7 +55,7 @@ describe Kontena::Workers::HealthCheckWorker do
     it 'terminates worker if it exist' do
       worker = spy(:worker, :alive? => true)
       subject.workers[container.id] = worker
-      expect(Celluloid::Actor).to receive(:kill).with(worker)
+      expect(worker).to receive(:terminate)
       subject.stop_container_check(container.id)
     end
   end


### PR DESCRIPTION
When `ContainerHealthCheckWorker` triggered a restart for a container, `HealthCheckWorker` sees a `kill` and `die` events and thus brutally killed the corresponding `ContainerHealthCheckWorker` actor. This happens so quickly that the call from docker restart has not event returned yet and can leave Docker and docker api in weird state. This also means that service event log will not get the `... restarted successfully` event at all.

The restart was also happening on a `defer` block which can actually make things even worse as it might allow multiple restarts to be happening at the same time. At least theoretically. :) 

Fixes #2439 