### PR TITLE
Server: Fix GridServices::Update with multiple names for the same service secret

### DIFF
--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -78,14 +78,13 @@ module GridServices
     def build_grid_service_secrets(existing_secrets)
       service_secrets = []
       self.secrets.each do |secret|
-        service_secret = existing_secrets.find{|s| s.secret == secret['secret']}
+        service_secret = existing_secrets.find{|s| s.secret == secret['secret'] && s.name == secret['name'] }
         unless service_secret
           service_secret = GridServiceSecret.new(
               secret: secret['secret'],
               name: secret['name']
           )
         end
-        service_secret.name = secret['name']
         service_secrets << service_secret
       end
 

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -365,18 +365,58 @@ describe GridServices::Create do
       expect(outcome.success?).to be(false)
     end
 
-    it 'validates secret existence' do
-      secret = GridSecret.create!(grid: grid, name: 'EXISTING_SECRET', value: 'secret')
-      outcome = described_class.new(
-          grid: grid,
-          image: 'redis:2.8',
-          name: 'redis',
-          stateful: false,
-          secrets: [
-            {secret: 'EXISTING_SECRET', name: 'SOME_SECRET'}
-          ]
-      ).run
-      expect(outcome.success?).to be(true)
+    context 'with a grid secret' do
+      let :secret do
+        GridSecret.create!(grid: grid, name: 'EXISTING_SECRET', value: 'secret')
+      end
+
+      before do
+        secret
+      end
+
+      it 'saves service secret' do
+        outcome = described_class.new(
+            grid: grid,
+            image: 'redis:2.8',
+            name: 'redis',
+            stateful: false,
+            secrets: [
+              {secret: 'EXISTING_SECRET', name: 'SOME_SECRET'}
+            ]
+        ).run
+        expect(outcome.success?).to be(true)
+        expect(outcome.result.secrets.map{|s| s.attributes}).to match [hash_including(
+            'secret' => 'EXISTING_SECRET',
+            'type' => 'env',
+            'name' => 'SOME_SECRET',
+        )]
+      end
+
+      it 'maps the same service secret twice' do
+        outcome = described_class.new(
+            grid: grid,
+            image: 'redis:2.8',
+            name: 'redis',
+            stateful: false,
+            secrets: [
+              {secret: 'EXISTING_SECRET', name: 'SOME_SECRET'},
+              {secret: 'EXISTING_SECRET', name: 'SOME_SECRET2'},
+            ]
+        ).run
+        expect(outcome.success?).to be(true)
+        expect(outcome.result.secrets.map{|s| s.attributes}).to match [
+          hash_including(
+            'secret' => 'EXISTING_SECRET',
+            'type' => 'env',
+            'name' => 'SOME_SECRET',
+          ),
+          hash_including(
+            'secret' => 'EXISTING_SECRET',
+            'type' => 'env',
+            'name' => 'SOME_SECRET2',
+          ),
+        ]
+      end
     end
 
     it 'validates env syntax' do

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -209,6 +209,50 @@ describe GridServices::Update do
           expect(service.reload.secrets.map{|gss| gss.secret}).to eq ['SECRET1']
         end
       end
+
+      context 'for a service with multiple names for the same secret' do
+        let(:secret1) { GridSecret.create!(grid: grid, name: 'SECRET1', value: 'secret') }
+
+        let(:service) {
+          GridService.create(grid: grid, stack: stack, name: 'redis',
+            image_name: 'redis:2.8',
+            secrets: [
+              {secret: secret1.name, name: 'SECRET1'},
+              {secret: secret1.name, name: 'SECRET2'},
+            ],
+          )
+        }
+
+        it 'keeps both secret names' do
+          subject = described_class.new(
+              grid_service: service,
+              secrets: [
+                {secret: secret1.name, name: 'SECRET1'},
+                {secret: secret1.name, name: 'SECRET2'},
+              ]
+          )
+          outcome = nil
+          expect {
+            outcome = subject.run
+
+            expect(outcome).to be_success
+          }.to not_change{service.reload.revision}.and not_change{service.reload.updated_at}
+
+          expect(outcome.result.secrets.map{|s| s.attributes}).to match [
+            hash_including(
+              'secret' => 'SECRET1',
+              'type' => 'env',
+              'name' => 'SECRET1',
+            ),
+            hash_including(
+              'secret' => 'SECRET1',
+              'type' => 'env',
+              'name' => 'SECRET2',
+            ),
+          ]
+
+        end
+      end
     end
 
     context 'hooks' do


### PR DESCRIPTION
Fixes #2505

The `GridServices::Common#build_grid_service_secrets` looked up existing secrets using only the `secret` field. When updating a service with multiple different names for the same secret, it would duplicate the first of those secrets, overriding the other secret names.