### PR TITLE
CLI: Error out from init-cloud when master already cloud-enabled

### DIFF
--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -14,13 +14,26 @@ module Kontena::Cli::Master
     requires_current_master_token
     requires_current_account_token
 
+    def master_config
+      @master_config ||= client.get('config')
+    end
+
+    def current_master_cloud_config
+      return @cloud_config if @cloud_config
+      master_client_id = master_config['oauth2.client_id']
+      @cloud_config = cloud_client.get('user/masters')['data'].find { |cm| cm['attributes']['client-id'] == master_client_id }
+    end
+
+    def current_master_cloud_name
+      @cloud_name ||= current_master_cloud_config.nil? ? nil : current_master_cloud_config['attributes']['name']
+    end
+
     def already_cloud_enabled?
-      cfg = client.get('config')
-      cfg['cloud.enabled'].to_s == 'true' && cfg['cloud.provider_is_kontena'].to_s == 'true'
+      !current_master_cloud_config.nil?
     end
 
     def execute
-      exit_with_error "Current master #{pastel.cyan(current_master.name)} is already registered to use Kontena Cloud" if already_cloud_enabled?
+      exit_with_error "Current master is already registered to use Kontena Cloud as #{pastel.cyan(current_master_cloud_name)}" if already_cloud_enabled?
       args = ["--current"]
       args << "--force" if self.force?
       args += ["--cloud-master-id", self.cloud_master_id.shellescape] if self.cloud_master_id

--- a/cli/lib/kontena/cli/master/init_cloud_command.rb
+++ b/cli/lib/kontena/cli/master/init_cloud_command.rb
@@ -14,7 +14,13 @@ module Kontena::Cli::Master
     requires_current_master_token
     requires_current_account_token
 
+    def already_cloud_enabled?
+      cfg = client.get('config')
+      cfg['cloud.enabled'].to_s == 'true' && cfg['cloud.provider_is_kontena'].to_s == 'true'
+    end
+
     def execute
+      exit_with_error "Current master #{pastel.cyan(current_master.name)} is already registered to use Kontena Cloud" if already_cloud_enabled?
       args = ["--current"]
       args << "--force" if self.force?
       args += ["--cloud-master-id", self.cloud_master_id.shellescape] if self.cloud_master_id

--- a/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
+++ b/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
@@ -27,10 +27,15 @@ describe Kontena::Cli::Master::InitCloudCommand do
   end
 
   it 'exits with error if master is already registered to use cloud' do
-    expect(subject.client).to receive(:get).with('config').and_return(
-      'cloud.enabled' => true,
-      'cloud.provider_is_kontena' => 'true'
+    expect(subject.cloud_client).to receive(:get).with('user/masters').and_return(
+      'data' => [
+        { 'attributes' => { 'client-id' => 'abc123', 'name' => 'testmaster' } },
+        { 'attributes' => { 'client-id' => 'def234', 'name' => 'foo' } },
+      ]
     )
-    expect{subject.run(['--force'])}.to exit_with_error.and output(/already registered/).to_stderr
+    expect(subject.client).to receive(:get).with('config').and_return(
+      'oauth2.client_id' => 'abc123'
+    )
+    expect{subject.run(['--force'])}.to exit_with_error.and output(/already registered.+?testmaster/).to_stderr
   end
 end

--- a/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
+++ b/cli/spec/kontena/cli/master/init_cloud_command_spec.rb
@@ -20,8 +20,17 @@ describe Kontena::Cli::Master::InitCloudCommand do
   end
 
   it 'runs the invite self after deploy callback' do
+    allow(subject).to receive(:already_cloud_enabled?).and_return(false)
     expect(Kontena).to receive(:run!).with(%w(cloud master add --current --force)).and_return(true)
     expect_any_instance_of(Kontena::Callbacks::InviteSelfAfterDeploy).to receive(:after).and_return(true)
     subject.run(['--force'])
+  end
+
+  it 'exits with error if master is already registered to use cloud' do
+    expect(subject.client).to receive(:get).with('config').and_return(
+      'cloud.enabled' => true,
+      'cloud.provider_is_kontena' => 'true'
+    )
+    expect{subject.run(['--force'])}.to exit_with_error.and output(/already registered/).to_stderr
   end
 end


### PR DESCRIPTION
Fixes #2679

Exits with an error message when trying to run `kontena master init-cloud` for a master that is already using Kontena Cloud.
