### PR TITLE
CLI: Exit with error from node ssh --any if no nodes are online

### DIFF
--- a/cli/lib/kontena/cli/nodes/ssh_command.rb
+++ b/cli/lib/kontena/cli/nodes/ssh_command.rb
@@ -21,7 +21,8 @@ module Kontena::Cli::Nodes
         node = client.get("nodes/#{current_grid}/#{self.node}")
       elsif any?
         nodes = client.get("grids/#{current_grid}/nodes")['nodes']
-        node = nodes.select{ |node| node['connected'] }.first
+        node = nodes.find{ |node| node['connected'] }
+        exit_with_error "There are no online nodes" if node.nil?
       else
         exit_with_error "No node name given. Use --any to connect to the first available node"
       end

--- a/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
@@ -16,17 +16,23 @@ describe Kontena::Cli::Nodes::SshCommand do
     allow(client).to receive(:get).with('nodes/test-grid/test-node').and_return(node)
   end
 
-  context '--any' do
-    it "fails if using both --any and a node name as a command" do
-      expect(subject).to_not receive(:exec)
-      expect{subject.run(['--any', 'ls', '-l'])}.to exit_with_error.and output(/Cannot combine --any with a node name/).to_stderr
+  describe '--any flag' do
+    context 'used together with a node name' do
+      it "fails and outputs an error message" do
+        expect(subject).to_not receive(:exec)
+        expect{subject.run(['--any', 'ls', '-l'])}.to exit_with_error.and output(/Cannot combine --any with a node name/).to_stderr
+      end
     end
 
-    it "fails if using --any and there are no connected nodes" do
-      expect(subject.client).to receive(:get).with("grids/test-grid/nodes").and_return(
-        'nodes' => [ { 'connected' => false } ]
-      )
-      expect{subject.run(['--any'])}.to exit_with_error.and output(/no online nodes/).to_stderr
+    context 'used when there are no connected nodes' do
+      before do
+        expect(subject.client).to receive(:get).with("grids/test-grid/nodes").and_return('nodes' => [ { 'connected' => false } ])
+      end
+
+      it "fails and outputs an error message" do
+        expect(subject).to_not receive(:exec)
+        expect{subject.run(['--any'])}.to exit_with_error.and output(/no online nodes/).to_stderr
+      end
     end
   end
 

--- a/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/ssh_command_spec.rb
@@ -16,9 +16,18 @@ describe Kontena::Cli::Nodes::SshCommand do
     allow(client).to receive(:get).with('nodes/test-grid/test-node').and_return(node)
   end
 
-  it "fails if using both --any and a node name as a command" do
-    expect(subject).to_not receive(:exec)
-    expect{subject.run(['--any', 'ls', '-l'])}.to exit_with_error.and output(/Cannot combine --any with a node name/).to_stderr
+  context '--any' do
+    it "fails if using both --any and a node name as a command" do
+      expect(subject).to_not receive(:exec)
+      expect{subject.run(['--any', 'ls', '-l'])}.to exit_with_error.and output(/Cannot combine --any with a node name/).to_stderr
+    end
+
+    it "fails if using --any and there are no connected nodes" do
+      expect(subject.client).to receive(:get).with("grids/test-grid/nodes").and_return(
+        'nodes' => [ { 'connected' => false } ]
+      )
+      expect{subject.run(['--any'])}.to exit_with_error.and output(/no online nodes/).to_stderr
+    end
   end
 
   it "uses the public IP by default" do


### PR DESCRIPTION
This PR makes `kontena node ssh --any` exit with proper error message when there are no connected nodes. 

Before:

```console
$ kontena node ssh --any
 [error] NoMethodError : undefined method `[]' for nil:NilClass
         See /Users/kimmo/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
```

After:

```console
$ kontena node ssh --any
 [error] There are no online nodes
```
