### PR TITLE
[1.3] Fix Ubuntu kontena-server/kontena-agent packages to be incompatible with docker 17.06

### DIFF
--- a/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu/kontena-agent/DEBIAN/control
@@ -2,7 +2,7 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.10) | docker-ce (<< 17.06) | docker-ee (<< 17.06), resolvconf
 Provides: kontena-weave, kontena-etcd
 Conflicts: kontena-weave, kontena-etcd
 Replaces: kontena-weave, kontena-etcd

--- a/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
+++ b/agent/packaging/ubuntu_xenial/kontena-agent/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-agent
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce (<< 17.06) | docker-ee (<< 17.06), resolvconf
 Description: Kontena Agent

--- a/server/packaging/ubuntu/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker-ce | docker-ee
+Depends: docker-engine (>= 1.10) | docker-ce (<< 17.06) | docker-ee (<< 17.06)
 Description: Kontena Server

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce | docker-ee, resolvconf
+Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce (<< 17.06) | docker-ee (<< 17.06), resolvconf
 Description: Kontena Server

--- a/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
+++ b/server/packaging/ubuntu_xenial/kontena-server/DEBIAN/control
@@ -2,5 +2,5 @@ Package: kontena-server
 Version: VERSION
 Maintainer: info@kontena.io
 Architecture: all
-Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce (<< 17.06) | docker-ee (<< 17.06), resolvconf
+Depends: docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce (<< 17.06) | docker-ee (<< 17.06)
 Description: Kontena Server


### PR DESCRIPTION
Fixes #2588 for 1.3.x (see #2589 for 1.4)

Installing the `kontena-agent` `1.3.x` package with `docker-ce` `17.06` installed will now fail:

```
dpkg: dependency problems prevent configuration of kontena-agent:
 kontena-agent depends on docker-engine (>= 1.10) | docker.io (>= 1.11) | docker-ce (<< 17.06) | docker-ee (<< 17.06); however:
  Package docker-engine is not installed.
  Package docker.io is not installed.
  Version of docker-ce on system is 17.06.0~ce-0~ubuntu.
  Package docker-ee is not installed.

dpkg: error processing package kontena-agent (--install):
 dependency problems - leaving unconfigured
```

With the new `kontena-agent` package installed, `apt upgrade` will hold `docker-ce` back:

```
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Calculating upgrade... Done
The following packages have been kept back:
  cloud-init docker-ce
0 upgraded, 0 newly installed, 0 to remove and 2 not upgraded.
```

Although the way it resolves the dependencies when you try and force an upgrade (`apt install docker-ce`) is odd, it wants to replace the docker-ce `17.03.*` package with the older distro docker.io package:

```
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 docker-ce : Conflicts: docker.io but 1.12.6-0ubuntu1~16.04.1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

This shows up in a `apt dist-upgrade`:

```
apt dist-upgrade
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Calculating upgrade... Done
The following package was automatically installed and is no longer required:
  libltdl7
Use 'apt autoremove' to remove it.
The following packages will be REMOVED:
  docker-ce
The following NEW packages will be installed:
  bridge-utils containerd docker.io runc ubuntu-fan
The following packages have been kept back:
  cloud-init
0 upgraded, 5 newly installed, 1 to remove and 1 not upgraded.
Need to get 16.4 MB of archives.
After this operation, 5512 kB disk space will be freed.
Do you want to continue? [Y/n]
```