### PR TITLE
Allow server port to be set from PORT env

### DIFF
--- a/docs/references/environment-variables.md
+++ b/docs/references/environment-variables.md
@@ -17,6 +17,7 @@ toc_order: 2
 - `AUTH_API_URL`: specifies authentication server url (default: https://auth.kontena.io)
 - `WEBSOCKET_TIMEOUT`: websocket timeout in seconds (default: 5.0)
 - `KONTENA_CLOCK_SKEW`: acceptable clock skew for connecting agents (default: 1.0s)
+- `PORT`: server port (default: 9292)
 
   The acceptable range of clock offsets is between `WEBSOCKET_TIMEOUT` + `KONTENA_CLOCK_SKEW` (default: 6.0) seconds in the past, and `KONTENA_CLOCK_SKEW` (default: 1.0) seconds in the future.
 

--- a/server/run.sh
+++ b/server/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "** Starting Kontena Master version `cat VERSION` **"
-exec puma -p 9292 -e production
+exec puma -p ${PORT:-9292} -e production


### PR DESCRIPTION
This allows the Kontena master to be run in environments like Heroku.