### PR TITLE
server: bump development mode mongoid pool size

### DIFF
--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -2,6 +2,8 @@ development:
   clients:
     default:
       uri: <%= ENV['MONGODB_URI'] || 'mongodb://localhost:27017/kontena_development' %>
+      options:
+        max_pool_size: 25
   options:
     use_utc: true
     raise_not_found_error: false


### PR DESCRIPTION
Fixes #2360

The effective default `max_pool_size` of 5 when running with `RACK_ENV=development` could occasionally errors on connection pool contention: `Timeout::Error: Timed out attempting to dequeue connection after 1 sec.`

Bump the development-mode pool size to match the pool size used for tests. The production environment has a higher max pool size.