### PR TITLE
cli: Only use STDIN.raw for tty-mode execs

### DIFF
--- a/cli/lib/kontena/cli/containers/exec_command.rb
+++ b/cli/lib/kontena/cli/containers/exec_command.rb
@@ -29,7 +29,7 @@ module Kontena::Cli::Containers
       end
       ws.on :open do
         ws.text(cmd)
-        stdin_reader = self.stream_stdin_to_ws(ws) if self.interactive?
+        stdin_reader = self.stream_stdin_to_ws(ws, tty: self.tty?) if self.interactive?
       end
       ws.on :close do |e|
         if e.reason.include?('code: 404')

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -5,10 +5,10 @@ module Kontena::Cli::Helpers
 
     # @param [WebSocket::Client::Simple] ws
     # @return [Thread]
-    def stream_stdin_to_ws(ws)
+    def stream_stdin_to_ws(ws, tty: nil)
       require 'io/console'
       Thread.new {
-        if STDIN.tty?
+        if tty
           STDIN.raw {
             while char = STDIN.readpartial(1024)
               ws.text(JSON.dump({ stdin: char }))

--- a/cli/lib/kontena/cli/services/exec_command.rb
+++ b/cli/lib/kontena/cli/services/exec_command.rb
@@ -131,7 +131,7 @@ module Kontena::Cli::Services
       end
       ws.on :open do
         ws.text(cmd)
-        stdin_stream = self.stream_stdin_to_ws(ws)
+        stdin_stream = self.stream_stdin_to_ws(ws, tty: self.tty?)
       end
       ws.on :close do |e|
         if e.code != 1000


### PR DESCRIPTION
Fixes #2498

The CLI would use use `STDIN.raw` mode whenever the stdin was a TTY, even in `-i` mode without `-t`, where there was no pty on the remote container exec end to interpret the resulting tty control codes.

Now `kontena service exec -i` works correctly even with a tty stdin, such that ^D results in stdin EOF, and ^C interrupts the CLI process.