### PR TITLE
Fix init-cloud call args during deploy wizard

### DIFF
--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -9,7 +9,7 @@ module Kontena
         args << '--force'
         args += ["--cloud-master-id", command.cloud_master_id] if command.cloud_master_id
         args += ["--provider", command.result[:provider]] if command.result[:provider]
-        args << ["--version", command.result[:version]] if command.result[:version]
+        args += ["--version", command.result[:version]] if command.result[:version]
         args
       end
 

--- a/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
+++ b/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
@@ -7,9 +7,9 @@ module Kontena
       def init_cloud_args
         args = []
         args << '--force'
-        args << "--cloud-master-id #{command.cloud_master_id}" if command.cloud_master_id
-        args << "--provider #{command.result[:provider]}" if command.result[:provider]
-        args << "--version #{command.result[:version]}" if command.result[:version]
+        args += ["--cloud-master-id", command.cloud_master_id] if command.cloud_master_id
+        args += ["--provider", command.result[:provider]] if command.result[:provider]
+        args << ["--version", command.result[:version]] if command.result[:version]
         args
       end
 


### PR DESCRIPTION
Fixes:
```
ERROR Command [["master", "init-cloud", "--force", "--provider aws", "--version 1.3.0.rc3"]] exception
ERROR Unrecognised option '--provider aws' (Clamp::UsageError)
```
