### PR TITLE
Fix nil resource usage error on node show cmd

### DIFF
--- a/cli/lib/kontena/cli/nodes/show_command.rb
+++ b/cli/lib/kontena/cli/nodes/show_command.rb
@@ -43,9 +43,10 @@ module Kontena::Cli::Nodes
         mem_used = mem['used'] - (mem['cached'] + mem['buffers'])
         puts "    memory: #{to_gigabytes(mem_used, 2)} of #{to_gigabytes(mem['total'], 2)} GB"
       end
-      if node['resource_usage']['filesystem']
+      fs = node.dig('resource_usage','filesystem')
+      if fs
         puts "    filesystem:"
-        node['resource_usage']['filesystem'].each do |filesystem|
+        fs.each do |filesystem|
           puts "      - #{filesystem['name']}: #{to_gigabytes(filesystem['used'], 2)} of #{to_gigabytes(filesystem['total'], 2)} GB"
         end
       end

--- a/cli/spec/kontena/cli/nodes/show_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/show_command_spec.rb
@@ -43,4 +43,33 @@ describe Kontena::Cli::Nodes::ShowCommand do
       '      - /var/lib/docker: 2.89 of 15.57 GB',
     ])
   end
+
+  it 'does not fail with missing fs stats' do
+    node_info = node
+    node_info.delete('resource_usage')
+    allow(client).to receive(:get).with('nodes/test-grid/core-01').and_return(node_info)
+
+    expect{subject.run(['core-01'])}.to output_lines([
+      'development/core-01:',
+      '  id: XI4K:NPOL:EQJ4:S4V7:EN3B:DHC5:KZJD:F3U2:PCAN:46EV:IO4A:63S5',
+      '  agent version: 1.4.0.dev',
+      '  docker version: 1.12.6',
+      '  connected: yes',
+      '  last connect: 2017-07-04T08:36:02.235Z',
+      '  last seen: 2017-07-04T08:36:02.280Z',
+      '  public ip: 91.150.10.190',
+      '  private ip: 192.168.66.101',
+      '  overlay ip: 10.81.0.1',
+      '  os: Container Linux by CoreOS 1409.5.0 (Ladybug)',
+      '  kernel: 4.11.6-coreos-r1',
+      '  drivers:',
+      '    storage: overlay',
+      '    volume: local',
+      '  initial node: yes',
+      '  labels:',
+      '    - test',
+      '  stats:',
+      '    cpus: 1'
+    ])
+  end
 end


### PR DESCRIPTION
When node just joins grid and has not yet reported any resource usages CLI fails `node show` command with nasty `[error] NoMethodError : undefined method '[]' for nil:NilClass`
Backtrace:
```
/Users/jussi/code/kontena/cli/lib/kontena/cli/nodes/show_command.rb:47:in `execute': undefined method `[]' for nil:NilClass (NoMethodError)
	from /Users/jussi/code/kontena/cli/lib/kontena/command.rb:202:in `run'
	from /Users/jussi/.rvm/gems/ruby-2.3.3/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Users/jussi/code/kontena/cli/lib/kontena/command.rb:202:in `run'
	from /Users/jussi/.rvm/gems/ruby-2.3.3/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
	from /Users/jussi/code/kontena/cli/lib/kontena/command.rb:202:in `run'
	from /Users/jussi/.rvm/gems/ruby-2.3.3/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
	from ./bin/kontena:18:in `<main>'
```

Fixed by using `dig` rather than chained `[]` calls

