### PR TITLE
Remove hardcoded read mode because it's default

### DIFF
--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -11,8 +11,6 @@ test:
       uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost:27017/kontena_test' %>
       options:
         max_pool_size: 25
-        read: 
-          mode: :primary
         write:
           w: 1
   options:
@@ -23,8 +21,6 @@ production:
     default:
       options:
         max_pool_size: 40
-        read: 
-          mode: :primary
         write:
           w: 1
       uri: <%= ENV['MONGODB_URI'] || ENV['MONGOHQ_URL'] %>


### PR DESCRIPTION
Now this options confuses mongo driver when trying to connect mongos (sharded cluster).