### PR TITLE
Fix spinner nesting during master deploy wizard

### DIFF
--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -47,7 +47,7 @@ module Kontena::Cli::Cloud::Master
       masters = []
       spinner "Retrieving a list of your registered Kontena Masters in Kontena Cloud" do |spin|
         begin
-          masters = Kontena.run!(%w(cloud master list --return))
+          masters = Kontena.run!(%w(cloud master list --return --quiet))
         rescue SystemExit
           spin.fail
         end


### PR DESCRIPTION
There was an unnecessary spinner nesting happening during the master deploy wizard.

Before: 
![image](https://user-images.githubusercontent.com/224971/28919916-431014b6-7858-11e7-94c2-c2be3328c85f.png)

After:
![image](https://user-images.githubusercontent.com/224971/28919944-5fc88c64-7858-11e7-8f13-2c9e3acffc17.png)
