### PR TITLE
[WiP] Reconfigurable grid weave secret

### DIFF
--- a/agent/lib/kontena/launchers/weave.rb
+++ b/agent/lib/kontena/launchers/weave.rb
@@ -15,10 +15,6 @@ module Kontena::Launchers
 
     CONTAINER_NAME = 'weave'
 
-    def weave_password
-      ENV['KONTENA_TOKEN']
-    end
-
     # @param node_info [Kontena::Actor::Observable<Kontena::Models::NodeInfo>]
     def initialize(start: true)
       async.start if start
@@ -57,7 +53,7 @@ module Kontena::Launchers
 
       state = {}
       state.merge! self.ensure_container(IMAGE,
-        password: self.weave_password,
+        password: node.weave_secret,
         trusted_subnets: node.grid_trusted_subnets
       )
       state.merge! self.ensure_peers(node.peer_ips)

--- a/agent/lib/kontena/models/node.rb
+++ b/agent/lib/kontena/models/node.rb
@@ -23,6 +23,7 @@ class Node
     @node_number = data['node_number']
     @initial_member = data['initial_member']
     @grid = data['grid']
+    @weave = data['grid']['weave']
   end
 
   def statsd_conf
@@ -47,6 +48,11 @@ class Node
   # @return [String]
   def grid_supernet
     @grid['supernet']
+  end
+
+  # @return [String]
+  def weave_secret
+    @weave['secret']
   end
 
   # @return [IPAddress] 10.81.0.X

--- a/cli/lib/kontena/cli/grid_command.rb
+++ b/cli/lib/kontena/cli/grid_command.rb
@@ -3,6 +3,7 @@ class Kontena::Cli::GridCommand < Kontena::Command
   subcommand ["list","ls"], "List all grids", load_subcommand('grids/list_command')
   subcommand "create", "Create a new grid", load_subcommand('grids/create_command')
   subcommand "update", "Update grid", load_subcommand('grids/update_command')
+  subcommand "reset-token", "Reset grid tokens", load_subcommand('grids/reset_token_command')
   subcommand "use", "Switch to use specific grid", load_subcommand('grids/use_command')
   subcommand "show", "Show grid details", load_subcommand('grids/show_command')
   subcommand "logs", "Show logs from grid containers", load_subcommand('grids/logs_command')

--- a/cli/lib/kontena/cli/grids/reset_token_command.rb
+++ b/cli/lib/kontena/cli/grids/reset_token_command.rb
@@ -1,0 +1,24 @@
+module Kontena::Cli::Grids
+  class ResetTokenCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+
+    requires_current_master
+    requires_current_master_token
+    requires_current_grid
+
+    parameter "[GRID]", "Grid name"
+
+    option "--force", :flag, "Force token update"
+
+    def execute
+      confirm("Resetting the grid weave secrets will temporarily disrupt the overlay network, and cause transient service errors. Are you sure?")
+
+      data = {}
+
+      spinner "Resetting grid #{current_grid.colorize(:cyan)} token" do
+        client.post("grids/#{current_grid}/token", data)
+      end
+    end
+  end
+end

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -18,6 +18,7 @@ class Grid
   field :default_affinity, type: Array, default: []
   field :subnet, type: String, default: SUBNET
   field :supernet, type: String, default: SUPERNET
+  field :weave_secret, type: String
 
   has_many :host_nodes, dependent: :destroy
   has_many :host_node_stats

--- a/server/app/mutations/grids/common.rb
+++ b/server/app/mutations/grids/common.rb
@@ -4,6 +4,21 @@ module Grids
       base.extend(ClassMethods)
     end
 
+    def reschedule_grid(grid)
+      GridScheduler.new(grid).reschedule
+    end
+
+    def notify_nodes(grid)
+      grid.host_nodes.connected.each do |node|
+        plugger = Agent::NodePlugger.new(node)
+        plugger.send_node_info
+      end
+    rescue => exc
+      Logging.logger.error(self.class.name) { exc }
+    else
+      Logging.logger.info(self.class.name) { "notified grid #{grid.to_path} nodes" }
+    end
+
     module ClassMethods
       def common_validations
         # common inputs for both create + update

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -27,19 +27,12 @@ module Grids
         return
       end
 
-      self.notify_nodes
+      Celluloid::Future.new do
+        self.notify_nodes(self.grid)
+        self.reschedule_grid(self.grid)
+      end
 
       self.grid
-    end
-
-    def notify_nodes
-      Celluloid::Future.new {
-        grid.host_nodes.connected.each do |node|
-          plugger = Agent::NodePlugger.new(grid, node)
-          plugger.send_node_info
-        end
-        GridScheduler.new(grid).reschedule
-      }
     end
   end
 end

--- a/server/app/mutations/grids/update_token.rb
+++ b/server/app/mutations/grids/update_token.rb
@@ -1,0 +1,41 @@
+require_relative 'common'
+
+module Grids
+  class UpdateToken < Mutations::Command
+    include Common
+
+    required do
+      model :grid
+      model :user
+    end
+
+    def validate
+      add_error(:user, :invalid, 'Operation not allowed') unless user.can_update?(grid)
+    end
+
+    def generate_secret
+      SecureRandom.base64(64)
+    end
+
+    def update_weave_secret(grid)
+      grid.weave_secret = self.generate_secret
+    end
+
+    def execute
+      update_weave_secret(self.grid)
+
+      unless self.grid.save
+        self.grid.errors.each do |key, message|
+          add_error(key, :invalid, message)
+        end
+        return
+      end
+
+      Celluloid::Future.new do
+        notify_nodes(self.grid)
+      end
+
+      self.grid
+    end
+  end
+end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -100,6 +100,25 @@ module V1
           r.route 'grid_event_logs'
         end
 
+        r.on 'token' do
+          r.post do
+            r.is do
+              data = parse_json_body
+              data[:grid] = @grid
+              data[:user] = current_user
+              outcome = Grids::UpdateToken.run(data)
+              if outcome.success?
+                @grid = outcome.result
+                audit_event(r, @grid, @grid, 'update-token')
+                response.status = 201
+              else
+                response.status = 422
+                {error: outcome.errors.message}
+              end
+            end
+          end
+        end
+
         r.get do
           r.is do
             render('grids/show')

--- a/server/app/serializers/rpc/grid_serializer.rb
+++ b/server/app/serializers/rpc/grid_serializer.rb
@@ -10,6 +10,7 @@ module Rpc
     attribute :supernet
     attribute :stats
     attribute :logs
+    attribute :weave
 
     def id
       object.to_path
@@ -28,6 +29,12 @@ module Rpc
           opts: object.grid_logs_opts.opts,
         }
       end
+    end
+
+    def weave
+      {
+        secret: object.weave_secret,
+      }
     end
   end
 end

--- a/server/db/migrations/27_grid_weave_secret.rb
+++ b/server/db/migrations/27_grid_weave_secret.rb
@@ -1,0 +1,7 @@
+class GridWeaveSecret < Mongodb::Migration
+  def self.up
+    Grid.all.each do |grid|
+      grid.set(:weave_secret => grid.token)
+    end
+  end
+end


### PR DESCRIPTION
Follows #2582
Fixes #2502

Grid has `weave_secret`, defaults to `token`. Can be replaced using `kontena grid reset-token`. Agents `Kontena::Launchers::Weave` observes the update, and reconfigures weave to use the new secret.