### PR TITLE
Upgrade agent, test vagrant docker-compose to version 1.13

### DIFF
--- a/agent/Vagrantfile
+++ b/agent/Vagrantfile
@@ -29,13 +29,6 @@ def vm_cpus
   $vb_cpus.nil? ? $vm_cpus : $vb_cpus
 end
 
-provision_script = <<SCRIPT
-sudo mkdir -p /opt/bin
-curl -sL https://github.com/docker/compose/releases/download/1.5.0/docker-compose-`uname -s`-`uname -m` > /opt/bin/docker-compose
-chmod 755 /opt/bin/docker-compose
-SCRIPT
-
-
 Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
@@ -74,7 +67,7 @@ Vagrant.configure("2") do |config|
       if File.exist?(CLOUD_CONFIG_PATH)
         config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/vagrantfile-user-data"
         config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
-        config.vm.provision :shell, :inline => provision_script
+        config.vm.provision :shell, :path => 'vagrant-provision.sh'
       end
     end
   end

--- a/agent/vagrant-provision.sh
+++ b/agent/vagrant-provision.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -uex
+
+## docker-compose
+DOCKER_COMPOSE_VERSION=1.11.1
+
+[ -d /opt/bin ] || sudo install -d /opt/bin
+
+[ -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION ] || sudo install -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION
+[ -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin ] || sudo install -d /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin
+[ -e /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin/docker-compose ] || (
+  curl -o /tmp/docker-compose -sL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m`
+  sudo install -m 755 -t /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin /tmp/docker-compose
+)
+
+sudo ln -sf /opt/docker-compose_$DOCKER_COMPOSE_VERSION/bin/docker-compose /opt/bin/docker-compose

--- a/agent/vagrant-provision.sh
+++ b/agent/vagrant-provision.sh
@@ -3,7 +3,7 @@
 set -uex
 
 ## docker-compose
-DOCKER_COMPOSE_VERSION=1.11.1
+DOCKER_COMPOSE_VERSION=1.13.0
 
 [ -d /opt/bin ] || sudo install -d /opt/bin
 

--- a/test/vagrant-provision.sh
+++ b/test/vagrant-provision.sh
@@ -3,7 +3,7 @@
 set -uex
 
 ## docker-compose
-DOCKER_COMPOSE_VERSION=1.11.1
+DOCKER_COMPOSE_VERSION=1.13.0
 
 [ -d /opt/bin ] || sudo install -d /opt/bin
 


### PR DESCRIPTION
Using the same [`test/vagrant-provision.sh`](https://github.com/kontena/kontena/blob/master/test/vagrant-provision.sh) provisioning script for the agent to install and upgrade specific docker-compose versions when re-provisioning.

Needed for `docker-compose run --rm`...
```
$ docker ps -a | grep share_agent_run
09841cb43e25        860865f22eaf                 "/app/bin/kontena-age"    12 days ago         Exited (0) 12 days ago                                                     share_agent_run_38
0af91e72586f        860865f22eaf                 "/app/bin/kontena-age"    13 days ago         Exited (0) 12 days ago                                                     share_agent_run_37
1a7b66f58722        860865f22eaf                 "/app/bin/kontena-age"    13 days ago         Exited (0) 13 days ago                                                     share_agent_run_36
00415281d07d        6ddc72a96b0c                 "/app/bin/kontena-age"    13 days ago         Exited (0) 13 days ago                                                     share_agent_run_35
...
<snip hundreds of these>
```