### PR TITLE
Test: update Gemfile.lock

### DIFF
--- a/test/Gemfile.lock
+++ b/test/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       opto (= 1.8.5)
       retriable (~> 2.1.0)
       ruby_dig (~> 0.0.2)
-      safe_yaml (~> 1.0)
       semantic (~> 1.5)
       tty-prompt (= 0.12.0)
       tty-table (~> 0.8.0)
@@ -27,7 +26,7 @@ GEM
     equatable (0.5.0)
     excon (0.49.0)
     hash_validator (0.7.1)
-    kommando (0.1.1)
+    kommando (0.1.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     liquid (4.0.0)
@@ -52,7 +51,6 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby_dig (0.0.2)
-    safe_yaml (1.0.4)
     semantic (1.6.0)
     tty-color (0.4.2)
     tty-cursor (0.4.0)
@@ -84,7 +82,7 @@ PLATFORMS
 
 DEPENDENCIES
   dotenv
-  kommando (~> 0.1.1)
+  kommando (~> 0.1.2)
   kontena-cli!
   rspec
 


### PR DESCRIPTION
Fixes #2475 bumping the `Gemfile` dep version, but not updating the `Gemfile.lock`, which seems to cause the `plugin support` specs to fail when the `Gemfile.lock` still contains `kommand` 0.1.1?

```
plugin support
  spinner
Could not find gem 'kommando (~> 0.1.2)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
    is available by including Kontena::Cli::ShellSpinner (FAILED - 1)
Could not find gem 'kommando (~> 0.1.2)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
    is available by including Kontena::Cli::Common (FAILED - 2)
Could not find gem 'kommando (~> 0.1.2)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
    is available without including anything (FAILED - 3)
  client
Could not find gem 'kommando (~> 0.1.2)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
    does not need be required (FAILED - 4)
  config
Could not find gem 'kommando (~> 0.1.2)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
    does not need to be required (FAILED - 5)
  common
Could not find gem 'kommando (~> 0.1.2)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
    has access to the essentials (FAILED - 6)

Failures:

  1) plugin support spinner is available by including Kontena::Cli::ShellSpinner
     Failure/Error: expect(k.code).to be_zero
       expected `7.zero?` to return true, got false
     # ./spec/features/plugin/run_spec.rb:7:in `block (3 levels) in <top (required)>'

  2) plugin support spinner is available by including Kontena::Cli::Common
     Failure/Error: expect(k.code).to be_zero
       expected `7.zero?` to return true, got false
     # ./spec/features/plugin/run_spec.rb:13:in `block (3 levels) in <top (required)>'

  3) plugin support spinner is available without including anything
     Failure/Error: expect(k.code).to be_zero
       expected `7.zero?` to return true, got false
     # ./spec/features/plugin/run_spec.rb:19:in `block (3 levels) in <top (required)>'

  4) plugin support client does not need be required
     Failure/Error: expect(k.code).to be_zero
       expected `7.zero?` to return true, got false
     # ./spec/features/plugin/run_spec.rb:27:in `block (3 levels) in <top (required)>'

  5) plugin support config does not need to be required
     Failure/Error: expect(k.code).to be_zero
       expected `7.zero?` to return true, got false
     # ./spec/features/plugin/run_spec.rb:35:in `block (3 levels) in <top (required)>'

  6) plugin support common has access to the essentials
     Failure/Error: expect(k.code).to be_zero
       expected `7.zero?` to return true, got false
     # ./spec/features/plugin/run_spec.rb:43:in `block (3 levels) in <top (required)>'

Finished in 6.41 seconds (files took 0.27717 seconds to load)
6 examples, 6 failures

Failed examples:

rspec ./spec/features/plugin/run_spec.rb:5 # plugin support spinner is available by including Kontena::Cli::ShellSpinner
rspec ./spec/features/plugin/run_spec.rb:11 # plugin support spinner is available by including Kontena::Cli::Common
rspec ./spec/features/plugin/run_spec.rb:17 # plugin support spinner is available without including anything
rspec ./spec/features/plugin/run_spec.rb:25 # plugin support client does not need be required
rspec ./spec/features/plugin/run_spec.rb:33 # plugin support config does not need to be required
rspec ./spec/features/plugin/run_spec.rb:41 # plugin support common has access to the essentials
```