### PR TITLE
Server: dockerignore docs/ to optimize image build

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -8,3 +8,4 @@ build
 release
 *.pem
 vendor
+docs


### PR DESCRIPTION
This will leave the `server/docs` directory out of the `docker build` context and the resulting `kontena/server` image.

### Before
Building the server docker image is unnecessarily slow if you happen to have a `./docs/vendor/bundle`:

```
Sending build context to Docker daemon  76.4 MB
```

### After
```
Sending build context to Docker daemon 1.434 MB
```

This server `app` directory itself weighs in at 1.3MB, so this is pretty close.