### PR TITLE
Fix cli node list sorting, specs

### DIFF
--- a/cli/lib/kontena/cli/nodes/list_command.rb
+++ b/cli/lib/kontena/cli/nodes/list_command.rb
@@ -70,7 +70,7 @@ module Kontena::Cli::Nodes
           end
         end
 
-        grid_nodes.sort { |n| n['node_number'] }
+        grid_nodes.sort_by { |n| n['node_number'] }
       end
     end
 

--- a/cli/spec/kontena/cli/nodes/list_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/list_command_spec.rb
@@ -133,7 +133,7 @@ describe Kontena::Cli::Nodes::ListCommand do
                 {
                   "connected" => false,
                   "name" => nil,
-                  "node_number" => nil,
+                  "node_number" => 3,
                   "initial_member" => false,
                   'agent_version' => nil,
                 },
@@ -146,7 +146,7 @@ describe Kontena::Cli::Nodes::ListCommand do
           expect{subject.run([])}.to output_table [
             [':warning node-1', '1.1-dev', 'online',  '1 / 3', '-'],
             [':warning node-2', '1.1-dev', 'online',  '2 / 3', '-'],
-            [':offline (initializing)', '', 'offline', '-', '-'],
+            [':offline (initializing)', 'offline', '-', '-'], # missing agent_version
           ]
         end
       end

--- a/cli/spec/kontena/cli/nodes/list_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/list_command_spec.rb
@@ -7,6 +7,8 @@ describe Kontena::Cli::Nodes::ListCommand do
   let(:subject) { described_class.new("kontena") }
 
   before do
+    Kontena.pastel.resolver.color.disable!
+
     allow(subject).to receive(:health_icon) {|health| health.inspect }
     allow(subject).to receive(:client).and_return(client)
   end

--- a/cli/spec/kontena/cli/table_generator_spec.rb
+++ b/cli/spec/kontena/cli/table_generator_spec.rb
@@ -5,6 +5,10 @@ require 'kontena/cli/common'
 describe Kontena::Cli::TableGenerator do
   let(:data) { [{'a' => 'a1', 'b' => 'b1', 'c' => 'c1'}, {'a' => 'a2', 'b' => 'b2', 'c' => 'c2'}] }
 
+  before do
+    Kontena.pastel.resolver.color.disable!
+  end
+
   context Kontena::Cli::TableGenerator::Helper do
     let(:klass) { Class.new(Kontena::Command) }
 

--- a/cli/spec/support/output_helpers.rb
+++ b/cli/spec/support/output_helpers.rb
@@ -32,11 +32,13 @@ module OutputHelpers
     supports_block_expectations
 
     match do |block|
+      @errors = []
+
       @expected = lines
       begin
         @real = CaptureStdoutLines.capture(block)
       rescue Exception => error
-        @error = error
+        @errors = [error.to_s]
         return false
       end
 
@@ -52,23 +54,25 @@ module OutputHelpers
         line = 0
         @real.zip(@expected) do |real, expected|
           line += 1
-          error = values_match?(real.split(/\S+/), expected)
-          if error
-            @error ||= ""
-            @error << "\n#{error}"
-            @error.strip!
+          fields = real.split(/\s{2,}/)
+          unless values_match?(fields, expected)
+            @errors << [
+              "on line #{line}:",
+              " expected: #{expected}",
+              " received: #{fields}",
+            ].join("\n")
           end
         end
       else
-        @error = "expected #{@expected.size} lines but got #{@real.size} lines instead:\n"
-        @error += "Expected:\n#{@expected.map(&:inspect).join("\n")}"
-        @error += "Received:\n#{@real.map(&:inspect).join("\n")}"
+        @errors << "expected #{@expected.size} lines but got #{@real.size} lines instead:\n"
+          + " Expected:\n#{@expected.map(&:inspect).join("\n")}"
+          + " Received:\n#{@real.map(&:inspect).join("\n")}"
       end
-      @error.nil?
+      @errors.empty?
     end
 
     failure_message do |block|
-      @error
+      @errors.join "\n"
     end
 
     chain :with_header do |header|
@@ -77,10 +81,6 @@ module OutputHelpers
 
     chain :without_header do
       @no_header = true
-    end
-
-    failure_message do |block|
-      return @error
     end
   end
 

--- a/cli/spec/support/output_helpers.rb
+++ b/cli/spec/support/output_helpers.rb
@@ -64,9 +64,11 @@ module OutputHelpers
           end
         end
       else
-        @errors << "expected #{@expected.size} lines but got #{@real.size} lines instead:\n"
-          + " Expected:\n#{@expected.map(&:inspect).join("\n")}"
-          + " Received:\n#{@real.map(&:inspect).join("\n")}"
+        @errors << [
+          "expected #{@expected.size} lines but got #{@real.size} lines instead:",
+          " Expected:", @expected.map{|l| l.inspect},
+          " Received:", @real.map{|l| l.split(/\s{2,}/).inspect},
+        ].join("\n")
       end
       @errors.empty?
     end


### PR DESCRIPTION
Fixes #2510
Fixes the `output_lines` matcher used by the `node list` specs - it was broken and passing even though the output lines were wrong.