### PR TITLE
agent: fix websocket client to not deadlock on sync actor calls from on_pong

### DIFF
--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -133,7 +133,8 @@ module Kontena
       # run the blocking websocket client connect+read in a separate thread
       defer {
         ws.on_pong do |delay|
-          actor.on_pong(delay)
+          # XXX: called with the client mutex locked, do not block
+          actor.async.on_pong(delay)
         end
 
         # blocks until open, raises on errors


### PR DESCRIPTION
Fixes #2649 based on testing with the same short ping interval / busy sends used to repro the bug

Keeping the sync call to `on_open` because that updates the `@connected` state.

The `on_message` could possibly also be changed to `async`, but it is called from the `read` block with the driver unlocked, so it should not cause similar deadlocks. Keeping it sync could allow some degree of websocket flow control in theory, but that won't happen in practice with the server EM write buffering + the agent `on_message` unbounded async calls.