### PR TITLE
cli: change stacks deploy helper to wait on deployment state

### DIFF
--- a/cli/lib/kontena/cli/stacks/stacks_helper.rb
+++ b/cli/lib/kontena/cli/stacks/stacks_helper.rb
@@ -4,10 +4,9 @@ module Kontena::Cli::Stacks
     def wait_for_deployment_to_start(deployment, timeout = 600)
       started = false
       Timeout::timeout(timeout) do
-        until started
-          deployment = client.get("stacks/#{deployment['stack_id']}/deploys/#{deployment['id']}")
-          started = true if deployment['service_deploys'].size > 0
+        while deployment['state'] == 'created'
           sleep 1
+          deployment = client.get("stacks/#{deployment['stack_id']}/deploys/#{deployment['id']}")
         end
         if deployment['state'] == 'error'
           deployment['service_deploys'].each do |service_deploy|

--- a/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
@@ -24,4 +24,25 @@ describe Kontena::Cli::Stacks::DeployCommand do
       subject.run(['test-stack'])
     end
   end
+
+  it 'exits with error if the stack deploy fails to start' do
+    expect(client).to receive(:post).with('stacks/test-grid/test-stack/deploy', {}).once.and_return({
+        'id' => '59524bd753caed000801b6a3',
+        'stack_id' => 'test-grid/test-stack',
+        'created_at' => '2017-06-27T12:13:11.181Z',
+        'state' => 'created',
+        'service_deploys' => [],
+    })
+
+    expect(client).to receive(:get).with('stacks/test-grid/test-stack/deploys/59524bd753caed000801b6a3').once.and_return({
+        'id' => '59524bd753caed000801b6a3',
+        'stack_id' => 'test-grid/test-stack',
+        'created_at' => '2017-06-27T12:13:11.181Z',
+        'state' => 'error',
+        'service_deploys' => [],
+    })
+    expect(subject).to receive(:sleep).once
+
+    expect{subject.run(['test-stack'])}.to exit_with_error.and output(/deploy failed/).to_stderr
+  end
 end

--- a/test/spec/features/stack/upgrade_spec.rb
+++ b/test/spec/features/stack/upgrade_spec.rb
@@ -65,7 +65,7 @@ describe 'stack upgrade' do
       end
     end
 
-    skip 'fails to deploy if linked' do
+    it 'fails to deploy if linked' do
       with_fixture_dir("stack/links") do
         k = run 'kontena stack upgrade --no-deploy links-external-linked external-linked_2.yml'
         expect(k.code).to eq(0), k.out


### PR DESCRIPTION
Fixes #2523

The stack deployment is not guaranteed to ever see any `service_deploys`, if it goes into an `error` state before starting those (raise from `remove_services`). This changes `wait_for_deployment_to_start` to just expect the `state` to change from `created`. The first thing the server `StackDeployWorker` does is update the state to `ongoing`.

This means that the `Waiting for deployment to start...` phase is now shorter, and the `wait_for_deploy_to_finish` has to wait for the first service deploy to start. I think it can deal with that as-is?