### PR TITLE
Increase short RpcClient timeouts from 2s to 5s

### DIFF
--- a/server/app/routes/v1/etcd_api.rb
+++ b/server/app/routes/v1/etcd_api.rb
@@ -16,7 +16,7 @@ module V1
         node = grid.host_nodes.connected.first
         halt_request(404, {error: 'Not connected to any nodes'}) if !node
 
-        client = node.rpc_client(2)
+        client = node.rpc_client(5)
 
         r.get do
           r.is do

--- a/server/app/services/grid_service_instance_deployer.rb
+++ b/server/app/services/grid_service_instance_deployer.rb
@@ -133,7 +133,7 @@ class GridServiceInstanceDeployer
 
   # @param [HostNode] node
   # @raise [RpcClient::TimeoutError]
-  def notify_node(node, timeout: 2.0)
+  def notify_node(node, timeout: 5.0)
     rpc_client = RpcClient.new(node.node_id, timeout)
     rpc_client.request('/service_pods/notify_update', [])
   end

--- a/server/app/services/volume_instance_scheduler.rb
+++ b/server/app/services/volume_instance_scheduler.rb
@@ -9,7 +9,7 @@ class VolumeInstanceDeployer
     volume_instance = node.volume_instances.find_by(name: volume_name)
     unless volume_instance
       volume_instance = VolumeInstance.create!(host_node: node, volume: service_volume.volume, name: volume_name)
-      rpc_client = RpcClient.new(node.node_id, 2)
+      rpc_client = RpcClient.new(node.node_id, 5)
       rpc_client.request('/volumes/notify_update', [])
     end
     volume_instance


### PR DESCRIPTION
In some cases the 2 seconds timeout used is just too short. This PR increases the cases where 2secs timeout was used to use 5 secs timeout.

Fixes #2460 