### PR TITLE
CLI: Use the "press any key" dialog from tty-prompt library

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "excon", "~> 0.49.0"
-  spec.add_runtime_dependency "tty-prompt", "0.12.0"
+  spec.add_runtime_dependency "tty-prompt", "0.13.0"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "excon", "~> 0.49.0"
-  spec.add_runtime_dependency "tty-prompt", "0.13.0"
+  spec.add_runtime_dependency "tty-prompt", "0.13.1"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -276,44 +276,14 @@ module Kontena
       def any_key_to_continue_with_timeout(timeout=9)
         return nil if running_silent?
         return nil unless $stdout.tty?
-        start_time = Time.now.to_i
-        end_time   = start_time + timeout
-        Thread.main['any_key.timed_out']   = false
-        msg = "Press any key to continue or ctrl-c to cancel.. (Automatically continuing in ? seconds)"
-
-        reader_thread = Thread.new do
-          Thread.main['any_key.char'] = $stdin.getch
-        end
-
-        countdown_thread = Thread.new do
-          time_left = timeout
-          while time_left > 0 && Thread.main['any_key.char'].nil?
-            print "\r#{pastel.bright_white("#{msg.sub("?", time_left.to_s)}")} "
-            time_left = end_time - Time.now.to_i
-            sleep 0.1
-          end
-          print "\r#{' ' * msg.length}  \r"
-          reader_thread.kill if reader_thread.alive?
-        end
-
-        countdown_thread.join
-
-        if Thread.main['any_key.char'] == "\u0003"
-          error "Canceled"
-        end
+        prompt.keypress("Press any key to continue or ctrl-c to cancel (Automatically continuing in :countdown seconds) ...", timeout: timeout)
       end
 
       def any_key_to_continue(timeout = nil)
         return nil if running_silent?
         return nil unless $stdout.tty?
         return any_key_to_continue_with_timeout(timeout) if timeout
-        msg = "Press any key to continue or ctrl-c to cancel.. "
-        print pastel.bright_cyan("#{msg}")
-        char = $stdin.getch
-        print "\r#{' ' * msg.length}\r"
-        if char == "\u0003"
-          error "Canceled"
-        end
+        prompt.keypress("Press any key to continue or ctrl-c to cancel.. ")
       end
 
       def display_account_login_info


### PR DESCRIPTION
Fixes #2651

Replaced the own custom "press any key to continue" dialog with the implementation from tty-prompt.

Upgraded to TTY-Prompt 0.13.1 which [solves the earlier problem](https://github.com/piotrmurach/tty-prompt/issues/56) in `#keypress` that left the countdown running in another thread after pressing a key and finally caused a timeout exception to halt the operation going on in main thread.
