### PR TITLE
Remove unnecessary request parsing in auth middleware

### DIFF
--- a/server/app/middlewares/token_authentication.rb
+++ b/server/app/middlewares/token_authentication.rb
@@ -12,7 +12,6 @@ class TokenAuthentication
   # Use the option :soft_exclude to parse the token if it exists, but allow
   # request even without token
   attr_reader :opts
-  attr_reader :request
   attr_reader :excludes
   attr_reader :soft_excludes
   attr_reader :allow_expired
@@ -37,8 +36,6 @@ class TokenAuthentication
     if excluded_path?(env[PATH_INFO])
       return @app.call(env)
     end
-
-    @request = Rack::Request.new(env)
 
     auth = http_authorization(env)
 


### PR DESCRIPTION
The token authentication middleware in server API had some leftover call to `Rack::Request.new(env)` and the result was being assigned to an instance variable that was never used.


