### PR TITLE
Server: Fix HostNode connected_at field to type: Time

### DIFF
--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -28,7 +28,7 @@ class HostNode
   field :last_seen_at, type: Time
   field :agent_version, type: String
   field :docker_version, type: String
-  field :connected_at, type: DateTime
+  field :connected_at, type: Time
 
   embeds_many :volume_drivers, class_name: 'HostNodeDriver'
   embeds_many :network_drivers, class_name: 'HostNodeDriver'

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -214,7 +214,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
         expect(host_node.node_id).to eq node_id
         expect(host_node.connected).to eq true
-        expect(host_node.connected_at.to_s).to eq connected_at.to_datetime.to_s
+        expect(host_node.connected_at.to_s).to eq connected_at.to_s
 
         # XXX: racy via mongo pubsub
         expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/master_info', [{ 'version' => '0.9.1'}]])


### PR DESCRIPTION
#2144 added the `HostNode` `connected_at` field using `type: DateTime` because during development, the `:connected_at.lt => Time.parse(...)` comparisons apparently failed when using `type: Time`: https://github.com/kontena/kontena/pull/2144/files/#r116803960

However, I'm unable to repro this anymore (even using the older mongoid version that branch was developed with), and using mongoid `DateTime` vs `Time` results in `DateTime` vs `ActiveSupport::TimeWithZone` objects with slightly different JSON timestamp formats in the nodes API: https://github.com/kontena/kontena/pull/2483/files#r122190556

```
DEBUG [Request]: GET http://localhost:9292/v1/nodes/development/core-01 | Headers: {Accept: application/json, Authorization: Bearer} 
DEBUG [Response]: Headers: {Content-Type: application/json, X-Kontena-Version: 1.4.0.dev}  | Status: 200 | Body: 
{...,"created_at":"2016-10-27T08:15:31.084Z","updated_at":"2017-06-28T13:06:51.577Z","connected_at":"2017-06-28T13:06:43.047+00:00",...}}
```

Changing the field back to the `Time` type, so that the `created_at` and `connected_at` types and resulting API JSON timestamps match: 

```
irb(main):004:0> host_node = HostNode.find_by(name: 'core-02')
irb(main):005:0> [host_node.created_at, host_node.created_at.class, host_node.created_at.to_json]
=> [Thu, 22 Jun 2017 12:28:39 UTC +00:00, ActiveSupport::TimeWithZone, "\"2017-06-22T12:28:39.571Z\""]
irb(main):006:0> [host_node.connected_at, host_node.connected_at.class, host_node.connected_at.to_json]
=> [Wed, 28 Jun 2017 13:47:27 UTC +00:00, ActiveSupport::TimeWithZone, "\"2017-06-28T13:47:27.223Z\""]
```

```
DEBUG [Request]: GET http://localhost:9292/v1/nodes/development/core-01 | Headers: {Accept: application/json, Authorization: Bearer} 
DEBUG [Response]: Headers: {Content-Type: application/json, X-Kontena-Version: 1.4.0.dev}  | Status: 200 | Body: 
{...,"created_at":"2016-10-27T08:15:31.084Z","updated_at":"2017-06-28T13:40:42.378Z","connected_at":"2017-06-28T13:31:00.182Z",...}}
```

The `:connected_at.lt => ...` comparisons used by the `NodePlugger` still seem to work just fine:

```
irb(main):010:0> HostNode.where(id: host_node.id, :connected_at.lt => DateTime.parse('2017-06-28T13:47:30.182Z')).map{|hn| hn.connected_at}
=> [Wed, 28 Jun 2017 13:47:27 UTC +00:00]
irb(main):011:0> HostNode.where(id: host_node.id, :connected_at.lt => Time.parse('2017-06-28T13:47:30.182Z')).map{|hn| hn.connected_at}
=> [Wed, 28 Jun 2017 13:47:27 UTC +00:00]
```

```
irb(main):015:0> node = HostNode.find_by(name: 'core-02')
irb(main):016:0> connected_at = Time.parse('2017-06-28T13:47:30.182Z')
irb(main):018:0> [node.connected_at, connected_at]
=> [Wed, 28 Jun 2017 13:47:27 UTC +00:00, 2017-06-28 13:47:30 UTC]

irb(main):019:0> HostNode.where(:id => node.id).any_of({:connected_at => nil}, {:connected_at.lt => connected_at}).find_one_and_update({:$set => {connected: true, last_seen_at: Time.now.utc, connected_at: connected_at}})
=> #<HostNode _id: 594bb7f7de3578534f5fb32a, ..., connected_at: 2017-06-28 13:47:27 UTC, ...>

irb(main):020:0> node.reload
=> #<HostNode _id: 594bb7f7de3578534f5fb32a, ..., connected_at: 2017-06-28 13:47:30 UTC,...>
irb(main):021:0> [node.connected_at, connected_at]
=> [Wed, 28 Jun 2017 13:47:30 UTC +00:00, 2017-06-28 13:47:30 UTC]
```

I don't think this needs any migrations, because it looks like both types are stored identically in mongo (from before the change):

```
> db.host_nodes.find({}, {name: 1, created_at: 1, connected_at: 1})
{ "_id" : ObjectId("594bb7f7de3578534f5fb32a"), "name" : "core-02", "created_at" : ISODate("2017-06-22T12:28:39.571Z"), "connected_at" : ISODate("2017-06-28T13:06:42.182Z") }
```