### PR TITLE
cli: update grid cloud-config to use [Link] Unmanaged=true

### DIFF
--- a/cli/lib/kontena/machine/cloud_config/cloudinit.yml
+++ b/cli/lib/kontena/machine/cloud_config/cloudinit.yml
@@ -19,10 +19,23 @@ write_files:
       fs.inotify.max_user_instances = 8192
 coreos:
   units:
-    - name: 50-docker.network
-      mask: true
-    - name: 50-docker-veth.network
-      mask: true
+    - name: 50-weave.network
+      content: |
+        [Match]
+        Name=weave datapath vxlan-6784
+
+        [Network]
+        Description=Network interfaces managed by weave
+
+        [Link]
+        Unmanaged=true
+    - name: 90-dummy.network
+      content: |
+        [Match]
+        Name=dummy0
+
+        [Link]
+        Unmanaged=true
     - name: zz-default.network
       content: |
         # default should not match virtual Docker/weave bridge/veth network interfaces


### PR DESCRIPTION
See #2253

Remove the masking of the `50-docker.network` and (non-existant) `50-docker-veth.network` which have been fixed in CoreOS, and add a similar `50-weave.network` + `90-dummy.network` to also leave the weave interfaces unmanaged. This configuration should also work better on VMware, where the `yy-vmware.network` would still have matched the Docker and Weave interfaces otherwise.

This keeps the `zz-default.network` override with `[Match] Name=...`, because IMO as long as we're overriding it to configure the DNS settings, it's also worth limiting the match scope. However, longterm I think it would be best to leave the CoreOS `zz-default.network` untouched, and override `/etc/systemd/resolved.conf` to configure the `kontena.local` DNS instead?