### PR TITLE
Recreate service pod worker on unexpected dead actor error

### DIFF
--- a/agent/lib/kontena/workers/service_pod_manager.rb
+++ b/agent/lib/kontena/workers/service_pod_manager.rb
@@ -122,7 +122,10 @@ module Kontena::Workers
           workers[service_pod.id].async.update(service_pod)
         end
       rescue Celluloid::DeadActorError
+        error "tried to call dead worker: #{service_pod.name}"
         workers.delete(service_pod.id)
+        info "recreating worker for: #{service_pod.name}"
+        ensure_service_worker(service_pod)
       end
     end
 


### PR DESCRIPTION
Cannot reproduce this situation but in theory there is a condition where `ServicePodManager` calls dead `ServicePodWorker`. Previously this just cleared worker from `workers` pool, which is fine if service still exists in master. If it does not exist in master this can lead into situation where worker is gone but actual container still exists -> container can block new deployments because no worker is doing container remove/cleanup.

Probably fixes #2625, #2608