### PR TITLE
Use latest HostNodeStat entry when serializing host node

### DIFF
--- a/server/app/serializers/host_node_serializer.rb
+++ b/server/app/serializers/host_node_serializer.rb
@@ -69,7 +69,7 @@ class HostNodeSerializer < KontenaJsonSerializer
   end
 
   def resource_usage
-    stats = object.host_node_stats.last
+    stats = object.host_node_stats.latest
     if stats
       {
         memory: stats.memory,


### PR DESCRIPTION
This PR will use `SortableStat.latest` method introduced in #2534 also when serializing `HostNode`   with the `HostNodeSerializer` class.