### PR TITLE
Fix kontena node rm: NameError: undefined local variable or method `node_id'

### DIFF
--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::Nodes
         exit_with_error "Node #{node['name']} is still online. You must terminate the node before removing it."
       end
 
-      confirm_command(node_id) unless forced?
+      confirm_command(self.node) unless forced?
 
       spinner "Removing #{self.node.colorize(:cyan)} node from #{current_grid.colorize(:cyan)} grid " do
         client(token).delete("nodes/#{node['id']}")

--- a/cli/spec/kontena/cli/nodes/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/remove_command_spec.rb
@@ -18,6 +18,13 @@ describe Kontena::Cli::Nodes::RemoveCommand do
     end
 
     it 'removes the node' do
+      expect(subject).to receive(:confirm_command).with('node-1')
+      expect(client).to receive(:delete).with('nodes/test-grid/node-1')
+
+      subject.run(['node-1'])
+    end
+
+    it 'removes the node with --force' do
       expect(client).to receive(:delete).with('nodes/test-grid/node-1')
 
       subject.run(['--force', 'node-1'])


### PR DESCRIPTION
Broken in #2483, not caught by specs because they use `--force`:

```
NameError: undefined local variable or method `node_id' for #<Kontena::Cli::Nodes::RemoveCommand:0x000000019a5e10>
Did you mean?  node
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/nodes/remove_command.rb:20:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:201:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:201:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:201:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
  bin/kontena:18:in `<top (required)>'
```