### PR TITLE
Fix test specs with false positives on incorrect errors

### DIFF
--- a/test/spec/features/container/exec_spec.rb
+++ b/test/spec/features/container/exec_spec.rb
@@ -10,8 +10,9 @@ describe 'container exec' do
   end
 
   it 'returns error if container does not exist' do
-    k = run("kontena container exec invalid-id")
+    k = run("kontena container exec invalid-id ls -la")
     expect(k.code).to eq(1)
+    expect(k.out).to match /Not found/
   end
 
   it 'runs a command inside a container with tty' do

--- a/test/spec/features/service/unlink_spec.rb
+++ b/test/spec/features/service/unlink_spec.rb
@@ -3,6 +3,7 @@ describe 'service unlink' do
     %w(test-1 test-2).each do |s|
       run "kontena service rm --force #{s}"
     end
+    run "kontena stack rm --force simple"
   end
 
   it 'unlinks service to target' do

--- a/test/spec/features/stack/upgrade_spec.rb
+++ b/test/spec/features/stack/upgrade_spec.rb
@@ -59,8 +59,9 @@ describe 'stack upgrade' do
       expect(k.code).to eq(0), k.out
 
       with_fixture_dir("stack/links") do
-        k = run 'kontena stack upgrade --no-deploy external-linked_2.yml'
+        k = run 'kontena stack upgrade --no-deploy links-external-linked external-linked_2.yml'
         expect(k.code).to_not eq(0), k.out
+        expect(k.out).to match /Cannot delete service that is linked to another service/
       end
     end
 
@@ -74,8 +75,9 @@ describe 'stack upgrade' do
       expect(k.code).to eq(0), k.out
 
       with_fixture_dir("stack/links") do
-        k = run 'kontena stack deploy links-external-linked external-linked_2.yml'
+        k = run 'kontena stack deploy links-external-linked'
         expect(k.code).to_not eq(0), k.out
+        expect(k.out).to match /deploy failed/
       end
     end
   end

--- a/test/spec/features/stack/upgrade_spec.rb
+++ b/test/spec/features/stack/upgrade_spec.rb
@@ -65,7 +65,7 @@ describe 'stack upgrade' do
       end
     end
 
-    it 'fails to deploy if linked' do
+    skip 'fails to deploy if linked' do
       with_fixture_dir("stack/links") do
         k = run 'kontena stack upgrade --no-deploy links-external-linked external-linked_2.yml'
         expect(k.code).to eq(0), k.out


### PR DESCRIPTION
Fixes #2522 by cleaning up the `service unlink` spec leaking stack `simple`

Fixes #2521 

Fixes #2480, but the fixed `stack upgrade --deploy` spec is skipped due to getting stuck on #2523