### PR TITLE
CLI: Fix error message when trying to use nonexistent master

### DIFF
--- a/cli/lib/kontena/cli/master/list_command.rb
+++ b/cli/lib/kontena/cli/master/list_command.rb
@@ -13,7 +13,7 @@ module Kontena::Cli::Master
 
     def mark_if_current(row)
       unless quiet?
-        row.name.insert(0, pastel.yellow('* ')) if row.name == current_master_name
+        row.name.to_s.insert(0, pastel.yellow('* ')) if row.name == current_master_name
       end
     end
 

--- a/cli/lib/kontena/cli/master/use_command.rb
+++ b/cli/lib/kontena/cli/master/use_command.rb
@@ -18,8 +18,7 @@ module Kontena::Cli::Master
 
       master = config.find_server(name)
       if master.nil?
-        exit_with_error p"Could not resolve master by name '#{name}'." +
-              "\nFor a list of known masters please run: kontena master list"
+        exit_with_error "Could not resolve master by name '#{name}'. For a list of known masters please run: kontena master list"
       else
         config.current_master = master['name']
         config.write


### PR DESCRIPTION
Fixes #2647 

The `master list` can crash if there's a master with null as name in `.kontena_client.json` and the `current_server` is null.

