### PR TITLE
Automatically determine volume driver version from installed plugins

### DIFF
--- a/docs/using-kontena/volumes.md
+++ b/docs/using-kontena/volumes.md
@@ -27,7 +27,7 @@ See volume [scopes](#volume-scopes) for details on the different scopes.
 The driver has to be specified **without** a version tag, i.e. `rexray/s3fs:latest` is **not** supported. This is because using a hard version info on volume specification will make running multiple volume plugin versions within the grid impossible and also makes upgrading volume plugins really hard. Kontena will match the reported plugin version automatically and thus is able to create and manage the volumes.
 
 **NOTE:**
-There should be always only one version of a v2 volume plugin installed on a node at any given time. Having multiple versions installed will make volumes seen multiple times on a node and thus makes the automatic selection of correct volume and driver impossible. It is also advisable to install the plugins with `--alias` as that allows smoother (and less confusing) upgrades of the plugins.
+There should be always only one version of a v2 volume plugin installed on a node at any given time. Having multiple versions installed will make volumes seen multiple times on a node and thus makes the automatic selection of correct volume and driver impossible. If not using the default latest version, then it is advisable to install the plugins with `--alias`, as that allows smoother (and less confusing) upgrades of the plugins.
 
 ### Listing volumes
 

--- a/docs/using-kontena/volumes.md
+++ b/docs/using-kontena/volumes.md
@@ -26,6 +26,9 @@ See volume [scopes](#volume-scopes) for details on the different scopes.
 
 The driver has to be specified **without** a version tag, i.e. `rexray/s3fs:latest` is **not** supported. This is because using a hard version info on volume specification will make running multiple volume plugin versions within the grid impossible and also makes upgrading volume plugins really hard. Kontena will match the reported plugin version automatically and thus is able to create and manage the volumes.
 
+**NOTE:**
+There should be always only one version of a v2 volume plugin installed on a node at any given time. Having multiple versions installed will make volumes seen multiple times on a node and thus makes the automatic selection of correct volume and driver impossible. It is also advisable to install the plugins with `--alias` as that allows smoother (and less confusing) upgrades of the plugins.
+
 ### Listing volumes
 
 ```

--- a/docs/using-kontena/volumes.md
+++ b/docs/using-kontena/volumes.md
@@ -20,16 +20,18 @@ Volumes can be managed from the Kontena CLI using the `kontena volume xyz` comma
 
 ### Creating volumes
 
-`kontena volume create --driver rexray --scope instance my-volume`
+`kontena volume create --driver rexray/s3fs --scope instance my-volume`
 
 See volume [scopes](#volume-scopes) for details on the different scopes.
+
+The driver has to be specified **without** a version tag, i.e. `rexray/s3fs:latest` for is **not** supported. This is because using a hard version info on volume specification will make running multiple volume plugin versions within the grid impossible and also makes upgrading volume plugins really hard. Kontena will match the reported plugin version automatically and thus is able to create and manage the volumes.
 
 ### Listing volumes
 
 ```
 $ kontena volume ls
 
-NAME                      SCOPE                     DRIVER                    CREATED AT               
+NAME                      SCOPE                     DRIVER                    CREATED AT
 redis-data                grid                      local                     2017-04-06T06:57:34.374Z
 test-s3fs                 grid                      rexray/s3fs               2017-04-05T13:06:26.252Z
 ```

--- a/docs/using-kontena/volumes.md
+++ b/docs/using-kontena/volumes.md
@@ -24,7 +24,7 @@ Volumes can be managed from the Kontena CLI using the `kontena volume xyz` comma
 
 See volume [scopes](#volume-scopes) for details on the different scopes.
 
-The driver has to be specified **without** a version tag, i.e. `rexray/s3fs:latest` for is **not** supported. This is because using a hard version info on volume specification will make running multiple volume plugin versions within the grid impossible and also makes upgrading volume plugins really hard. Kontena will match the reported plugin version automatically and thus is able to create and manage the volumes.
+The driver has to be specified **without** a version tag, i.e. `rexray/s3fs:latest` is **not** supported. This is because using a hard version info on volume specification will make running multiple volume plugin versions within the grid impossible and also makes upgrading volume plugins really hard. Kontena will match the reported plugin version automatically and thus is able to create and manage the volumes.
 
 ### Listing volumes
 

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -64,6 +64,8 @@ class HostNode
     "#{self.grid.try(:name)}/#{self.name}"
   end
 
+  # @param [String] name Name of the volume driver
+  # @return [HostNodeDriver, nil] Given driver or nil if not found
   def volume_driver(name)
     self.volume_drivers.find_by(name: name)
   end

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -64,6 +64,10 @@ class HostNode
     "#{self.grid.try(:name)}/#{self.name}"
   end
 
+  def volume_driver(name)
+    self.volume_drivers.find_by(name: name)
+  end
+
   ##
   # @param [Hash] attrs
   def attributes_from_docker(attrs)

--- a/server/app/models/volume.rb
+++ b/server/app/models/volume.rb
@@ -41,7 +41,7 @@ class Volume
 
   def driver_for_node(host_node)
     nodes_driver = host_node.volume_driver(self.driver)
-    if nodes_driver['version']
+    if nodes_driver && nodes_driver['version']
       "#{self.driver}:#{nodes_driver['version']}"
     else
       self.driver

--- a/server/app/models/volume.rb
+++ b/server/app/models/volume.rb
@@ -39,4 +39,13 @@ class Volume
     self.grid.grid_services.where("service_volumes.volume_id" => self.id)
   end
 
+  def driver_for_node(host_node)
+    nodes_driver = host_node.volume_driver(self.driver)
+    if nodes_driver['version']
+      "#{self.driver}:#{nodes_driver['version']}"
+    else
+      self.driver
+    end
+  end
+
 end

--- a/server/app/models/volume.rb
+++ b/server/app/models/volume.rb
@@ -39,6 +39,10 @@ class Volume
     self.grid.grid_services.where("service_volumes.volume_id" => self.id)
   end
 
+  # Returns "fully qualified" driver name for the given node.
+  # I.e. adds version tag to the agent reported plugin/driver version.
+  # @param [HostNode] host_node
+  # @return [String] driver name with version tag (driver:version)
   def driver_for_node(host_node)
     nodes_driver = host_node.volume_driver(self.driver)
     if nodes_driver && nodes_driver['version']

--- a/server/app/models/volume_instance.rb
+++ b/server/app/models/volume_instance.rb
@@ -12,4 +12,8 @@ class VolumeInstance
 
   index({ host_node_id: 1 })
   index({ volume_id: 1 })
+
+  def driver
+    self.volume.driver_for_node(self.host_node)
+  end
 end

--- a/server/app/mutations/volumes/create.rb
+++ b/server/app/mutations/volumes/create.rb
@@ -16,6 +16,9 @@ module Volumes
       if self.grid.volumes.find_by(name: self.name)
         add_error(:name, :already_exists, "Volume with given name already exists")
       end
+      if self.driver.include?(':')
+        add_error(:driver, :tag, "Driver version tag cannot be used")
+      end
     end
 
     def execute

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -174,7 +174,7 @@ module Rpc
               name: volume_name,
               path: sv.path,
               flags: sv.flags,
-              driver: sv.volume.driver,
+              driver: sv.volume.driver_for_node(service_instance.host_node),
               driver_opts: sv.volume.driver_opts
           }
         else
@@ -188,5 +188,6 @@ module Rpc
 
       volume_specs
     end
+
   end
 end

--- a/server/app/serializers/rpc/volume_serializer.rb
+++ b/server/app/serializers/rpc/volume_serializer.rb
@@ -20,7 +20,7 @@ module Rpc
     end
 
     def driver
-      object.volume.driver
+      object.driver
     end
 
     def driver_opts

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -284,4 +284,22 @@ describe HostNode do
     end
 
   end
+
+  describe '#volume_driver' do
+    let(:grid) { Grid.create!(name: 'test') }
+    let(:node) { HostNode.create(name: 'node-1', grid: grid)}
+
+    it 'returns correct volume driver' do
+      node.volume_drivers.create!(name: 'foo', version: '1')
+
+      driver = node.volume_driver('foo')
+      expect(driver['name']).to eq('foo')
+      expect(driver['version']).to eq('1')
+    end
+
+    it 'returns nil for unknown driver' do
+      driver = node.volume_driver('foo')
+      expect(driver).to be_nil
+    end
+  end
 end

--- a/server/spec/models/volume_spec.rb
+++ b/server/spec/models/volume_spec.rb
@@ -32,4 +32,28 @@ describe Volume do
       expect(vol.name_for_service(service, 1)).to eq('stack.a-volume')
     end
   end
+
+  describe '#driver_for_node' do
+    let(:node) do
+      grid.host_nodes.create!(name: 'node-1')
+    end
+
+    it 'returns plain driver when no driver on node' do
+      vol = Volume.create!(grid: grid, name: 'a-volume', scope: 'instance', driver: 'foo')
+      expect(vol.driver_for_node(node)).to eq('foo')
+    end
+
+    it 'returns plain driver when driver on node has no version' do
+      vol = Volume.create!(grid: grid, name: 'a-volume', scope: 'instance', driver: 'local')
+      node.volume_drivers.create(name: 'local', version: nil)
+      expect(vol.driver_for_node(node)).to eq('local')
+    end
+
+    it 'returns versioned driver when driver on node has version' do
+      vol = Volume.create!(grid: grid, name: 'a-volume', scope: 'instance', driver: 'local')
+      node.volume_drivers.create(name: 'local', version: '1.2.3')
+      expect(vol.driver_for_node(node)).to eq('local:1.2.3')
+    end
+
+  end
 end

--- a/server/spec/mutations/volumes/create_spec.rb
+++ b/server/spec/mutations/volumes/create_spec.rb
@@ -32,6 +32,19 @@ describe Volumes::Create do
       }.to_not change{Volume.count}
     end
 
+    it 'does not allow tag in driver' do
+      expect {
+        outcome = Volumes::Create.run(
+          grid: grid,
+          name: "foobar",
+          driver: 'foo/bar:latest',
+          scope: 'instance'
+        )
+        expect(outcome).to_not be_success
+        expect(outcome.errors.symbolic).to eq 'driver' => :tag
+      }.to_not change{Volume.count}
+    end
+
     it 'creates new grid volume' do
       expect {
         outcome = Volumes::Create.run(


### PR DESCRIPTION
replaces #2518 

Docker plugin versioning causes lot of mismatches. E.g. if you install `rexray/s3fs:0.8.2` and the later on upgrade that to `0.9.2` the plugin is still reported to be on version `0.8.2`.

If Kontena volumes would be created with a "pinned"  plugin version it would be impossible to run multiple versions of a plugin within the grid. Then again, if Kontena would just ignore the version everywhere it would mean that all plugins would need to always be installed with `--alias` to be able to create the actual volumes in first place.

Hence this PR changes things so that:
- Volumes cannot be created with a tag (`:` is not allowed in the name)
- "Fully qualified" driver is sent to agent with both `ServicePod` and `VolumeInstance`. The driver version is looked up when serializing from `HostNode.volume_drivers`. This means that agent creates the volume with the nodes reported driver with version tag. `VolumeManager` driver match check checks fully qualified drivers.