### PR TITLE
Agent: minimal update of ruby 2.4 dependencies

### DIFF
--- a/agent/Gemfile.lock
+++ b/agent/Gemfile.lock
@@ -1,9 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.0)
+    activesupport (4.2.9)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -39,11 +38,11 @@ GEM
     fluent-logger (0.6.2)
       msgpack (>= 0.5.6, < 2)
     hitimes (1.2.3)
-    i18n (0.7.0)
-    json (1.8.3)
+    i18n (0.8.6)
+    json (1.8.6)
     kontena-websocket-client (0.1.0)
       websocket-driver (~> 0.6.5)
-    minitest (5.5.0)
+    minitest (5.10.3)
     mixlib-log (1.6.0)
     msgpack (1.0.3)
     rake (10.4.2)
@@ -66,10 +65,10 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     statsd-ruby (1.3.0)
-    thread_safe (0.3.4)
+    thread_safe (0.3.6)
     timers (4.1.1)
       hitimes
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     vmstat (2.1.0)
     webmock (1.21.0)


### PR DESCRIPTION
Minimal update to fix travis deploys (which `bundle install`s and runs the server+agent rakefiles with ruby 2.4): https://travis-ci.org/kontena/kontena/jobs/258102052#L1141

* json-1.8.3 is not compatible with Ruby 2.4: https://github.com/flori/json/issues/303

