### PR TITLE
Fix node token clear to use DELETE /v1/nodes/:id/token

### DIFF
--- a/cli/lib/kontena/cli/nodes/env_command.rb
+++ b/cli/lib/kontena/cli/nodes/env_command.rb
@@ -14,10 +14,15 @@ module Kontena::Cli::Nodes
       grid_uri = self.current_master['url'].sub('http', 'ws')
     end
 
-    def execute
-      token_node = client.get("nodes/#{current_grid}/#{name}/token")
+    def get_node_token
+      return client.get("nodes/#{current_grid}/#{name}/token")
+    rescue Kontena::Errors::StandardError => exc
+      raise unless exc.status == 404
+      return nil
+    end
 
-      unless token_node['token']
+    def execute
+      unless token_node = get_node_token()
         exit_with_error "Node #{name} was not created with a node token. Use `kontena grid env` instead"
       end
 

--- a/cli/lib/kontena/cli/nodes/reset_token_command.rb
+++ b/cli/lib/kontena/cli/nodes/reset_token_command.rb
@@ -17,16 +17,16 @@ module Kontena::Cli::Nodes
     def execute
       confirm("Resetting the node token will disconnect the agent (unless using --no-reset-connection), and require you to reconfigure the kontena-agent using the new `kontena node env` values before it will be able to reconnect. Are you sure?")
 
-      data = {}
-
-      data[:token] = self.token unless self.clear_token?
-      data[:reset_connection] = self.reset_connection?
-
       spinner "Resetting node #{self.node.colorize(:cyan)} websocket connection token" do
         if self.clear_token?
-          client.delete("nodes/#{current_grid}/#{self.node}/token", data)
+          client.delete("nodes/#{current_grid}/#{self.node}/token",
+            reset_connection: self.reset_connection?,
+          )
         else
-          client.put("nodes/#{current_grid}/#{self.node}/token", data)
+          client.put("nodes/#{current_grid}/#{self.node}/token",
+            token: self.token,
+            reset_connection: self.reset_connection?,
+          )
         end
       end
     end

--- a/cli/lib/kontena/cli/nodes/reset_token_command.rb
+++ b/cli/lib/kontena/cli/nodes/reset_token_command.rb
@@ -19,12 +19,15 @@ module Kontena::Cli::Nodes
 
       data = {}
 
-      data[:token] = self.token
-      data[:token] = '' if self.clear_token?
+      data[:token] = self.token unless self.clear_token?
       data[:reset_connection] = self.reset_connection?
 
       spinner "Resetting node #{self.node.colorize(:cyan)} websocket connection token" do
-        client.put("nodes/#{current_grid}/#{self.node}/token", data)
+        if self.clear_token?
+          client.delete("nodes/#{current_grid}/#{self.node}/token", data)
+        else
+          client.put("nodes/#{current_grid}/#{self.node}/token", data)
+        end
       end
     end
   end

--- a/cli/spec/kontena/cli/nodes/env_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/env_command_spec.rb
@@ -31,15 +31,8 @@ describe Kontena::Cli::Nodes::EnvCommand do
   end
 
   context 'for a node without any token' do
-    let :node_token do
-      {
-        "id" => nil,
-        "token" => nil,
-      }
-    end
-
     before do
-      expect(client).to receive(:get).with('nodes/test-grid/node-1/token').and_return(node_token)
+      expect(client).to receive(:get).with('nodes/test-grid/node-1/token').and_raise(Kontena::Errors::StandardError.new(404, "Host node does not have a node token"))
     end
 
     it 'uses the grid token' do

--- a/cli/spec/kontena/cli/nodes/reset_token_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/reset_token_command_spec.rb
@@ -30,9 +30,15 @@ describe Kontena::Cli::Nodes::ResetTokenCommand do
     subject.run(['--force', '--no-reset-connection', 'test-node'])
   end
 
-  it 'PUTs to clear token without reset_connection' do
-    expect(client).to receive(:put).with('nodes/test-grid/test-node/token', {token: '', reset_connection: false})
+  it 'DELETEs to clear token without reset_connection' do
+    expect(client).to receive(:delete).with('nodes/test-grid/test-node/token', {reset_connection: false})
 
     subject.run(['--force', '--no-reset-connection', '--clear-token', 'test-node'])
+  end
+
+  it 'DELETEs to clear token with reset_connection' do
+    expect(client).to receive(:delete).with('nodes/test-grid/test-node/token', {reset_connection: true})
+
+    subject.run(['--force', '--clear-token', 'test-node'])
   end
 end

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -44,6 +44,7 @@ class HostNode
   has_many :volume_instances, dependent: :destroy
   has_and_belongs_to_many :images
 
+  validates_length_of :token, minimum: 16, maximum: 256, allow_nil: true
   after_save :reserve_node_number, :ensure_unique_name
 
   index({ grid_id: 1 })

--- a/server/app/mutations/host_nodes/update_token.rb
+++ b/server/app/mutations/host_nodes/update_token.rb
@@ -9,7 +9,8 @@ module HostNodes
     end
 
     optional do
-      string :token, nils: true, empty: true
+      string :token, nils: true
+      boolean :clear_token
       boolean :reset_connection
     end
 
@@ -20,12 +21,12 @@ module HostNodes
     end
 
     def update_token(node)
-      if self.token.nil?
-        node.token = self.generate_token
-      elsif self.token.empty?
+      if self.clear_token
         node.token = nil
-      else
+      elsif self.token
         node.token = self.token
+      else
+        node.token = self.generate_token
       end
     end
 

--- a/server/app/routes/v1/nodes_api.rb
+++ b/server/app/routes/v1/nodes_api.rb
@@ -35,6 +35,8 @@ module V1
           r.is do
             # GET /v1/nodes/:grid/:node/token
             r.get do
+              halt_request(404, {error: "Host node does not have a node token"}) unless @node.token
+
               render('host_nodes/token')
             end
 

--- a/server/app/routes/v1/nodes_api.rb
+++ b/server/app/routes/v1/nodes_api.rb
@@ -54,6 +54,20 @@ module V1
                 halt_request(422, {error: outcome.errors.message})
               end
             end
+
+            r.delete do
+              data = parse_json_body
+              outcome = HostNodes::UpdateToken.run(
+                host_node: @node,
+                clear_token: true,
+                reset_connection: data['reset_connection'],
+              )
+              if outcome.success?
+                {}
+              else
+                halt_request(422, {error: outcome.errors.message})
+              end
+            end
           end
         end
 

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -485,6 +485,8 @@ Accept: application/json
 
 Get a node token, used to configure the agent `KONTENA_NODE_TOKEN` env.
 
+Returns HTTP 404 if the node does not have a node token.
+
 ### Endpoint
 
 `GET /v1/nodes/:id/token`

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -305,6 +305,7 @@ follow | Stream logs
 	"updated_at": "2017-06-14T13:37:36.968Z",
 	"last_seen_at": "2017-06-14T13:38:03.785Z",
 	"connected_at": "2017-06-14T12:33:05.084Z",
+	"has_token": false,
 	"node_number": 1,
 	"initial_member": true,
 	"agent_version": "1.0.0",
@@ -379,6 +380,7 @@ Attribute | Description
 ---------- | -------
 id | A unique id for the node
 name | A unique name (within a grid) for the node
+has_token | Does the node have a node token
 connected | Is the node connected to the master (boolean)
 node_number | A sequential number for the node
 initial_member | Is the node part of initial grid members (boolean)
@@ -431,6 +433,27 @@ Update a node details.
 
 `PUT /v1/nodes/{id}`
 
+## Reset node token
+
+```http
+PUT /v1/nodes/mygrid/misty-sun-87/token HTTP/1.1
+Authorization: Bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Accept: application/json
+Content-Type: application/json
+
+{
+	"reset_connection": true
+}
+```
+
+Update node token. The optional `reset_connection` parameter causes any currently connected agent to be force-disconnected at the next keepalive interval. The agent will not be able to reconnect using the old node token.
+
+Use the optional `token` parameter to use a pre-generated token instead of having the server generate a new token. The node token must be between 16 and 64 bytes long.
+
+### Endpoint
+
+`PUT /v1/nodes/{id}/token`
+
 ## Get a node details
 
 ```http
@@ -444,6 +467,46 @@ Get a node details.
 ### Endpoint
 
 `GET /v1/nodes/:id`
+
+## Get node token
+
+```http
+GET /v1/nodes/my-grid/misty-sun-87/token HTTP/1.1
+Authorization: Bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Accept: application/json
+```
+
+```json
+{
+   "id" : "my-grid/misty-sun-87",
+   "token" : "ZxeA2iQ1MT61oT808BG/ty6aKtSnsD4f1cUub+DHWTfKoCBLTVYuP/WrRyDvjZAWdHZ3jBf/mhjGMiWhJ4YpSg=="
+}
+```
+
+Get a node token, used to configure the agent `KONTENA_NODE_TOKEN` env.
+
+### Endpoint
+
+`GET /v1/nodes/:id/token`
+
+## Clear node token
+
+```http
+DELETE /v1/nodes/my-grid/misty-sun-87/token HTTP/1.1
+Authorization: Bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Content-Type: application/json
+Accept: application/json
+
+{
+  "reset_connection": true
+}
+```
+
+Clear node token. Prevents the agent from reconnecting using the old node token. The agent can reconnect using the grid token.
+
+### Endpoint
+
+`DELETE /v1/nodes/:id/token`
 
 ## Delete a node
 

--- a/server/spec/api/v1/nodes_spec.rb
+++ b/server/spec/api/v1/nodes_spec.rb
@@ -110,6 +110,14 @@ describe '/v1/nodes', celluloid: true do
             'token' => 'asdfasdfasdfasdf',
         })
       end
+
+      it "returns 404 if node does not have a token" do
+        node.token = nil
+        node.save!
+
+        get "/v1/nodes/#{node.to_path}/token", nil, request_headers
+        expect(response.status).to eq(404)
+      end
     end
 
     describe 'PUT /token' do

--- a/server/spec/api/v1/nodes_spec.rb
+++ b/server/spec/api/v1/nodes_spec.rb
@@ -24,7 +24,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'GET' do
     it 'returns node with valid id and has_token' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c', token: 'asdf')
+      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c', token: 'asdfasdfasdfasdf')
       get "/v1/nodes/#{node.to_path}", nil, request_headers
       expect(response.status).to eq(200)
       expect(json_response).to_not include 'token'
@@ -61,7 +61,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'GET /token' do
     let(:node) do
-      node = grid.host_nodes.create!(name: 'abc', token: 'asdf')
+      node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf')
     end
 
     it "returns 403 without admin role" do
@@ -72,7 +72,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'PUT /token' do
     let(:node) do
-      node = grid.host_nodes.create!(name: 'abc', token: 'asdf')
+      node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf')
     end
 
     it "returns 403 without admin role" do
@@ -88,7 +88,7 @@ describe '/v1/nodes', celluloid: true do
 
     describe 'GET /token' do
       let(:node) do
-        node = grid.host_nodes.create!(name: 'abc', token: 'asdf')
+        node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf')
       end
 
       it "returns node token" do
@@ -96,14 +96,14 @@ describe '/v1/nodes', celluloid: true do
         expect(response.status).to eq(200)
         expect(json_response).to eq({
             'id' => 'test/abc',
-            'token' => 'asdf',
+            'token' => 'asdfasdfasdfasdf',
         })
       end
     end
 
     describe 'PUT /token' do
       let(:node) do
-        node = grid.host_nodes.create!(name: 'abc', token: 'asdf', connected: true)
+        node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf', connected: true)
       end
 
       it "generates new node token" do
@@ -113,39 +113,48 @@ describe '/v1/nodes', celluloid: true do
             'id' => 'test/abc',
             'token' => String,
         })
-        expect(json_response['token']).to_not eq 'asdf'
+        expect(json_response['token']).to_not eq 'asdfasdfasdfasdf'
 
         expect(node.reload).to be_connected
       end
 
       it "updates given token" do
-        put "/v1/nodes/#{node.to_path}/token", { 'token' => 'asdf2' }.to_json, request_headers
+        put "/v1/nodes/#{node.to_path}/token", { 'token' => 'asdfasdfasdfasdf2' }.to_json, request_headers
         expect(response.status).to eq(200)
         expect(json_response).to eq({
             'id' => 'test/abc',
-            'token' => 'asdf2',
+            'token' => 'asdfasdfasdfasdf2',
         })
       end
 
-      it "clears token" do
+      it "fails with empty token" do
         put "/v1/nodes/#{node.to_path}/token", { 'token' => '' }.to_json, request_headers
-        expect(response.status).to eq(200)
-        expect(json_response).to eq({
-            'id' => 'test/abc',
-            'token' => nil,
-        })
+        expect(response.status).to eq(422)
+        expect(json_response).to eq 'error' => { 'token' => "Token can't be blank" }
       end
 
       it "resets node connection" do
         expect{
-          put "/v1/nodes/#{node.to_path}/token", { 'token' => 'asdf2', 'reset_connection' => true }.to_json, request_headers
+          put "/v1/nodes/#{node.to_path}/token", { 'token' => 'asdfasdfasdfasdf2', 'reset_connection' => true }.to_json, request_headers
           expect(response.status).to eq(200)
         }.to change{node.reload.connected?}.from(true).to(false)
 
         expect(json_response).to eq({
             'id' => 'test/abc',
-            'token' => 'asdf2',
+            'token' => 'asdfasdfasdfasdf2',
         })
+      end
+    end
+
+    describe 'DELETE /token' do
+      let(:node) do
+        node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf', connected: true)
+      end
+
+      it "clears token" do
+        delete "/v1/nodes/#{node.to_path}/token", { }.to_json, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response).to eq({})
       end
     end
   end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -133,7 +133,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with a grid token and node ID that has a node token " do
-      let(:host_node) { grid.host_nodes.create!(name: 'node-1', node_id: 'nodeABC', token: 'secret') }
+      let(:host_node) { grid.host_nodes.create!(name: 'node-1', node_id: 'nodeABC', token: 'asdfasdfasdfasdf') }
 
       let(:grid_token) { 'secret123' }
       let(:node_token) { nil }
@@ -155,7 +155,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with the wrong node token" do
-      let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'secret') }
+      let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf') }
 
       let(:grid_token) { nil }
       let(:node_token) { 'the wrong secret' }
@@ -177,10 +177,10 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with the wrong node ID" do
-      let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'secret', node_id: 'nodeABC') }
+      let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf', node_id: 'nodeABC') }
 
       let(:grid_token) { nil }
-      let(:node_token) { 'secret' }
+      let(:node_token) { 'asdfasdfasdfasdf' }
       let(:node_id) { 'nodeXYZ' }
 
       before do
@@ -201,11 +201,11 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with a duplicate node ID" do
-      let(:host_node1) { grid.host_nodes.create!(name: 'node-1', token: 'secret1', node_id: 'nodeABC') }
-      let(:host_node2) { grid.host_nodes.create!(name: 'node-2', token: 'secret2') }
+      let(:host_node1) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf1', node_id: 'nodeABC') }
+      let(:host_node2) { grid.host_nodes.create!(name: 'node-2', token: 'asdfasdfasdfasdf2') }
 
       let(:grid_token) { nil }
-      let(:node_token) { 'secret2' }
+      let(:node_token) { 'asdfasdfasdfasdf2' }
       let(:node_id) { 'nodeABC' }
 
       before do
@@ -333,10 +333,10 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       end
 
       context 'with a valid node token' do
-        let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'test token') }
+        let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf') }
 
         let(:grid_token) { nil }
-        let(:node_token) { 'test token' }
+        let(:node_token) { 'asdfasdfasdfasdf' }
 
         before do
           host_node

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -347,28 +347,33 @@ describe HostNode do
       expect(node2.token).to be_nil
     end
 
+    it 'does not allow empty tokens' do
+      expect{HostNode.create!(grid: grid, name: 'node-1', token: '')}.to raise_error(Mongoid::Errors::Validations)
+    end
+
     context 'with a node that has a node token' do
-      let(:node1) { HostNode.create!(name: 'node-1', grid: grid, token: 'asdf') }
+      let(:token) { 'asdf'* 4 }
+      let(:node1) { HostNode.create!(name: 'node-1', grid: grid, token: token) }
 
       before do
         node1
       end
 
       it 'has a node token' do
-        expect(node1.token).to eq 'asdf'
+        expect(node1.token).to eq 'asdfasdfasdfasdf'
 
-        expect(HostNode.find_by(token: 'asdf').id).to eq node1.id
+        expect(HostNode.find_by(token: token).id).to eq node1.id
       end
 
       it 'does not allow multiple nodes to share the same token' do
-        expect{HostNode.create!(name: 'node-2', grid: grid, token: 'asdf')}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdf" }/)
+        expect{HostNode.create!(name: 'node-2', grid: grid, token: token)}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdfasdfasdfasdf" }/)
       end
 
       context 'with a second grid' do
         let(:grid2) { Grid.create!(name: 'test2') }
 
         it 'does not allow nodes to share the same token' do
-          expect{HostNode.create!(name: 'node-2', grid: grid2, token: 'asdf')}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdf" }/)
+          expect{HostNode.create!(name: 'node-2', grid: grid2, token: token)}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdfasdfasdfasdf" }/)
         end
       end
     end

--- a/server/spec/mutations/host_nodes/create_spec.rb
+++ b/server/spec/mutations/host_nodes/create_spec.rb
@@ -20,6 +20,17 @@ describe HostNodes::Create do
     expect(outcome.errors.message).to eq 'name' => "Name isn't in the right format"
   end
 
+  it 'fails with an empty token' do
+    outcome = described_class.run(
+      grid: grid,
+      name: 'foo',
+      token: '',
+    )
+
+    expect(outcome).to_not be_success
+    expect(outcome.errors.message).to eq 'token' => "Token can't be blank"
+  end
+
   it 'creates with defaults' do
     outcome = described_class.run(
       grid: grid,
@@ -39,11 +50,11 @@ describe HostNodes::Create do
     outcome = described_class.run(
       grid: grid,
       name: 'foobar',
-      token: 'asdf',
+      token: 'asdfasdfasdfasdf',
     )
     expect(outcome).to be_success
     expect(outcome.result).to be_a HostNode
-    expect(outcome.result.token).to eq 'asdf'
+    expect(outcome.result.token).to eq 'asdfasdfasdfasdf'
   end
 
   it 'creates with labels' do
@@ -60,7 +71,7 @@ describe HostNodes::Create do
     let(:node) do
       grid.host_nodes.create!(
         name: 'test-1',
-        token: 'asdfasdf',
+        token: 'asdfasdfasdfasdf',
       )
     end
 

--- a/server/spec/mutations/host_nodes/update_token_spec.rb
+++ b/server/spec/mutations/host_nodes/update_token_spec.rb
@@ -19,24 +19,45 @@ describe HostNodes::UpdateToken do
       expect(node.token).to eq outcome.result.token
     end
 
+    it 'fails with an empty token' do
+      outcome = described_class.run(
+        host_node: node,
+        token: '',
+      )
+
+      expect(outcome).to_not be_success
+      expect(outcome.errors.message).to eq 'token' => "Token can't be blank"
+    end
+
+    it 'fails with a short token' do
+      outcome = described_class.run(
+        host_node: node,
+        token: 'asdf',
+      )
+
+      expect(outcome).to_not be_success
+      expect(outcome.errors.message).to eq 'token' => "is too short (minimum is 16 characters)"
+    end
+
+
     it 'updates given node token' do
       outcome = described_class.run(
         host_node: node,
-        token: 'asdf'
+        token: 'asdfasdfasdfasdf'
       )
 
       expect(outcome).to be_success
-      expect(outcome.result.token).to eq 'asdf'
+      expect(outcome.result.token).to eq 'asdfasdfasdfasdf'
 
       node.reload
 
       expect(outcome.result).to eq node
-      expect(node.token).to eq 'asdf'
+      expect(node.token).to eq 'asdfasdfasdfasdf'
     end
   end
 
   context "with an existing host node with a token" do
-    let(:node) { grid.host_nodes.create!(name: 'node-1', token: 'asdf')}
+    let(:node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf')}
 
     before do
       node
@@ -50,7 +71,7 @@ describe HostNodes::UpdateToken do
       expect(outcome).to be_success
       expect(outcome.result.token).to be_a String
       expect(outcome.result.token).to_not be_empty
-      expect(outcome.result.token).to_not eq 'asdf'
+      expect(outcome.result.token).to_not eq 'asdfasdfasdfasdf'
     end
 
     it 'generates a new node token with explicit nil' do
@@ -62,23 +83,23 @@ describe HostNodes::UpdateToken do
       expect(outcome).to be_success
       expect(outcome.result.token).to be_a String
       expect(outcome.result.token).to_not be_empty
-      expect(outcome.result.token).to_not eq 'asdf'
+      expect(outcome.result.token).to_not eq 'asdfasdfasdfasdf'
     end
 
     it 'updates given node token' do
       outcome = described_class.run(
         host_node: node,
-        token: 'asdf2'
+        token: 'asdfasdfasdfasdf2'
       )
 
       expect(outcome).to be_success
-      expect(outcome.result.token).to eq 'asdf2'
+      expect(outcome.result.token).to eq 'asdfasdfasdfasdf2'
     end
 
     it 'clears the node token' do
       outcome = described_class.run(
         host_node: node,
-        token: '',
+        clear_token: true,
       )
 
       expect(outcome).to be_success
@@ -105,7 +126,7 @@ describe HostNodes::UpdateToken do
       it 'fails to update to a duplicate token' do
         outcome = described_class.run(
           host_node: node2,
-          token: 'asdf'
+          token: 'asdfasdfasdfasdf'
         )
 
         expect(outcome).to_not be_success
@@ -115,7 +136,7 @@ describe HostNodes::UpdateToken do
   end
 
   context "with an existing host node that is connected" do
-    let(:node) { grid.host_nodes.create!(name: 'node-1', token: 'asdf', connected: true)}
+    let(:node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf', connected: true)}
 
     before do
       node
@@ -127,7 +148,7 @@ describe HostNodes::UpdateToken do
       )
 
       expect(outcome).to be_success
-      expect(outcome.result.token).to_not eq 'asdf'
+      expect(outcome.result.token).to_not eq 'asdfasdfasdfasdf'
       expect(outcome.result).to be_connected
     end
 
@@ -138,7 +159,7 @@ describe HostNodes::UpdateToken do
       )
 
       expect(outcome).to be_success
-      expect(outcome.result.token).to_not eq 'asdf'
+      expect(outcome.result.token).to_not eq 'asdfasdfasdfasdf'
       expect(outcome.result).to_not be_connected
     end
   end


### PR DESCRIPTION
Change `kontena node reset-token --clear-token` to use `DELETE /v1/nodes/:id/token` which calls `HostNodes::UpdateToken.run :clear_token => true`. Also accepts the optional `reset_connection: true` parameter.

* Validate node tokens to be 16..64 chars in length, rejecting empty tokens
* Add `DELETE /v1/nodes/:id/token` to replace `PUT /v1/nodes/:id/token` `{ "token": "" }`
* Change `GET /v1/nodes/:id/token` to return HTTP 404 instead of `{ "token": null }` if no node token