### PR TITLE
Add rbtrace support to server & agent

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk --update add tzdata ruby ruby-irb ruby-bigdecimal \
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 
-RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-dev git && \
+RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-dev libffi-dev git && \
     gem install bundler --no-ri --no-rdoc && \
     cd /app ; bundle install --without development test && \
     apk del build-dependencies

--- a/agent/Gemfile
+++ b/agent/Gemfile
@@ -9,6 +9,7 @@ gem 'etcd'
 gem 'statsd-ruby'
 gem 'vmstat'
 gem 'fluent-logger', '~>0.6.2'
+gem 'rbtrace', require: false
 
 group :development, :test do
   gem 'rake', require: false

--- a/agent/Gemfile.lock
+++ b/agent/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
     etcd (0.3.0)
       mixlib-log
     excon (0.58.0)
+    ffi (1.9.18)
     fluent-logger (0.6.2)
       msgpack (>= 0.5.6, < 2)
     hashdiff (0.3.4)
@@ -49,6 +50,10 @@ GEM
     msgpack (1.0.3)
     public_suffix (2.0.5)
     rake (12.0.0)
+    rbtrace (0.4.8)
+      ffi (>= 1.0.6)
+      msgpack (>= 0.4.3)
+      trollop (>= 1.16.2)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -72,6 +77,7 @@ GEM
     thread_safe (0.3.6)
     timers (4.1.1)
       hitimes
+    trollop (2.1.2)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     vmstat (2.3.0)
@@ -96,6 +102,7 @@ DEPENDENCIES
   kontena-websocket-client (~> 0.1.0)
   msgpack (~> 1.0.3)
   rake
+  rbtrace
   rspec
   simplecov
   statsd-ruby

--- a/agent/bin/kontena-agent
+++ b/agent/bin/kontena-agent
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'rbtrace' if ENV['RBTRACE'].to_s == 'true'
 require_relative '../lib/kontena-agent'
 
 Docker.options[:read_timeout] = (60*60)

--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -6,5 +6,6 @@ agent:
   net: host
   environment:
     - KONTENA_PEER_INTERFACE=eth1
+    - RBTRACE=true
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk --update add tzdata ruby ruby-irb ruby-bigdecimal \
 
 ADD Gemfile Gemfile.lock /app/
 
-RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-dev && \
+RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-dev libffi-dev && \
     gem install bundler --no-ri --no-rdoc && \
     cd /app ; bundle install --without development test && \
     apk del build-dependencies

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -17,6 +17,7 @@ gem 'httpclient', '~> 2.3'
 gem 'authority'
 gem 'mongoid-enum'
 gem 'rollbar', require: false
+gem 'rbtrace', require: false
 gem 'acme-client'
 gem 'json-jwt', '= 1.5.2'
 gem 'jsonpath'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -104,6 +104,10 @@ GEM
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    rbtrace (0.4.8)
+      ffi (>= 1.0.6)
+      msgpack (>= 0.4.3)
+      trollop (>= 1.16.2)
     rerun (0.10.0)
       listen (~> 2.7, >= 2.7.3)
     roda (2.26.0)
@@ -139,6 +143,7 @@ GEM
       tilt (<= 1.5.0)
     timers (4.1.2)
       hitimes
+    trollop (2.1.2)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     url_safe_base64 (0.2.2)
@@ -175,6 +180,7 @@ DEPENDENCIES
   rack-attack
   rack-test
   random_token
+  rbtrace
   rerun
   roda (~> 2.26.0)
   rollbar

--- a/server/app/initializers/00_rbtrace.rb
+++ b/server/app/initializers/00_rbtrace.rb
@@ -1,0 +1,1 @@
+require 'rbtrace' if ENV['RBTRACE'].to_s == 'true'

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,6 +10,7 @@ api:
     - VAULT_IV=kfsdfopweu09fewjlhfksdjifjpoweop
     - ACME_ENDPOINT=https://acme-staging.api.letsencrypt.org/
     - INITIAL_ADMIN_CODE=initialadmincode
+    - RBTRACE=true
   links:
    - mongodb
 mongodb:


### PR DESCRIPTION
Includes [rbtrace](https://github.com/tmm1/rbtrace) gem to server & agent that can be enabled with `RBTRACE` environment variable (disabled by default).

