### PR TITLE
Unlimited connections for weave

### DIFF
--- a/agent/lib/kontena/network_adapters/weave.rb
+++ b/agent/lib/kontena/network_adapters/weave.rb
@@ -209,7 +209,7 @@ module Kontena::NetworkAdapters
       until weave && weave.running? do
         exec_params = [
           '--local', 'launch-router', '--ipalloc-range', '', '--dns-domain', 'kontena.local',
-          '--password', ENV['KONTENA_TOKEN']
+          '--password', ENV['KONTENA_TOKEN'], '--conn-limit', '0'
         ]
         exec_params += ['--trusted-subnets', trusted_subnets.join(',')] if trusted_subnets
         @executor_pool.execute(exec_params)
@@ -277,7 +277,7 @@ module Kontena::NetworkAdapters
       return true if weave.config['Image'].split(':')[1] != WEAVE_VERSION
       cmd = Hash[*weave.config['Cmd'].flatten(1)]
       return true if cmd['--trusted-subnets'] != node.grid['trusted_subnets'].to_a.join(',')
-
+      return true if cmd['--conn-limit'].nil?
       false
     end
 

--- a/agent/spec/lib/kontena/network_adapters/weave_spec.rb
+++ b/agent/spec/lib/kontena/network_adapters/weave_spec.rb
@@ -134,7 +134,7 @@ describe Kontena::NetworkAdapters::Weave do
       )
       weave_config = {
         'Image' => valid_image,
-        'Cmd' => ['--trusted-subnets', '']
+        'Cmd' => ['--trusted-subnets', '', '--conn-limit', '0']
       }
       weave = double(:weave, config: weave_config)
       expect(subject.config_changed?(weave, node)).to be_falsey
@@ -166,6 +166,34 @@ describe Kontena::NetworkAdapters::Weave do
         'Cmd' => ['--trusted-subnets', '']
       }
 
+      weave = double(:weave, config: weave_config)
+      expect(subject.config_changed?(weave, node)).to be_truthy
+    end
+
+    it 'returns false if connection limit is same' do
+      node = Node.new(
+        'grid' => {
+          'trusted_subnets' => []
+        }
+      )
+      weave_config = {
+        'Image' => valid_image,
+        'Cmd' => ['--trusted-subnets', '', '--conn-limit', '0']
+      }
+      weave = double(:weave, config: weave_config)
+      expect(subject.config_changed?(weave, node)).to be_falsey
+    end
+
+    it 'returns true if connection limit is not used' do
+      node = Node.new(
+        'grid' => {
+          'trusted_subnets' => []
+        }
+      )
+      weave_config = {
+        'Image' => valid_image,
+        'Cmd' => ['--trusted-subnets', '']
+      }
       weave = double(:weave, config: weave_config)
       expect(subject.config_changed?(weave, node)).to be_truthy
     end


### PR DESCRIPTION
This PR makes weave use unlimited connections between peers, essentially making Kontena grid more expandable. Weave [default](https://github.com/weaveworks/weave/blob/master/prog/weaver/main.go#L179) is `30` which has effectively set the max size of for the grid also.

fixes #2539 

