### PR TITLE
Update test kommando to fix missing bash failures

### DIFF
--- a/test/Gemfile
+++ b/test/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gem 'dotenv'
 gem 'rspec'
-gem 'kommando'
+gem 'kommando', '~> 0.1.1'
 gem 'kontena-cli', path: '../cli'

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 gem 'dotenv'
 gem 'rspec'
-gem 'kommando', '~> 0.1.1'
+gem 'kommando', '~> 0.1.2'
 gem 'kontena-cli', path: '../cli'

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     equatable (0.5.0)
     excon (0.49.0)
     hash_validator (0.7.1)
-    kommando (0.0.19)
+    kommando (0.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     liquid (4.0.0)
@@ -84,7 +84,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
-  kommando
+  kommando (~> 0.1.1)
   kontena-cli!
   rspec
 

--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -1,36 +1,38 @@
 PATH
   remote: ../cli
   specs:
-    kontena-cli (1.1.1)
+    kontena-cli (1.3.0)
       clamp (~> 1.1.0)
       excon (~> 0.49.0)
-      hash_validator (~> 0.7.0)
+      hash_validator (~> 0.7.1)
       launchy (~> 2.4.3)
       liquid (~> 4.0.0)
-      opto (= 1.8.3)
+      opto (= 1.8.5)
       retriable (~> 2.1.0)
       ruby_dig (~> 0.0.2)
       safe_yaml (~> 1.0)
       semantic (~> 1.5)
-      tty-prompt (~> 0.10)
+      tty-prompt (= 0.12.0)
+      tty-table (~> 0.8.0)
+      websocket-driver-kontena (= 0.6.5)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.0)
+    addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    clamp (1.1.1)
+    clamp (1.1.2)
     diff-lcs (1.2.5)
     dotenv (2.1.1)
     equatable (0.5.0)
     excon (0.49.0)
-    hash_validator (0.7.0)
+    hash_validator (0.7.1)
     kommando (0.0.19)
     launchy (2.4.3)
       addressable (~> 2.3)
     liquid (4.0.0)
-    necromancer (0.3.0)
-    opto (1.8.3)
+    necromancer (0.4.0)
+    opto (1.8.5)
     pastel (0.7.1)
       equatable (~> 0.5.0)
       tty-color (~> 0.4.0)
@@ -53,12 +55,28 @@ GEM
     safe_yaml (1.0.4)
     semantic (1.6.0)
     tty-color (0.4.2)
-    tty-cursor (0.3.0)
-    tty-prompt (0.10.1)
-      necromancer (~> 0.3.0)
+    tty-cursor (0.4.0)
+    tty-prompt (0.12.0)
+      necromancer (~> 0.4.0)
       pastel (~> 0.7.0)
-      tty-cursor (~> 0.3.0)
+      tty-cursor (~> 0.4.0)
       wisper (~> 1.6.1)
+    tty-screen (0.5.0)
+    tty-table (0.8.0)
+      equatable (~> 0.5.0)
+      necromancer (~> 0.4.0)
+      pastel (~> 0.7.0)
+      tty-screen (~> 0.5.0)
+      unicode-display_width (~> 1.1.0)
+      verse (~> 0.5.0)
+    unicode-display_width (1.1.3)
+    unicode_utils (1.4.0)
+    verse (0.5.0)
+      unicode-display_width (~> 1.1.0)
+      unicode_utils (~> 1.4.0)
+    websocket-driver-kontena (0.6.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     wisper (1.6.1)
 
 PLATFORMS
@@ -71,4 +89,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.14.3
+   1.15.1

--- a/test/Rakefile
+++ b/test/Rakefile
@@ -71,7 +71,7 @@ namespace :compose do
 
   task :teardown_master do
     sh "docker-compose stop api mongodb"
-    sh "docker-compose rm --force api mongodb"
+    sh "docker-compose rm -v --force api mongodb"
     sh "kontena master remove --force compose-e2e"
   end
 
@@ -82,7 +82,7 @@ namespace :compose do
     # Workaround https://github.com/docker/compose/issues/4550
     #   Strip trailing CR from the docker-compose run output
     sh "kontena node rm --force $(docker-compose run --rm agent hostname | tr -d $'\r')"
-    sh "docker-compose rm --force agent"
+    sh "docker-compose rm -v --force agent"
     sh "kontena grid rm --force e2e"
   end
 end


### PR DESCRIPTION
Fixes #2468 by bumping the `test/Gemfile` `kommando` dep to `0.1.1`, which falls back to `/bin/sh` if `bash` is missing. Updating the `Gemfile.lock` also bumped the `kontena-cli` deps.

Also fixes #1903 by using `docker-compose rm -v` during teardown
