### PR TITLE
Ubuntu kontena-agent: Use /usr/bin/dockerd for compatibility with Docker 1.12 - 17.06

### DIFF
--- a/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
@@ -2,7 +2,7 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.12) | docker-ce | docker-ee, resolvconf
 Provides: kontena-weave, kontena-etcd
 Conflicts: kontena-weave, kontena-etcd
 Replaces: kontena-weave, kontena-etcd

--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.12) | docker.io (>= 1.12) | docker-ce | docker-ee, resolvconf
 Description: Kontena Agent

--- a/agent/packaging/ubuntu_xenial/kontena-agent/etc/systemd/system/docker.service.d/50-kontena.conf
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/etc/systemd/system/docker.service.d/50-kontena.conf
@@ -1,4 +1,4 @@
 [Service]
 Environment='DOCKER_OPTS=--insecure-registry="10.81.0.0/16"'
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// ${DOCKER_OPTS}
+ExecStart=/usr/bin/dockerd -H fd:// ${DOCKER_OPTS}

--- a/docs/getting-started/installing/ubuntu.md
+++ b/docs/getting-started/installing/ubuntu.md
@@ -18,9 +18,9 @@ Kontena requires [Docker Engine](https://docs.docker.com/engine/) to be installe
 
 The `kontena-server` and `kontena-agent` packages are compatible with Docker 1.12 and later versions. They have been tested with the following package variants and versions:
 
-* `docker.io` `1.12.*`
-* `docker-engine` `1.12.*` - `17.05.*`
-* `docker-ce` `1.12.*` - `17.06.*`
+* `docker.io` `1.12.6`
+* `docker-engine` `1.12.6` - `17.05.0`
+* `docker-ce` `1.12.6` - `17.06.0`
 
 #### Ubuntu Xenial (16.04)
 

--- a/docs/getting-started/installing/ubuntu.md
+++ b/docs/getting-started/installing/ubuntu.md
@@ -16,6 +16,12 @@ title: Ubuntu
 
 Kontena requires [Docker Engine](https://docs.docker.com/engine/) to be installed on every host (Master and Nodes).
 
+The `kontena-server` and `kontena-agent` packages are compatible with Docker 1.12 and later versions. They have been tested with the following package variants and versions:
+
+* `docker.io` `1.12.*`
+* `docker-engine` `1.12.*` - `17.05.*`
+* `docker-ce` `1.12.*` - `17.06.*`
+
 #### Ubuntu Xenial (16.04)
 
 ```

--- a/server/packaging/ubuntu/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker-ce | docker-ee
+Depends: docker-engine (>= 1.12) | docker-ce | docker-ee
 Description: Kontena Server

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.12) | docker.io (>= 1.12) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.12) | docker.io (>= 1.12) | docker-ce | docker-ee
 Description: Kontena Server

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.12) | docker.io (>= 1.12) | docker-ce | docker-ee, resolvconf
 Description: Kontena Server


### PR DESCRIPTION
Fixes #2588 by replacing `ExecStart=/usr/bin/docker daemon` with `ExecStart=/usr/bin/dockerd`

* :x:  `docker.io` `1.10.3-0ubuntu6` does NOT support `/usr/bin/dockerd`
* :white_check_mark:  `docker.io` `1.12.6-0ubuntu1~16.04.1` supports `/usr/bin/dockerd`
* :grey_exclamation:  `docker-engine` `1.10.*` is no longer available
* :x: `docker-engine` `1.11.2-0~xenial` does NOT support `/usr/bin/dockerd`
* :white_check_mark: `docker-engine` `1.12.6-0~ubuntu-xenial` supports `/usr/bin/dockerd`
* :white_check_mark:  `docker-engine` `1.13.1-0~ubuntu-xenial` supports `/usr/bin/dockerd`
* :white_check_mark: `docker-engine` `17.05.0~ce-0~ubuntu-xenial` supports `/usr/bin/dockerd`

* :white_check_mark: `docker-ce` `17.03.2~ce-0~ubuntu-xenial` supports `/usr/bin/dockerd`
* :exclamation: `docker-ce` `17.06.0~ce-0~ubuntu` fails with `/usr/bin/docker daemon`

Breaks compatibility with Docker < 1.12, bumping the minimum version from 1.10 to 1.12.

See https://github.com/kontena/kontena/issues/2588#issuecomment-315717468: