### PR TITLE
Fix agent Docker.info caching

### DIFF
--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -20,6 +20,10 @@ module Kontena
       @read_pipe, @write_pipe = IO.pipe
     end
 
+    def docker_info
+      @docker_info ||= Docker.info
+    end
+
     def configure(opts)
       @opts = opts
 
@@ -28,13 +32,13 @@ module Kontena
 
         @node_id = node_id
       else
-        @node_id = Docker.info['ID']
+        @node_id = docker_info['ID']
       end
 
       if node_labels = opts[:node_labels]
         @node_labels = node_labels.split()
       else
-        @node_labels = Docker.info['Labels'].to_a
+        @node_labels = docker_info['Labels'].to_a
       end
     end
 

--- a/agent/lib/kontena/workers/node_info_worker.rb
+++ b/agent/lib/kontena/workers/node_info_worker.rb
@@ -49,7 +49,7 @@ module Kontena::Workers
 
     def publish_node_info
       debug 'publishing node information'
-      node_info = Docker.info()
+      node_info = Docker.info
       node_info['PublicIp'] = self.public_ip
       node_info['PrivateIp'] = self.private_ip
       node_info['AgentVersion'] = Kontena::Agent::VERSION


### PR DESCRIPTION
Fixes #2237

The agent `NodeInfoWorker` would cache the `Docker.info` at startup, and use the same values for each `publish_node_info`. This would fail to notice any new volume drivers that appear after agent startup.