### PR TITLE
Unify common grid create/update POST/PUT parameters

### DIFF
--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -121,9 +121,7 @@ module Kontena::Cli::Grids
     module Parameters
       def self.included(base)
         base.option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
-        base.option "--no-default-affinity", :flag, "Unset grid default affinity"
         base.option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
-        base.option "--no-statsd-server", :flag, "Unset statsd server setting"
         base.option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
         base.option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
       end
@@ -158,10 +156,6 @@ module Kontena::Cli::Grids
           }
         end
 
-        if no_statsd_server?
-          payload[:stats] = { statsd:  nil }
-        end
-
         if log_forwarder
           payload[:logs] = {
             forwarder: log_forwarder,
@@ -171,10 +165,6 @@ module Kontena::Cli::Grids
 
         unless default_affinity_list.empty?
           payload[:default_affinity] = default_affinity_list
-        end
-
-        if no_default_affinity?
-          payload[:default_affinity] = []
         end
       end
     end

--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -120,14 +120,12 @@ module Kontena::Cli::Grids
 
     module Parameters
       def self.included(base)
-        base.class_eval do
-          option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
-          option "--no-default-affinity", :flag, "Unset grid default affinity"
-          option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
-          option "--no-statsd-server", :flag, "Unset statsd server setting"
-          option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
-          option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
-        end
+        base.option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
+        base.option "--no-default-affinity", :flag, "Unset grid default affinity"
+        base.option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
+        base.option "--no-statsd-server", :flag, "Unset statsd server setting"
+        base.option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
+        base.option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
       end
 
       def validate_log_opts

--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -117,5 +117,68 @@ module Kontena::Cli::Grids
         exit_with_error "No grid given or selected"
       end
     end
+
+    module Parameters
+      def self.included(base)
+        base.class_eval do
+          option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
+          option "--no-default-affinity", :flag, "Unset grid default affinity"
+          option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
+          option "--no-statsd-server", :flag, "Unset statsd server setting"
+          option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
+          option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
+        end
+      end
+
+      def validate_log_opts
+        if !log_opt_list.empty? && log_forwarder.nil?
+          raise Kontena::Errors::StandardError.new(1, "Need to specify --log-forwarder when using --log-opt")
+        end
+      end
+
+      def parse_log_opts
+        opts = {}
+        log_opt_list.each do |opt|
+          key, value = opt.split('=')
+          opts[key.to_sym] = value
+        end
+        opts
+      end
+
+      def validate_grid_parameters
+        validate_log_opts
+      end
+
+      def build_grid_parameters(payload)
+        if statsd_server
+          server, port = statsd_server.split(':')
+          payload[:stats] = {
+            statsd: {
+              server: server,
+              port: port || 8125
+            }
+          }
+        end
+
+        if no_statsd_server?
+          payload[:stats] = { statsd:  nil }
+        end
+
+        if log_forwarder
+          payload[:logs] = {
+            forwarder: log_forwarder,
+            opts: parse_log_opts
+          }
+        end
+
+        unless default_affinity_list.empty?
+          payload[:default_affinity] = default_affinity_list
+        end
+
+        if no_default_affinity?
+          payload[:default_affinity] = []
+        end
+      end
+    end
   end
 end

--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -10,26 +10,31 @@ module Kontena::Cli::Grids
     option "--initial-size", "INITIAL_SIZE", "Initial grid size (number of nodes)", default: 1
     option "--silent", :flag, "Reduce output verbosity"
     option "--token", "[TOKEN]", "Set grid token"
-    option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
     option "--subnet", "[CIDR]", "Configure grid overlay subnet"
     option "--supernet", "[CIDR]", "Configure grid IPAM supernet"
+
+    include Common::Parameters
 
     requires_current_master_token
 
     def execute
+      validate_grid_parameters
+
+      if initial_size == 1
+        warning "Option --initial-size=1 is only recommended for test/dev usage" unless running_silent?
+      end
+
       payload = {
         name: name
       }
       payload[:token] = self.token if self.token
       payload[:initial_size] = self.initial_size if self.initial_size
-      payload[:default_affinity] = self.default_affinity_list unless self.default_affinity_list.empty?
       payload[:subnet] = subnet if subnet
       payload[:supernet] = supernet if supernet
-      
+
+      build_grid_parameters(payload)
+
       grid = nil
-      if initial_size == 1
-        warning "Option --initial-size=1 is only recommended for test/dev usage" unless running_silent?
-      end
       spinner "Creating #{pastel.cyan(name)} grid " do
         grid = client.post('grids', payload)
       end

--- a/cli/lib/kontena/cli/grids/create_command.rb
+++ b/cli/lib/kontena/cli/grids/create_command.rb
@@ -34,9 +34,8 @@ module Kontena::Cli::Grids
 
       build_grid_parameters(payload)
 
-      grid = nil
-      spinner "Creating #{pastel.cyan(name)} grid " do
-        grid = client.post('grids', payload)
+      grid = spinner "Creating #{pastel.cyan(name)} grid " do
+        client.post('grids', payload)
       end
       if grid
         spinner "Switching scope to #{pastel.cyan(name)} grid " do

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -6,63 +6,19 @@ module Kontena::Cli::Grids
     include Common
 
     parameter "NAME", "Grid name"
-    option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
-    option "--no-statsd-server", :flag, "Unset statsd server setting"
-    option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
-    option "--no-default-affinity", :flag, "Unset grid default affinity"
-    option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
-    option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
+
+    include Common::Parameters
+
+    requires_current_master_token
 
     def execute
-      require_api_url
-      token = require_token
-      validate_log_opts
+      validate_grid_parameters
+
       payload = {}
-      if statsd_server
-        server, port = statsd_server.split(':')
-        payload[:stats] = {
-          statsd: {
-            server: server,
-            port: port || 8125
-          }
-        }
-      end
 
-      if no_statsd_server?
-        payload[:stats] = { statsd:  nil }
-      end
+      build_grid_parameters(payload)
 
-      if log_forwarder
-        payload[:logs] = {
-          forwarder: log_forwarder,
-          opts: parse_log_opts
-        }
-      end
-
-      unless default_affinity_list.empty?
-        payload[:default_affinity] = default_affinity_list
-      end
-
-      if no_default_affinity?
-        payload[:default_affinity] = []
-      end
-
-      client(token).put("grids/#{name}", payload)
-    end
-
-    def validate_log_opts
-      if !log_opt_list.empty? && log_forwarder.nil?
-        raise Kontena::Errors::StandardError.new(1, "Need to specify --log-forwarder when using --log-opt")
-      end
-    end
-
-    def parse_log_opts
-      opts = {}
-      log_opt_list.each do |opt|
-        key, value = opt.split('=')
-        opts[key.to_sym] = value
-      end
-      opts
+      client.put("grids/#{name}", payload)
     end
   end
 end

--- a/cli/lib/kontena/cli/grids/update_command.rb
+++ b/cli/lib/kontena/cli/grids/update_command.rb
@@ -9,6 +9,9 @@ module Kontena::Cli::Grids
 
     include Common::Parameters
 
+    option "--no-default-affinity", :flag, "Unset grid default affinity"
+    option "--no-statsd-server", :flag, "Unset statsd server setting"
+
     requires_current_master_token
 
     def execute
@@ -17,6 +20,14 @@ module Kontena::Cli::Grids
       payload = {}
 
       build_grid_parameters(payload)
+
+      if no_statsd_server?
+        payload[:stats] = { statsd:  nil }
+      end
+
+      if no_default_affinity?
+        payload[:default_affinity] = []
+      end
 
       client.put("grids/#{name}", payload)
     end

--- a/docs/using-kontena/grids.md
+++ b/docs/using-kontena/grids.md
@@ -40,10 +40,10 @@ The grid token is used when provisioning nodes using the Kontena plugins or `kon
 
 The grid token is used to both grant access to the Kontena master, as well as the shared secret used for the overlay networking encryption.
 
-## Update options
-These options can be set using `kontena grid update` while the grid is running.
+### Update options
+These options can be set using `kontena grid create`, or later using `kontena grid update` while the grid is running.
 
-### Default Affinity
+#### Default Affinity
 
 The `kontena grid create --default-affinity=AFFINITY-FILTER` option acts as if each Kontena service were configured with the given service affinity by default.
 This can be used to avoid deploying services to specific grid nodes by default, using a per-service affinity to only deploy specific services to those grid nodes.
@@ -55,22 +55,23 @@ This will re-schedule the grid services, and may cause service instances to be m
 
 To disable any previously set grid default affinity use `kontena grid update --no-default-affinity grid_name`.
 
-### `statsd` Server
+#### `statsd` Server
 
-The `kontena grid update --statsd-server HOST:PORT` option configures each host node to send stats metrics for each host node and service container to a remote statsd receiver using the UDP StatsD protocol.
+The `kontena grid create --statsd-server HOST:PORT` option configures each host node to send stats metrics for each host node and service container to a remote statsd receiver using the UDP StatsD protocol.
 
+This option can be changed using `kontena grid update --statsd-server`.
 To disable previously set statsd setting use `kontena grid update --no-statsd-server grid_name`.
 
 See the [Statistics](stats.md#exporting-stats) documentation for further details.
 
-### Logging options
+#### Logging options
 
-The `kontena grid update --log-forwarder fluentd --log-opt fluentd-server=xyz:22445` options configures each host node to send container logs to a remote log collection service.
+The `kontena grid create --log-forwarder fluentd --log-opt fluentd-server=xyz:22445` options configures each host node to send container logs to a remote log collection service.
 
+This option can be changed using `kontena grid update --log-forwarder --log-opt`.
 Use `kontena grid update --log-forwarder none` to disable log forwarding.
 
 See the [Logs](logs.md) documentation for further details.
-
 
 ## Initial Nodes
 

--- a/server/app/mutations/grids/common.rb
+++ b/server/app/mutations/grids/common.rb
@@ -1,0 +1,77 @@
+module Grids
+  module Common
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def common_validations
+        # common inputs for both create + update
+        optional do
+          array :default_affinity do
+            string
+          end
+          array :trusted_subnets do
+            string
+          end
+          hash :stats do
+            optional do
+              hash :statsd do
+                required do
+                  string :server
+                  integer :port
+                end
+              end
+            end
+          end
+          hash :logs do
+            required do
+              string :forwarder, in: ['fluentd', 'none'] # Only fluentd now supported, none removes log shipping
+            end
+            optional do
+              model :opts, class: Hash
+            end
+          end
+        end
+      end
+    end
+
+    def validate_common
+      if self.trusted_subnets
+        self.trusted_subnets.each do |subnet|
+          begin
+            IPAddr.new(subnet)
+          rescue IPAddr::InvalidAddressError
+            add_error(:trusted_subnets, :invalid, "Invalid trusted_subnet #{subnet}")
+          end
+        end
+      end
+      if self.logs
+        case self.logs[:forwarder]
+        when 'fluentd'
+          validate_logs_fluentd_opts(self.logs[:opts])
+        end
+      end
+    end
+
+    def validate_logs_fluentd_opts(opts)
+      address = opts['fluentd-address']
+      add_error(:logs, :forwarder, 'fluentd-address option must be given') unless address
+    end
+
+    # @param grid [Grid] set attributes on Grid
+    def execute_common(grid)
+      grid.stats = self.stats if self.stats
+      grid.trusted_subnets = self.trusted_subnets if self.trusted_subnets
+      grid.default_affinity = self.default_affinity if self.default_affinity
+
+      if self.logs
+        if self.logs[:forwarder] == 'none'
+          grid.grid_logs_opts = nil
+        else
+          grid.grid_logs_opts = GridLogsOpts.new(forwarder: self.logs[:forwarder], opts: self.logs[:opts])
+        end
+      end
+    end
+  end
+end

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -1,73 +1,27 @@
+require_relative 'common'
+
 module Grids
   class Update < Mutations::Command
+    include Common
 
     required do
       model :grid
       model :user
     end
 
-    optional do
-      hash :stats do
-        optional do
-          hash :statsd do
-            required do
-              string :server
-              integer :port
-            end
-          end
-        end
-      end
-      array :trusted_subnets do
-        string
-      end
-      array :default_affinity do
-        string
-      end
-      hash :logs do
-        required do
-          string :forwarder, in: ['fluentd', 'none'] # Only fluentd now supported, none removes log shipping
-        end
-        optional do
-          model :opts, class: Hash
-        end
-      end
-    end
+    common_validations
 
     def validate
       add_error(:user, :invalid, 'Operation not allowed') unless user.can_update?(grid)
-      if self.trusted_subnets
-        self.trusted_subnets.each do |subnet|
-          begin
-            IPAddr.new(subnet)
-          rescue IPAddr::InvalidAddressError
-            add_error(:trusted_subnets, :invalid, "Invalid trusted_subnet #{subnet}")
-          end
-        end
-      end
-      if self.logs
-        case self.logs[:forwarder]
-        when 'fluentd'
-          validate_fluentd_opts(self.logs[:opts])
-        end
-      end
+
+      validate_common
     end
 
     def execute
-      attributes = {}
-      attributes[:stats] = self.stats if self.stats
-      attributes[:trusted_subnets] = self.trusted_subnets if self.trusted_subnets
-      attributes[:default_affinity] = self.default_affinity if self.default_affinity
+      execute_common(self.grid)
 
-      if self.logs
-        if self.logs[:forwarder] == 'none'
-          self.grid.grid_logs_opts = nil
-        else
-          self.grid.grid_logs_opts = GridLogsOpts.new(forwarder: self.logs[:forwarder], opts: self.logs[:opts])
-        end
-      end
-      grid.update_attributes(attributes)
-      if grid.errors.size > 0
-        grid.errors.each do |key, message|
+      unless self.grid.save
+        self.grid.errors.each do |key, message|
           add_error(key, :invalid, message)
         end
         return
@@ -75,7 +29,7 @@ module Grids
 
       self.notify_nodes
 
-      grid
+      self.grid
     end
 
     def notify_nodes
@@ -86,11 +40,6 @@ module Grids
         end
         GridScheduler.new(grid).reschedule
       }
-    end
-
-    def validate_fluentd_opts(opts)
-      address = opts['fluentd-address']
-      add_error(:logs, :forwarder, 'fluentd-address option must be given') unless address
     end
   end
 end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -32,9 +32,12 @@ module V1
               name: data['name'],
               initial_size: data['initial_size'] || 1,
               token: data['token'],
-              default_affinity: data['default_affinity'],
               subnet: data['subnet'],
               supernet: data['supernet'],
+              default_affinity: data['default_affinity'],
+              trusted_subnets: data['trusted_subnets'],
+              stats: data['stats'],
+              logs: data['logs'],
           )
 
           if outcome.success?

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -164,8 +164,8 @@ Attribute        | Example                 | Description
 ---------------- | ----------------------- | ------------
 default_affinity | `[ "label!=reserved" ]` |
 trusted_subnets  | `[ "192.168.66.0/24" ]` |
-stats            | `{ "statsd": { "server": "127.0.0.1", "port": 8125 } }` |
-logs             | `{ "forwarder": "fluentd", "opts": { "fluentd-address": "127.0.0.1" } }` |
+stats            | `{ "statsd": { "server": "127.0.0.1", "port": 8125 } }` | To disable statsd exporting, use `{ "statsd": null }`
+logs             | `{ "forwarder": "fluentd", "opts": { "fluentd-address": "127.0.0.1" } }` | To disable logs exporting, use `{ "forwarder": "none" }`
 
 ## Get a Grid
 

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -121,10 +121,17 @@ Grid can be only created by users with master_admin role.
 
 ### JSON Attributes
 
-Attribute | Description
----------- | -------
-name | (required) A user provided name
-initial_size | Initial (minimum) number of nodes in the grid (initial members are part of etcd cluster)
+Attribute        | Default          | Example  | Description
+---------------- | ---------------- | ---------
+name             | (required)       | `"test"`    | user provided name
+initial_size     | (required)       | `3`         | Initial (minimum) number of nodes in the grid ([Grids / Initial Nodes](http://www.kontena.io/docs/using-kontena/grids.html#initial-nodes))
+token            | (generated)      | `"J6d...ArKg=="` |(optional) Use a fixed grid token instead of having the server generate a new one
+subnet           | `"10.81.0.0/16"` | |
+supernet         | `"10.80.0.0/12"` | |
+default_affinity | `[]`             | `[ "label!=reserved" ]` |
+trusted_subnets  | `[]`             | `[ "192.168.66.0/24" ]` |
+stats            | `{}`             | `{ "statsd": { "server": "127.0.0.1", "port": 8125 } }` |
+logs             | `null`           | `{ "forwarder": "fluentd", "opts": { "fluentd-address": "127.0.0.1" } }` |
 
 ## Update a Grid
 
@@ -151,10 +158,14 @@ Only `master_admin` or `grid_admin` roles can modify a grid.
 
 ### JSON Attributes
 
-Attribute | Description
----------- | -------
-stats | Statsd export endpoint
-trusted_subnets | Initial (minimum) number of nodes in the grid (initial members are part of etcd cluster)
+All attributes are optional. Only the given grid parameters are updated, omitted attributes are left as-is.
+
+Attribute        | Example                 | Description
+---------------- | ----------------------- | ------------
+default_affinity | `[ "label!=reserved" ]` |
+trusted_subnets  | `[ "192.168.66.0/24" ]` |
+stats            | `{ "statsd": { "server": "127.0.0.1", "port": 8125 } }` |
+logs             | `{ "forwarder": "fluentd", "opts": { "fluentd-address": "127.0.0.1" } }` |
 
 ## Get a Grid
 
@@ -301,8 +312,8 @@ follow | Stream logs
 	"kernel_version": "4.7.3-coreos-r2",
 	"driver": "overlay",
 	"network_drivers": [
-		{"name": "bridge"}, 
-		{"name": "host"}, 
+		{"name": "bridge"},
+		{"name": "host"},
 		{"name": "null"}
 	],
 	"volume_drivers": [


### PR DESCRIPTION
Update the `kontena grid create` CLI, `POST /v1/grids` API and server `Grids::Create` mutations to accept the same options as previously accepted by `kontena grid update`, `PUT /v1/grids/:grid` and `Grids::Update`:

* `--default-affinity` -> `{ "default_affinity": [ ... ] }` (this was already supported)
* `{ "trusted_subnets": [ ... ] }` (not exposed in `kontena grid create`, use `kontena grid trusted-subnet`)
* `--statsd-server` -> `{ "stats": { "statsd": ... } }`
* `--log-forwarder` `--log-opts` -> `{ "logs": { ... } }`

### CLI

#### `kontena grid create`
```
Usage:
    kontena grid create [OPTIONS] NAME

Parameters:
    NAME                          Grid name

Options:
    --initial-size INITIAL_SIZE   Initial grid size (number of nodes) (default: 1)
    --silent                      Reduce output verbosity
    --token [TOKEN]               Set grid token
    --subnet [CIDR]               Configure grid overlay subnet
    --supernet [CIDR]             Configure grid IPAM supernet
    --default-affinity [AFFINITY] Default affinity rule for the grid
    --statsd-server STATSD_SERVER Statsd server address (host:port)
    --log-forwarder LOG_FORWARDER Set grid wide log forwarder (set to 'none' to disable)
    --log-opt [LOG_OPT]           Set log options (key=value)
    -h, --help                    print help
    -D, --debug                   Enable debug (default: $DEBUG)
```

#### `kontena grid update`
```
Usage:
    kontena grid update [OPTIONS] NAME

Parameters:
    NAME                          Grid name

Options:
    --default-affinity [AFFINITY] Default affinity rule for the grid
    --statsd-server STATSD_SERVER Statsd server address (host:port)
    --log-forwarder LOG_FORWARDER Set grid wide log forwarder (set to 'none' to disable)
    --log-opt [LOG_OPT]           Set log options (key=value)
    --no-default-affinity         Unset grid default affinity
    --no-statsd-server            Unset statsd server setting
    -h, --help                    print help
    -D, --debug                   Enable debug (default: $DEBUG)
```