### PR TITLE
Read-only container instances

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -42,6 +42,7 @@ module Kontena
                   :networks,
                   :wait_for_port,
                   :volume_specs,
+                  :read_only,
                   :stop_grace_period
 
       # @param [Hash] attrs
@@ -83,6 +84,7 @@ module Kontena
         @secrets = attrs['secrets'] || []
         @networks = attrs['networks'] || []
         @wait_for_port = attrs['wait_for_port']
+        @read_only = attrs['read_only']
         @stop_grace_period = attrs['stop_grace_period']
       end
 
@@ -217,6 +219,7 @@ module Kontena
         host_config['CapAdd'] = self.cap_add if self.cap_add && self.cap_add.size > 0
         host_config['CapDrop'] = self.cap_drop if self.cap_drop && self.cap_drop.size > 0
         host_config['PidMode'] = self.pid if self.pid
+        host_config['ReadonlyRootfs'] = true if self.read_only
 
         log_opts = self.build_log_opts
         host_config['LogConfig'] = log_opts unless log_opts.empty?

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -42,6 +42,7 @@ module Kontena::Cli::Services
     option "--health-check-port", "PORT", "Port for health check"
     option "--health-check-protocol", "PROTOCOL", "Protocol of health check"
     option "--stop-timeout", "STOP_TIMEOUT", "Timeout (duration) to stop a container"
+    option "--read-only", :flag, "Read-only root fs for the container", default: false
 
     def execute
       require_api_url
@@ -89,6 +90,7 @@ module Kontena::Cli::Services
       data[:health_check] = health_check unless health_check.empty?
       data[:pid] = pid if pid
       data[:stop_grace_period] = stop_timeout if stop_timeout
+      data[:read_only] = read_only?
       data
     end
   end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -52,6 +52,7 @@ module Kontena
           puts "  stateful: #{service['stateful'] == true ? 'yes' : 'no' }"
           puts "  scaling: #{service['instances'] }"
           puts "  strategy: #{service['strategy']}"
+          puts "  read_only: #{service['read_only'] == true ? 'yes' : 'no'}"
           puts "  stop_grace_period: #{service['stop_grace_period']}s"
           puts "  deploy_opts:"
           if service['deploy_opts']['min_health']

--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -64,7 +64,7 @@ module Kontena::Cli::Stacks
       data['build'] = parse_build_options(options) if options['build']
       data['health_check'] = parse_health_check(options)
       data['stop_grace_period'] = options['stop_grace_period'] if options['stop_grace_period']
-      data['read_only'] = options['read_only'] if options['read_only']
+      data['read_only'] = options['read_only'] || false
       data
     end
 

--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -64,6 +64,7 @@ module Kontena::Cli::Stacks
       data['build'] = parse_build_options(options) if options['build']
       data['health_check'] = parse_health_check(options)
       data['stop_grace_period'] = options['stop_grace_period'] if options['stop_grace_period']
+      data['read_only'] = options['read_only'] if options['read_only']
       data
     end
 

--- a/cli/lib/kontena/cli/stacks/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/show_command.rb
@@ -57,6 +57,7 @@ module Kontena::Cli::Stacks
       puts "#{pad}  stateful: #{service['stateful'] == true ? 'yes' : 'no' }"
       puts "#{pad}  scaling: #{service['instances'] }"
       puts "#{pad}  strategy: #{service['strategy']}"
+      puts "#{pad}  read_only: #{service['read_only'] == true ? 'yes' : 'no'}"
       puts "#{pad}  deploy_opts:"
       puts "#{pad}    min_health: #{service['deploy_opts']['min_health']}"
       if service['deploy_opts']['wait_for_port']

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -75,7 +75,8 @@ module Kontena::Cli::Stacks::YAML
           'interval' => optional('integer'),
           'initial_delay' => optional('integer')
         }),
-        'stop_grace_period' => optional(/(\d+(?:\.\d+)?)([hms])/)
+        'stop_grace_period' => optional(/(\d+(?:\.\d+)?)([hms])/),
+        'read_only' => optional('boolean')
       }
     end
 

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -31,6 +31,7 @@ class GridService
   field :log_opts, type: Hash, default: {}
   field :devices, type: Array, default: []
   field :pid, type: String
+  field :read_only, type: Boolean, default: false
 
   field :deploy_requested_at, type: DateTime
   field :deployed_at, type: DateTime

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -249,6 +249,7 @@ module GridServices
             string
           end
           string :pid, in: ['host']
+          boolean :read_only
           hash :hooks do
             optional do
               array :post_start do

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -76,6 +76,7 @@ module GridServices
       attributes[:health_check] = self.health_check if self.health_check
       attributes[:volumes_from] = self.volumes_from if self.volumes_from
       attributes[:stop_grace_period] = parse_duration(self.stop_grace_period) if self.stop_grace_period
+      attributes[:read_only] = self.read_only
 
       embeds_changed = false
 

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -76,7 +76,7 @@ module GridServices
       attributes[:health_check] = self.health_check if self.health_check
       attributes[:volumes_from] = self.volumes_from if self.volumes_from
       attributes[:stop_grace_period] = parse_duration(self.stop_grace_period) if self.stop_grace_period
-      attributes[:read_only] = self.read_only
+      attributes[:read_only] = self.read_only unless self.read_only.nil?
 
       embeds_changed = false
 

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -49,7 +49,8 @@ module Rpc
         secrets: build_secrets,
         labels: build_labels,
         hooks: build_hooks,
-        networks: build_networks
+        networks: build_networks,
+        read_only: service.read_only
       }
     end
 

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -41,6 +41,7 @@ json.log_opts grid_service.log_opts
 json.strategy grid_service.strategy
 json.deploy_opts grid_service.deploy_opts
 json.pid grid_service.pid
+json.read_only grid_service.read_only
 json.instance_counts do
   if defined? instance_counts
     json.total instance_counts[:total]
@@ -54,14 +55,14 @@ json.hooks grid_service.hooks.as_json(only: [:name, :type, :cmd, :oneshot])
 json.revision grid_service.revision
 json.stack_revision grid_service.stack_revision
 if grid_service.health_check && grid_service.health_check.protocol
-	json.health_check do
-		json.protocol grid_service.health_check.protocol
-		json.uri grid_service.health_check.uri
-		json.port grid_service.health_check.port
-		json.timeout grid_service.health_check.timeout
-		json.initial_delay grid_service.health_check.initial_delay
-		json.interval grid_service.health_check.interval
-	end
-	json.health_status grid_service.health_status
+    json.health_check do
+        json.protocol grid_service.health_check.protocol
+        json.uri grid_service.health_check.uri
+        json.port grid_service.health_check.port
+        json.timeout grid_service.health_check.timeout
+        json.initial_delay grid_service.health_check.initial_delay
+        json.interval grid_service.health_check.interval
+    end
+    json.health_status grid_service.health_status
 end
 json.stop_grace_period grid_service.stop_grace_period

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -86,7 +86,7 @@ describe '/v1/services' do
         instances cmd entrypoint ports env memory memory_swap cpu_shares
         volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
         strategy deploy_opts pid instance_counts net dns hooks secrets revision
-        stack_revision stop_grace_period
+        stack_revision stop_grace_period read_only
       ).sort
 
   describe 'GET /:id' do

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'stack install' do
-  
+
   after(:each) do
     run 'kontena stack rm --force simple'
   end
@@ -62,6 +62,23 @@ describe 'stack install' do
       k = run 'kontena service show simple/redis'
       expect(k.code).to eq(0)
       expect(k.out.match(/stop_grace_period: 23s/)).to be_truthy
+    end
+  end
+
+  context 'For a stack with read_only' do
+    it 'creates stack service with read_only and updates it properly' do
+      with_fixture_dir("stack/read_only") do
+        run 'kontena stack install redis.yml'
+      end
+      k = run 'kontena service show simple/redis'
+      expect(k.code).to eq(0)
+      expect(k.out.match(/read_only: yes/)).to be_truthy
+      with_fixture_dir("stack/read_only") do
+        run 'kontena stack upgrade simple redis_read_only_false.yml'
+      end
+      k = run 'kontena service show simple/redis'
+      expect(k.code).to eq(0)
+      expect(k.out.match(/read_only: no/)).to be_truthy, k.out
     end
   end
 end

--- a/test/spec/fixtures/stack/read_only/redis.yml
+++ b/test/spec/fixtures/stack/read_only/redis.yml
@@ -1,0 +1,6 @@
+stack: simple
+version: 1.0.0
+services:
+  redis:
+    image: redis:alpine
+    read_only: true

--- a/test/spec/fixtures/stack/read_only/redis_read_only_false.yml
+++ b/test/spec/fixtures/stack/read_only/redis_read_only_false.yml
@@ -1,0 +1,6 @@
+stack: simple
+version: 1.0.0
+services:
+  redis:
+    image: redis:alpine
+    read_only: false


### PR DESCRIPTION
`read-only` containers are a great tool setting up the first line of defence:
https://diogomonica.com/2016/11/19/increasing-attacker-cost-using-immutable-infrastructure/

