### PR TITLE
Add unhealthy container counts to service API

### DIFF
--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -272,12 +272,13 @@ class GridService
 
   def health_status
     healthy = 0
-
+    unhealthy = 0
     self.containers.each do |c|
       healthy += 1 if c.health_status == 'healthy'
+      unhealthy += 1 if c.health_status == 'unhealthy'
     end
 
-    {healthy: healthy, total: self.containers.count}
+    {healthy: healthy, unhealthy: unhealthy, total: self.containers.count}
   end
 
   def ensure_stack

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -884,6 +884,11 @@ follow | Stream logs
   "log_opts": null,
   "hooks": [],
   "health_check": {},
+  "health_status": {
+      "healthy": 1,
+      "unhealthy": 0,
+      "total": 1
+  },
   "instances": {
     "total": 1,
     "running": 1
@@ -922,6 +927,7 @@ log_opts | Log driver options (object)
 hooks | Commands to be executed when service instance is deployed
 instance_counts | Stats about how many instances this service currently has
 stop_grace_period | How long to wait when attempting to stop a container if it doesn’t handle SIGTERM (or whatever stop signal has been specified with the image), before sending SIGKILL.
+health_status | Health status of the service instances. Only counted if there is a health check defined for the service.
 
 ### Deploy Opt attributes
 

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -125,11 +125,14 @@ describe '/v1/services' do
     it 'returns health status' do
       redis_service.health_check = GridServiceHealthCheck.new(port: 5000, protocol: 'tcp')
       redis_service.save
-      container = redis_service.containers.create!(name: 'redis-1', container_id: 'aaa', health_status: 'healthy')
+      redis_service.containers.create!(name: 'redis-1', container_id: 'aaa', health_status: 'healthy')
+      redis_service.containers.create!(name: 'redis-2', container_id: 'bbb', health_status: 'unhealthy')
+      redis_service.containers.create!(name: 'redis-3', container_id: 'ccc')
       get "/v1/services/#{redis_service.to_path}", nil, request_headers
       expect(response.status).to eq(200)
-      expect(json_response['health_status']['total']).to eq(1)
+      expect(json_response['health_status']['total']).to eq(3)
       expect(json_response['health_status']['healthy']).to eq(1)
+      expect(json_response['health_status']['unhealthy']).to eq(1)
     end
 
     it 'returns no health check or status if protocol nil' do

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -249,7 +249,7 @@ describe GridService do
       unhealthy_container = grid_service.containers.create!(name: 'redis-2')
       unhealthy_container.update_attribute(:health_status, 'unhealthy')
 
-      expect(grid_service.health_status).to eq({healthy: 1, total: 2})
+      expect(grid_service.health_status).to eq({healthy: 1, unhealthy: 1, total: 2})
     end
 
     it 'returns nil if container is not found' do


### PR DESCRIPTION
Added `unhealthy` instance count also to the `GET "/v1/services/...` API.

fixes #2564 