### PR TITLE
Fix grid user remove access check

### DIFF
--- a/server/app/mutations/grids/unassign_user.rb
+++ b/server/app/mutations/grids/unassign_user.rb
@@ -7,9 +7,8 @@ module Grids
     end
 
     def validate
-      unless current_user.grids.include?(grid)
-        add_error(:grid, :invalid, 'Invalid grid')
-        return
+      unless current_user.can_assign?(self.user, {to: self.grid})
+        add_error(:grid, :invalid, 'Operation not allowed')
       end
 
       unless grid.users.include?(user)

--- a/server/app/mutations/grids/unassign_user.rb
+++ b/server/app/mutations/grids/unassign_user.rb
@@ -9,6 +9,7 @@ module Grids
     def validate
       unless current_user.can_assign?(self.user, {to: self.grid})
         add_error(:grid, :invalid, 'Operation not allowed')
+        return
       end
 
       unless grid.users.include?(user)

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -94,7 +94,7 @@ describe '/v1/grids', celluloid: true do
       expect(grid.trusted_subnets).to eq [ '192.168.0.0/24' ]
       expect(grid.stats).to eq 'statsd' => { 'server' => '127.0.0.1', 'port' => 8125 }
       expect(grid.grid_logs_opts.forwarder).to eq 'fluentd'
-      expect(grid.grid_logs_opts.opts).to eq 'fluentd-address' => '127.0.0.1' 
+      expect(grid.grid_logs_opts.opts).to eq 'fluentd-address' => '127.0.0.1'
     end
 
     it 'a new grid has a generated token unless supplied' do
@@ -264,8 +264,9 @@ describe '/v1/grids', celluloid: true do
     end
 
     describe '/users' do
+      let(:grid) { david.grids.first }
+
       it 'returns grid users' do
-        grid = david.grids.first
         get "/v1/grids/#{grid.to_path}/users", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['users'].size).to eq(1)
@@ -454,34 +455,45 @@ describe '/v1/grids', celluloid: true do
       post "/v1/grids/#{grid.to_path}/users", {email: 'invalid@domain.com'}.to_json, request_headers
       expect(response.status).to eq(404)
     end
-    it 'assigns user to grid' do
+
+    it 'does not allow non-admins to add users' do
       grid = david.grids.first
-      expect(UserAuthorizer).to receive(:assignable_by?).with(david, {to: grid}).and_return(true)
-      post "/v1/grids/#{grid.to_path}/users", {email: emily.email}.to_json, request_headers
-      expect(grid.reload.users.size).to eq(2)
-      expect(emily.reload.grids.include?(grid)).to be_truthy
+      post "/v1/grids/#{grid.to_path}/users", {email: thomas.email}.to_json, request_headers
+      expect(response.status).to eq(422)
+      expect(json_response['error']).to eq 'grid' => 'Operation not allowed'
     end
 
-    it 'creates audit log entry' do
-      grid = david.grids.first
-      allow(UserAuthorizer).to receive(:assignable_by?).with(david, {to: grid}).and_return(true)
-      expect {
+    context 'for a grid admin' do
+      before do
+        david.roles << Role.create(name: 'grid_admin', description: 'Grid admin')
+      end
+
+      let(:grid) { david.grids.first }
+
+      it 'assigns user to grid' do
         post "/v1/grids/#{grid.to_path}/users", {email: emily.email}.to_json, request_headers
-      }.to change{ AuditLog.count }.by(1)
-      audit_log = AuditLog.last
-      expect(audit_log.event_name).to eq('assign user')
-      expect(audit_log.resource_id).to eq(emily.id.to_s)
-      expect(audit_log.grid).to eq(grid)
-    end
+        expect(response.status).to eq(201)
+        expect(grid.reload.users.size).to eq(2)
+        expect(emily.reload.grids.include?(grid)).to be_truthy
+      end
 
-    it 'returns array of grid users' do
-      grid = david.grids.first
-      allow(UserAuthorizer).to receive(:assignable_by?).with(david, {to: grid}).and_return(true)
-      post "/v1/grids/#{grid.to_path}/users", {email: emily.email}.to_json, request_headers
-      expect(response.status).to eq(201)
-      expect(json_response['users'].size).to eq(2)
-    end
+      it 'creates audit log entry' do
+        expect {
+          post "/v1/grids/#{grid.to_path}/users", {email: emily.email}.to_json, request_headers
+          expect(response.status).to eq(201)
+        }.to change{ AuditLog.count }.by(1)
+        audit_log = AuditLog.last
+        expect(audit_log.event_name).to eq('assign user')
+        expect(audit_log.resource_id).to eq(emily.id.to_s)
+        expect(audit_log.grid).to eq(grid)
+      end
 
+      it 'returns array of grid users' do
+        post "/v1/grids/#{grid.to_path}/users", {email: emily.email}.to_json, request_headers
+        expect(response.status).to eq(201)
+        expect(json_response['users'].size).to eq(2)
+      end
+    end
   end
 
   describe 'DELETE /:name/users/:email' do
@@ -491,54 +503,67 @@ describe '/v1/grids', celluloid: true do
       expect(response.status).to eq(403)
     end
 
-    it 'validates that unassigned user belongs to grid' do
-      grid = david.grids.first
-      grid.users << thomas
-      delete "/v1/grids/#{grid.to_path}/users/#{emily.email}", nil, request_headers
-      expect(response.status).to eq(422)
-    end
-
-    it 'validates that user cannot remove last user from grid' do
-      grid = david.grids.first
-
-      delete "/v1/grids/#{grid.to_path}/users/#{david.email}", nil, request_headers
-      expect(response.status).to eq(422)
-    end
-
     it 'requires existing email' do
       grid = david.grids.first
       delete "/v1/grids/#{grid.to_path}/users/invalid@domain.com", nil, request_headers
       expect(response.status).to eq(404)
     end
 
-    it 'unassigns user from grid' do
+    it 'does not allow non-admins to remove users' do
       grid = david.grids.first
-      grid.users << emily
-      delete "/v1/grids/#{grid.to_path}/users/#{emily.email}", nil, request_headers
-      expect(grid.reload.users.size).to eq(1)
-      expect(emily.reload.grids.include?(grid)).to be_falsey
+      grid.users << thomas
+      delete "/v1/grids/#{grid.to_path}/users/#{thomas.email}", nil, request_headers
+      expect(response.status).to eq(422)
+      expect(json_response['error']).to eq 'grid' => 'Operation not allowed'
     end
 
-    it 'creates audit log entry' do
-      grid = david.grids.first
-      grid.users << emily
-      expect {
+    context 'for a grid admin' do
+      let(:grid) { david.grids.first }
+
+      before do
+        david.roles << Role.create(name: 'grid_admin', description: 'Grid admin')
+        grid.users << emily
+      end
+
+      it 'validates that unassigned user belongs to grid' do
+        delete "/v1/grids/#{grid.to_path}/users/#{thomas.email}", nil, request_headers
+        expect(response.status).to eq(422)
+        expect(json_response['error']).to eq 'user' => 'Invalid user'
+      end
+
+      it 'unassigns user from grid' do
         delete "/v1/grids/#{grid.to_path}/users/#{emily.email}", nil, request_headers
-      }.to change{ AuditLog.count }.by(1)
-      audit_log = AuditLog.last
-      expect(audit_log.event_name).to eq('unassign user')
-      expect(audit_log.resource_id).to eq(emily.id.to_s)
-      expect(audit_log.grid).to eq(grid)
+        expect(response.status).to eq(200)
+        expect(grid.reload.users.size).to eq(1)
+        expect(thomas.reload.grids.include?(grid)).to be_falsey
+      end
+
+      it 'creates audit log entry' do
+        expect {
+          delete "/v1/grids/#{grid.to_path}/users/#{emily.email}", nil, request_headers
+          expect(response.status).to eq(200)
+        }.to change{ AuditLog.count }.by(1)
+        audit_log = AuditLog.last
+        expect(audit_log.event_name).to eq('unassign user')
+        expect(audit_log.resource_id).to eq(emily.id.to_s)
+        expect(audit_log.grid).to eq(grid)
+      end
+
+      it 'returns array of grid users' do
+        delete "/v1/grids/#{grid.to_path}/users/#{emily.email}", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response['users'].size).to eq(1)
+      end
     end
 
-    it 'returns array of grid users' do
+    it 'validates that user cannot remove last user from grid' do
       grid = david.grids.first
-      grid.users << emily
-      delete "/v1/grids/#{grid.to_path}/users/#{emily.email}", nil, request_headers
-      expect(response.status).to eq(200)
-      expect(json_response['users'].size).to eq(1)
-    end
+      david.roles << Role.create(name: 'grid_admin', description: 'Grid admin')
 
+      delete "/v1/grids/#{grid.to_path}/users/#{david.email}", nil, request_headers
+      expect(response.status).to eq(422)
+      expect(json_response['error']).to eq 'grid' => 'Cannot remove last user'
+    end
   end
 
 

--- a/server/spec/mutations/grids/assign_user_spec.rb
+++ b/server/spec/mutations/grids/assign_user_spec.rb
@@ -8,49 +8,52 @@ describe Grids::AssignUser do
     grid
   }
 
-  describe '#run' do
+  it 'validates that current user has permission to assign users' do
+    expect(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(false)
+    grid.users.delete_all
+    outcome = described_class.new(
+        current_user: current_user,
+        user: user,
+        grid: grid
+    ).run
+    expect(outcome).to_not be_success
+    expect(outcome.errors.message).to eq 'grid' => "Operation not allowed"
+  end
 
-    it 'validates that current user has permission to assign users' do
-      expect(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(false)
-      grid.users.delete_all
-      outcome = described_class.new(
-          current_user: current_user,
-          user: user,
-          grid: grid
-      ).run
-      expect(outcome.errors.size).to eq(1)
+  context 'for an authorized user' do
+    before do
+      allow(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(true)
     end
 
     it 'assigns a user to grid' do
-      allow(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(true)
       expect {
-        described_class.new(
+        outcome = described_class.new(
             current_user: current_user,
             user: user,
             grid: grid
         ).run
+        expect(outcome).to be_success
       }.to change{ user.grids.size }.by(1)
     end
 
     it 'publishes update event for user' do
-      allow(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(true)
       expect(user).to receive(:publish_update_event).once
       outcome = described_class.new(
           current_user: current_user,
           user: user,
           grid: grid
       ).run
+      expect(outcome).to be_success
     end
 
     it 'returns array of grid users' do
-      allow(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(true)
       outcome = described_class.new(
           current_user: current_user,
           user: user,
           grid: grid
       ).run
-      expect(outcome.result.is_a?(Array))
-      expect(outcome.result.size).to eq(2)
+      expect(outcome).to be_success
+      expect(outcome.result).to match_array [current_user, user]
     end
 
   end

--- a/server/spec/mutations/grids/unassign_user_spec.rb
+++ b/server/spec/mutations/grids/unassign_user_spec.rb
@@ -2,6 +2,7 @@
 describe Grids::UnassignUser do
   let(:current_user) { User.create!(email: 'jane@domain.com') }
   let(:user) { User.create!(email: 'joe@domain.com')}
+  let(:user2) { User.create!(email: 'joe2@domain.com')}
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
     grid.users << current_user
@@ -13,7 +14,7 @@ describe Grids::UnassignUser do
     expect(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(false)
     outcome = described_class.new(
         current_user: current_user,
-        user: user,
+        user: user2,
         grid: grid
     ).run
     expect(outcome).to_not be_success

--- a/server/spec/mutations/grids/unassign_user_spec.rb
+++ b/server/spec/mutations/grids/unassign_user_spec.rb
@@ -5,65 +5,74 @@ describe Grids::UnassignUser do
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
     grid.users << current_user
+    grid.users << user
     grid
   }
 
-  describe '#run' do
+  context 'for an authorized user' do
+    before do
+      allow(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(true)
+    end
 
     it 'validates that current user belongs to grid' do
       grid.users.delete_all
+
       outcome = described_class.new(
-          current_user: current_user,
-          user: user,
-          grid: grid
+        current_user: current_user,
+        user: user,
+        grid: grid
       ).run
-      expect(outcome.errors.size).to eq(1)
+      expect(outcome.errors.message).to eq 'grid' => "Invalid grid"
     end
 
     it 'unassigns a user from grid' do
-      grid.users << user
       expect {
-        described_class.new(
-            current_user: current_user,
-            user: user,
-            grid: grid
+        outcome = described_class.new(
+          current_user: current_user,
+          user: user,
+          grid: grid
         ).run
+        expect(outcome).to be_success
       }.to change{ user.grids.size }.by(-1)
     end
 
-    it 'publishes update event for user' do
-      grid.users << user
-      expect(grid).to receive(:publish_update_event).once      
-      outcome = described_class.new(
-          current_user: current_user,
-          user: user,
-          grid: grid
-      ).run
-    end
-
-    context 'when a grid has only one user'
-    it 'returns error' do
-      expect {
-        outcome = described_class.new(
-            current_user: current_user,
-            user: current_user,
-            grid: grid
-        ).run
-        expect(outcome.success?).to be_falsey
-      }.to change{ user.grids.size }.by(0)
-
-    end
-
     it 'returns array of grid users' do
-      grid.users << user
       outcome = described_class.new(
           current_user: current_user,
           user: user,
           grid: grid
       ).run
-      expect(outcome.result.is_a?(Array))
-      expect(outcome.result.size).to eq(1)
+      expect(outcome).to be_success
+      expect(outcome.result).to eq [current_user]
     end
 
+    it 'publishes update event for user' do
+      expect(grid).to receive(:publish_update_event).once
+      outcome = described_class.new(
+        current_user: current_user,
+        user: user,
+        grid: grid
+      ).run
+      expect(outcome).to be_success
+    end
+
+    context 'with only a single user in the grid' do
+      before do
+        grid.users = [current_user]
+        grid.save!
+      end
+
+      it 'returns error if removing the only grid user' do
+        expect {
+          outcome = described_class.new(
+              current_user: current_user,
+              user: current_user,
+              grid: grid
+          ).run
+          expect(outcome).to_not be_success
+          expect(outcome.errors.message).to eq 'grid' => "Cannot remove last user"
+        }.to_not change{ user.grids.size }
+      end
+    end
   end
 end

--- a/server/spec/mutations/grids/unassign_user_spec.rb
+++ b/server/spec/mutations/grids/unassign_user_spec.rb
@@ -9,20 +9,20 @@ describe Grids::UnassignUser do
     grid
   }
 
-  context 'for an authorized user' do
-    before do
-      allow(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(true)
-    end
-
-    it 'validates that current user belongs to grid' do
-      grid.users.delete_all
-
-      outcome = described_class.new(
+  it 'validates that current user has permission to unassign users' do
+    expect(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(false)
+    outcome = described_class.new(
         current_user: current_user,
         user: user,
         grid: grid
-      ).run
-      expect(outcome.errors.message).to eq 'grid' => "Invalid grid"
+    ).run
+    expect(outcome).to_not be_success
+    expect(outcome.errors.message).to eq 'grid' => "Operation not allowed"
+  end
+
+  context 'for an authorized user' do
+    before do
+      allow(UserAuthorizer).to receive(:assignable_by?).with(current_user, {to: grid}).and_return(true)
     end
 
     it 'unassigns a user from grid' do


### PR DESCRIPTION
Fixes #2578 

The `Grids::UnassignUser` mutation only validated that the user belonged to the grid, instead of using the `user.can_assign?` authorizer.