### PR TITLE
Rewrite agent websocket client

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk --update add tzdata ruby ruby-irb ruby-bigdecimal \
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 
-RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-dev && \
+RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-dev git && \
     gem install bundler --no-ri --no-rdoc && \
     cd /app ; bundle install --without development test && \
     apk del build-dependencies
@@ -15,4 +15,4 @@ RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-de
 WORKDIR /app
 ADD . /app
 
-CMD ["/app/bin/kontena-agent"]
+CMD ["bundle", "exec", "/app/bin/kontena-agent"]

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -15,4 +15,4 @@ RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-de
 WORKDIR /app
 ADD . /app
 
-CMD ["bundle", "exec", "/app/bin/kontena-agent"]
+CMD ["/app/bin/kontena-agent"]

--- a/agent/Gemfile
+++ b/agent/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'kontena-websocket-client', git: 'https://github.com/kontena/kontena-websocket-client.git'
 gem 'docker-api', '~> 1.32.0'
-gem 'eventmachine', '~> 1.2.3'
-gem 'faye-websocket', '~> 0.10.7'
 gem 'msgpack', '~> 1.0.3'
 gem 'activesupport', '~> 4.2.0'
 gem 'celluloid', '~> 0.17.3'

--- a/agent/Gemfile
+++ b/agent/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'kontena-websocket-client', git: 'https://github.com/kontena/kontena-websocket-client.git'
+gem 'kontena-websocket-client', '~> 0.1.0'
 gem 'docker-api', '~> 1.32.0'
 gem 'msgpack', '~> 1.0.3'
 gem 'activesupport', '~> 4.2.0'

--- a/agent/Gemfile.lock
+++ b/agent/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/kontena/kontena-websocket-client.git
-  revision: e70d1435cdce9d2979e5b9914cbdf05d6e0e1f57
-  specs:
-    kontena-websocket-client (0.1.0)
-      websocket-driver (~> 0.6.5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -48,6 +41,8 @@ GEM
     hitimes (1.2.3)
     i18n (0.7.0)
     json (1.8.3)
+    kontena-websocket-client (0.1.0)
+      websocket-driver (~> 0.6.5)
     minitest (5.5.0)
     mixlib-log (1.6.0)
     msgpack (1.0.3)
@@ -94,7 +89,7 @@ DEPENDENCIES
   dotenv
   etcd
   fluent-logger (~> 0.6.2)
-  kontena-websocket-client!
+  kontena-websocket-client (~> 0.1.0)
   msgpack (~> 1.0.3)
   rake
   rspec
@@ -104,4 +99,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/agent/Gemfile.lock
+++ b/agent/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/kontena/kontena-websocket-client.git
+  revision: e70d1435cdce9d2979e5b9914cbdf05d6e0e1f57
+  specs:
+    kontena-websocket-client (0.1.0)
+      websocket-driver (~> 0.6.5)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -35,11 +42,7 @@ GEM
     dotenv (1.0.2)
     etcd (0.3.0)
       mixlib-log
-    eventmachine (1.2.3)
     excon (0.54.0)
-    faye-websocket (0.10.7)
-      eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.5.1)
     fluent-logger (0.6.2)
       msgpack (>= 0.5.6, < 2)
     hitimes (1.2.3)
@@ -90,9 +93,8 @@ DEPENDENCIES
   docker-api (~> 1.32.0)
   dotenv
   etcd
-  eventmachine (~> 1.2.3)
-  faye-websocket (~> 0.10.7)
   fluent-logger (~> 0.6.2)
+  kontena-websocket-client!
   msgpack (~> 1.0.3)
   rake
   rspec
@@ -102,4 +104,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.3
+   1.15.1

--- a/agent/bin/kontena-agent
+++ b/agent/bin/kontena-agent
@@ -31,9 +31,12 @@ else
 end
 Kontena::Logging.initialize_logger(STDOUT, log_level)
 
-agent = Kontena::Agent.new(
+agent = Kontena::Agent.instance
+agent.configure(
   api_uri: api_uri,
   grid_token: grid_token,
   node_token: node_token,
+  ssl_verify: ENV['KONTENA_SSL_VERIFY'],
+  ssl_hostname: ENV['KONTENA_SSL_HOSTNAME'],
 )
 agent.run!

--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -1,13 +1,11 @@
 require 'docker'
-require 'faye/websocket'
-require 'eventmachine'
 require 'thread'
-
 require 'statsd'
 require 'celluloid/current'
 require 'celluloid/autostart'
 require 'active_support/core_ext/time'
 require 'active_support/core_ext/module/delegation'
+require 'kontena-websocket-client'
 
 require_relative 'ipaddr_helpers'
 

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -1,78 +1,131 @@
+require 'singleton'
 require_relative 'logging'
 
 module Kontena
   class Agent
+    include Singleton
     include Logging
 
     VERSION = File.read('./VERSION').strip
 
-    def initialize(opts)
-      info "initializing agent (version #{VERSION})"
-      @opts = opts
-      @client = Kontena::WebsocketClient.new(@opts[:api_uri],
-        grid_token: @opts[:grid_token],
-        node_token: @opts[:node_token],
-      )
-      @supervisor = Celluloid::Supervision::Container.run!
-      self.supervise_state
-      self.supervise_launchers
-      self.supervise_network_adapter
-      self.supervise_lb
-      self.supervise_workers
+    # Called from other actors
+    def self.shutdown
+      instance.write_signal('shutdown')
     end
 
-    # Connect to master server
-    def connect!
-      start_em
-      @client.ensure_connect
+    def initialize
+      info "initializing agent (version #{VERSION})"
+
+      @read_pipe, @write_pipe = IO.pipe
+    end
+
+    def configure(opts)
+      @opts = opts
+    end
+
+    def ssl_verify?
+      return false if @opts[:ssl_verify].nil?
+      return false if @opts[:ssl_verify].empty?
+      return true
+    end
+
+    def ssl_params
+      {
+        verify_mode: self.ssl_verify? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
+      }
+    end
+
+    def ssl_hostname
+      @opts[:ssl_hostname]
+    end
+
+    def write_signal(sig)
+      @write_pipe.puts(sig)
     end
 
     def run!
-      self_read, self_write = IO.pipe
-
-      %w(TERM TTIN).each do |sig|
-        trap sig do
-          self_write.puts(sig)
-        end
+      trap 'TERM' do
+        write_signal('shutdown')
+      end
+      trap 'TTIN' do
+        write_signal('trace')
       end
 
-      begin
-        connect!
+      self.supervise
 
-        while readable_io = IO.select([self_read])
-          signal = readable_io.first[0].gets.strip
-          handle_signal(signal)
-        end
-      rescue Interrupt
-        exit(0)
+      while line = @read_pipe.gets
+        handle_signal line.strip
       end
+    rescue Interrupt
+      exit(0)
     end
 
     # @param [String] signal
     def handle_signal(signal)
       info "Got signal #{signal}"
       case signal
-      when 'TERM'
-        info "Shutting down..."
-        EM.stop
-        @supervisor.shutdown
-        raise Interrupt
-      when 'TTIN'
-        Thread.list.each do |thread|
-          warn "Thread #{thread.object_id.to_s(36)} #{thread['label']}"
-          if thread.backtrace
-            warn thread.backtrace.join("\n")
-          else
-            warn "no backtrace available"
-          end
+      when 'shutdown'
+        self.handle_shutdown
+      when 'trace'
+        self.handle_trace
+      end
+    end
+
+    def handle_shutdown
+      info "Shutting down..."
+      @supervisor.shutdown # shutdown all actors
+      @write_pipe.close # let run! break and return
+    end
+
+    def handle_trace
+      info "Dump thread trace..."
+
+      Thread.list.each do |thread|
+        warn "Thread #{thread.object_id.to_s(36)} #{thread['label']}"
+        if thread.backtrace
+          warn thread.backtrace.join("\n")
+        else
+          warn "no backtrace available"
         end
       end
+    end
+
+    def supervise
+      @supervisor = Celluloid::Supervision::Container.run!
+
+      self.supervise_state
+      self.supervise_rpc
+      self.supervise_launchers
+      self.supervise_network_adapter
+      self.supervise_lb
+      self.supervise_workers
     end
 
     def supervise_state
       @supervisor.supervise(
         type: Kontena::Workers::NodeInfoWorker,
         as: :node_info_worker
+      )
+    end
+
+    def supervise_rpc
+      @supervisor.supervise(
+        type: Kontena::RpcServer,
+        as: :rpc_server,
+      )
+      @supervisor.supervise(
+        type: Kontena::RpcClient,
+        as: :rpc_client,
+      )
+      @supervisor.supervise(
+        type: Kontena::WebsocketClient,
+        as: :websocket_client,
+        args: [@opts[:api_uri],
+          grid_token: @opts[:grid_token],
+          node_token: @opts[:node_token],
+          ssl_params: self.ssl_params,
+          ssl_hostname: self.ssl_hostname,
+        ],
       )
     end
 
@@ -158,15 +211,6 @@ module Kontena
         type: Kontena::LoadBalancers::Registrator,
         as: :lb_registrator
       )
-    end
-
-    def start_em
-      EM.epoll
-      Thread.new {
-        Thread.current.abort_on_exception = true
-        EventMachine.run
-      } unless EventMachine.reactor_running?
-      sleep 0.01 until EventMachine.reactor_running?
     end
   end
 end

--- a/agent/lib/kontena/helpers/rpc_helper.rb
+++ b/agent/lib/kontena/helpers/rpc_helper.rb
@@ -12,13 +12,7 @@ module Kontena
       # @raise [Kontena::RpcClient::Error]
       # @return [Object]
       def rpc_request(method, params)
-        response, error = rpc_client.request_with_error(method, params)
-
-        if error
-          raise error
-        else
-          return response
-        end
+        rpc_client.request(method, params)
       end
     end
   end

--- a/agent/lib/kontena/rpc_client.rb
+++ b/agent/lib/kontena/rpc_client.rb
@@ -23,72 +23,61 @@ module Kontena
 
     attr_reader :requests
 
-    # @param [Kontena::WebsocketClient] client
-    def initialize(client)
+    def initialize
       @requests = {}
-      @client = client
       info 'initialized'
     end
 
+    def websocket_client
+      Celluloid::Actor[:websocket_client]
+    end
+
     def connected?
-      @client.connected?
+      websocket_client && websocket_client.connected?
     end
 
     # @param [String] method
     # @param [Array] params
     def notification(method, params)
-      @client.send_notification(method, params)
+      websocket_client.async.send_notification(method, params)
     rescue => exc
       logger.error exc.message
     end
 
-    # This method should not raise, or the Actor will crash, and terminate any other pending requests.
+    # Aborts caller on errors.
     #
     # @param [String] method
     # @param [Array] params
     # @param [Fixnum] timeout seconds
-    # @return [Object, Exception]
-    def request_with_error(method, params, timeout: 30)
+    # @raise abort
+    # @return [Object]
+    def request(method, params, timeout: 30)
       id = request_id
       @requests[id] = nil
 
-      if !wait_until("websocket client is connected", timeout: timeout, threshold: 10.0, interval: 0.1) { @client.connected? }
-        return nil, TimeoutError.new(500, 'WebsocketClient is not connected')
+      if !wait_until("websocket client is connected", timeout: timeout, threshold: 10.0, interval: 0.1) { connected? }
+        raise TimeoutError.new(500, 'WebsocketClient is not connected')
       end
 
-      @client.send_request(id, method, params)
+      websocket_client.send_request(id, method, params)
 
       if !wait_until("request #{method} has response wth id=#{id}", timeout: timeout, interval: 0.01) { @requests[id] }
-        return nil, TimeoutError.new(500, 'Request timed out')
+        raise TimeoutError.new(500, 'Request timed out')
       end
 
       result, error = @requests.delete(id)
 
       if error
-        return result, Error.new(error['code'], error['message'])
-      else
-        return result, nil
-      end
-    end
-
-    # Async request wrapper.
-    #
-    # Logs a warning and returns nil on errors.
-    # Use Kontena::Helpers::RpcError.rpc_request to get a raised error instead.
-    #
-    # @return [Object, nil]
-    def request(method, params, **opts)
-      result, error = request_with_error(method, params, **opts)
-
-      if error
-        warn "RPC request #{method} failed: #{error}"
-        return nil
+        raise Error.new(error['code'], error['message'])
       else
         return result
       end
+    rescue => exc
+      warn exc
+      abort exc
     end
 
-    # Called from Kontena::WebsocketClient in the EM thread
+    # Sent by the Kontena::WebsocketClient actor
     def handle_response(response)
       type, msgid, error, result = response
       @requests[msgid] = [result, error]

--- a/agent/lib/kontena/rpc_server.rb
+++ b/agent/lib/kontena/rpc_server.rb
@@ -32,6 +32,7 @@ module Kontena
     exclusive :handle_notification
 
     ##
+    # @param ws_client [Kontena::WebsocketClient] celluloid actor proxy
     # @param [Array] message msgpack-rpc request array
     # @return [Array]
     def handle_request(ws_client, message)
@@ -58,7 +59,7 @@ module Kontena
     # @param [WebsocketClient] ws_client
     # @param [Array, Hash] msg
     def send_message(ws_client, msg)
-      ws_client.send_message(MessagePack.dump(msg).bytes)
+      ws_client.async.send_message(MessagePack.dump(msg).bytes)
     end
 
     ##

--- a/agent/spec/lib/kontena/rpc_client_spec.rb
+++ b/agent/spec/lib/kontena/rpc_client_spec.rb
@@ -1,10 +1,11 @@
 describe Kontena::RpcClient, :celluloid => true do
 
   let(:ws_client) { instance_double(Kontena::WebsocketClient) }
-  let(:subject) { described_class.new(ws_client) }
+  let(:subject) { described_class.new() }
 
   before do
     allow(ws_client).to receive(:connected?).and_return(true)
+    allow(subject.wrapped_object).to receive(:websocket_client).and_return(ws_client)
   end
 
   describe '#request_id' do
@@ -24,7 +25,7 @@ describe Kontena::RpcClient, :celluloid => true do
     end
   end
 
-  describe '#request_with_error' do
+  describe '#request' do
     it "returns the response" do
       expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) do |id, method, params|
         Celluloid.after(0.0) {
@@ -32,7 +33,7 @@ describe Kontena::RpcClient, :celluloid => true do
         }
       end
 
-      expect(subject.request_with_error("/test", ["foo"], timeout: 1.0)).to eq ["foobar", nil]
+      expect(subject.request("/test", ["foo"], timeout: 1.0)).to eq "foobar"
     end
 
     it "returns any error" do
@@ -42,34 +43,16 @@ describe Kontena::RpcClient, :celluloid => true do
         }
       end
 
-      expect(subject.request_with_error("/test", ["foo"], timeout: 1.0)).to eq [nil, Kontena::RpcClient::Error.new(500, "test error")]
+      expect{subject.request("/test", ["foo"], timeout: 1.0)}.to raise_error(Kontena::RpcClient::Error, "test error")
     end
 
     it "returns a timeout error" do
       expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) # do nothing..
 
-      expect(subject.request_with_error("/test", ["foo"], timeout: 0.01)).to match [nil, Kontena::RpcClient::TimeoutError]
-    end
-  end
-
-  describe '#request' do
-    it "returns the response" do
-      expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) do |id, method, params|
-        Celluloid.after(0.0) {
-          subject.async.handle_response([1, id, nil, "foobar"])
-        }
-      end
-
-      expect(subject.wrapped_object).not_to receive(:warn)
-      expect(subject.request("/test", ["foo"], timeout: 1.0)).to eq "foobar"
-    end
-
-    it "returns nil and logs a warning on errors" do
-      expect(ws_client).to receive(:send_request).with(Fixnum, "/test", ["foo"]) # do nothing..
-
       expect(subject.wrapped_object).to receive(:warn).with(/timeout after waiting/)
-      expect(subject.wrapped_object).to receive(:warn).with("RPC request /test failed: Request timed out")
-      expect(subject.request("/test", ["foo"], timeout: 0.01)).to be_nil
+      expect(subject.wrapped_object).to receive(:warn).with(Kontena::RpcClient::TimeoutError)
+
+      expect{subject.request("/test", ["foo"], timeout: 0.01)}.to raise_error(Kontena::RpcClient::TimeoutError)
     end
   end
 
@@ -93,13 +76,9 @@ describe Kontena::RpcClient, :celluloid => true do
       expect(subject.wrapped_object).to receive(:sleep).at_least(:once).and_call_original
 
       requests = (1..count).map{ |i|
-        subject.future.request_with_error("/echo", [i])
+        subject.future.request("/echo", [i])
       }
-      responses = requests.map{|f|
-        response, error = f.value
-        expect(error).to be_nil
-        response[0]
-      }
+      responses = requests.map{|f| f.value[0] }
 
       expect(responses).to match_array (1..count).to_a
     end

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -1,248 +1,595 @@
-
-describe Kontena::WebsocketClient do
-  let(:api_uri) { 'http://test' }
-  let(:grid_token) { 'test' }
+describe Kontena::WebsocketClient, :celluloid => true do
+  let(:url) { 'ws://socket.example.com' }
+  let(:grid_token) { 'secret' }
   let(:node_token) { nil }
+  let(:ssl_params) { {} }
+  let(:options) {  {} }
 
-  let(:subject) { described_class.new(api_uri, grid_token: grid_token, node_token: node_token)}
+  let(:node_id) { 'ABCD' }
+  let(:labels) { ['region=test'] }
 
-  before(:each) {
-    Celluloid.boot
-    allow_any_instance_of(described_class).to receive(:host_id).and_return('ABCD')
-    allow_any_instance_of(described_class).to receive(:labels).and_return(['region=test'])
-  }
-  after(:each) { Celluloid.shutdown }
-
-  around(:each, :em => true) do |example|
-    EM.run {
-      example.run
-      EM.stop
-    }
+  before do
+    allow_any_instance_of(described_class).to receive(:host_id).and_return(node_id)
+    allow_any_instance_of(described_class).to receive(:labels).and_return(labels)
   end
 
-  describe '#connected?' do
-    it 'returns false by default' do
-      expect(subject.connected?).to eq(false)
+  let(:actor) {
+    described_class.new(url,
+      grid_token: grid_token,
+      node_token: node_token,
+      ssl_params: ssl_params,
+      autostart: false,
+      **options
+    )
+  }
+  subject { actor.wrapped_object }
+  let(:async) { instance_double(described_class) }
+
+  before do
+    allow(subject).to receive(:async).and_return(async)
+  end
+
+  before do
+    # run timers immediately, once
+    allow(subject.wrapped_object).to receive(:every) do |&block|
+      block.call
+    end
+  end
+
+  describe '#initialize' do
+    it 'is not connected' do
+      expect(subject.connected?).to be false
     end
 
-    it 'returns true if connection is established' do
-      subject.on_open(spy(:event))
-      expect(subject.connected?).to eq(true)
+    it 'is not connecting' do
+      expect(subject.connecting?).to be false
+    end
+  end
+
+  describe '#start' do
+    it 'connects' do
+      expect(subject).to receive(:connect)
+
+      actor.start
     end
   end
 
   describe '#connect' do
-    it 'sets connecting to true' do
-      expect {
-        subject.connect
-      }.to change{ subject.connecting? }.from(false).to(true)
+    it 'creates a websocket client and calls run_websocket' do
+      expect(async).to receive(:connect_client)
+      expect(subject).to receive(:publish).with('websocket:connect', nil)
+
+      actor.connect
+
+      expect(subject).to be_connecting
+      expect(subject).to_not be_connected
+      expect(subject.ws).to be_a Kontena::Websocket::Client
+      expect(subject.ws.url).to eq 'ws://socket.example.com'
+      expect(subject.ws.ssl?).to be false
+      expect(subject.ws.ssl_verify?).to be false
+      expect(subject.ws.instance_variable_get('@headers')).to match(
+        'Kontena-Grid-Token' => 'secret',
+        'Kontena-Node-Id' => 'ABCD',
+        'Kontena-Version' => Kontena::Agent::VERSION,
+        'Kontena-Node-Labels' => 'region=test',
+        'Kontena-Connected-At' => String,
+      )
     end
 
-    it 'sets connected to false' do
-      subject.on_open(spy)
-      expect {
-        subject.connect
-      }.to change{ subject.connected? }.from(true).to(false)
-    end
-  end
+    context 'with a node token' do
+      let(:grid_token) { nil }
+      let(:node_token) { 'node-secret' }
+      it 'creates a websocket client with Kontena-Node-Token header' do
+        expect(async).to receive(:connect_client)
 
-  describe '#on_open' do
-    it 'sets connected to true' do
-      expect(subject.connected?).to be_falsey
-      subject.on_open(spy)
-      expect(subject.connected?).to be_truthy
-    end
+        actor.connect
 
-    it 'sets connecting to false' do
-      subject.connect
-      expect(subject.connecting?).to be_truthy
-      subject.on_open(spy)
-      expect(subject.connecting?).to be_falsey
-    end
-
-    it 'cancels ping timer' do
-      timer = spy(:timer)
-      allow(subject).to receive(:ping_timer).and_return(timer)
-      expect(timer).to receive(:cancel)
-      subject.on_open(spy)
-    end
-  end
-
-  describe '#on_error' do
-    context "For a server that is ECONNREFUSED" do
-      subject do
-        described_class.new('ws://127.0.0.1:1337', grid_token: 'test-token')
+        expect(subject).to be_connecting
+        expect(subject).to_not be_connected
+        expect(subject.ws).to be_a Kontena::Websocket::Client
+        expect(subject.ws.url).to eq 'ws://socket.example.com'
+        expect(subject.ws.ssl?).to be false
+        expect(subject.ws.ssl_verify?).to be false
+        expect(subject.ws.instance_variable_get('@headers')).to match(
+          'Kontena-Node-Token' => 'node-secret',
+          'Kontena-Node-Id' => 'ABCD',
+          'Kontena-Version' => Kontena::Agent::VERSION,
+          'Kontena-Node-Labels' => 'region=test',
+          'Kontena-Connected-At' => String,
+        )
       end
+    end
+  end
 
-      it "logs an error", :em => false do
-        expect(subject).to receive(:error).with(/connection refused/) do |event|
-          EM.stop
+  describe '#ws' do
+    it 'fails when not connected' do
+      expect{subject.ws}.to raise_error(RuntimeError, "not connected")
+    end
+  end
+
+  describe '#send_message' do
+    it 'fails when not connected' do
+      expect{actor.send_message('asdf')}.to raise_error(RuntimeError, "not connected")
+    end
+  end
+  describe '#send_notification' do
+    it 'fails when not connected' do
+      expect{actor.send_notification('/test', [])}.to raise_error(RuntimeError, "not connected")
+    end
+  end
+  describe '#send_request' do
+    it 'fails when not connected' do
+      expect{actor.send_request(1, '/test', [])}.to raise_error(RuntimeError, "not connected")
+    end
+  end
+
+  context 'with an invalid URL' do
+    let(:url) { 'http://api.example.com' }
+
+    describe '#connect' do
+      it 'logs error and does not set connecting' do
+        expect(subject).to receive(:error).with(ArgumentError) do |err|
+          expect(err.message).to eq 'Invalid websocket URL: http://api.example.com'
         end
 
-        # XXX: EM will segfault if the mock raises
-        # =>   https://github.com/eventmachine/eventmachine/issues/765
-        EM.run {
-          subject.connect
-        }
+        actor.connect
+
+        expect(subject.connecting?).to be false
       end
     end
   end
 
-  describe '#on_close' do
-    let(:event) { Faye::WebSocket::API::CloseEvent.new('close', {}) }
+  context 'for a wss:// URL with defaults' do
+    let(:url) { 'wss://socket.example.com' }
+
+    describe '#connect' do
+      it 'creates a websocket client with ssl, and ssl_verify' do
+        expect(async).to receive(:connect_client)
+
+        actor.connect
+
+        expect(subject.ws).to be_a Kontena::Websocket::Client
+        expect(subject.ws.url).to eq 'wss://socket.example.com'
+        expect(subject.ws.ssl?).to be true
+        expect(subject.ws.ssl_verify?).to be true
+      end
+    end
+  end
+
+  context 'for a wss:// URL without ssl verify' do
+    let(:url) { 'wss://socket.example.com' }
+    let(:ssl_params) { { verify_mode: OpenSSL::SSL::VERIFY_NONE }}
+
+    describe '#connect' do
+      it 'creates a websocket client with ssl and no ssl_verify' do
+        expect(async).to receive(:connect_client)
+
+        actor.connect
+
+        expect(subject.ws).to be_a Kontena::Websocket::Client
+        expect(subject.ws.url).to eq 'wss://socket.example.com'
+        expect(subject.ws.ssl?).to be true
+        expect(subject.ws.ssl_verify?).to be false
+      end
+    end
+  end
+
+  context 'for a wss:// URL with ssl_hostname' do
+    let(:url) { 'wss://socket.example.com' }
+    let(:options) { { ssl_hostname: 'test'} }
+
+    describe '#connect' do
+      it 'creates a websocket client with ssl and ssl_hostname' do
+        expect(async).to receive(:connect_client)
+
+        actor.connect
+
+        expect(subject.ws).to be_a Kontena::Websocket::Client
+        expect(subject.ws.url).to eq 'wss://socket.example.com'
+        expect(subject.ws.ssl?).to be true
+        expect(subject.ws.ssl_hostname).to eq 'test'
+        expect(subject.ws.ssl_verify?).to be true
+      end
+    end
+  end
+
+  context 'for a connecting websocket client' do
+    let(:ws_client) { instance_double(Kontena::Websocket::Client) }
 
     before do
-      allow(EM).to receive(:next_tick) do |&block| block.call end
-    end
-
-    it 'sets connected to false' do
-      subject.on_open(spy)
-      expect {
-        subject.on_close(event)
-      }.to change{ subject.connected? }.from(true).to(false)
-    end
-
-    it 'sets connecting to false' do
       subject.instance_variable_set('@connecting', true)
-      expect {
-        subject.on_close(event)
-      }.to change{ subject.connecting? }.from(true).to(false)
+      subject.instance_variable_set('@ws', ws_client)
     end
 
-    it 'aborts on 4001 error code' do
-      event = Faye::WebSocket::API::CloseEvent.new('close', code: 4001)
-      expect(subject).to receive(:handle_invalid_token).and_call_original
-      expect(subject).to receive(:abort)
-      subject.on_close(event)
+    it 'is not connected' do
+      expect(subject.connected?).to be false
     end
 
-    it 'aborts on 4010 error code' do
-      event = Faye::WebSocket::API::CloseEvent.new('close', code: 4010)
-      expect(subject).to receive(:handle_invalid_version).and_call_original
-      expect(subject).to receive(:abort)
-      subject.on_close(event)
+    it 'is connecting' do
+      expect(subject.connecting?).to be true
     end
 
-    it 'disconnects on 4030 error code' do
-      event = Faye::WebSocket::API::CloseEvent.new('close', code: 4030)
-      expect(subject).to_not receive(:abort)
-      subject.on_close(event)
+    describe '#start' do
+      it 'does not connect' do
+        expect(subject).not_to receive(:connect)
+
+        actor.start
+      end
     end
 
-    it 'aborts on 4040 error code' do
-      event = Faye::WebSocket::API::CloseEvent.new('close', code: 4040)
-      expect(subject).to receive(:handle_invalid_connection).and_call_original
-      expect(subject).to receive(:abort)
-      subject.on_close(event)
+    describe '#connect_client' do
+      before do
+        allow(ws_client).to receive(:on_pong) do |&block|
+          @on_pong = block
+        end
+      end
+
+      it 'runs the websocket client in a separate thread, and is no longer connecting after it returns' do
+        expect(ws_client).to receive(:connect) do
+          expect(Celluloid.actor?).to be false
+        end
+        expect(subject).to receive(:on_open) do
+          expect(Celluloid.actor?).to be true
+          expect(Celluloid.current_actor).to eq actor
+        end
+
+        expect(ws_client).to receive(:read) do |&block|
+          expect(subject).to receive(:on_message).with('test')
+
+          block.call 'test'
+
+          allow(ws_client).to receive(:close_code).and_return(1000)
+          allow(ws_client).to receive(:close_reason).and_return ''
+        end
+        expect(subject).to_not receive(:on_error)
+        expect(subject).to receive(:on_close).with(1000, '')
+
+        expect(ws_client).to receive(:disconnect)
+
+        actor.connect_client(ws_client)
+
+        expect(subject.connecting?).to be false
+        expect(subject.connected?).to be false
+      end
+
+      it 'handles websocket connect errors' do
+        expect(ws_client).to receive(:connect) do |&block|
+          raise Kontena::Websocket::SSLVerifyError.new(OpenSSL::X509::V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT), 'certificate verify failed: self signed certificate'
+        end
+        expect(ws_client).to receive(:disconnect)
+
+        expect(subject).to receive(:on_error).with(Kontena::Websocket::SSLVerifyError)
+
+        actor.connect_client(ws_client)
+
+        expect(subject.connecting?).to be false
+        expect(subject.connected?).to be false
+      end
+
+      it 'handles websocket read errors' do
+        expect(ws_client).to receive(:connect)
+        expect(subject).to receive(:on_open)
+        expect(ws_client).to receive(:read) do |&block|
+          raise Kontena::Websocket::TimeoutError, 'ping timeout'
+        end
+        expect(ws_client).to receive(:disconnect)
+
+        expect(subject).to receive(:on_error).with(Kontena::Websocket::TimeoutError)
+
+        actor.connect_client(ws_client)
+
+        expect(subject.connecting?).to be false
+        expect(subject.connected?).to be false
+      end
+
+      it 'handles websocket close errors' do
+        expect(ws_client).to receive(:connect)
+        expect(subject).to receive(:on_open)
+
+        expect(ws_client).to receive(:read) do |&block|
+          raise Kontena::Websocket::CloseError.new(1337, 'testing')
+        end
+        expect(subject).to receive(:on_close).with(1337, 'testing')
+
+        expect(ws_client).to receive(:disconnect)
+
+        actor.connect_client(ws_client)
+
+        expect(subject.connecting?).to be false
+        expect(subject.connected?).to be false
+      end
+
+      it 'handles websocket close' do
+        expect(ws_client).to receive(:connect)
+        expect(subject).to receive(:on_open)
+
+        expect(ws_client).to receive(:read) do |&block|
+          allow(ws_client).to receive(:close_code).and_return(1337)
+          allow(ws_client).to receive(:close_reason).and_return 'testing'
+        end
+        expect(subject).to receive(:on_close).with(1337, 'testing')
+
+        expect(ws_client).to receive(:disconnect)
+
+        actor.connect_client(ws_client)
+
+        expect(subject.connecting?).to be false
+        expect(subject.connected?).to be false
+      end
+
+      it 'handles unkonwn errors' do
+        expect(ws_client).to receive(:connect) do |&block|
+          fail 'test'
+        end
+        expect(ws_client).to receive(:disconnect)
+
+        expect(subject).not_to receive(:on_error)
+        expect(subject.logger).to receive(:error)
+
+        actor.connect_client(ws_client)
+
+        expect(subject.connecting?).to be false
+        expect(subject.connected?).to be false
+      end
     end
 
-    it 'aborts on 4041 error code' do
-      event = Faye::WebSocket::API::CloseEvent.new('close', code: 4040)
-      expect(subject).to receive(:handle_invalid_connection).and_call_original
-      expect(subject).to receive(:abort)
-      subject.on_close(event)
+    describe '#ws' do
+      it 'returns websocket client' do
+        expect(subject.ws).to eq ws_client
+      end
     end
 
-    it 'publishes websocket:close' do
-      expect(Celluloid::Notifications).to receive(:publish).with('websocket:close', nil)
-      subject.on_close(event)
+    describe '#on_open' do
+      context 'without ssl' do
+        before do
+          allow(ws_client).to receive(:ssl_cert!).and_return(nil)
+          allow(ws_client).to receive(:ssl_verify?).and_return(false)
+        end
+
+        it 'updates connecting -> connected and published websocket:open' do
+          expect(subject).to receive(:info).with('unsecure connection established without SSL')
+          expect(subject).to receive(:publish).with('websocket:open', nil)
+
+          actor.on_open
+
+          expect(subject.connecting?).to be false
+          expect(subject.connected?).to be true
+        end
+      end
+
+      context 'for a wss:// URL with ssl_verify' do
+        let(:url) { 'wss://socket.example.com' }
+        let(:ssl_params) { { verify_mode: OpenSSL::SSL::VERIFY_PEER }}
+
+        before do
+          allow(ws_client).to receive(:ssl_verify?).and_return(true)
+        end
+
+        it 'logs the subject and issuer of a verified cert' do
+          expect(ws_client).to receive(:ssl_cert!).and_return(instance_double(OpenSSL::X509::Certificate,
+            issuer: '/CN=ca',
+            subject: '/CN=test',
+          ))
+          expect(subject).to receive(:info).with('secure connection established with KONTENA_SSL_VERIFY: /CN=test (issuer /CN=ca)')
+
+          actor.on_open
+        end
+      end
+
+      context 'for a wss:// URL without ssl verify' do
+        let(:url) { 'wss://socket.example.com' }
+        let(:ssl_params) { { verify_mode: OpenSSL::SSL::VERIFY_NONE }}
+
+        before do
+          allow(ws_client).to receive(:ssl_verify?).and_return(false)
+        end
+
+        it 'logs a warning about unverified cert' do
+          expect(ws_client).to receive(:ssl_cert!).and_raise(Kontena::Websocket::SSLVerifyError.new(OpenSSL::X509::V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT), 'self signed certificate')
+          expect(subject).to receive(:warn).with('insecure connection established with SSL errors: certificate verify failed: self signed certificate')
+
+          actor.on_open
+        end
+
+        it 'logs a warning about verified cert' do
+          expect(ws_client).to receive(:ssl_cert!).and_return(instance_double(OpenSSL::X509::Certificate,
+            issuer: '/CN=ca',
+            subject: '/CN=test',
+          ))
+
+          expect(subject).to receive(:warn).with('secure connection established without KONTENA_SSL_VERIFY=true: /CN=test (issuer /CN=ca)')
+
+          actor.on_open
+        end
+      end
+    end
+
+    describe '#on_error' do
+      let(:ssl_cert) { instance_double(OpenSSL::X509::Certificate,
+        subject: OpenSSL::X509::Name.parse('/CN=test'),
+        issuer: OpenSSL::X509::Name.parse('/CN=test-ca'),
+      ) }
+
+      it 'logs ssl verify errors with cert details' do
+        expect(subject).to receive(:error).with("unable to connect to SSL server with KONTENA_SSL_VERIFY=true: certificate verify failed: self signed certificate (subject /CN=test, issuer /CN=test-ca)")
+
+        subject.on_error(Kontena::Websocket::SSLVerifyError.new(OpenSSL::X509::V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT, ssl_cert, [], 'self signed certificate'))
+      end
+
+      it 'logs ssl verify errors' do
+        expect(subject).to receive(:error).with("unable to connect to SSL server with KONTENA_SSL_VERIFY=true: certificate verify failed: self signed certificate")
+
+        subject.on_error(Kontena::Websocket::SSLVerifyError.new(OpenSSL::X509::V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT, nil, [], 'self signed certificate'))
+      end
+
+      it 'logs ssl errors' do
+        expect(subject).to receive(:error).with("unable to connect to SSL server: SSL_connect SYSCALL returned=5 errno=0 state=unknown state")
+
+        subject.on_error(Kontena::Websocket::SSLConnectError.new('SSL_connect SYSCALL returned=5 errno=0 state=unknown state'))
+      end
+
+      it 'logs protocol errors' do
+        expect(subject).to receive(:error).with("unexpected response from server, check url: Error during WebSocket handshake: Unexpected response code: 404")
+
+        subject.on_error(Kontena::Websocket::ProtocolError.new('Error during WebSocket handshake: Unexpected response code: 404'))
+      end
+
+      it 'logs other errors' do
+        expect(subject).to receive(:error).with("websocket error: testing")
+
+        subject.on_error(Kontena::Websocket::Error.new('testing')) # XXX: other examples?
+      end
     end
   end
 
-  describe '#verify_connection' do
-    let :ws do
-      instance_double(Faye::WebSocket::Client)
-    end
+  context 'for a connected websocket client' do
+    let(:ws_client) { instance_double(Kontena::Websocket::Client) }
 
     before do
-      stub_const("Kontena::WebsocketClient::PING_TIMEOUT", 0.1)
-      allow(subject).to receive(:ws).and_return(ws)
+      subject.instance_variable_set('@connecting', false)
+      subject.instance_variable_set('@connected', true)
+      subject.instance_variable_set('@ws', ws_client)
     end
 
-    it "logs a warning if delay is over threshold", :em => false do
-      expect(ws).to receive(:ping) do |&block|
-        sleep 0.05
-
-        block.call
-
-        EM.stop
-      end
-
-      expect(subject).to receive(:warn).with(/keepalive ping \d+.\d+s/)
-
-      EM.run {
-        subject.verify_connection
-      }
+    it 'is not connected' do
+      expect(subject.connected?).to be true
     end
 
-    it "logs an error and closes the connection if over timeout", :em => false do
-      expect(ws).to receive(:ping) do |&block|
-        # nothing, let the ping timer expire
-      end
-
-      expect(subject).to receive(:connected?).and_return(true)
-      expect(subject).to receive(:error).with(/keepalive ping \d+.\d+s timeout/)
-
-      expect(subject).to receive(:close) do
-        EM.stop
-      end
-
-      EM.run {
-        subject.verify_connection
-      }
-    end
-  end
-
-  describe '#close' do
-    let :ws do
-      instance_double(Faye::WebSocket::Client)
+    it 'is not connecting' do
+      expect(subject.connecting?).to be false
     end
 
-    before do
-      allow(subject).to receive(:ws).and_return(ws)
+    describe '#start' do
+      it 'does not connect' do
+        expect(subject).not_to receive(:connect)
+
+        actor.start
+      end
     end
 
-    it 'publishes event', :em => true do
-      expect(Celluloid::Notifications).to receive(:publish).with('websocket:disconnect', nil)
-      expect(ws).to receive(:close)
-      subject.close
+    describe '#ws' do
+      it 'returns websocket client' do
+        expect(subject.ws).to eq ws_client
+      end
     end
 
-    context "for a connected websocket", :em => true do
-      let :open_event do
-        double(:open_event)
-      end
-      let :close_event do
-        double(:close_event, code: 1006, reason: "Connection closed")
-      end
+    describe '#send_message' do
+      it 'sends message via websocket client' do
+        expect(ws_client).to receive(:send).with('asdf')
 
-      let :close_timer do
-        instance_double(EM::Timer)
+        subject.send_message('asdf')
       end
+    end
+    describe '#send_notification' do
+      it 'sends message via websocket client' do
+        expect(ws_client).to receive(:send).with([147, 2, 165, 47, 116, 101, 115, 116, 145, 164, 97, 115, 100, 102])
+
+        subject.send_notification('/test', ['asdf'])
+      end
+    end
+    describe '#send_request' do
+      it 'sends message via websocket client' do
+        expect(ws_client).to receive(:send).with([148, 0, 1, 165, 47, 116, 101, 115, 116, 145, 164, 97, 115, 100, 102])
+
+        subject.send_request(1, '/test', ['asdf'])
+      end
+    end
+
+    describe '#on_message' do
+      let(:rpc_request) { [0, 1, '/test', ['foo']] }
+      let(:rpc_response) { [1, 1, '/test', ['foo']] }
+      let(:rpc_notification) { [2, '/test', ['foo']] }
+
+      let(:rpc_server) { instance_double(Kontena::RpcServer) }
+      let(:rpc_server_async) { instance_double(Kontena::RpcServer) }
+      let(:rpc_client) { instance_double(Kontena::RpcClient) }
+      let(:rpc_client_async) { instance_double(Kontena::RpcClient) }
 
       before do
-        subject.on_open open_event
+        allow(subject).to receive(:rpc_server).and_return(rpc_server)
+        allow(subject).to receive(:rpc_client).and_return(rpc_client)
 
-        expect(subject).to be_connected
-        expect(subject).to_not be_connecting
+        allow(rpc_server).to receive(:async).and_return(rpc_server_async)
+        allow(rpc_client).to receive(:async).and_return(rpc_client_async)
       end
 
-      it 'eventually sets connection to closed ' do
-        expect(Celluloid::Notifications).to receive(:publish).with('websocket:disconnect', nil)
+      it 'passes an RPC request to the rpc server' do
+        expect(rpc_server_async).to receive(:handle_request).with(actor, rpc_request)
 
-        expect(ws).to receive(:close) { }
+        actor.on_message MessagePack.dump(rpc_request).bytes
+      end
 
-        subject.close
+      it 'passes an RPC response to the rpc client' do
+        expect(rpc_client_async).to receive(:handle_response).with(rpc_response)
 
-        expect(subject).to be_connected
-        expect(subject).to_not be_connecting
+        actor.on_message MessagePack.dump(rpc_response).bytes
+      end
 
-        expect(Celluloid::Notifications).to receive(:publish).with('websocket:close', nil)
+      it 'passes an RPC notification to the rpc server' do
+        expect(rpc_server_async).to receive(:handle_notification).with(rpc_notification)
 
-        subject.on_close close_event
+        actor.on_message MessagePack.dump(rpc_notification).bytes
+      end
+    end
 
-        expect(subject).to_not be_connected
-        expect(subject).to_not be_connecting
+    describe '#on_close' do
+      it 'publishes websocket:close' do
+        expect(subject).to receive(:publish).with('websocket:close', nil)
+
+        actor.on_close(1000, '')
+      end
+
+      it 'aborts on 4001 error code', log_celluloid_actor_crashes: false do
+        expect(subject).to receive(:handle_invalid_token).and_call_original
+        expect(Kontena::Agent).to receive(:shutdown)
+
+        actor.on_close(4001, "Invalid token")
+      end
+
+      it 'aborts on 4010 error code', log_celluloid_actor_crashes: false do
+        expect(subject).to receive(:handle_invalid_version).and_call_original
+        expect(Kontena::Agent).to receive(:shutdown)
+
+        actor.on_close(4010, "Invalid version")
+      end
+
+      it 'disconnects on 4030 error code' do
+        expect(subject).to_not receive(:abort)
+
+        actor.on_close(4030, "Invalid clock")
+      end
+
+      it 'aborts on 4040 error code', log_celluloid_actor_crashes: false do
+        expect(subject).to receive(:handle_invalid_connection).and_call_original
+        expect(Kontena::Agent).to receive(:shutdown)
+
+        actor.on_close(4040, "Invalid node")
+      end
+
+      it 'aborts on 4041 error code', log_celluloid_actor_crashes: false do
+        expect(subject).to receive(:handle_invalid_connection).and_call_original
+        expect(Kontena::Agent).to receive(:shutdown)
+
+        actor.on_close(4041, "Invalid connection")
+      end
+    end
+
+    describe '#on_pong' do
+      it "logs a warning if delay is over threshold", :em => false do
+        sleep 0.05
+
+        expect(subject).to receive(:warn).with(/server ping 3.20s of 5.00s timeout/)
+
+        subject.on_pong(3.2)
+      end
+    end
+
+    describe '#close' do
+      it 'publishes event and closes websocket' do
+        expect(subject).to receive(:publish).with('websocket:disconnect', nil)
+        expect(ws_client).to receive(:close)
+
+        actor.close
       end
     end
   end
@@ -263,15 +610,6 @@ describe Kontena::WebsocketClient do
     it 'returns trus if notification message' do
       msg = [2, 1, 1]
       expect(subject.notification_message?(msg)).to be_truthy
-    end
-  end
-
-  describe '#send_message' do
-    it 'does not raise error if ws is nil' do
-      allow(subject).to receive(:@ws).and_return(nil)
-      expect {
-        subject.send_message('foo')
-      }.not_to raise_error
     end
   end
 end

--- a/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
+++ b/agent/spec/lib/kontena/workers/volumes/volume_manager_spec.rb
@@ -25,27 +25,25 @@ describe Kontena::Workers::Volumes::VolumeManager, :celluloid => true do
 
   describe '#populate_volumes_from_master' do
     it 'fails with a warning if no proper response from master' do
-      expect(rpc_client).to receive(:request_with_error).with('/node_volumes/list', [node.id]).and_return([
+      expect(rpc_client).to receive(:request).with('/node_volumes/list', [node.id]).and_return(
         {
           'volumes' => 'foo'
-        },
-        nil
-      ])
+        }
+      )
       expect(subject.wrapped_object).to receive(:error).with(/Invalid response from master/)
       expect{subject.populate_volumes_from_master}.not_to raise_error
     end
 
     it 'calls terminate and ensure with volumes from master' do
       expect(subject.wrapped_object).to receive(:terminate_volumes).with(['123', '456'])
-      expect(rpc_client).to receive(:request_with_error).with('/node_volumes/list', [node.id]).and_return([
+      expect(rpc_client).to receive(:request).with('/node_volumes/list', [node.id]).and_return(
         {
           'volumes' => [
             {'name' => 'foo', 'volume_instance_id' => '123'},
             {'name' => 'bar', 'volume_instance_id' => '456'}
           ]
-        },
-        nil
-      ])
+        }
+      )
       expect(subject.wrapped_object).to receive(:ensure_volume).twice
       subject.populate_volumes_from_master
     end

--- a/docs/references/environment-variables.md
+++ b/docs/references/environment-variables.md
@@ -29,6 +29,8 @@ toc_order: 2
 The `KONTENA_URI` and either of `KONTENA_TOKEN` or `KONTENA_NODE_TOKEN` is required.
 
 - `KONTENA_URI`: Kontena Master websocket uri, `ws://...` or `wss://...` (required)
+- `KONTENA_SSL_VERIFY`: Verify `wss://` server SSL certificate (default: no verification)
+- `KONTENA_SSL_HOSTNAME`: Override hostname for SSL SNI and certificate subject verification
 - `KONTENA_TOKEN`: Kontena [Grid token](../using-kontena/nodes.md#grid-token)
 - `KONTENA_NODE_TOKEN`: Kontena [Node token](../using-kontena/nodes.md#node-token)
 - `KONTENA_PEER_INTERFACE`: network interface for peer/private communication (default: eth1)
@@ -44,6 +46,8 @@ The `KONTENA_URI` and either of `KONTENA_TOKEN` or `KONTENA_NODE_TOKEN` is requi
 - `WEAVEEXEC_IMAGE`: weave exec image (default: weaveworks/weaveexec)
 - `WEAVE_VERSION`: weave net version
 - `WEBSOCKET_TIMEOUT`: websocket timeout in seconds (default: 5.0)
+- `SSL_CERT_FILE`: path to SSL CA cert bundle file
+- `SSL_CERT_PATH`: path to SSL CA cert bundle directory
 
 ## Kontena CLI
 


### PR DESCRIPTION
Fixes #2500 by replacing the EventMachine-based `faye-websocket` client with the new `kontena-websocket-client` running as a Celluloid actor, which has full support for SSL certificate verification.

* Drop `eventmachine` and `faye-websocket` dependencies

    Now with 100% less EventMachine.

* Add `kontena-websocket-client` dependency

    Supports SSL certification verification.

* Agent `WebsocketClient` is now a celluloid actor

    The new `Kontena::Websocket::Client` should implement open/ping/close timeouts with keepalive pings at least as robustly as the old EM-based client, probably even more robustly.

* Fix agent RPC server/client websocket message sends to log a warning and abort the celluloid call on websocket send errors

## Testing

### Default behavior with `KONTENA_URI=wss://` + invalid cert

Intended to be backwards-compatible, but show a warning with the validation error + cert details.

```
I, [2017-07-13T12:31:42.360771 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://kontena.test:9293
W, [2017-07-13T13:48:19.964864 #1]  WARN -- Kontena::WebsocketClient: insecure connection established with SSL errors: certificate verify failed: self signed certificate: /CN=kontena.test (issuer /CN=kontena.test)
```

### Default behavior with `KONTENA_URI=wss://` + valid cert

Backwards compatible, but suggesting to configure `KONTENA_SSL_VERIFY=true` to protect from MITM attacks:

```
I, [2017-07-14T05:31:49.094554 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://aws-master-1.kontena.io/
W, [2017-07-14T05:31:54.470200 #1]  WARN -- Kontena::WebsocketClient: secure connection established without KONTENA_SSL_VERIFY=true: /CN=aws-master-1.kontena.io (issuer /C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3)
```

### Error case with `KONTENA_SSL_VERIFY=true` (not signed by default CAs)

```
I, [2017-07-13T12:30:35.566300 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://kontena.test:9293
E, [2017-07-13T12:30:35.619952 #1] ERROR -- Kontena::WebsocketClient: unable to connect to SSL server with KONTENA_SSL_VERIFY=true: certificate verify failed: self signed certificate
```

### Error case with verify + CA, but wrong host
```
I, [2017-07-13T12:34:41.603775 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://192.168.66.1:9293
E, [2017-07-13T12:34:41.714384 #1] ERROR -- Kontena::WebsocketClient: unable to connect to SSL server with KONTENA_SSL_VERIFY=true: Server certificate did not match hostname 192.168.66.1: /CN=kontena.test
```

### Error case with valid public cert, but invalid server (not a kontena master)

```
I, [2017-07-13T13:00:33.856768 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://socket.kontena.io
E, [2017-07-13T13:00:39.522231 #1] ERROR -- Kontena::WebsocketClient: unexpected response from server, check url: Error during WebSocket handshake: Unexpected response code: 404
```

### Error case with DNS errors

```
I, [2017-07-13T12:46:14.146281 #1]  INFO -- Kontena::WebsocketClient: connecting to master at ws://api.kontena.io
E, [2017-07-13T12:46:19.189549 #1] ERROR -- Kontena::WebsocketClient: unable to connect to server: getaddrinfo: Name does not resolve
```

### Success behavior with valid custom cert (using `SSL_CERT_FILE=/etc/kontena-agent/ca.pem`)

```
I, [2017-07-13T12:32:50.385409 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://kontena.test:9293
I, [2017-07-13T12:32:50.527173 #1]  INFO -- Kontena::WebsocketClient: secure connection established with SSL: /CN=kontena.test (issuer /CN=kontena.test)
```

### Success with a public cert (using a hosted master)

```
I, [2017-07-13T13:15:31.962935 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://XXX.platforms.us-east-1.kontena.cloud/
I, [2017-07-13T13:15:37.702015 #1]  INFO -- Kontena::WebsocketClient: secure connection established with SSL: /CN=*.platforms.us-east-1.kontena.cloud (issuer /C=US/O=Amazon/OU=Server CA 1B/CN=Amazon)
E, [2017-07-13T13:15:37.709481 #1] ERROR -- Kontena::WebsocketClient: master does not accept our token, shutting down ...
```

### Success with a custom `KONTENA_SSL_HOSTNAME=kontena.test`
```
I, [2017-07-14T08:20:59.766136 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://192.168.66.1:9293
I, [2017-07-14T08:20:59.855784 #1]  INFO -- Kontena::WebsocketClient: secure connection established with KONTENA_SSL_VERIFY: /CN=kontena.test (issuer /CN=kontena.test)
```

### Error case with DNS MITM + invalid self-signed cert

```
I, [2017-07-13T13:18:16.266705 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://XXX.platforms.us-east-1.kontena.cloud/
E, [2017-07-13T13:18:16.364581 #1] ERROR -- Kontena::WebsocketClient: unable to connect to SSL server with KONTENA_SSL_VERIFY=true: certificate verify failed: self signed certificate
```

### Error case with DNS MITM + valid cert, but wrong subject

```
I, [2017-07-13T13:21:07.320320 #1]  INFO -- Kontena::WebsocketClient: connecting to master at wss://XXX.platforms.us-east-1.kontena.cloud/
E, [2017-07-13T13:21:07.600087 #1] ERROR -- Kontena::WebsocketClient: unable to connect to SSL server with KONTENA_SSL_VERIFY=true: Server certificate did not match hostname XXX.platforms.us-east-1.kontena.cloud: /OU=Domain Control Validated/OU=PositiveSSL Wildcard/CN=*.kontena.io
```