### PR TITLE
Fix Etcd launcher to tolerate docker errors better

### DIFF
--- a/agent/lib/kontena/launchers/etcd.rb
+++ b/agent/lib/kontena/launchers/etcd.rb
@@ -31,12 +31,12 @@ module Kontena::Launchers
       begin
         self.start_etcd(node)
       rescue Docker::Error::ServerError => exc
+        log_error(exc)
         if retries < 4
           retries += 1
           sleep 0.25
           retry
         end
-        log_error(exc)
       rescue => exc
         log_error(exc)
       end

--- a/agent/lib/kontena/launchers/etcd.rb
+++ b/agent/lib/kontena/launchers/etcd.rb
@@ -105,7 +105,7 @@ module Kontena::Launchers
         return container
       elsif container && !container.running?
         info 'etcd container exists but not running, starting it'
-        container.start
+        container.start!
         @running = true
         add_dns(container.id, weave_ip)
         return container
@@ -150,7 +150,7 @@ module Kontena::Launchers
           'VolumesFrom' => ['kontena-etcd-data']
         }
       )
-      container.start
+      container.start!
       add_dns(container.id, weave_ip)
       info 'started etcd service'
       @running = true

--- a/agent/lib/kontena/launchers/etcd.rb
+++ b/agent/lib/kontena/launchers/etcd.rb
@@ -84,18 +84,16 @@ module Kontena::Launchers
 
     # @param [String] image
     # @param [Node] node
+    # @raise [Docker::Error] Unexpected Docker errors will fall through. Most probably they are
+    #        Docker::ErrorServerError from either trying to get the container or in starting it.
     def create_container(image, node)
       cluster_size = node.grid['initial_size']
       node_number = node.node_number
       cluster_state = 'new'
       weave_ip = node.overlay_ip
 
-      container = nil
-      begin
-        container = Docker::Container.get('kontena-etcd')
-      rescue Docker::Error::NotFoundError
-        info "etcd container does not exist"
-      end
+      container = self.get_container
+
       if container && container.info['Config']['Image'] != image
         container.delete(force: true)
       elsif container && container.running?
@@ -155,6 +153,18 @@ module Kontena::Launchers
       info 'started etcd service'
       @running = true
       container
+    end
+
+    # Gets kontena-etcd container
+    # @return [Docker::Container, nil] The container or nil if not found
+    # @raise [Docker::Error] Lets unexpected Docker errors fall through
+    def get_container
+      begin
+        Docker::Container.get('kontena-etcd')
+      rescue Docker::Error::NotFoundError
+        info "etcd container does not exist"
+        nil
+      end
     end
 
     # Removes possible previous member with the same IP

--- a/agent/lib/kontena/launchers/etcd.rb
+++ b/agent/lib/kontena/launchers/etcd.rb
@@ -90,7 +90,12 @@ module Kontena::Launchers
       cluster_state = 'new'
       weave_ip = node.overlay_ip
 
-      container = Docker::Container.get('kontena-etcd') rescue nil
+      container = nil
+      begin
+        container = Docker::Container.get('kontena-etcd')
+      rescue Docker::Error::NotFoundError
+        info "etcd container does not exist"
+      end
       if container && container.info['Config']['Image'] != image
         container.delete(force: true)
       elsif container && container.running?

--- a/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
+++ b/agent/spec/lib/kontena/launchers/etcd_launcher_spec.rb
@@ -122,7 +122,7 @@ describe Kontena::Launchers::Etcd do
         allow(container).to receive(:running?).and_return(false)
         allow(container).to receive(:info).and_return({'Config' => {'Image' => 'etcd'}})
         expect(subject.wrapped_object).to receive(:add_dns)
-        expect(container).to receive(:start)
+        expect(container).to receive(:start!)
 
         subject.create_container('etcd', node)
 
@@ -157,7 +157,7 @@ describe Kontena::Launchers::Etcd do
             'RestartPolicy' => {'Name' => 'always'},
             'VolumesFrom' => ['kontena-etcd-data']
           })).and_return(etcd_container)
-        expect(etcd_container).to receive(:start)
+        expect(etcd_container).to receive(:start!)
         allow(etcd_container).to receive(:id).and_return('12345')
         expect(subject.wrapped_object).to receive(:publish).with('dns:add', {id: etcd_container.id, ip: '10.81.0.1', name: 'etcd.kontena.local'})
 
@@ -191,7 +191,7 @@ describe Kontena::Launchers::Etcd do
             'RestartPolicy' => {'Name' => 'always'},
             'VolumesFrom' => ['kontena-etcd-data']
           })).and_return(etcd_container)
-        expect(etcd_container).to receive(:start)
+        expect(etcd_container).to receive(:start!)
         allow(etcd_container).to receive(:id).and_return('12345')
         expect(subject.wrapped_object).to receive(:publish).with('dns:add', {id: etcd_container.id, ip: '10.81.0.1', name: 'etcd.kontena.local'})
 
@@ -320,7 +320,7 @@ describe Kontena::Launchers::Etcd do
             'RestartPolicy' => {'Name' => 'always'},
             'VolumesFrom' => ['kontena-etcd-data']
           })).and_return(etcd_container)
-        expect(etcd_container).to receive(:start)
+        expect(etcd_container).to receive(:start!)
         allow(etcd_container).to receive(:id).and_return('12345')
         expect(subject.wrapped_object).to receive(:publish).with('dns:add', {id: etcd_container.id, ip: '10.81.0.2', name: 'etcd.kontena.local'})
 


### PR DESCRIPTION
If Docker gave unexpected error while getting etcd container info, agent decided to reconfigure etcd membership. 

![image](https://user-images.githubusercontent.com/3205505/27432897-e519f7a0-575a-11e7-88e6-3e67b0bdc0cd.png)


This PR changes to use `start!` instead of plain `start` when starting etcd container to allow possible start errors to fall through and get at least logged.

fixes #2508 