### PR TITLE
Fix volume driver mismatches

### DIFF
--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -111,9 +111,10 @@ module Kontena::Workers::Volumes
       begin
         debug "volume #{volume_name} exists"
         volume = Docker::Volume.get(volume_name)
-        if volume && volume.info['Driver'] == driver
+        drivers_match = drivers_match?(driver, volume.info['Driver'])
+        if volume && drivers_match
           return true
-        elsif volume && volume.info['Driver'] != driver
+        elsif volume && !drivers_match
           raise DriverMismatchError.new("Volume driver not as expected. Expected #{driver}, existing volume has #{volume.info['Driver']}")
         end
       rescue Docker::Error::NotFoundError
@@ -122,6 +123,10 @@ module Kontena::Workers::Volumes
       rescue => error
         abort error
       end
+    end
+
+    def drivers_match?(expected, actual)
+      expected.split(':', 2)[0] == actual.split(':', 2)[0]
     end
 
     def terminate_volumes(current_ids)

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -129,7 +129,7 @@ module Kontena::Workers::Volumes
       if expected.include?(':')
         expected == actual
       else
-        expected.split(':', 2)[0] == actual.split(':', 2)[0]
+        expected == actual.split(':', 2)[0]
       end
     end
 

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -126,7 +126,11 @@ module Kontena::Workers::Volumes
     end
 
     def drivers_match?(expected, actual)
-      expected.split(':', 2)[0] == actual.split(':', 2)[0]
+      if expected.include?(':')
+        expected == actual
+      else
+        expected.split(':', 2)[0] == actual.split(':', 2)[0]
+      end
     end
 
     def terminate_volumes(current_ids)

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -149,6 +149,11 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
       }.to raise_error(Kontena::Workers::Volumes::VolumeManager::DriverMismatchError)
     end
 
+    it 'return true if volume exists with different plugin version' do
+      expect(Docker::Volume).to receive(:get).with('foo').and_return(double(:volume, :info => {'Driver' => 'rexray/s3fs:foobar'}))
+      expect(subject.volume_exist?('foo', 'rexray/s3fs:latest')).to be_truthy
+    end
+
   end
 
   describe '#terminate_volumes' do

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -154,6 +154,11 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
       expect(subject.volume_exist?('foo', 'rexray/s3fs:latest')).to be_truthy
     end
 
+    it 'return true if volume exists with plugin version and requested volume does not specify version' do
+      expect(Docker::Volume).to receive(:get).with('foo').and_return(double(:volume, :info => {'Driver' => 'rexray/s3fs:latest'}))
+      expect(subject.volume_exist?('foo', 'rexray/s3fs')).to be_truthy
+    end
+
   end
 
   describe '#terminate_volumes' do

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -149,9 +149,9 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
       }.to raise_error(Kontena::Workers::Volumes::VolumeManager::DriverMismatchError)
     end
 
-    it 'return true if volume exists with different plugin version' do
+    it 'return false if volume exists with different plugin version and requested volume specifies version' do
       expect(Docker::Volume).to receive(:get).with('foo').and_return(double(:volume, :info => {'Driver' => 'rexray/s3fs:foobar'}))
-      expect(subject.volume_exist?('foo', 'rexray/s3fs:latest')).to be_truthy
+      expect{subject.volume_exist?('foo', 'rexray/s3fs:latest')}.to raise_error(Kontena::Workers::Volumes::VolumeManager::DriverMismatchError)
     end
 
     it 'return true if volume exists with plugin version and requested volume does not specify version' do

--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -26,7 +26,7 @@ module Kontena::Cli::Nodes
       puts "  kernel: #{node['kernel_version']}"
       puts "  drivers:"
       puts "    storage: #{node['driver']}"
-      puts "    volume: #{node['volume_drivers'].to_a.map{|v| v['name']}.join(',')}"
+      puts "    volume: #{node['volume_drivers'].to_a.map{|v| [v['name'], v['version']].compact.join(':')}.join(',')}"
       puts "  initial node: #{node['initial_member'] ? 'yes' : 'no'}"
       puts "  labels:"
       if node['labels']

--- a/server/app/services/scheduler/filter/volume_plugin.rb
+++ b/server/app/services/scheduler/filter/volume_plugin.rb
@@ -33,15 +33,15 @@ module Scheduler
       # @param [Hash] needed_drivers
       # @param [HostNode] node
       def all_drivers_present?(needed_drivers, node)
-        needed_drivers.reject { |nd|
-          !node.volume_drivers.find_index { |vd|
+        needed_drivers.all? { |nd|
+          node.volume_drivers.any? { |vd|
             if nd['version']
               vd['name'] == nd['name'] && vd['version'] == nd['version']
             else
               vd['name'] == nd['name']
             end
-          }.nil?
-        }.empty?
+          }
+        }
       end
     end
   end

--- a/server/app/services/scheduler/filter/volume_plugin.rb
+++ b/server/app/services/scheduler/filter/volume_plugin.rb
@@ -1,7 +1,6 @@
 module Scheduler
   module Filter
     class VolumePlugin
-      include Logging
 
       ##
       # Filters nodes that have the needed volume driver plugins
@@ -19,7 +18,13 @@ module Scheduler
         }.compact
 
         nodes = nodes.select { |node|
-          volume_drivers = node.volume_drivers.map { |v| v['name'] }
+          volume_drivers = node.volume_drivers.map { |v|
+            if v['version']
+              "#{v['name']}:#{v['version']}"
+            else
+              v['name']
+            end
+          }
           (needed_drivers - volume_drivers).empty?
         }
 
@@ -29,7 +34,6 @@ module Scheduler
 
         nodes
       end
-
     end
   end
 end

--- a/server/spec/services/scheduler/filter/volume_plugin_spec.rb
+++ b/server/spec/services/scheduler/filter/volume_plugin_spec.rb
@@ -4,37 +4,11 @@ describe Scheduler::Filter::VolumePlugin do
   let(:grid) { Grid.create(name: 'test') }
   let(:nodes) do
     nodes = []
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node1', name: 'node-1',
-      volume_drivers: [{'name' => 'local'}, {'name' => 'foo'}]
-    )
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node2', name: 'node-2',
-      volume_drivers: [{'name' => 'foo'}]
-    )
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node3', name: 'node-3',
-      volume_drivers: [{'name' => 'local'}, {'name' => 'bar'}]
-    )
+    nodes << HostNode.create!(grid: grid, node_id: 'node1', name: 'node-1')
+    nodes << HostNode.create!(grid: grid, node_id: 'node2', name: 'node-2')
+    nodes << HostNode.create!(grid: grid, node_id: 'node3', name: 'node-3')
     nodes
   end
-
-  let(:local_volume) do
-    grid.volumes.create!(name: 'local', driver: 'local', scope: 'instance')
-  end
-
-  let(:foo_volume) do
-    grid.volumes.create!(name: 'foo', driver: 'foo', scope: 'instance')
-  end
-
-  let(:bar_volume) do
-    grid.volumes.create!(name: 'bar', driver: 'bar', scope: 'instance')
-  end
-
-  let(:service) do
-    grid.grid_services.create!(name: 'redis', image_name: 'redis', volumes: ['foo:/data'])
-  end
-
   let(:service_no_vols) do
     grid.grid_services.create!(name: 'nginx', image_name: 'nginx')
   end
@@ -47,24 +21,90 @@ describe Scheduler::Filter::VolumePlugin do
       end
     end
 
-    it 'returns all nodes with needed single driver' do
-      service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
-      service.service_volumes << ServiceVolume.new(bind_mount: '/var/lib', path: '/data')
-      expect(subject.for_service(service, 1, nodes).map{|n| n.name}).to eq(['node-1', 'node-3'])
+    context 'v1 volume driver' do
+      before(:each) do
+        nodes[0].volume_drivers = [{'name' => 'local'}, {'name' => 'foo'}]
+        nodes[1].volume_drivers = [{'name' => 'foo'}]
+        nodes[2].volume_drivers = [{'name' => 'local'}, {'name' => 'bar'}]
+      end
+
+      let(:local_volume) do
+        grid.volumes.create!(name: 'local', driver: 'local', scope: 'instance')
+      end
+
+      let(:foo_volume) do
+        grid.volumes.create!(name: 'foo', driver: 'foo', scope: 'instance')
+      end
+
+      let(:bar_volume) do
+        grid.volumes.create!(name: 'bar', driver: 'bar', scope: 'instance')
+      end
+
+      let(:service) do
+        grid.grid_services.create!(name: 'redis', image_name: 'redis', volumes: ['foo:/data'])
+      end
+
+      it 'returns all nodes with needed single driver' do
+        service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(bind_mount: '/var/lib', path: '/data')
+        expect(subject.for_service(service, 1, nodes).map{|n| n.name}).to eq(['node-1', 'node-3'])
+      end
+
+      it 'returns all nodes with needed single driver' do
+        service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(volume: foo_volume, path: '/data')
+        expect(subject.for_service(service, 1, nodes).map{|n| n.name}).to eq(['node-1'])
+      end
+
+      it 'raises if no nodes with all needed drivers' do
+        service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(volume: foo_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(volume: bar_volume, path: '/data')
+        expect{subject.for_service(service, 1, nodes)}.to raise_error(Scheduler::Error)
+      end
     end
 
-    it 'returns all nodes with needed single driver' do
-      service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
-      service.service_volumes << ServiceVolume.new(volume: foo_volume, path: '/data')
-      expect(subject.for_service(service, 1, nodes).map{|n| n.name}).to eq(['node-1'])
-    end
+    context 'v2 volume driver' do
+      before(:each) do
+        nodes[0].volume_drivers = [{'name' => 'local'}, {'name' => 'foo', 'version' => '1.2'}]
+        nodes[1].volume_drivers = [{'name' => 'foo', 'version' => '1.2'}]
+        nodes[2].volume_drivers = [{'name' => 'local'}, {'name' => 'bar', 'version' => 'latest'}]
+      end
 
-    it 'raises if no nodes with all needed drivers' do
-      service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
-      service.service_volumes << ServiceVolume.new(volume: foo_volume, path: '/data')
-      service.service_volumes << ServiceVolume.new(volume: bar_volume, path: '/data')
-      expect{subject.for_service(service, 1, nodes)}.to raise_error(Scheduler::Error)
-    end
+      let(:local_volume) do
+        grid.volumes.create!(name: 'local', driver: 'local', scope: 'instance')
+      end
 
+      let(:foo_volume) do
+        grid.volumes.create!(name: 'foo', driver: 'foo:1.2', scope: 'instance')
+      end
+
+      let(:bar_volume) do
+        grid.volumes.create!(name: 'bar', driver: 'bar:latest', scope: 'instance')
+      end
+
+      let(:service) do
+        grid.grid_services.create!(name: 'redis', image_name: 'redis', volumes: ['foo:/data'])
+      end
+
+      it 'returns all nodes with needed single driver' do
+        service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(bind_mount: '/var/lib', path: '/data')
+        expect(subject.for_service(service, 1, nodes).map{|n| n.name}).to eq(['node-1', 'node-3'])
+      end
+
+      it 'returns all nodes with needed single driver' do
+        service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(volume: foo_volume, path: '/data')
+        expect(subject.for_service(service, 1, nodes).map{|n| n.name}).to eq(['node-1'])
+      end
+
+      it 'raises if no nodes with all needed drivers' do
+        service.service_volumes << ServiceVolume.new(volume: local_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(volume: foo_volume, path: '/data')
+        service.service_volumes << ServiceVolume.new(volume: bar_volume, path: '/data')
+        expect{subject.for_service(service, 1, nodes)}.to raise_error(Scheduler::Error)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR makes node filtering to actually use volume plugin/driver version as part of the criteria. (commit by @jakolehm, cherry picked that from a WIP branch). 

This also changes the agents `VolumeManager` to omit the version/tag when checking volume existence as there might be different plugin versions used within the grid.


Fixes #2261 