### PR TITLE
Fix server grids update notify

### DIFF
--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -35,7 +35,7 @@ module Grids
     def notify_nodes
       Celluloid::Future.new {
         grid.host_nodes.connected.each do |node|
-          plugger = Agent::NodePlugger.new(grid, node)
+          plugger = Agent::NodePlugger.new(node)
           plugger.send_node_info
         end
         GridScheduler.new(grid).reschedule


### PR DESCRIPTION
Fixes #2584

Trivial fix that does not fix the actual underlying issue of missing error logging/handling for `Celluloid::Future` blocks: #2126