### PR TITLE
cli: fix Dockerfile gem install needing ruby-dev for websocket-driver

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -7,8 +7,11 @@ ARG CLI_VERSION
 RUN apk update && \
   apk --update add ruby ruby-json ruby-bigdecimal ruby-io-console \
   ca-certificates libssl1.0 openssl libstdc++ && \
-  gem install kontena-cli --no-rdoc --no-ri -v ${CLI_VERSION} && \
   chmod +x /usr/local/bin/docker
+
+RUN apk --update add --virtual build-dependencies ruby-dev build-base openssl-dev && \
+  gem install kontena-cli --no-rdoc --no-ri -v ${CLI_VERSION} && \
+  apk del build-dependencies
 
 VOLUME ["/root"]
 WORKDIR /root


### PR DESCRIPTION
Travis 1.4.0.pre5 cli `release:docker_push` failed due to `gem install kontena-cli` now depending on the `kontena-websocket-client` -> `websocket-driver` native extensions:

```
Step 5/8 : RUN apk update &&   apk --update add ruby ruby-json ruby-bigdecimal ruby-io-console   ca-certificates libssl1.0 openssl libstdc++ &&   gem install kontena-cli --no-rdoc --no-ri -v ${CLI_VERSION} &&   chmod +x /usr/local/bin/docker

 ---> Running in 4e4342edf434

fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz

fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz

v3.5.2-131-g833fa41a4d [http://dl-cdn.alpinelinux.org/alpine/v3.5/main]

v3.5.2-125-g9cb91a548a [http://dl-cdn.alpinelinux.org/alpine/v3.5/community]

OK: 7962 distinct packages available

fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz

fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/community/x86_64/APKINDEX.tar.gz

(1/19) Installing ca-certificates (20161130-r1)

(2/19) Installing libcrypto1.0 (1.0.2k-r0)

(3/19) Installing libssl1.0 (1.0.2k-r0)

(4/19) Installing libgcc (6.2.1-r1)

(5/19) Installing libstdc++ (6.2.1-r1)

(6/19) Installing openssl (1.0.2k-r0)

(7/19) Installing libffi (3.2.1-r2)

(8/19) Installing gdbm (1.12-r0)

(9/19) Installing gmp (6.1.1-r0)

(10/19) Installing ncurses-terminfo-base (6.0-r7)

(11/19) Installing ncurses-terminfo (6.0-r7)

(12/19) Installing ncurses-libs (6.0-r7)

(13/19) Installing readline (6.3.008-r4)

(14/19) Installing yaml (0.1.7-r0)

(15/19) Installing ruby-libs (2.3.3-r0)

(16/19) Installing ruby (2.3.3-r0)

(17/19) Installing ruby-bigdecimal (2.3.3-r0)

(18/19) Installing ruby-io-console (2.3.3-r0)

(19/19) Installing ruby-json (2.3.3-r0)

Executing busybox-1.25.1-r0.trigger

Executing ca-certificates-20161130-r1.trigger

OK: 32 MiB in 30 packages

Successfully installed excon-0.49.0

Successfully installed necromancer-0.4.0

Successfully installed equatable-0.5.0

Successfully installed tty-color-0.4.2

Successfully installed pastel-0.7.1

Successfully installed tty-cursor-0.4.0

Successfully installed wisper-1.6.1

Successfully installed tty-prompt-0.12.0

Successfully installed clamp-1.1.2

Successfully installed ruby_dig-0.0.2

Successfully installed public_suffix-2.0.5

Successfully installed addressable-2.5.1

Successfully installed launchy-2.4.3

Successfully installed hash_validator-0.7.1

Successfully installed retriable-2.1.0

Successfully installed opto-1.8.5

Successfully installed semantic-1.6.0

Successfully installed liquid-4.0.0

Successfully installed tty-screen-0.5.0

Successfully installed unicode_utils-1.4.0

Successfully installed unicode-display_width-1.1.3

Successfully installed verse-0.5.0

Successfully installed tty-table-0.8.0

Successfully installed websocket-extensions-0.1.2

Building native extensions.  This could take a while...

ERROR:  Error installing kontena-cli:

	ERROR: Failed to build gem native extension.

    current directory: /usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5/ext/websocket-driver

/usr/bin/ruby -r ./siteconf20170728-13-k6lfmn.rb extconf.rb

mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h

extconf failed, exit code 1

Gem files will remain installed in /usr/lib/ruby/gems/2.3.0/gems/websocket-driver-0.6.5 for inspection.

Results logged to /usr/lib/ruby/gems/2.3.0/extensions/x86_64-linux/2.3.0/websocket-driver-0.6.5/gem_make.out

The command '/bin/sh -c apk update &&   apk --update add ruby ruby-json ruby-bigdecimal ruby-io-console   ca-certificates libssl1.0 openssl libstdc++ &&   gem install kontena-cli --no-rdoc --no-ri -v ${CLI_VERSION} &&   chmod +x /usr/local/bin/docker' returned a non-zero code: 1
```