### PR TITLE
Service cpus limit

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -213,7 +213,7 @@ module Kontena
         end
         if self.cpus
           host_config['CpuPeriod'] = 100000
-          host_config['CpuQuota'] = host_config['CpuPeriod'] * self.cpus
+          host_config['CpuQuota'] = (host_config['CpuPeriod'] * self.cpus).to_i
         end
 
         host_config['NetworkMode'] = self.net

--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -19,6 +19,7 @@ module Kontena
                   :entrypoint,
                   :memory,
                   :memory_swap,
+                  :cpus,
                   :cpu_shares,
                   :privileged,
                   :pid,
@@ -64,6 +65,7 @@ module Kontena
         @entrypoint = attrs['entrypoint']
         @memory = attrs['memory']
         @memory_swap = attrs['memory_swap']
+        @cpus = attrs['cpus']
         @cpu_shares = attrs['cpu_shares']
         @privileged = attrs['privileged'] || false
         @cap_add = attrs['cap_add']
@@ -208,6 +210,10 @@ module Kontena
         end
         if self.can_expose_ports? && self.ports
           host_config['PortBindings'] = self.build_port_bindings
+        end
+        if self.cpus
+          host_config['CpuPeriod'] = 100000
+          host_config['CpuQuota'] = host_config['CpuPeriod'] * self.cpus
         end
 
         host_config['NetworkMode'] = self.net

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -321,6 +321,16 @@ describe Kontena::Models::ServicePod do
       expect(host_config['CpuShares']).to eq(500)
     end
 
+    it 'does not include CpuQuota if cpus not defined' do
+      expect(host_config['CpuShares']).to be_nil
+    end
+
+    it 'includes CpuPeriod & CpuQuota if cpus is defined' do
+      data['cpus'] = 1.5
+      expect(host_config['CpuPeriod']).to eq(100_000)
+      expect(host_config['CpuQuota']).to eq(150_000)
+    end
+
     it 'sets PidMode if set' do
       data['pid'] = 'host'
       expect(host_config['PidMode']).to eq('host')

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -16,7 +16,9 @@ module Kontena::Cli::Services
     option ["-v", "--volume"], "VOLUME", "Add a volume or bind mount it from the host", multivalued: true
     option "--volumes-from", "VOLUMES_FROM", "Mount volumes from another container", multivalued: true
     option ["-a", "--affinity"], "AFFINITY", "Set service affinity", multivalued: true
-    option "--cpus", "CPUS", "Number of CPUs"
+    option "--cpus", "CPUS", "Number of CPUs" do |cpus|
+      Float(cpus)
+    end
     option ["-c", "--cpu-shares"], "CPU_SHARES", "CPU shares (relative weight)"
     option ["-m", "--memory"], "MEMORY", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)"
     option ["--memory-swap"], "MEMORY_SWAP", "Total memory usage (memory + swap), set \'-1\' to disable swap (format: <number><optional unit>, where unit = b, k, m or g)"
@@ -70,7 +72,7 @@ module Kontena::Cli::Services
       data[:volumes_from] = volumes_from_list unless volumes_from_list.empty?
       data[:memory] = parse_memory(memory) if memory
       data[:memory_swap] = parse_memory(memory_swap) if memory_swap
-      data[:cpus] = cpus.to_f if cpus
+      data[:cpus] = cpus if cpus
       data[:cpu_shares] = cpu_shares if cpu_shares
       data[:affinity] = affinity_list unless affinity_list.empty?
       data[:env] = env_list unless env_list.empty?

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -16,6 +16,7 @@ module Kontena::Cli::Services
     option ["-v", "--volume"], "VOLUME", "Add a volume or bind mount it from the host", multivalued: true
     option "--volumes-from", "VOLUMES_FROM", "Mount volumes from another container", multivalued: true
     option ["-a", "--affinity"], "AFFINITY", "Set service affinity", multivalued: true
+    option "--cpus", "CPUS", "Number of CPUs"
     option ["-c", "--cpu-shares"], "CPU_SHARES", "CPU shares (relative weight)"
     option ["-m", "--memory"], "MEMORY", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)"
     option ["--memory-swap"], "MEMORY_SWAP", "Total memory usage (memory + swap), set \'-1\' to disable swap (format: <number><optional unit>, where unit = b, k, m or g)"
@@ -69,6 +70,7 @@ module Kontena::Cli::Services
       data[:volumes_from] = volumes_from_list unless volumes_from_list.empty?
       data[:memory] = parse_memory(memory) if memory
       data[:memory_swap] = parse_memory(memory_swap) if memory_swap
+      data[:cpus] = cpus.to_f if cpus
       data[:cpu_shares] = cpu_shares if cpu_shares
       data[:affinity] = affinity_list unless affinity_list.empty?
       data[:env] = env_list unless env_list.empty?

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -161,6 +161,14 @@ module Kontena
             end
           end
 
+          unless service['cpus'].to_s.empty?
+            puts "  cpus: #{service['cpus']}"
+          end
+
+          unless service['cpu_shares'].to_s.empty?
+            puts "  cpu_shares: #{service['cpu_shares']}"
+          end
+
           unless service['memory'].to_s.empty?
             puts "  memory: #{int_to_filesize(service['memory'])}"
           end

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -14,6 +14,7 @@ module Kontena::Cli::Services
     option ["-e", "--env"], "ENV", "Set environment variables", multivalued: true
     option ["-l", "--link"], "LINK", "Add link to another service in the form of name:alias", multivalued: true
     option ["-a", "--affinity"], "AFFINITY", "Set service affinity", multivalued: true
+    option "--cpus", "CPUS", "Number of CPUs"
     option ["-c", "--cpu-shares"], "CPU_SHARES", "CPU shares (relative weight)"
     option ["-m", "--memory"], "MEMORY", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)"
     option ["--memory-swap"], "MEMORY_SWAP", "Total memory usage (memory + swap), set \'-1\' to disable swap (format: <number><optional unit>, where unit = b, k, m or g)"
@@ -60,6 +61,7 @@ module Kontena::Cli::Services
       data[:links] = parse_links(link_list) unless link_list.empty?
       data[:memory] = parse_memory(memory) if memory
       data[:memory_swap] = parse_memory(memory_swap) if memory_swap
+      data[:cpus] = cpus.to_f if cpus
       data[:cpu_shares] = cpu_shares if cpu_shares
       data[:affinity] = affinity_list unless affinity_list.empty?
       data[:env] = env_list unless env_list.empty?

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -14,7 +14,9 @@ module Kontena::Cli::Services
     option ["-e", "--env"], "ENV", "Set environment variables", multivalued: true
     option ["-l", "--link"], "LINK", "Add link to another service in the form of name:alias", multivalued: true
     option ["-a", "--affinity"], "AFFINITY", "Set service affinity", multivalued: true
-    option "--cpus", "CPUS", "Number of CPUs"
+    option "--cpus", "CPUS", "Number of CPUs" do |cpus|
+      Float(cpus)
+    end
     option ["-c", "--cpu-shares"], "CPU_SHARES", "CPU shares (relative weight)"
     option ["-m", "--memory"], "MEMORY", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)"
     option ["--memory-swap"], "MEMORY_SWAP", "Total memory usage (memory + swap), set \'-1\' to disable swap (format: <number><optional unit>, where unit = b, k, m or g)"
@@ -61,7 +63,7 @@ module Kontena::Cli::Services
       data[:links] = parse_links(link_list) unless link_list.empty?
       data[:memory] = parse_memory(memory) if memory
       data[:memory_swap] = parse_memory(memory_swap) if memory_swap
-      data[:cpus] = cpus.to_f if cpus
+      data[:cpus] = cpus if cpus
       data[:cpu_shares] = cpu_shares if cpu_shares
       data[:affinity] = affinity_list unless affinity_list.empty?
       data[:env] = env_list unless env_list.empty?

--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -33,6 +33,7 @@ module Kontena::Cli::Stacks
       data['ports'] = parse_stringified_ports(options['ports'] || [])
       data['memory'] = parse_memory(options['mem_limit'].to_s) if options['mem_limit']
       data['memory_swap'] = parse_memory(options['memswap_limit'].to_s) if options['memswap_limit']
+      data['cpus'] = options['cpus'] if options['cpus']
       data['cpu_shares'] = options['cpu_shares'] if options['cpu_shares']
       data['volumes'] = options['volumes'] || []
       data['volumes_from'] = options['volumes_from'] || []

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -27,6 +27,7 @@ module Kontena::Cli::Stacks::YAML
         'cap_add' => optional('array'),
         'cap_drop' => optional('array'),
         'command' => optional('string'),
+        'cpus' => optional('float'),
         'cpu_shares' => optional('integer'),
         'external_links' => optional('array'),
         'mem_limit' => optional('string'),

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -19,6 +19,7 @@ class GridService
   field :env, type: Array, default: []
   field :memory, type: Integer
   field :memory_swap, type: Integer
+  field :cpus, type: Float
   field :cpu_shares, type: Integer
   field :volumes, type: Array, default: []
   field :volumes_from, type: Array, default: []

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -230,6 +230,7 @@ module GridServices
           array :volumes_from do
             string
           end
+          float :cpus
           integer :cpu_shares, min: 0, max: 1024
           integer :memory
           integer :memory_swap

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -58,6 +58,7 @@ module GridServices
       attributes[:container_count] = self.container_count if self.container_count
       attributes[:container_count] = self.instances if self.instances
       attributes[:user] = self.user if self.user
+      attributes[:cpus] = self.cpus if self.cpus
       attributes[:cpu_shares] = self.cpu_shares if self.cpu_shares
       attributes[:memory] = self.memory if self.memory
       attributes[:memory_swap] = self.memory_swap if self.memory_swap

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -29,6 +29,7 @@ module Rpc
         memory: service.memory,
         memory_swap: service.memory_swap,
         cpu_shares: service.cpu_shares,
+        cpus: service.cpus,
         privileged: service.privileged,
         cap_add: service.cap_add,
         cap_drop: service.cap_drop,

--- a/server/app/services/grid_service_scheduler.rb
+++ b/server/app/services/grid_service_scheduler.rb
@@ -22,6 +22,7 @@ class GridServiceScheduler
       Scheduler::Filter::VolumeInstance.new,
       Scheduler::Filter::Affinity.new,
       Scheduler::Filter::Port.new,
+      Scheduler::Filter::Cpu.new,
       Scheduler::Filter::Memory.new,
       Scheduler::Filter::Dependency.new
     ]

--- a/server/app/services/scheduler/filter/cpu.rb
+++ b/server/app/services/scheduler/filter/cpu.rb
@@ -1,0 +1,25 @@
+module Scheduler
+  module Filter
+    class Cpu
+
+      ##
+      # @param [GridService] service
+      # @param [Integer] instance_number
+      # @param [Array<HostNode>] nodes
+      # @return [Array<HostNode>]
+      def for_service(service, instance_number, nodes)
+        return nodes if service.cpus.nil?
+
+        candidates = nodes.dup.select { |n|
+          n.cpus.to_f >= service.cpus.to_f
+        }
+
+        if candidates.empty?
+          raise Scheduler::Error, "Did not find any nodes with #{service.cpus} CPUs available"
+        end
+
+        candidates
+      end
+    end
+  end
+end

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -20,6 +20,7 @@ json.env grid_service.env
 json.secrets grid_service.secrets.as_json(only: [:secret, :name, :type])
 json.memory grid_service.memory
 json.memory_swap grid_service.memory_swap
+json.cpus grid_service.cpus
 json.cpu_shares grid_service.cpu_shares
 json.volumes grid_service.service_volumes.map {|sv| sv.to_s}
 json.volumes_from grid_service.volumes_from

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -870,6 +870,7 @@ follow | Stream logs
   ],
   "memory": 1024000000,
   "memory_swap": 4096000000,
+  "cpus": 1.5,
   "cpu_shares": 1024,
   "volumes": [
     "/data"
@@ -918,6 +919,7 @@ env | List of user-defined environment variables to set on the instances of the 
 secrets | Array of mapped secrets from Kontena Vault
 memory | Memory limit (excluding optional swap)
 memory_swap | Allowed memory (including swap)
+cpus | Specify how much of the available CPU resources (CPU cores) a service instance can use.
 cpu_shares | Relative cpu shares (0-1024)
 volumes | A list of volumes
 volumes_from | A list of volumes to mount from other services

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -83,7 +83,7 @@ describe '/v1/services' do
 
   EXPECTED_FIELDS = %w(
         id created_at updated_at stack image affinity name stateful user
-        instances cmd entrypoint ports env memory memory_swap cpu_shares
+        instances cmd entrypoint ports env memory memory_swap cpus cpu_shares
         volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
         strategy deploy_opts pid instance_counts net dns hooks secrets revision
         stack_revision stop_grace_period read_only

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -117,6 +117,17 @@ describe GridServices::Create do
       expect(outcome.result.user).to eq('redis')
     end
 
+    it 'saves cpus' do
+      outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: true,
+          cpus: 2
+      ).run
+      expect(outcome.result.cpus).to eq(2)
+    end
+
     it 'saves cpu_shares' do
       outcome = described_class.new(
           grid: grid,
@@ -466,7 +477,7 @@ describe GridServices::Create do
       expect(outcome).to_not be_success
       expect(outcome.errors.message).to eq 'env' => [ "Env[0] isn't in the right format" ]
     end
-    
+
     it 'saves stop_grace_period with default if not given' do
       outcome = described_class.new(
           grid: grid,


### PR DESCRIPTION
> Specify how much of the available CPU resources a service instance can use. For example, if the host machine has two CPUs and you set `cpus: 1.5`, the service instance will be guaranteed to be able to access at most one and a half of the CPUs. Kontena scheduler will automatically target deployment to nodes that have at least number of specified CPUs available.

Related #2450