### PR TITLE
[WiP] Refactor agent RPCs to use implicit node IDs

### DIFF
--- a/agent/lib/kontena/actors/container_coroner.rb
+++ b/agent/lib/kontena/actors/container_coroner.rb
@@ -6,10 +6,8 @@ module Kontena::Actors
 
     INVESTIGATION_PERIOD = 20
 
-    # @param [String] node_id
     # @param [Boolean] autostart
-    def initialize(node_id, autostart = true)
-      @node_id = node_id
+    def initialize(autostart = true)
       async.process if autostart
     end
 
@@ -30,7 +28,7 @@ module Kontena::Actors
     end
 
     def report(data)
-      rpc_request('/containers/cleanup', [@node_id, data])
+      rpc_request('/containers/cleanup', [data])
     rescue => exc
       warn "failed to send report: #{exc.message}"
       sleep 1

--- a/agent/lib/kontena/workers/container_info_worker.rb
+++ b/agent/lib/kontena/workers/container_info_worker.rb
@@ -68,7 +68,6 @@ module Kontena::Workers
       return if labels['io.kontena.container.skip_logs']
 
       data = {
-        node: self.node_info['ID'],
         container: data
       }
       rpc_client.async.request('/containers/save', [data])
@@ -87,11 +86,6 @@ module Kontena::Workers
         time: event.time
       }
       rpc_client.async.request('/containers/event', [data])
-    end
-
-    # @return [Hash]
-    def node_info
-      @node_info ||= Docker.info
     end
   end
 end

--- a/agent/lib/kontena/workers/container_info_worker.rb
+++ b/agent/lib/kontena/workers/container_info_worker.rb
@@ -15,7 +15,7 @@ module Kontena::Workers
       subscribe('container:publish_info', :on_container_publish_info)
       subscribe('websocket:connected', :on_websocket_connected)
       info 'initialized'
-      @container_coroner = Kontena::Actors::ContainerCoroner.new(self.node_info['ID'], autostart)
+      @container_coroner = Kontena::Actors::ContainerCoroner.new(autostart)
       async.start if autostart
     end
 

--- a/agent/lib/kontena/workers/node_stats_worker.rb
+++ b/agent/lib/kontena/workers/node_stats_worker.rb
@@ -93,7 +93,6 @@ module Kontena::Workers
       @stats_since = Time.now
 
       data = {
-        id: docker_info['ID'],
         memory: calculate_memory,
         usage: {
           container_seconds: container_seconds

--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -42,14 +42,14 @@ module Kontena::Workers
     end
 
     def on_pod_event(_, event)
-      rpc_client.async.notification("/node_service_pods/event", [node.id, event])
+      rpc_client.async.notification("/node_service_pods/event", [event])
     rescue => exc
       error "sending event to master failed: #{exc.message}"
     end
 
     def populate_workers_from_master
       exclusive {
-        response = rpc_request("/node_service_pods/list", [node.id])
+        response = rpc_request("/node_service_pods/list", [])
 
         # sanity-check
         unless response['service_pods'].is_a?(Array)

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -13,11 +13,10 @@ module Kontena::Workers
     include Kontena::Helpers::RpcHelper
     include Kontena::Helpers::EventLogHelper
 
-    attr_reader :node, :prev_state, :service_pod
+    attr_reader :prev_state, :service_pod
     attr_accessor :service_pod, :container_state_changed
 
-    def initialize(node, service_pod)
-      @node = node
+    def initialize(service_pod)
       @service_pod = service_pod
       @prev_state = nil # sync'd to master
       @container_state_changed = true
@@ -262,7 +261,7 @@ module Kontena::Workers
       }
 
       if state != @prev_state
-        rpc_client.async.request('/node_service_pods/set_state', [node.id, state])
+        rpc_client.async.request('/node_service_pods/set_state', [state])
         @prev_state = state
       end
     end

--- a/agent/lib/kontena/workers/volumes/volume_manager.rb
+++ b/agent/lib/kontena/workers/volumes/volume_manager.rb
@@ -38,7 +38,7 @@ module Kontena::Workers::Volumes
 
     def populate_volumes_from_master
       exclusive {
-        response = rpc_request("/node_volumes/list", [node.id])
+        response = rpc_request("/node_volumes/list", [])
 
         # sanity-check
         unless response['volumes'].is_a?(Array)
@@ -96,7 +96,7 @@ module Kontena::Workers::Volumes
       }
       # Only send "managed" volumes to server
       if volume['volume_instance_id']
-        rpc_client.async.request('/node_volumes/set_state', [node.id, volume])
+        rpc_client.async.request('/node_volumes/set_state', [volume])
       else
         debug "Skip sending un-managed volume: #{volume['name']}"
       end

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -276,7 +276,7 @@ class WebsocketBackend
   # @param [Faye::WebSocket::Event] ws
   # @param [Array] data
   def handle_rpc_request(client, data)
-    @queue << [client[:ws], client[:grid_id], data]
+    @queue << [client[:node_id].to_s, data, client[:ws]]
   end
 
   # @param [Faye::WebSocket::Event] ws
@@ -287,7 +287,7 @@ class WebsocketBackend
       return
     end
 
-    @queue << [client[:grid_id].to_s, data]
+    @queue << [client[:node_id].to_s, data]
   end
 
   # Unplug client on websocket connection close.

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -230,15 +230,20 @@ class WebsocketBackend
   def on_message(ws, event)
     data = MessagePack.unpack(event.data.pack('c*'))
     @msg_counter += 1
+
+    unless client = client_for_ws(ws)
+      fail "Message from unplugged client: #{ws}"
+    end
+
     if rpc_notification?(data)
-      handle_rpc_notification(ws, data)
+      handle_rpc_notification(client, data)
     elsif rpc_request?(data)
-      handle_rpc_request(ws, data)
+      handle_rpc_request(client, data)
     elsif rpc_response?(data)
-      handle_rpc_response(data)
+      handle_rpc_response(client, data)
     end
   rescue => exc
-    logger.error "Cannot unpack message, reason #{exc.message}"
+    logger.error "on_message #{exc.message}"
   end
 
   ##
@@ -264,31 +269,25 @@ class WebsocketBackend
 
   ##
   # @param [Array] data
-  def handle_rpc_response(data)
-    MongoPubsub.publish_async("rpc_client:#{data[1]}", {message: data})
+  def handle_rpc_response(client, data)
+    MongoPubsub.publish_async("rpc_client/#{client[:id]}/#{data[1]}", {message: data})
   end
 
   # @param [Faye::WebSocket::Event] ws
   # @param [Array] data
-  def handle_rpc_request(ws, data)
-    client = client_for_ws(ws)
-    if client
-      @queue << [ws, client[:grid_id].to_s, data]
-    end
+  def handle_rpc_request(client, data)
+    @queue << [client[:ws], client[:grid_id], data]
   end
 
   # @param [Faye::WebSocket::Event] ws
   # @param [Array] data
-  def handle_rpc_notification(ws, data)
+  def handle_rpc_notification(client, data)
     if @queue.size > QUEUE_DROP_NOTIFICATIONS_LIMIT # too busy to handle notifications
       @msg_dropped += 1
       return
     end
 
-    client = client_for_ws(ws)
-    if client
-      @queue << [client[:grid_id].to_s, data]
-    end
+    @queue << [client[:grid_id].to_s, data]
   end
 
   # Unplug client on websocket connection close.

--- a/server/app/services/rpc/container_exec_handler.rb
+++ b/server/app/services/rpc/container_exec_handler.rb
@@ -1,9 +1,10 @@
-module Rpc 
+module Rpc
   class ContainerExecHandler
     include Logging
 
-    def initialize(grid)
-      @grid = grid
+    # @params [HostNode] node
+    def initialize(node)
+      @node = node
     end
 
     def output(uuid, stream, chunk)

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -7,8 +7,9 @@ module Rpc
     attr_accessor :logs_buffer_size
     attr_accessor :stats_buffer_size
 
-    def initialize(grid)
-      @grid = grid
+    # @params [HostNode] node
+    def initialize(node)
+      @node = node
       @logs = []
       @stats = []
       @cached_containers = {}
@@ -24,7 +25,7 @@ module Rpc
 
     # @param [Hash] data
     def save(data)
-      info_mapper = ContainerInfoMapper.new(@grid)
+      info_mapper = ContainerInfoMapper.new(@node)
       info_mapper.from_agent(data)
 
       {}
@@ -33,13 +34,9 @@ module Rpc
     # @param [String] node_id
     # @param [Array<String>] ids
     def cleanup(node_id, ids)
-      node = @grid.host_nodes.find_by(node_id: node_id)
-      if node
-        @grid.containers.unscoped.where(
-          :host_node_id => node.id,
-          :container_id.in => ids
-        ).destroy
-      end
+      @node.containers.unscoped.where(
+        :container_id.in => ids
+      ).destroy
     end
 
     # @param [Hash] data
@@ -52,8 +49,8 @@ module Rpc
           created_at = Time.now.utc
         end
         @logs << {
-          grid_id: @grid.id,
-          host_node_id: container['host_node_id'],
+          grid_id: @node.grid_id,
+          host_node_id: @node.id,
           grid_service_id: container['grid_service_id'],
           instance_number: container['instance_number'],
           container_id: container['_id'],
@@ -72,7 +69,7 @@ module Rpc
     # @param [Hash] data
     def health(data)
       container = Container.find_by(
-        grid_id: @grid.id, container_id: data['id']
+        node_id: @node.id, container_id: data['id']
       )
       if container
         container.set_health_status(data['status'])
@@ -90,8 +87,8 @@ module Rpc
       if container
         time = data['time'] ? Time.parse(data['time']) : Time.now.utc
         @stats << {
-          grid_id: @grid.id,
-          host_node_id: container['host_node_id'],
+          grid_id: @node.grid_id,
+          host_node_id: @node.id,
           grid_service_id: container['grid_service_id'],
           container_id: container['_id'],
           spec: data['spec'],

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -31,9 +31,8 @@ module Rpc
       {}
     end
 
-    # @param [String] node_id
     # @param [Array<String>] ids
-    def cleanup(node_id, ids)
+    def cleanup(ids)
       @node.containers.unscoped.where(
         :container_id.in => ids
       ).destroy

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -142,7 +142,7 @@ module Rpc
         container = @cached_containers[id]
       else
         container = @db_session[:containers].find(
-            grid_id: @grid.id, container_id: id
+            host_node_id: @node.node_id, container_id: id
           ).limit(1).first
         @cached_containers[id] = container if container
       end

--- a/server/app/services/rpc/container_info_mapper.rb
+++ b/server/app/services/rpc/container_info_mapper.rb
@@ -13,7 +13,7 @@ module Rpc
       info = data['container']
       labels = info['Config']['Labels'] || {}
       container_id = data['container']['Id']
-      container = grid.containers.unscoped.find_by(container_id: container_id)
+      container = @node.containers.unscoped.find_by(container_id: container_id)
       if container
         self.update_service_container(container, info)
       elsif !labels['io.kontena.service.id'].nil?

--- a/server/app/services/rpc/node_handler.rb
+++ b/server/app/services/rpc/node_handler.rb
@@ -1,8 +1,9 @@
 module Rpc
   class NodeHandler
 
-    def initialize(grid)
-      @grid = grid
+    # @params [HostNode] node
+    def initialize(node)
+      @node = node
       @db_session = HostNode.collection.client.with(
         write: {
           w: 0, fsync: false, j: false
@@ -10,35 +11,24 @@ module Rpc
       )
     end
 
-    def get(id)
-      node = @grid.host_nodes.find_by(node_id: id)
-      if node
-        HostNodeSerializer.new(node).to_hash
-      else
-        {}
-      end
+    # @param [String] node_id
+    def get(node_id)
+      HostNodeSerializer.new(@node).to_hash
     end
 
     # @param [Hash] data
     def update(data)
-      node_id = data['ID']
-      node = @grid.host_nodes.find_by(node_id: node_id)
-
-      raise "Missing HostNode: #{node_id}" unless node
-
-      node.attributes_from_docker(data)
-      node.save!
+      @node.attributes_from_docker(data)
+      @node.save!
     end
 
     # @param [Hash] data
     def stats(data)
-      node = @grid.host_nodes.find_by(node_id: data['id'])
-      return unless node
       time = data['time'] ? Time.parse(data['time']) : Time.now.utc
 
       stat = {
-        grid_id: @grid.id,
-        host_node_id: node.id,
+        grid_id: @node.grid_id,
+        host_node_id: @node.id,
         memory: data['memory'],
         load: data['load'],
         filesystem: data['filesystem'],

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -2,8 +2,9 @@ module Rpc
   class NodeServicePodHandler
     include Logging
 
-    def initialize(grid)
-      @grid = grid
+    # @params [HostNode] node
+    def initialize(node)
+      @node = node
       @lru_cache = LruRedux::ThreadSafeCache.new(1000)
     end
 
@@ -24,11 +25,10 @@ module Rpc
     # @return [Array<Hash>]
     def list(id)
       start = Time.now.to_f
-      node = @grid.host_nodes.find_by(node_id: id)
-      raise 'Node not found' unless node
+
       raise 'Migration not done' unless migration_done?
 
-      service_pods = node.grid_service_instances.includes(:grid_service).map { |i|
+      service_pods = @node.grid_service_instances.includes(:grid_service).map { |i|
         cached_pod(i)
       }.compact
       end_time = Time.now.to_f
@@ -39,10 +39,7 @@ module Rpc
     # @param [String] id
     # @param [Hash] pod
     def set_state(id, pod)
-      node = @grid.host_nodes.find_by(node_id: id)
-      raise 'Node not found' unless node
-
-      service_instance = node.grid_service_instances.find_by(
+      service_instance = @node.grid_service_instances.find_by(
         grid_service_id: pod['service_id'], instance_number: pod['instance_number']
       )
       raise 'Instance not found' unless service_instance
@@ -58,18 +55,15 @@ module Rpc
     # @param [String] id
     # @param [Hash] event
     def event(id, event)
-      node = @grid.host_nodes.find_by(node_id: id)
-      return unless node
-
-      service = GridService.where(id: event['service_id'], grid_id: node.grid_id).first
+      service = GridService.where(id: event['service_id'], grid_id: @node.grid_id).first
       return unless service
 
       EventLog.create(
         severity: event['severity'] || EventLog::INFO,
         msg: event['data'],
         type: event['type'],
-        grid_id: node.grid_id,
-        host_node_id: node.id,
+        grid_id: @node.grid_id,
+        host_node_id: @node.id,
         stack_id: service.stack_id,
         grid_service_id: service.id,
         meta: {

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -21,9 +21,8 @@ module Rpc
       }
     end
 
-    # @param [String] id
     # @return [Array<Hash>]
-    def list(id)
+    def list
       start = Time.now.to_f
 
       raise 'Migration not done' unless migration_done?
@@ -36,9 +35,8 @@ module Rpc
       { service_pods: service_pods }
     end
 
-    # @param [String] id
     # @param [Hash] pod
-    def set_state(id, pod)
+    def set_state(pod)
       service_instance = @node.grid_service_instances.find_by(
         grid_service_id: pod['service_id'], instance_number: pod['instance_number']
       )
@@ -52,9 +50,8 @@ module Rpc
       {}
     end
 
-    # @param [String] id
     # @param [Hash] event
-    def event(id, event)
+    def event(event)
       service = GridService.where(id: event['service_id'], grid_id: @node.grid_id).first
       return unless service
 

--- a/server/app/services/rpc/node_volume_handler.rb
+++ b/server/app/services/rpc/node_volume_handler.rb
@@ -8,9 +8,8 @@ module Rpc
       @node = node
     end
 
-    # @param [String] id
     # @return [Array<Hash>]
-    def list(id)
+    def list
       volumes = @node.volume_instances.map { |v|
         VolumeSerializer.new(v).to_hash
       }.compact
@@ -18,9 +17,8 @@ module Rpc
       { volumes: volumes }
     end
 
-    # @param [String] id
     # @param [Hash] volume
-    def set_state(id, data)
+    def set_state(data)
       volume_instance = @node.volume_instances.find_by(id: data['volume_instance_id'])
       unless volume_instance
         volume_id = data['volume_id']

--- a/server/app/services/rpc/node_volume_handler.rb
+++ b/server/app/services/rpc/node_volume_handler.rb
@@ -3,17 +3,15 @@ module Rpc
     include Celluloid
     include Logging
 
-    def initialize(grid)
-      @grid = grid
+    # @params [HostNode] node
+    def initialize(node)
+      @node = node
     end
 
     # @param [String] id
     # @return [Array<Hash>]
     def list(id)
-      node = @grid.host_nodes.find_by(node_id: id)
-      raise "Node not found" unless node
-
-      volumes = node.volume_instances.map { |v|
+      volumes = @node.volume_instances.map { |v|
         VolumeSerializer.new(v).to_hash
       }.compact
 
@@ -23,14 +21,11 @@ module Rpc
     # @param [String] id
     # @param [Hash] volume
     def set_state(id, data)
-      node = @grid.host_nodes.find_by(node_id: id)
-      raise "Node not found" unless node
-
-      volume_instance = node.volume_instances.find_by(id: data['volume_instance_id'])
+      volume_instance = @node.volume_instances.find_by(id: data['volume_instance_id'])
       unless volume_instance
         volume_id = data['volume_id']
         if volume_id
-          volume = @grid.volumes.find_by(id: volume_id)
+          volume = @node.grid.volumes.find_by(id: volume_id)
           if volume
             volume_instance = VolumeInstance.create!(host_node: node, volume: volume, name: data['name'])
           else

--- a/server/app/services/rpc_client.rb
+++ b/server/app/services/rpc_client.rb
@@ -69,7 +69,7 @@ class RpcClient
   # @param [Array] resp
   # @return [MongoPubsub::Subscription]
   def subscribe_to_response(request_id, resp)
-    MongoPubsub.subscribe("#{RPC_CHANNEL}:#{request_id}") do |msg|
+    MongoPubsub.subscribe("#{RPC_CHANNEL}/#{node_id}/#{request_id}") do |msg|
       resp_message = msg['message']
       if resp_message && resp_message[0] == 1 && resp_message[1] == request_id
         error = resp_message[2]

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -40,36 +40,37 @@ class RpcServer
     @processing = true
     while @processing && data = @queue.pop
       @counter += 1
-      size = data.size
-      if size == 2
-        handle_notification(data[0], data[1])
-      elsif size == 3
-        handle_request(data[0], data[1], data[2])
+
+      node_id, rpc_message, ws_client = data
+      if ws
+        handle_request(node_id, rpc_message, ws_client)
+      else
+        handle_notification(node_id, rpc_message)
       end
       Thread.pass
     end
   end
 
   # @param [Faye::Websocket] ws_client
-  # @param [String] grid_id
+  # @param [String] node_id
   # @param [Array] message msgpack-rpc request array
   # @return [Array]
-  def handle_request(ws_client, grid_id, message)
-    msg_id = message[1]
-    handler = message[2].split('/')[1]
-    method = message[2].split('/')[2]
-    if instance = handling_instance(grid_id, handler)
+  def handle_request(node_id, rpc_message, ws_client)
+    msg_type, msg_id, rpc_method, rpc_args = rpc_message
+    handler, method = rpc_method.split('/', 2)
+
+    if instance = handling_instance(node_id, handler)
       begin
-        result = instance.send(method, *message[3])
+        result = instance.send(method, *rpc_args)
         send_message(ws_client, [1, msg_id, nil, result])
       rescue RpcServer::Error => exc
         send_message(ws_client, [1, msg_id, {code: exc.code, message: exc.message}, nil])
-        @handlers[grid_id].delete(handler)
+        @handlers[node_id].delete(handler)
       rescue => exc
         error "#{exc.class.name}: #{exc.message}"
         debug exc.backtrace.join("\n")
         send_message(ws_client, [1, msg_id, {code: 500, message: "#{exc.class.name}: #{exc.message}"}, nil])
-        @handlers[grid_id].delete(handler)
+        @handlers[node_id].delete(handler)
       end
     else
       warn "handler #{handler} not implemented"
@@ -77,39 +78,40 @@ class RpcServer
     end
   end
 
-  # @param [String] grid_id
+  # @param [String] node_id
   # @param [Array] message msgpack-rpc notification array
-  def handle_notification(grid_id, message)
-    handler = message[1].split('/')[1]
-    method = message[1].split('/')[2]
+  def handle_notification(node_id, rpc_message)
+    msg_type, rpc_method, rpc_args = rpc_message
+    handler, method = rpc_method.split('/', 2)
+
     if instance = handling_instance(grid_id, handler)
       begin
-        instance.send(method, *message[2])
+        instance.send(method, *rpc_args)
       rescue => exc
         error "#{exc.class.name}: #{exc.message}"
         error exc.backtrace.join("\n")
-        @handlers[grid_id].delete(handler)
+        @handlers[node_id].delete(handler)
       end
     else
       warn "handler #{handler} not implemented"
     end
   end
 
-  # @param [String] grid_id
-  # @param [String] name
+  # @param [String] node_id
+  # @param [String] handler
   # @return [Object]
-  def handling_instance(grid_id, name)
+  def handling_instance(node_id, name)
     return unless HANDLERS[name]
 
-    @handlers[grid_id] ||= {}
-    unless @handlers[grid_id][name]
-      grid = Grid.find(grid_id)
-      if grid
-        @handlers[grid_id][name] = HANDLERS[name].new(grid)
+    @handlers[node_id] ||= {}
+    unless @handlers[node_id][name]
+      node = HostNode.find(node_id)
+      if node
+        @handlers[node_id][name] = HANDLERS[name].new(node)
       end
     end
 
-    @handlers[grid_id][name]
+    @handlers[node_id][name]
   end
 
   # @param [Faye::Websocket] ws

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -42,7 +42,7 @@ class RpcServer
       @counter += 1
 
       node_id, rpc_message, ws_client = data
-      if ws
+      if rpc_message[0] == 0
         handle_request(node_id, rpc_message, ws_client)
       else
         handle_notification(node_id, rpc_message)
@@ -57,7 +57,7 @@ class RpcServer
   # @return [Array]
   def handle_request(node_id, rpc_message, ws_client)
     msg_type, msg_id, rpc_method, rpc_args = rpc_message
-    handler, method = rpc_method.split('/', 2)
+    root, handler, method = rpc_method.split('/')
 
     if instance = handling_instance(node_id, handler)
       begin
@@ -82,9 +82,9 @@ class RpcServer
   # @param [Array] message msgpack-rpc notification array
   def handle_notification(node_id, rpc_message)
     msg_type, rpc_method, rpc_args = rpc_message
-    handler, method = rpc_method.split('/', 2)
+    root, handler, method = rpc_method.split('/')
 
-    if instance = handling_instance(grid_id, handler)
+    if instance = handling_instance(node_id, handler)
       begin
         instance.send(method, *rpc_args)
       rescue => exc


### PR DESCRIPTION
Scope all RPC requests/responses/notifications by the authenticated node ID from the websocket connection. This is a security feature, preventing malicious nodes from being able to leak/manipulate the state of other nodes by their node ID. This also simplifies the agent/server RPC callers/handlers.

* Change the server `RpcServer` handlers to be per-node, based on the authenticated node from the websocket connection

* Removes any explicit node ID parameters from agent -> server RPCs, using the rpc handler `@node` instead

* Server `RpcClient`-> agent RPC responses are now also routed using a per-node `rpc_client/:node_id/:rpc_id` pubsub name

# TODO

* Fix specs
* Consider moving the server `Rpc::ContainerHandler` buffering to a separate actor, with periodic flushing... having it be per-node means the stats/logs buffers are even longer now?