### PR TITLE
Always create HostNode with unique name and node_number

### DIFF
--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -165,6 +165,7 @@ module Kontena
         type: Kontena::WebsocketClient,
         as: :websocket_client,
         args: [@opts[:api_uri], @node_id,
+          node_name: self.node_name,
           grid_token: @opts[:grid_token],
           node_token: @opts[:node_token],
           node_labels: @node_labels,

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -30,14 +30,16 @@ module Kontena
 
     # @param [String] api_uri
     # @param [String] node_id
+    # @param [String] node_name
     # @param [String] grid_token
     # @param [String] node_token
     # @param [Array<String>] node_labels
     # @param [Hash] ssl_params
     # @param [String] ssl_hostname
-      def initialize(api_uri, node_id, grid_token: nil, node_token: nil, node_labels: [], ssl_params: {}, ssl_hostname: nil, autostart: true)
+      def initialize(api_uri, node_id, node_name:, grid_token: nil, node_token: nil, node_labels: [], ssl_params: {}, ssl_hostname: nil, autostart: true)
       @api_uri = api_uri
       @node_id = node_id
+      @node_name = node_name
       @grid_token = grid_token
       @node_token = node_token
       @node_labels = node_labels
@@ -87,6 +89,7 @@ module Kontena
       info "connecting to master at #{api_uri}"
       headers = {
           'Kontena-Node-Id' => @node_id.to_s,
+          'Kontena-Node-Name' => @node_name,
           'Kontena-Version' => Kontena::Agent::VERSION,
           'Kontena-Node-Labels' => @node_labels.join(','),
           'Kontena-Connected-At' => Time.now.utc.strftime(STRFTIME),

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -1,6 +1,7 @@
 describe Kontena::WebsocketClient, :celluloid => true do
   let(:url) { 'ws://socket.example.com' }
   let(:node_id) { 'ABCD' }
+  let(:node_name) { 'test-1' }
   let(:grid_token) { 'secret' }
   let(:node_token) { nil }
   let(:node_labels) { ['region=test'] }
@@ -17,6 +18,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
 
   let(:actor) {
     described_class.new(url, node_id,
+      node_name: node_name,
       grid_token: grid_token,
       node_token: node_token,
       node_labels: node_labels,
@@ -74,6 +76,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
       expect(subject.ws.instance_variable_get('@headers')).to match(
         'Kontena-Grid-Token' => 'secret',
         'Kontena-Node-Id' => 'ABCD',
+        'Kontena-Node-Name' => 'test-1',
         'Kontena-Version' => Kontena::Agent::VERSION,
         'Kontena-Node-Labels' => 'region=test',
         'Kontena-Connected-At' => String,
@@ -97,6 +100,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
         expect(subject.ws.instance_variable_get('@headers')).to match(
           'Kontena-Node-Token' => 'node-secret',
           'Kontena-Node-Id' => 'ABCD',
+          'Kontena-Node-Name' => 'test-1',
           'Kontena-Version' => Kontena::Agent::VERSION,
           'Kontena-Node-Labels' => 'region=test',
           'Kontena-Connected-At' => String,

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -149,11 +149,15 @@ class WebsocketBackend
   # @raise [CloseError]
   # @return [HostNode]
   def find_node(req)
-    node_id = req.env['HTTP_KONTENA_NODE_ID'].to_s
+    node_id = req.env['HTTP_KONTENA_NODE_ID']
     node_labels = req.env['HTTP_KONTENA_NODE_LABELS'].to_s.split(',')
     init_attrs = {
       labels: node_labels,
     }
+
+    if node_id.nil? || node_id.empty?
+      raise CloseError.new(4000), "Missing Kontena-Node-ID"
+    end
 
     if grid_token = req.env['HTTP_KONTENA_GRID_TOKEN']
       return find_node_by_grid_token(node_id, grid_token, init_attrs)

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -77,10 +77,11 @@ class WebsocketBackend
 
   # @param node_id [String] request header Kontena-Node-Id
   # @param grid_token [String] request header Kontena-Grid-Token
+  # @param node_name [String] initialize name for new node
   # @param init_attrs [Hash] initialize attributes on new node
   # @raise [CloseError]
   # @return [HostNode] with node_id set
-  def find_node_by_grid_token(node_id, grid_token, init_attrs)
+  def find_node_by_grid_token(node_id, grid_token, node_name:, **init_attrs)
     # check grid
     grid = Grid.find_by(token: grid_token.to_s)
 
@@ -89,7 +90,7 @@ class WebsocketBackend
     node = grid.host_nodes.find_by(node_id: node_id)
 
     if !node
-      node = grid.host_nodes.create!(node_id: node_id, **init_attrs)
+      node = grid.host_nodes.create!(node_id: node_id, name: node_name, **init_attrs)
 
       logger.info "new node #{node} connected using grid token"
 
@@ -150,6 +151,7 @@ class WebsocketBackend
   # @return [HostNode]
   def find_node(req)
     node_id = req.env['HTTP_KONTENA_NODE_ID']
+    node_name = req.env['HTTP_KONTENA_NODE_NAME']
     node_labels = req.env['HTTP_KONTENA_NODE_LABELS'].to_s.split(',')
     init_attrs = {
       labels: node_labels,
@@ -158,9 +160,12 @@ class WebsocketBackend
     if node_id.nil? || node_id.empty?
       raise CloseError.new(4000), "Missing Kontena-Node-ID"
     end
+    if node_name.nil? || node_name.empty?
+      raise CloseError.new(4000), "Missing Kontena-Node-Name"
+    end
 
     if grid_token = req.env['HTTP_KONTENA_GRID_TOKEN']
-      return find_node_by_grid_token(node_id, grid_token, init_attrs)
+      return find_node_by_grid_token(node_id, grid_token, node_name: node_name, **init_attrs)
 
     elsif node_token = req.env['HTTP_KONTENA_NODE_TOKEN']
       return find_node_by_node_token(node_id, node_token, init_attrs)

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -75,25 +75,6 @@ class WebsocketBackend
     end
   end
 
-  # @param grid [Grid]
-  # @param node_id [String]
-  # @param name [String]
-  # @param attrs [Hash]
-  # @raise [Mongo::Error::OperationFailure] concurrent race
-  # @return [HostNode]
-  def create_node(grid, node_id, name, attrs)
-    node = grid.host_nodes.new(node_id: node_id, name: name, **attrs)
-    node.ensure_unique_name
-
-    if node.name != name
-      logger.warn "rename node #{node_id} on name collision: #{node.name}"
-    end
-
-    # XXX: this can still race with concurrent creates, and result in unique name index conflicts
-    node.save!
-    node
-  end
-
   # @param node_id [String] request header Kontena-Node-Id
   # @param grid_token [String] request header Kontena-Grid-Token
   # @param node_name [String] initialize name for new node
@@ -109,7 +90,9 @@ class WebsocketBackend
     node = grid.host_nodes.find_by(node_id: node_id)
 
     if !node
-      node = create_node(grid, node_id, node_name, init_attrs)
+      node = grid.create_node!(node_name, ensure_unique_name: true,
+        node_id: node_id, **init_attrs
+      )
 
       logger.info "new node #{node} connected using grid token"
 

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -6,6 +6,7 @@ class Grid
   include Mongoid::Timestamps
   include Authority::Abilities
   include EventStream
+  include Logging
 
   NODE_NUMBERS = (1..254)
   SUBNET = '10.81.0.0/16'

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -79,6 +79,8 @@ class Grid
       return node
 
     rescue Mongo::Error::OperationFailure => exc
+      raise unless exc.message =~ /^E11000 duplicate key error/
+
       if self.host_nodes.where(node_number: node.node_number).exists?
         warn "retry node #{name} node_number allocation on error: #{exc}"
         node.name = name

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -56,7 +56,7 @@ class Grid
 
   # @return [Array<Integer>]
   def free_node_numbers
-    reserved_numbers = self.host_nodes.map{|node| node.node_number }.flatten
+    reserved_numbers = HostNode.where(grid: self).distinct(:node_number)
     NODE_NUMBERS.to_a - reserved_numbers
   end
 

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -51,11 +51,12 @@ class HostNode
   has_and_belongs_to_many :images
 
   validates_length_of :token, minimum: 16, maximum: 256, allow_nil: true
-  after_save :reserve_node_number, :ensure_unique_name
+  after_save :reserve_node_number
 
   index({ grid_id: 1 })
   index({ node_id: 1 }, { unique: true, sparse: true })
   index({ labels: 1 })
+  index({ grid_id: 1, name: 1 }, { unique: true })
   index({ grid_id: 1, node_number: 1 }, { unique: true, sparse: true })
   index({ token: 1 }, { unique: true, sparse: true })
 
@@ -196,16 +197,6 @@ class HostNode
       self.update_attribute(:node_number, node_number)
     rescue Mongo::Error::OperationFailure
       retry
-    end
-  end
-
-  def ensure_unique_name
-    return if self.name.to_s.empty?
-    return unless self.grid
-    return unless self.grid.respond_to?(:host_nodes)
-
-    if self.grid.host_nodes.unscoped.where(:id.ne => self.id, name: self.name).count > 0
-      self.set(name: "#{self.name}-#{self.node_number}")
     end
   end
 end

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -50,15 +50,15 @@ class HostNode
   has_many :volume_instances, dependent: :destroy
   has_and_belongs_to_many :images
 
+  validates :node_number, presence: true
   validates :name, presence: true
   validates_length_of :token, minimum: 16, maximum: 256, allow_nil: true
-  after_save :reserve_node_number
 
   index({ grid_id: 1 })
   index({ node_id: 1 }, { unique: true, sparse: true })
   index({ labels: 1 })
   index({ grid_id: 1, name: 1 }, { unique: true })
-  index({ grid_id: 1, node_number: 1 }, { unique: true, sparse: true })
+  index({ grid_id: 1, node_number: 1 }, { unique: true })
   index({ token: 1 }, { unique: true, sparse: true })
 
   scope :connected, -> { where(connected: true) }
@@ -126,9 +126,7 @@ class HostNode
   end
 
   def initial_member?
-    return false if self.node_number.nil?
-    return true if self.node_number <= self.grid.initial_size
-    false
+    self.node_number <= self.grid.initial_size
   end
 
   # @param label [String] match label name before =
@@ -180,31 +178,5 @@ class HostNode
   # @return [String] Overlay IP, without subnet mask
   def overlay_ip
     (IPAddr.new(self.grid.subnet) | self.node_number).to_s
-  end
-
-  # Before saving, add unique suffix to self.name
-  def ensure_unique_name(suffix: 1)
-    name = self.name
-
-    while self.grid.host_nodes.unscoped.where(name: self.name).exists?
-      self.name = "#{name}-#{suffix}"
-      suffix = suffix.succ
-    end
-  end
-
-  private
-
-  def reserve_node_number
-    return unless self.node_number.nil?
-    return if self.grid.nil?
-
-    free_numbers = self.grid.free_node_numbers
-    begin
-      node_number = free_numbers.shift
-      raise Error.new('Node numbers not available. Grid is full?') if node_number.nil?
-      self.update_attribute(:node_number, node_number)
-    rescue Mongo::Error::OperationFailure
-      retry
-    end
   end
 end

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -183,13 +183,12 @@ class HostNode
   end
 
   # Before saving, add unique suffix to self.name
-  def ensure_unique_name
+  def ensure_unique_name(suffix: 1)
     name = self.name
-    suffix = 1
 
     while self.grid.host_nodes.unscoped.where(name: self.name).exists?
       self.name = "#{name}-#{suffix}"
-      suffix += 1
+      suffix = suffix.succ
     end
   end
 

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -182,6 +182,17 @@ class HostNode
     (IPAddr.new(self.grid.subnet) | self.node_number).to_s
   end
 
+  # Before saving, add unique suffix to self.name
+  def ensure_unique_name
+    name = self.name
+    suffix = 1
+
+    while self.grid.host_nodes.unscoped.where(name: self.name).exists?
+      self.name = "#{name}-#{suffix}"
+      suffix += 1
+    end
+  end
+
   private
 
   def reserve_node_number

--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -50,6 +50,7 @@ class HostNode
   has_many :volume_instances, dependent: :destroy
   has_and_belongs_to_many :images
 
+  validates :name, presence: true
   validates_length_of :token, minimum: 16, maximum: 256, allow_nil: true
   after_save :reserve_node_number
 
@@ -102,9 +103,6 @@ class HostNode
       volume_drivers: attrs.dig('Drivers', 'Volume') || [],
       network_drivers: attrs.dig('Drivers', 'Network') || [],
     }
-    if self.name.nil?
-      self.name = attrs['Name']
-    end
     if self.labels.nil? || self.labels.size == 0
       self.labels = attrs['Labels']
     end

--- a/server/app/mutations/host_nodes/create.rb
+++ b/server/app/mutations/host_nodes/create.rb
@@ -25,17 +25,14 @@ module HostNodes
     end
 
     # @return [HostNode]
-    def build_host_node
-      host_node = HostNode.new(
-        grid: self.grid,
-        name: self.name,
+    def create_host_node
+      host_node = self.grid.create_node!(self.name,
         token: self.token || self.generate_token,
       )
-      host_node
     end
 
     def execute
-      host_node = build_host_node
+      host_node = create_host_node
 
       set_common_params(host_node)
 

--- a/server/db/migrations/28_host_node_name_index.rb
+++ b/server/db/migrations/28_host_node_name_index.rb
@@ -1,6 +1,18 @@
 class HostNodeNameIndex < Mongodb::Migration
   def self.up
-    # TODO: assign name to any nodes that are missing a name
+    HostNode.each do |node|
+      next if node.name
+
+      if node.node_number
+        node.name = "node-#{node.node_number}"
+      else
+        node.name = "unknown-node"
+        node.ensure_unique_name
+      end
+
+      node.save!
+    end
+
     HostNode.create_indexes
   end
 end

--- a/server/db/migrations/28_host_node_name_index.rb
+++ b/server/db/migrations/28_host_node_name_index.rb
@@ -1,18 +1,16 @@
 class HostNodeNameIndex < Mongodb::Migration
   def self.up
     HostNode.each do |node|
-      next if node.name
-
-      if node.node_number
-        node.name = "node-#{node.node_number}"
-      else
-        node.name = "unknown-node"
-        node.ensure_unique_name
+      unless node.node_number
+        node.set(node_number: node.grid.free_node_numbers.first)
       end
 
-      node.save!
+      unless node.name
+        node.set(name: "node-#{node.node_number}")
+      end
     end
 
+    HostNode.collection.indexes.drop_one('grid_id_1_node_number_1') rescue nil
     HostNode.create_indexes
   end
 end

--- a/server/db/migrations/28_host_node_name_index.rb
+++ b/server/db/migrations/28_host_node_name_index.rb
@@ -1,5 +1,6 @@
 class HostNodeNameIndex < Mongodb::Migration
   def self.up
+    # TODO: assign name to any nodes that are missing a name
     HostNode.create_indexes
   end
 end

--- a/server/db/migrations/28_host_node_name_index.rb
+++ b/server/db/migrations/28_host_node_name_index.rb
@@ -1,0 +1,5 @@
+class HostNodeNameIndex < Mongodb::Migration
+  def self.up
+    HostNode.create_indexes
+  end
+end

--- a/server/spec/api/v1/containers_spec.rb
+++ b/server/spec/api/v1/containers_spec.rb
@@ -36,7 +36,7 @@ describe '/v1/containers' do
   end
 
   let(:host_node) do
-    david.grids.first.host_nodes.create!(node_id: 'abc', name: 'node-a')
+    david.grids.first.create_node!('node-a', node_id: 'abc')
   end
 
   let(:redis_service) do

--- a/server/spec/api/v1/etcd_spec.rb
+++ b/server/spec/api/v1/etcd_spec.rb
@@ -11,12 +11,8 @@ describe '/v1/etcd/:grid_name/:etcd_path' do
   let(:grid) do
     grid = Grid.create!(name: 'test-grid')
     grid.users << david
-    grid.host_nodes.create(name: 'node-a', node_id: 'aaa', connected: true)
+    grid.create_node!('node-a', node_id: 'aaa', connected: true)
     grid
-  end
-
-  let(:node_a) do
-    HostNode.create(name: 'node-a', node_id: 'aaa', connected: true, grid: grid)
   end
 
   let(:fake_client) { spy(:rpc_client) }

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -256,7 +256,7 @@ describe '/v1/grids', celluloid: true do
       it 'returns grid nodes' do
         grid = david.grids.first
 
-        grid.host_nodes.create!(node_id: SecureRandom.uuid)
+        grid.host_nodes.create!(node_id: SecureRandom.uuid, name: 'test-1' )
         get "/v1/grids/#{grid.to_path}/nodes", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['nodes'].size).to eq(1)

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -256,7 +256,7 @@ describe '/v1/grids', celluloid: true do
       it 'returns grid nodes' do
         grid = david.grids.first
 
-        grid.host_nodes.create!(node_id: SecureRandom.uuid, name: 'test-1' )
+        grid.create_node!('test-1', node_id: SecureRandom.uuid)
         get "/v1/grids/#{grid.to_path}/nodes", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['nodes'].size).to eq(1)
@@ -309,7 +309,7 @@ describe '/v1/grids', celluloid: true do
       before do
         @grid = david.grids.first
 
-        node = @grid.host_nodes.create!(name: 'node-1', node_id: SecureRandom.uuid)
+        node = @grid.create_node!('node-1', node_id: SecureRandom.uuid)
 
         foo_service = @grid.grid_services.create!(name: 'foo', image_name: 'foo/bar')
         bar_service = @grid.grid_services.create!(name: 'bar', image_name: 'bar/foo')
@@ -395,7 +395,7 @@ describe '/v1/grids', celluloid: true do
     end
 
     let :node do
-      grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      grid.create_node!('abc', node_id: 'a:b:c')
     end
 
     before do

--- a/server/spec/api/v1/nodes_spec.rb
+++ b/server/spec/api/v1/nodes_spec.rb
@@ -340,7 +340,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'PUT (legacy)' do
     it 'saves node labels' do
-      node = grid.host_nodes.create!(node_id: 'abc')
+      node = grid.host_nodes.create!(node_id: 'abc', name: 'node')
       labels = ['foo=1', 'bar=2']
       put '/v1/nodes/abc', {labels: labels}.to_json, legacy_request_headers
       expect(response.status).to eq(200)
@@ -353,7 +353,7 @@ describe '/v1/nodes', celluloid: true do
     end
 
     it 'returns error with invalid token' do
-      grid.host_nodes.create!(node_id: 'abc')
+      grid.host_nodes.create!(node_id: 'abc', name: 'node')
       put '/v1/nodes/abc', {labels: []}.to_json, {}
       expect(response.status).to eq(404)
     end

--- a/server/spec/api/v1/nodes_spec.rb
+++ b/server/spec/api/v1/nodes_spec.rb
@@ -24,7 +24,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'GET' do
     it 'returns node with valid id and has_token' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c', token: 'asdfasdfasdfasdf')
+      node = grid.create_node!('abc', node_id: 'a:b:c', token: 'asdfasdfasdfasdf')
       get "/v1/nodes/#{node.to_path}", nil, request_headers
       expect(response.status).to eq(200)
       expect(json_response).to_not include 'token'
@@ -36,7 +36,7 @@ describe '/v1/nodes', celluloid: true do
     end
 
     it 'returns node without has_token' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      node = grid.create_node!('abc', node_id: 'a:b:c')
       get "/v1/nodes/#{node.to_path}", nil, request_headers
       expect(response.status).to eq(200)
       expect(json_response).to_not include 'token'
@@ -53,7 +53,7 @@ describe '/v1/nodes', celluloid: true do
     end
 
     it 'returns error with invalid token' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      node = grid.create_node!('abc', node_id: 'a:b:c')
       get "/v1/nodes/#{node.to_path}", nil, {}
       expect(response.status).to eq(403)
     end
@@ -61,7 +61,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'GET /token' do
     let(:node) do
-      node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf')
+      node = grid.create_node!('abc', token: 'asdfasdfasdfasdf')
     end
 
     it "returns 403 without admin role" do
@@ -72,7 +72,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'PUT /token' do
     let(:node) do
-      node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf')
+      node = grid.create_node!('abc', token: 'asdfasdfasdfasdf')
     end
 
     it "returns 403 without admin role" do
@@ -83,7 +83,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'DELETE /token' do
     let(:node) do
-      node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf')
+      node = grid.create_node!('abc', token: 'asdfasdfasdfasdf')
     end
 
     it "returns 403 without admin role" do
@@ -99,7 +99,7 @@ describe '/v1/nodes', celluloid: true do
 
     describe 'GET /token' do
       let(:node) do
-        node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf')
+        node = grid.create_node!('abc', token: 'asdfasdfasdfasdf')
       end
 
       it "returns node token" do
@@ -122,7 +122,7 @@ describe '/v1/nodes', celluloid: true do
 
     describe 'PUT /token' do
       let(:node) do
-        node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf', connected: true)
+        node = grid.create_node!('abc', token: 'asdfasdfasdfasdf', connected: true)
       end
 
       it "generates new node token" do
@@ -167,7 +167,7 @@ describe '/v1/nodes', celluloid: true do
 
     describe 'DELETE /token' do
       let(:node) do
-        node = grid.host_nodes.create!(name: 'abc', token: 'asdfasdfasdfasdf', connected: true)
+        node = grid.create_node!('abc', token: 'asdfasdfasdfasdf', connected: true)
       end
 
       it "clears token with connection reset" do
@@ -183,7 +183,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'GET /health' do
     let :node do
-      grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      grid.create_node!('abc', node_id: 'a:b:c')
     end
 
     let :rpc_client do
@@ -218,7 +218,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'GET /metrics' do
     let :node do
-      grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      grid.create_node!('abc', node_id: 'a:b:c')
     end
 
     before do
@@ -304,7 +304,7 @@ describe '/v1/nodes', celluloid: true do
 
   describe 'PUT' do
     it 'saves node labels' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      node = grid.create_node!('abc', node_id: 'a:b:c')
       labels = ['foo=1', 'bar=2']
       put "/v1/nodes/#{node.to_path}", {labels: labels}.to_json, request_headers
       expect(response.status).to eq(200)
@@ -312,7 +312,7 @@ describe '/v1/nodes', celluloid: true do
     end
 
     it 'saves availability' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c', labels: ['foo=bar'])
+      node = grid.create_node!('abc', node_id: 'a:b:c', labels: ['foo=bar'])
       put "/v1/nodes/#{node.to_path}", {availability: 'drain', labels: ['foo=bar']}.to_json, request_headers
       expect(response.status).to eq(200), response.body
       expect(node.reload.labels).to eq(['foo=bar'])
@@ -325,13 +325,13 @@ describe '/v1/nodes', celluloid: true do
     end
 
     it 'returns error with invalid token' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      node = grid.create_node!('abc', node_id: 'a:b:c')
       put "/v1/nodes/#{node.to_path}", {labels: []}.to_json, {}
       expect(response.status).to eq(403)
     end
 
     it 'returns 422 if mutation fails' do
-      node = grid.host_nodes.create!(name: 'abc', node_id: 'a:b:c')
+      node = grid.create_node!('abc', node_id: 'a:b:c')
       expect(HostNodes::Update).to receive(:run).and_return(double({:success? => false, :errors => double({:message => 'boom'})}))
       put "/v1/nodes/#{node.to_path}", {}, request_headers
       expect(response.status).to eq(422)
@@ -339,8 +339,10 @@ describe '/v1/nodes', celluloid: true do
   end
 
   describe 'PUT (legacy)' do
+    let(:node) { grid.create_node!('node', node_id: 'abc') }
+
     it 'saves node labels' do
-      node = grid.host_nodes.create!(node_id: 'abc', name: 'node')
+      node
       labels = ['foo=1', 'bar=2']
       put '/v1/nodes/abc', {labels: labels}.to_json, legacy_request_headers
       expect(response.status).to eq(200)
@@ -353,7 +355,7 @@ describe '/v1/nodes', celluloid: true do
     end
 
     it 'returns error with invalid token' do
-      grid.host_nodes.create!(node_id: 'abc', name: 'node')
+      node
       put '/v1/nodes/abc', {labels: []}.to_json, {}
       expect(response.status).to eq(404)
     end

--- a/server/spec/api/v1/service_instances_spec.rb
+++ b/server/spec/api/v1/service_instances_spec.rb
@@ -9,6 +9,9 @@ describe '/v1/services/:id/event_logs' do
   let! :grid do
     Grid.create!(name: 'terminal-a')
   end
+  let(:node) do
+    grid.create_node!('node', node_id: 'a')
+  end
 
   let(:david) do
     user = User.create!(email: 'david@domain.com', external_id: '123456')
@@ -60,7 +63,6 @@ describe '/v1/services/:id/event_logs' do
 
   describe 'DELETE /:id' do
     it 'removes service instance' do
-      node = HostNode.create(grid: grid, node_id: 'a', name: 'node')
       instance = redis_service.grid_service_instances.create!(
         instance_number: 2,
         deploy_rev: Time.now.utc.to_s,

--- a/server/spec/api/v1/service_instances_spec.rb
+++ b/server/spec/api/v1/service_instances_spec.rb
@@ -60,7 +60,7 @@ describe '/v1/services/:id/event_logs' do
 
   describe 'DELETE /:id' do
     it 'removes service instance' do
-      node = HostNode.create(grid: grid, node_id: 'a')
+      node = HostNode.create(grid: grid, node_id: 'a', name: 'node')
       instance = redis_service.grid_service_instances.create!(
         instance_number: 2,
         deploy_rev: Time.now.utc.to_s,

--- a/server/spec/api/v1/volumes_spec.rb
+++ b/server/spec/api/v1/volumes_spec.rb
@@ -58,10 +58,7 @@ describe '/v1/volumes' do
   end
 
   let! :node do
-    HostNode.create!(
-      grid: grid,
-      name: 'node-1'
-    )
+    grid.create_node!('node-1')
   end
 
   describe 'GET /' do
@@ -165,6 +162,4 @@ describe '/v1/volumes' do
       }.not_to change{Volume.count}
     end
   end
-
-
 end

--- a/server/spec/db/migrations/20_create_grid_service_instance_spec.rb
+++ b/server/spec/db/migrations/20_create_grid_service_instance_spec.rb
@@ -4,7 +4,8 @@ describe CreateGridServiceInstance do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:node) do
     HostNode.create!(
-      node_id: SecureRandom.uuid, grid: grid, connected: true
+      node_id: SecureRandom.uuid, grid: grid, name: 'node-1', node_number: 1,
+      connected: true
     )
   end
   let(:service) do

--- a/server/spec/db/migrations/28_host_node_name_index_spec.rb
+++ b/server/spec/db/migrations/28_host_node_name_index_spec.rb
@@ -18,7 +18,7 @@ describe HostNodeNameIndex do
   }
   let(:node3) {
     node = HostNode.create!(grid: grid, node_id: SecureRandom.uuid,
-      name: 'test-0',
+      name: 'test-0', node_number: 3,
       connected: true
     )
     node.unset(:name, :node_number)
@@ -37,6 +37,6 @@ describe HostNodeNameIndex do
 
     expect(node1.reload.name).to eq 'test-1'
     expect(node2.reload.name).to eq 'node-2'
-    expect(node3.reload.name).to eq 'unknown-node'
+    expect(node3.reload.name).to eq 'node-3'
   end
 end

--- a/server/spec/db/migrations/28_host_node_name_index_spec.rb
+++ b/server/spec/db/migrations/28_host_node_name_index_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../../db/migrations/28_host_node_name_index'
+
+describe HostNodeNameIndex do
+  let(:grid) { Grid.create!(name: 'test-grid') }
+  let(:node1) {
+    HostNode.create!(grid: grid, node_id: SecureRandom.uuid,
+      name: 'test-1', node_number: 1,
+      connected: true
+    )
+  }
+  let(:node2) {
+    node = HostNode.create!(grid: grid, node_id: SecureRandom.uuid,
+      name: 'test-2', node_number: 2,
+      connected: true
+    )
+    node.unset(:name)
+    node
+  }
+  let(:node3) {
+    node = HostNode.create!(grid: grid, node_id: SecureRandom.uuid,
+      name: 'test-0',
+      connected: true
+    )
+    node.unset(:name, :node_number)
+    node
+  }
+
+  before do
+    HostNode.collection.indexes.drop_all
+    node1
+    node2
+    node3
+  end
+
+  it 'initializes missing node names to allow creating the unique index' do
+    expect{described_class.up}.to_not raise_error # Mongo::Error::OperationFailure: exception: E11000 duplicate key error index: kontena_test.host_nodes.$grid_id_1_name_1 dup key: { : ObjectId('5992e4d3de3578212142bcef'), : null } (11000)
+
+    expect(node1.reload.name).to eq 'test-1'
+    expect(node2.reload.name).to eq 'node-2'
+    expect(node3.reload.name).to eq 'unknown-node'
+  end
+end

--- a/server/spec/jobs/container_cleanup_job_spec.rb
+++ b/server/spec/jobs/container_cleanup_job_spec.rb
@@ -2,9 +2,9 @@
 describe ContainerCleanupJob, celluloid: true do
 
   let(:grid) { Grid.create!(name: 'test-grid') }
-  let(:node1) { HostNode.create!(name: "node-1", connected: false, last_seen_at: 2.hours.ago, grid: grid) }
-  let(:node2) { HostNode.create!(name: "node-2", connected: true, last_seen_at: 2.seconds.ago, grid: grid) }
-  let(:node3) { HostNode.create!(name: "node-3", connected: true, last_seen_at: 3.seconds.ago, grid: grid) }
+  let(:node1) { grid.create_node!("node-1", connected: false, last_seen_at: 2.hours.ago)  }
+  let(:node2) { grid.create_node!("node-2", connected: true, last_seen_at: 2.seconds.ago) }
+  let(:node3) { grid.create_node!("node-3", connected: true, last_seen_at: 3.seconds.ago) }
   let(:service) do
     GridService.create!(name: 'test', image_name: 'test:latest', grid: grid)
   end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -81,6 +81,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     let(:grid_token) { nil }
     let(:node_token) { nil }
     let(:node_id) { 'nodeABC' }
+    let(:node_name) { 'node-1' }
     let(:node_labels) { 'test=yes' }
     let(:node_version) { '0.9.1' }
     let(:connected_at) { 1.second.ago.utc }
@@ -90,6 +91,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       'HTTP_KONTENA_GRID_TOKEN' => grid_token,
       'HTTP_KONTENA_NODE_TOKEN' => node_token,
       'HTTP_KONTENA_NODE_ID' => node_id,
+      'HTTP_KONTENA_NODE_NAME' => node_name,
       'HTTP_KONTENA_NODE_LABELS' => node_labels,
       'HTTP_KONTENA_VERSION' => node_version,
       'HTTP_KONTENA_CONNECTED_AT' => connected_at ? connected_at.strftime('%F %T.%NZ') : nil,
@@ -105,6 +107,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     context "without any token" do
       let(:rack_req) { instance_double(Rack::Request, env: {
         'HTTP_KONTENA_NODE_ID' => node_id,
+        'HTTP_KONTENA_NODE_NAME' => node_name,
       })}
 
       describe '#on_open' do
@@ -272,8 +275,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
       describe '#on_open' do
         it 'creates the node, but does not connect it' do
-          expect(subject.logger).to receive(:info).with('new node nodeABC connected using grid token')
-          expect(subject.logger).to receive(:warn).with('node nodeABC agent version 0.8.0 is not compatible with server version 0.9.1')
+          expect(subject.logger).to receive(:info).with('new node node-1 connected using grid token')
+          expect(subject.logger).to receive(:warn).with('node node-1 agent version 0.8.0 is not compatible with server version 0.9.1')
           expect(client_ws).to receive(:close).with(4010, 'agent version 0.8.0 is not compatible with server version 0.9.1')
 
           expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/master_info', [{ 'version' => '0.9.1'}]])
@@ -291,8 +294,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
       describe '#on_open' do
         it 'creates the node, but does not connect it' do
-          expect(subject.logger).to receive(:info).with('new node nodeABC connected using grid token')
-          expect(subject.logger).to receive(:warn).with(/node nodeABC connected too far in the past at #{connected_at}, \d+\.\d+s ago/)
+          expect(subject.logger).to receive(:info).with('new node node-1 connected using grid token')
+          expect(subject.logger).to receive(:warn).with(/node node-1 connected too far in the past at #{connected_at}, \d+\.\d+s ago/)
           expect(client_ws).to receive(:close).with(4020, /agent clock offset \d+\.\d+s exceeds threshold/)
 
           expect{
@@ -313,8 +316,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
       describe '#on_open' do
         it 'creates the node, but does not connect it' do
-          expect(subject.logger).to receive(:info).with('new node nodeABC connected using grid token')
-          expect(subject.logger).to receive(:warn).with(/node nodeABC connected too far in the future at #{connected_at}, \d+\.\d+s ahead/)
+          expect(subject.logger).to receive(:info).with('new node node-1 connected using grid token')
+          expect(subject.logger).to receive(:warn).with(/node node-1 connected too far in the future at #{connected_at}, \d+\.\d+s ahead/)
           expect(client_ws).to receive(:close).with(4020, /agent clock offset -\d+\.\d+s exceeds threshold/)
 
           expect{
@@ -341,8 +344,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
         let(:grid_token) { 'secret123' }
 
         it 'accepts the connection and creates a new host node' do
-          expect(subject.logger).to receive(:info).with('new node nodeABC connected using grid token')
-          expect(subject.logger).to receive(:info).with(/node nodeABC agent version 0.9.1 connected at #{connected_at}, \d+\.\d+s ago/)
+          expect(subject.logger).to receive(:info).with('new node node-1 connected using grid token')
+          expect(subject.logger).to receive(:info).with(/node node-1 agent version 0.9.1 connected at #{connected_at}, \d+\.\d+s ago/)
 
           expect{
             subject.on_open(client_ws, rack_req)
@@ -350,14 +353,15 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
           host_node = grid.host_nodes.first
 
-          expect(host_node.node_id).to eq node_id
+          expect(host_node.node_id).to eq 'nodeABC'
+          expect(host_node.name).to eq 'node-1'
           expect(host_node.labels).to eq ['test=yes']
           expect(host_node.connected).to eq true
           expect(host_node.connected_at.to_s).to eq connected_at.to_s
 
           # XXX: racy via mongo pubsub
           expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/master_info', [{ 'version' => '0.9.1'}]])
-          expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => nil)]])
+          expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => 'node-1')]])
 
           sleep 0.1
           EM.run_deferred_callbacks
@@ -365,7 +369,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       end
 
       context 'with a valid node token' do
-        let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf') }
+        let(:host_node) { grid.host_nodes.create!(name: 'test-1', token: 'asdfasdfasdfasdf') }
 
         let(:grid_token) { nil }
         let(:node_token) { 'asdfasdfasdfasdf' }
@@ -375,8 +379,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
         end
 
         it 'accepts the connection and sets the node ID' do
-          expect(subject.logger).to receive(:info).with('new node node-1 connected using node token with node_id nodeABC')
-          expect(subject.logger).to receive(:info).with(/node node-1 agent version 0.9.1 connected at #{connected_at}, \d+\.\d+s ago/)
+          expect(subject.logger).to receive(:info).with('new node test-1 connected using node token with node_id nodeABC')
+          expect(subject.logger).to receive(:info).with(/node test-1 agent version 0.9.1 connected at #{connected_at}, \d+\.\d+s ago/)
 
           expect{
             subject.on_open(client_ws, rack_req)
@@ -385,6 +389,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
           host_node.reload
 
           expect(host_node.node_id).to eq node_id
+          expect(host_node.name).to eq 'test-1' # the agent-provided Kontena-Node-Name: node-1 header is ignored
           expect(host_node.labels).to eq ['test=yes']
           expect(host_node.connected).to eq true
           expect(host_node.connected_at.to_s).to eq connected_at.to_s
@@ -403,7 +408,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
           # XXX: racy via mongo pubsub
           expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/master_info', [{ 'version' => '0.9.1'}]])
-          expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => 'node-1')]])
+          expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => 'test-1')]])
 
           sleep 0.1
           EM.run_deferred_callbacks
@@ -412,7 +417,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
         it 'accepts the connection if the node ID matches' do
           host_node.set(node_id: node_id, labels: ['test=yes', 'test2=no'])
 
-          expect(subject.logger).to receive(:info).with(/node node-1 agent version 0.9.1 connected at #{connected_at}, \d+\.\d+s ago/)
+          expect(subject.logger).to receive(:info).with(/node test-1 agent version 0.9.1 connected at #{connected_at}, \d+\.\d+s ago/)
 
           expect{
             subject.on_open(client_ws, rack_req)
@@ -438,7 +443,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
           # XXX: racy via mongo pubsub
           expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/master_info', [{ 'version' => '0.9.1'}]])
-          expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => 'node-1')]])
+          expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => 'test-1')]])
 
           sleep 0.1
           EM.run_deferred_callbacks

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -168,7 +168,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with a grid token and node ID that has a node token " do
-      let(:host_node) { grid.host_nodes.create!(name: 'node-1', node_id: 'nodeABC', token: 'asdfasdfasdfasdf') }
+      let(:host_node) { grid.create_node!('node-1', node_id: 'nodeABC', token: 'asdfasdfasdfasdf') }
 
       let(:grid_token) { 'secret123' }
       let(:node_token) { nil }
@@ -190,7 +190,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with the wrong node token" do
-      let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf') }
+      let(:host_node) { grid.create_node!('node-1', token: 'asdfasdfasdfasdf') }
 
       let(:grid_token) { nil }
       let(:node_token) { 'the wrong secret' }
@@ -212,7 +212,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with the wrong node ID" do
-      let(:host_node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf', node_id: 'nodeABC') }
+      let(:host_node) { grid.create_node!('node-1', token: 'asdfasdfasdfasdf', node_id: 'nodeABC') }
 
       let(:grid_token) { nil }
       let(:node_token) { 'asdfasdfasdfasdf' }
@@ -236,8 +236,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     context "with a duplicate node ID" do
-      let(:host_node1) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf1', node_id: 'nodeABC') }
-      let(:host_node2) { grid.host_nodes.create!(name: 'node-2', token: 'asdfasdfasdfasdf2') }
+      let(:host_node1) { grid.create_node!('node-1', token: 'asdfasdfasdfasdf1', node_id: 'nodeABC') }
+      let(:host_node2) { grid.create_node!('node-2', token: 'asdfasdfasdfasdf2') }
 
       let(:grid_token) { nil }
       let(:node_token) { 'asdfasdfasdfasdf2' }
@@ -368,7 +368,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
         end
 
         context "with a duplicate node name" do
-          let(:host_node1) { grid.host_nodes.create!(name: 'node-1', node_id: 'nodeXYZ') }
+          let(:host_node1) { grid.create_node!('node-1', node_id: 'nodeXYZ') }
 
           before do
             host_node1
@@ -379,7 +379,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
               host_node = nil
 
               expect(subject.logger).to receive(:warn).with('rename node nodeABC on name collision: node-1-1')
-              expect(subject.logger).to receive(:info).with('new node node-1-1 connected using grid token')
+              expect(subject.logger).to receive(:info).with('new node node-1-2 connected using grid token')
               expect(subject.logger).to receive(:info)
 
               expect{
@@ -387,7 +387,8 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
               }.to change{host_node = grid.host_nodes.find_by(node_id: node_id)}.from(nil).to(HostNode)
 
               expect(host_node.node_id).to eq node_id
-              expect(host_node.name).to eq 'node-1-1'
+              expect(host_node.node_number).to eq 2
+              expect(host_node.name).to eq 'node-1-2'
 
               # XXX: racy via mongo pubsub
               expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/master_info', [{ 'version' => '0.9.1'}]])
@@ -401,7 +402,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       end
 
       context 'with a valid node token' do
-        let(:host_node) { grid.host_nodes.create!(name: 'test-1', token: 'asdfasdfasdfasdf') }
+        let(:host_node) { grid.create_node!('test-1', token: 'asdfasdfasdfasdf') }
 
         let(:grid_token) { nil }
         let(:node_token) { 'asdfasdfasdfasdf' }
@@ -493,7 +494,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
     end
 
     let(:node) do
-      HostNode.create!(name: 'test-node', node_id: 'aa', grid: grid,
+      grid.create_node!('test-node', node_id: 'aa',
         connected: true, connected_at: connected_at,
       )
     end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -378,7 +378,6 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
             it 'creates the node with a suffixed name' do
               host_node = nil
 
-              expect(subject.logger).to receive(:warn).with('rename node nodeABC on name collision: node-1-1')
               expect(subject.logger).to receive(:info).with('new node node-1-2 connected using grid token')
               expect(subject.logger).to receive(:info)
 

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -391,7 +391,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
               # XXX: racy via mongo pubsub
               expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/master_info', [{ 'version' => '0.9.1'}]])
-              expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => 'node-1-1')]])
+              expect(subject).to receive(:send_message).with(client_ws, [2, '/agent/node_info', [hash_including('id' => 'nodeABC', 'name' => 'node-1-2')]])
 
               sleep 0.1
               EM.run_deferred_callbacks

--- a/server/spec/models/container_stat_spec.rb
+++ b/server/spec/models/container_stat_spec.rb
@@ -58,9 +58,9 @@ describe ContainerStat do
   describe 'aggregations' do
     let(:grid_1) { Grid.create!(name: 'grid_1') }
     let(:grid_2) { Grid.create!(name: 'grid_2') }
-    let(:grid_1_node_1) { HostNode.create!(grid: grid_1, name: 'grid_1_node_1')}
-    let(:grid_1_node_2) { HostNode.create!(grid: grid_1, name: 'grid_1_node_2')}
-    let(:grid_2_node_1) { HostNode.create!(grid: grid_2, name: 'grid_2_node_1')}
+    let(:grid_1_node_1) { grid_1.create_node!('grid_1_node_1') }
+    let(:grid_1_node_2) { grid_1.create_node!('grid_1_node_2') }
+    let(:grid_2_node_1) { grid_2.create_node!('grid_2_node_1') }
     let(:grid_1_service_1) { GridService.create!(grid: grid_1, name: 'grid_1_service_1', image_name: 'i1') }
     let(:grid_1_service_2) { GridService.create!(grid: grid_1, name: 'grid_1_service_2', image_name: 'i2') }
     let(:grid_2_service_1) { GridService.create!(grid: grid_2, name: 'grid_2_service_1', image_name: 'i1') }

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -23,6 +23,9 @@ describe Grid do
 
   it { should have_index_for(token: 1).with_options(unique: true) }
 
+  let(:initial_size) { 3 }
+  subject { Grid.create!(name: 'test', initial_size: initial_size) }
+
   describe '.after_create' do
     it 'creates default stack automatically' do
       expect {
@@ -43,6 +46,16 @@ describe Grid do
       HostNode.create!(grid: grid, node_id: 'bb', name: 'node-2', node_number: 5)
       available = (1..254).to_a - [1, 5]
       expect(grid.free_node_numbers).to eq(available)
+    end
+  end
+
+  describe '#create_node!' do
+    it 'creates and returns node with assigned node_number' do
+      node = subject.create_node!('test-node')
+
+      expect(node).to be_a HostNode
+      expect(node.name).to eq 'test-node'
+      expect(node.node_number).to eq 1
     end
   end
 

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -57,6 +57,28 @@ describe Grid do
       expect(node.name).to eq 'test-node'
       expect(node.node_number).to eq 1
     end
+
+    context 'with an existing node' do
+      let(:other_node) { subject.create_node!('test-node') }
+
+      before do
+        other_node
+      end
+
+      it 'fails with a duplicate name' do
+        expect{subject.create_node!('test-node')}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error/)
+      end
+
+      describe 'ensure_unique_name' do
+        it 'creates and node with suffixed name' do
+          node = subject.create_node!('test-node', ensure_unique_name: true)
+
+          expect(node).to be_a HostNode
+          expect(node.name).to eq 'test-node-2'
+          expect(node.node_number).to eq 2
+        end
+      end
+    end
   end
 
   describe '#has_initial_nodes?' do

--- a/server/spec/models/grid_spec.rb
+++ b/server/spec/models/grid_spec.rb
@@ -39,8 +39,8 @@ describe Grid do
 
     it 'returns only available numbers' do
       grid = Grid.create!(name: 'test')
-      HostNode.create(grid: grid, node_id: 'aa', node_number: 1)
-      HostNode.create(grid: grid, node_id: 'bb', node_number: 5)
+      HostNode.create!(grid: grid, node_id: 'aa', name: 'node-1', node_number: 1)
+      HostNode.create!(grid: grid, node_id: 'bb', name: 'node-2', node_number: 5)
       available = (1..254).to_a - [1, 5]
       expect(grid.free_node_numbers).to eq(available)
     end
@@ -50,22 +50,22 @@ describe Grid do
     let(:grid) { Grid.create!(name: 'test', initial_size: 3) }
 
     it 'returns true if initial nodes are created' do
-      HostNode.create(grid: grid, node_id: 'aa', node_number: 1)
-      HostNode.create(grid: grid, node_id: 'bb', node_number: 2)
-      HostNode.create(grid: grid, node_id: 'cc', node_number: 3)
+      HostNode.create!(grid: grid, node_id: 'aa', name: 'node-1', node_number: 1)
+      HostNode.create!(grid: grid, node_id: 'bb', name: 'node-2', node_number: 2)
+      HostNode.create!(grid: grid, node_id: 'cc', name: 'node-3', node_number: 3)
       expect(grid.has_initial_nodes?).to eq(true)
     end
 
     it 'returns false if nodes are missing' do
-      HostNode.create(grid: grid, node_id: 'aa', node_number: 1)
-      HostNode.create(grid: grid, node_id: 'bb', node_number: 2)
+      HostNode.create!(grid: grid, node_id: 'aa', name: 'node-1', node_number: 1)
+      HostNode.create!(grid: grid, node_id: 'bb', name: 'node-2', node_number: 2)
       expect(grid.has_initial_nodes?).to eq(false)
     end
 
     it 'returns false if there are enough nodes but initial node is missing' do
-      HostNode.create(grid: grid, node_id: 'aa', node_number: 1)
-      HostNode.create(grid: grid, node_id: 'bb', node_number: 2)
-      HostNode.create(grid: grid, node_id: 'cc', node_number: 4)
+      HostNode.create!(grid: grid, node_id: 'aa', name: 'node-1', node_number: 1)
+      HostNode.create!(grid: grid, node_id: 'bb', name: 'node-2', node_number: 2)
+      HostNode.create!(grid: grid, node_id: 'cc', name: 'node-4', node_number: 4)
       expect(grid.has_initial_nodes?).to eq(false)
     end
   end
@@ -74,12 +74,12 @@ describe Grid do
     let(:grid) { Grid.create!(name: 'test', initial_size: 3) }
 
     it 'returns true if node is initial member' do
-      node = HostNode.create(grid: grid, node_id: 'aa', node_number: 2)
+      node = HostNode.create!(grid: grid, node_id: 'aa', name: 'node-2', node_number: 2)
       expect(grid.initial_node?(node)).to be_truthy
     end
 
     it 'returns false if node is not initial member' do
-      node = HostNode.create(grid: grid, node_id: 'aa', node_number: 4)
+      node = HostNode.create!(grid: grid, node_id: 'aa', name: 'node-4',  node_number: 4)
       expect(grid.initial_node?(node)).to be_falsey
     end
   end

--- a/server/spec/models/host_node_spec.rb
+++ b/server/spec/models/host_node_spec.rb
@@ -21,26 +21,38 @@ describe HostNode do
   it { should have_many(:volume_instances) }
 
   it { should have_index_for(grid_id: 1) }
-  it { should have_index_for(grid_id: 1, node_number: 1).with_options(sparse: true, unique: true) }
+  it { should have_index_for(grid_id: 1, node_number: 1).with_options(unique: true) }
+  it { should have_index_for(grid_id: 1, name: 1).with_options(unique: true) }
   it { should have_index_for(node_id: 1) }
   it { should have_index_for(token: 1).with_options(sparse: true, unique: true) }
 
-  let(:grid) { Grid.create!(name: 'test') }
-  subject { HostNode.new(grid: grid, name: 'node-1') }
+  let(:grid) { Grid.create!(name: 'test', initial_size: 1) }
+  subject { HostNode.new(grid: grid, node_number: 1, name: 'node-1') }
+  let(:node2) { HostNode.create!(grid: grid, name: 'node-2', node_number: 2)}
 
-  context 'for an updated node with a name' do
-    let(:node) { grid.host_nodes.create!(node_id: 'ABC:XYZ', name: 'node') }
+  describe '#to_s' do
+    it "uses the node name" do
+      expect(subject.to_s).to eq 'node-1'
+    end
+  end
 
-    describe '#to_s' do
-      it "uses the node ID" do
-        expect(node.to_s).to eq 'node'
-      end
+  describe '#to_path' do
+    it 'uses the node name' do
+      expect(subject.to_path).to eq 'test/node-1'
+    end
+  end
+
+  context 'when the node exists' do
+    before do
+      subject.save!
     end
 
-    describe '#to_path' do
-      it 'uses the node ID' do
-        expect(node.to_path).to eq 'test/node'
-      end
+    it 'does not allow duplicate names' do
+      expect{HostNode.create!(grid: grid, node_number: 2, name: 'node-1')}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index/)
+    end
+
+    it 'does not allow duplicate node numbers' do
+      expect{HostNode.create!(grid: grid, node_number: 1, name: 'node-2')}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index/)
     end
   end
 
@@ -62,44 +74,35 @@ describe HostNode do
     let(:stateless_service) {
       GridService.create!(name: 'stateless', image_name: 'foo/bar:latest', grid: grid, stateful: false)
     }
-    let(:node) { HostNode.create(name: 'node-1', grid: grid)}
 
     it 'returns false by default' do
       expect(subject.stateful?).to be_falsey
     end
 
     it 'returns true if node has stateful service' do
-      stateful_service.containers.create!(name: 'stateful-1', host_node: node)
-      expect(node.stateful?).to be_truthy
+      stateful_service.containers.create!(name: 'stateful-1', host_node: subject)
+      expect(subject.stateful?).to be_truthy
     end
 
     it 'returns false if node has stateless service' do
-      stateless_service.containers.create!(name: 'stateless-1', host_node: node)
-      expect(node.stateful?).to be_falsey
+      stateless_service.containers.create!(name: 'stateless-1', host_node: subject)
+      expect(subject.stateful?).to be_falsey
     end
 
     it 'returns true if node has stateful and stateless service' do
-      stateful_service.containers.create!(name: 'stateful-1', host_node: node)
-      stateless_service.containers.create!(name: 'stateless-1', host_node: node)
-      expect(node.stateful?).to be_truthy
+      stateful_service.containers.create!(name: 'stateful-1', host_node: subject)
+      stateless_service.containers.create!(name: 'stateless-1', host_node: subject)
+      expect(subject.stateful?).to be_truthy
     end
   end
 
   describe '#initial_member?' do
-    let(:grid) { Grid.create!(name: 'test', initial_size: 1) }
-    let(:node_1) { HostNode.create(name: 'node-1', grid: grid, node_number: 1)}
-    let(:node_2) { HostNode.create(name: 'node-2', grid: grid, node_number: 2)}
-
     it 'returns true if initial_member' do
-      expect(node_1.initial_member?).to be_truthy
+      expect(subject.initial_member?).to be_truthy
     end
 
     it 'returns false if not initial_member' do
-      expect(node_2.initial_member?).to be_falsey
-    end
-
-    it 'returns false if node_number is not set' do
-      expect(subject.initial_member?).to be_falsey
+      expect(node2.initial_member?).to be_falsey
     end
   end
 
@@ -148,25 +151,6 @@ describe HostNode do
       expect(subject.volume_drivers.first.name).to eq('local')
       expect(subject.volume_drivers.last.name).to eq('foobar')
       expect(subject.volume_drivers.last.version).to eq('latest')
-    end
-  end
-
-  describe '#save!' do
-    let(:grid) { Grid.create!(name: 'test') }
-
-    it 'reserves node number' do |variable|
-      allow(subject).to receive(:grid).and_return(grid)
-      subject.attributes = {node_id: 'bb', grid_id: 1}
-      subject.save!
-      expect(subject.node_number).to eq(1)
-    end
-
-    it 'reserves node number successfully after race condition error' do
-      HostNode.create!(name: 'test-1', node_number: 1, grid_id: 1)
-      allow(subject).to receive(:grid).and_return(grid)
-      subject.attributes = {node_id: 'bb', grid_id: 1}
-      subject.save!
-      expect(subject.node_number).to eq(2)
     end
   end
 
@@ -250,25 +234,22 @@ describe HostNode do
     let(:stateless_service) {
       GridService.create!(name: 'stateless', image_name: 'foo/bar:latest', grid: grid, stateful: false)
     }
-    let(:node) { HostNode.create(name: 'node-1', grid: grid)}
-    let(:another_node) { HostNode.create(name: 'node-2', grid: grid)}
 
     it 'destroys all containers from a node' do
-
       stateful_service.containers.create!(
-        name: 'redis-1', host_node: node, instance_number: 1
+        name: 'redis-1', host_node: subject, instance_number: 1
       )
       stateful_service.containers.create!(
-        name: 'redis-1-volumes', host_node: node, instance_number: 1, container_type: 'volume'
+        name: 'redis-1-volumes', host_node: subject, instance_number: 1, container_type: 'volume'
       )
       stateful_service.containers.create!(
-        name: 'redis-2', host_node: another_node, instance_number: 2
+        name: 'redis-2', host_node: node2, instance_number: 2
       )
       stateful_service.containers.create!(
-        name: 'redis-2-volumes', host_node: another_node, instance_number: 2, container_type: 'volume'
+        name: 'redis-2-volumes', host_node: node2, instance_number: 2, container_type: 'volume'
       )
       expect {
-        node.destroy
+        subject.destroy
       }.to change{Container.unscoped.count}.by (-2)
     end
 
@@ -276,18 +257,18 @@ describe HostNode do
 
   describe '#volume_driver' do
     let(:grid) { Grid.create!(name: 'test') }
-    let(:node) { HostNode.create(name: 'node-1', grid: grid)}
 
     it 'returns correct volume driver' do
-      node.volume_drivers.create!(name: 'foo', version: '1')
+      subject.save!
+      subject.volume_drivers.create!(name: 'foo', version: '1')
 
-      driver = node.volume_driver('foo')
+      driver = subject.volume_driver('foo')
       expect(driver['name']).to eq('foo')
       expect(driver['version']).to eq('1')
     end
 
     it 'returns nil for unknown driver' do
-      driver = node.volume_driver('foo')
+      driver = subject.volume_driver('foo')
       expect(driver).to be_nil
     end
   end
@@ -296,46 +277,24 @@ describe HostNode do
     expect{HostNode.create!(grid: grid, name: '')}.to raise_error(Mongoid::Errors::Validations, /Name can't be blank/)
   end
 
-  context 'with another node' do
-    let(:another_node) { HostNode.create!(grid: grid, name: 'test-1') }
-
-    before do
-      another_node
-    end
-
-    it 'does not allow duplicate names' do
-      expect{HostNode.create!(grid: grid, name: 'test-1')}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index/)
-    end
-
-    describe '#ensure_unique_name' do
-      it 'adds a suffix' do
-        node = HostNode.new(grid: grid, name: 'test-1')
-
-        expect{node.ensure_unique_name}.to change{node.name}.to('test-1-1')
-
-        node.save!
-      end
-    end
-  end
-
   describe '#token' do
     let(:grid) { Grid.create!(name: 'test') }
 
     it 'allows multiple nodes without node tokens' do
-      node1 = HostNode.create!(name: 'node-1', grid: grid)
-      node2 = HostNode.create!(name: 'node-2', grid: grid)
+      node1 = HostNode.create!(grid: grid, name: 'node-1', node_number: 1)
+      node2 = HostNode.create!(grid: grid, name: 'node-2', node_number: 2)
 
       expect(node1.token).to be_nil
       expect(node2.token).to be_nil
     end
 
     it 'does not allow empty tokens' do
-      expect{HostNode.create!(grid: grid, name: 'node-1', token: '')}.to raise_error(Mongoid::Errors::Validations)
+      expect{HostNode.create!(grid: grid, name: 'node-1', node_number: 1, token: '')}.to raise_error(Mongoid::Errors::Validations)
     end
 
     context 'with a node that has a node token' do
       let(:token) { 'asdf'* 4 }
-      let(:node1) { HostNode.create!(name: 'node-1', grid: grid, token: token) }
+      let(:node1) { HostNode.create!(grid: grid, name: 'node-1', node_number: 1, token: token) }
 
       before do
         node1
@@ -348,14 +307,14 @@ describe HostNode do
       end
 
       it 'does not allow multiple nodes to share the same token' do
-        expect{HostNode.create!(name: 'node-2', grid: grid, token: token)}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdfasdfasdfasdf" }/)
+        expect{HostNode.create!(grid: grid, name: 'node-2', node_number: 2, token: token)}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdfasdfasdfasdf" }/)
       end
 
       context 'with a second grid' do
         let(:grid2) { Grid.create!(name: 'test2') }
 
         it 'does not allow nodes to share the same token' do
-          expect{HostNode.create!(name: 'node-2', grid: grid2, token: token)}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdfasdfasdfasdf" }/)
+          expect{HostNode.create!(grid: grid2, name: 'node-2', node_number: 2, token: token)}.to raise_error(Mongo::Error::OperationFailure, /E11000 duplicate key error index: kontena_test.host_nodes.\$token_1 dup key: { : "asdfasdfasdfasdf" }/)
         end
       end
     end

--- a/server/spec/models/host_node_stat_spec.rb
+++ b/server/spec/models/host_node_stat_spec.rb
@@ -11,10 +11,10 @@ describe HostNodeStat do
   it { should have_index_for(host_node_id: 1).with_options(background: true) }
   it { should have_index_for(host_node_id:1, created_at: 1).with_options(background: true) }
 
-  describe '.latest' do
-    let(:grid) { Grid.create!(name: 'test-grid') }
-    let(:node) { HostNode.create!(grid: grid, name: 'test-node') }
+  let(:grid) { Grid.create!(name: 'test-grid') }
+  let(:node) { grid.create_node!('test-node') }
 
+  describe '.latest' do
     it 'returns latest stat item' do
       node.host_node_stats.create
       last = node.host_node_stats.create
@@ -27,11 +27,9 @@ describe HostNodeStat do
   end
 
   describe 'aggregations' do
-    let(:grid) { Grid.create!(name: 'test-grid') }
     let(:other_grid) { Grid.create!(name: 'other-grid') }
-    let(:node) { HostNode.create!(grid: grid, name: 'test-node') }
-    let(:second_node) { HostNode.create!(grid: grid, name: 'second-node') }
-    let(:other_node) { HostNode.create!(grid: other_grid, name: 'other-node') }
+    let(:second_node) { grid.create_node!('second-node') }
+    let(:other_node) { other_grid.create_node!('other-node') }
     let(:stats) {
       HostNodeStat.create([
         { # 1) this record should be skipped

--- a/server/spec/models/volume_instance_spec.rb
+++ b/server/spec/models/volume_instance_spec.rb
@@ -15,7 +15,7 @@ describe VolumeInstance do
   end
 
   let(:node) do
-    grid.host_nodes.create!(name: 'node-1', node_id: 'abc')
+    grid.create_node!('node-1', node_id: 'abc')
   end
 
   it 'deletes volume instances when node is terminated' do

--- a/server/spec/models/volume_spec.rb
+++ b/server/spec/models/volume_spec.rb
@@ -35,7 +35,7 @@ describe Volume do
 
   describe '#driver_for_node' do
     let(:node) do
-      grid.host_nodes.create!(name: 'node-1')
+      grid.create_node!('node-1')
     end
 
     it 'returns plain driver when no driver on node' do

--- a/server/spec/mutations/grid_services/restart_spec.rb
+++ b/server/spec/mutations/grid_services/restart_spec.rb
@@ -2,7 +2,7 @@
 describe GridServices::Restart, celluloid: true do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:redis_service) { GridService.create(grid: grid, name: 'redis', image_name: 'redis:2.8')}
-  let(:node) { HostNode.create!(name: 'node-1', grid: grid)}
+  let(:node) { grid.create_node!('node-1') }
 
   describe '#run' do
     it 'sends restart' do

--- a/server/spec/mutations/grids/delete_spec.rb
+++ b/server/spec/mutations/grids/delete_spec.rb
@@ -12,7 +12,7 @@ describe Grids::Delete do
   }
 
   let(:node) {
-    grid.host_nodes.create!(node_id: 'abc')
+    grid.host_nodes.create!(node_id: 'abc', name: 'node-1', node_number: 1)
   }
 
   describe '#run' do

--- a/server/spec/mutations/host_nodes/common_spec.rb
+++ b/server/spec/mutations/host_nodes/common_spec.rb
@@ -1,9 +1,9 @@
 
 describe HostNodes::Common, celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }
-  let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA', connected: true) }
-  let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB', connected: true) }
-  let(:node_c) { HostNode.create!(name: 'node-c', grid: grid, node_id: 'CC', connected: false) }
+  let(:node_a) { grid.create_node!('node-a', node_id: 'AA', connected: true) }
+  let(:node_b) { grid.create_node!('node-b', node_id: 'BB', connected: true) }
+  let(:node_c) { grid.create_node!('node-c', node_id: 'CC', connected: false) }
   let(:described_class) {
     Class.new do
       include HostNodes::Common

--- a/server/spec/mutations/host_nodes/create_spec.rb
+++ b/server/spec/mutations/host_nodes/create_spec.rb
@@ -69,8 +69,7 @@ describe HostNodes::Create do
 
   context 'with an existing node in the same grid' do
     let(:node) do
-      grid.host_nodes.create!(
-        name: 'test-1',
+      grid.create_node!('test-1',
         token: 'asdfasdfasdfasdf',
       )
     end

--- a/server/spec/mutations/host_nodes/remove_spec.rb
+++ b/server/spec/mutations/host_nodes/remove_spec.rb
@@ -1,8 +1,8 @@
 
 describe HostNodes::Remove, celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }
-  let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA') }
-  let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB') }
+  let(:node_a) { grid.create_node!('node-a', node_id: 'AA') }
+  let(:node_b) { grid.create_node!('node-b', node_id: 'BB') }
 
   describe '#run' do
     let(:subject) { described_class.new(host_node: node_a) }

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -1,7 +1,7 @@
 
 describe HostNodes::Update, celluloid: true do
   let(:grid) { Grid.create!(name: 'test') }
-  let(:node) { HostNode.create!(name: 'node-1', grid: grid, node_id: 'AA') }
+  let(:node) { grid.create_node!('node-1', node_id: 'AA') }
 
   describe '#run' do
     context 'labels' do

--- a/server/spec/mutations/host_nodes/update_token_spec.rb
+++ b/server/spec/mutations/host_nodes/update_token_spec.rb
@@ -2,7 +2,7 @@ describe HostNodes::UpdateToken do
   let(:grid) { Grid.create!(name: 'test') }
 
   context "with an existing host node without a node token" do
-    let(:node) { grid.host_nodes.create!(name: 'node-1')}
+    let(:node) { grid.create_node!('node-1')}
 
     it 'generates a node token' do
       outcome = described_class.run(
@@ -57,7 +57,7 @@ describe HostNodes::UpdateToken do
   end
 
   context "with an existing host node with a token" do
-    let(:node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf')}
+    let(:node) { grid.create_node!('node-1', token: 'asdfasdfasdfasdf')}
 
     before do
       node
@@ -107,7 +107,7 @@ describe HostNodes::UpdateToken do
     end
 
     context "with a different host node without a node token" do
-      let(:node2) { grid.host_nodes.create!(name: 'node-2')}
+      let(:node2) { grid.create_node!('node-2')}
 
       before do
         node2
@@ -136,7 +136,7 @@ describe HostNodes::UpdateToken do
   end
 
   context "with an existing host node that is connected" do
-    let(:node) { grid.host_nodes.create!(name: 'node-1', token: 'asdfasdfasdfasdf', connected: true)}
+    let(:node) { grid.create_node!('node-1', token: 'asdfasdfasdfasdf', connected: true)}
 
     before do
       node

--- a/server/spec/mutations/volumes/delete_spec.rb
+++ b/server/spec/mutations/volumes/delete_spec.rb
@@ -16,11 +16,11 @@ describe Volumes::Delete do
   end
 
   let! :node1 do
-    HostNode.create!(grid: grid, id: 'foo', name: 'foo', connected: true)
+    grid.create_node!('foo', node_id: 'aaa', connected: true)
   end
 
   let! :node2 do
-    HostNode.create!(grid: grid, id: 'bar', name: 'bar', connected: false)
+    grid.create_node!('bar', node_id: 'bbb', connected: true)
   end
 
   describe '#run' do
@@ -33,8 +33,8 @@ describe Volumes::Delete do
 
     it 'deletes a volume that\'s not in use and notifies nodes where instances are' do
       rpc_client = double(:rpc_client)
-      expect(RpcClient).to receive(:new).and_return(rpc_client)
-      expect(rpc_client).to receive(:notify).once
+      allow(RpcClient).to receive(:new).and_return(rpc_client)
+      expect(rpc_client).to receive(:notify).twice
       volume.volume_instances.create!(name: 'foo1', host_node: node1)
       volume.volume_instances.create!(name: 'foo2', host_node: node2)
       expect {

--- a/server/spec/serializers/rpc/host_node_serializer_spec.rb
+++ b/server/spec/serializers/rpc/host_node_serializer_spec.rb
@@ -6,12 +6,10 @@ describe Rpc::HostNodeSerializer do
 
   context "for a minimal host node" do
     let(:host_node) {
-      HostNode.create!(
+      grid.create_node!('test-node',
         created_at: now,
         updated_at: now,
         node_id: 'wxyz',
-        grid: grid,
-        name: 'test-node',
       )
     }
 

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 describe Rpc::ServicePodSerializer do
   let(:grid) { Grid.create!(name: 'test-grid') }
-  let(:node) { HostNode.create!(name: 'node-1', node_id: 'a') }
+  let(:node) { grid.create_node!('node-1', node_id: 'a') }
   let(:lb) do
     GridService.create!(
       name: 'lb',

--- a/server/spec/services/agent/node_plugger_spec.rb
+++ b/server/spec/services/agent/node_plugger_spec.rb
@@ -10,7 +10,7 @@ describe Agent::NodePlugger do
 
   context 'for a brand new node' do
     let(:node) {
-      HostNode.create!(node_id: 'xyz', name: 'test-node')
+      grid.create_node!('test-node', node_id: 'xyz')
     }
 
     it 'marks node as connected' do
@@ -24,9 +24,9 @@ describe Agent::NodePlugger do
 
   context 'for an existing node' do
     let(:node) {
-      HostNode.create!(
+      grid.create_node!('test-node',
         node_id: 'xyz',
-        grid: grid, name: 'test-node', labels: ['region=ams2'],
+        labels: ['region=ams2'],
         connected: false,
         private_ip: '10.12.1.2', public_ip: '80.240.128.3',
       )
@@ -68,9 +68,9 @@ describe Agent::NodePlugger do
     let(:reconnected_at) { 2.seconds.ago }
     let(:connected_at) { 10.seconds.ago }
     let(:node) {
-      HostNode.create!(
+      grid.create_node!('test-node',
         node_id: 'xyz',
-        grid: grid, name: 'test-node', labels: ['region=ams2'],
+        labels: ['region=ams2'],
         connected: true, connected_at: reconnected_at,
         private_ip: '10.12.1.2', public_ip: '80.240.128.3',
       )

--- a/server/spec/services/agent/node_plugger_spec.rb
+++ b/server/spec/services/agent/node_plugger_spec.rb
@@ -10,7 +10,7 @@ describe Agent::NodePlugger do
 
   context 'for a brand new node' do
     let(:node) {
-      HostNode.create!(node_id: 'xyz')
+      HostNode.create!(node_id: 'xyz', name: 'test-node')
     }
 
     it 'marks node as connected' do
@@ -81,7 +81,7 @@ describe Agent::NodePlugger do
         expect(subject).to_not receive(:publish_update_event)
         expect(subject).to_not receive(:send_master_info)
         expect(subject).to_not receive(:send_node_info)
-        
+
         expect {
           subject.plugin! connected_at
         }.to_not change{ node.reload.connected_at }

--- a/server/spec/services/agent/node_unplugger_spec.rb
+++ b/server/spec/services/agent/node_unplugger_spec.rb
@@ -3,7 +3,7 @@ describe Agent::NodeUnplugger do
 
   let(:grid) { Grid.create! }
   let(:connected_at) { 1.minute.ago }
-  let(:node) { HostNode.create!(grid: grid, name: 'test-node', connected: true, connected_at: connected_at) }
+  let(:node) { grid.create_node!('test-node', connected: true, connected_at: connected_at) }
   let(:subject) { described_class.new(node) }
 
   context "For a connected node" do
@@ -25,7 +25,7 @@ describe Agent::NodeUnplugger do
   context "For a node that has reconnected" do
     let(:reconnected_at) { 10.seconds.ago }
 
-    let(:node) { HostNode.create!(grid: grid, name: 'test-node', connected: true, connected_at: reconnected_at) }
+    let(:node) { grid.create_node!('test-node', connected: true, connected_at: reconnected_at) }
     let(:subject) { described_class.new(node) }
 
     before do

--- a/server/spec/services/grid_scheduler_spec.rb
+++ b/server/spec/services/grid_scheduler_spec.rb
@@ -3,13 +3,12 @@ describe GridScheduler do
 
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:nodes) do
-    nodes = []
-    3.times { |i|
-      nodes << HostNode.create!(
-        name: "node-#{i + 1}", node_id: SecureRandom.uuid, grid: grid, connected: true
+    (1..3).map { |i|
+      grid.create_node!("node-#{i + 1}",
+        node_id: SecureRandom.uuid,
+        connected: true,
       )
     }
-    nodes
   end
   let(:service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid, container_count: 2) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -3,15 +3,15 @@ describe GridServiceDeployer do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
   let(:grid_service_deploy) { GridServiceDeploy.create(grid_service: grid_service, started_at: Time.now.utc) }
-  let(:node1) { HostNode.create!(node_id: SecureRandom.uuid, grid: grid) }
+  let(:node1) { HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-1', node_number: 1) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
   let(:subject) { described_class.new(strategy, grid_service_deploy, grid.host_nodes.to_a) }
   let(:deploy_rev) { Time.now.utc.to_s }
 
   describe '#selected_nodes' do
     before(:each) do
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
+      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-1', node_number: 1, labels: ['foo'])
+      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-2', node_number: 2, labels: ['foo'])
     end
 
     it 'returns instance_count amount of nodes by default' do
@@ -35,35 +35,37 @@ describe GridServiceDeployer do
       expect(subject.instance_count).to eq(grid_service.container_count)
     end
 
-    it 'returns count based on filtered nodes if strategy is daemon' do
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['bar'])
-      service = GridService.create!(
-        image_name: 'kontena/redis:2.8', name: 'redis', grid: grid,
-        container_count: 3, affinity: ['label==foo']
-      )
-      service_deploy = GridServiceDeploy.create(grid_service: service)
-      subject = described_class.new(
-        Scheduler::Strategy::Daemon.new, service_deploy, grid.host_nodes.to_a
-      )
-      expect(subject.instance_count).to eq(6)
-    end
+    context 'with labled nodes' do
+      before do
+        HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-1', node_number: 1, labels: ['foo'])
+        HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-2', node_number: 2, labels: ['foo'])
+        HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-3', node_number: 3, labels: ['bar'])
+      end
 
-    it 'returns count based on filtered nodes if strategy is daemon and stack is non-default' do
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['foo'])
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, labels: ['bar'])
-      stack = grid.stacks.create(name: 'redis')
-      service = GridService.create!(
-        image_name: 'kontena/redis:2.8', name: 'redis', grid: grid, stack: stack,
-        container_count: 1, affinity: ['label==foo'], strategy: 'daemon'
-      )
-      service_deploy = GridServiceDeploy.create(grid_service: service)
-      subject = described_class.new(
-        Scheduler::Strategy::Daemon.new, service_deploy, grid.host_nodes.to_a
-      )
-      expect(subject.instance_count).to eq(2)
+      it 'returns count based on filtered nodes if strategy is daemon' do
+        service = GridService.create!(
+          image_name: 'kontena/redis:2.8', name: 'redis', grid: grid,
+          container_count: 3, affinity: ['label==foo']
+        )
+        service_deploy = GridServiceDeploy.create(grid_service: service)
+        subject = described_class.new(
+          Scheduler::Strategy::Daemon.new, service_deploy, grid.host_nodes.to_a
+        )
+        expect(subject.instance_count).to eq(6)
+      end
+
+      it 'returns count based on filtered nodes if strategy is daemon and stack is non-default' do
+        stack = grid.stacks.create(name: 'redis')
+        service = GridService.create!(
+          image_name: 'kontena/redis:2.8', name: 'redis', grid: grid, stack: stack,
+          container_count: 1, affinity: ['label==foo'], strategy: 'daemon'
+        )
+        service_deploy = GridServiceDeploy.create(grid_service: service)
+        subject = described_class.new(
+          Scheduler::Strategy::Daemon.new, service_deploy, grid.host_nodes.to_a
+        )
+        expect(subject.instance_count).to eq(2)
+      end
     end
   end
 

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -3,15 +3,15 @@ describe GridServiceDeployer do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
   let(:grid_service_deploy) { GridServiceDeploy.create(grid_service: grid_service, started_at: Time.now.utc) }
-  let(:node1) { HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-1', node_number: 1) }
+  let(:node1) { grid.create_node!('node-1', node_id: SecureRandom.uuid, node_number: 1) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
   let(:subject) { described_class.new(strategy, grid_service_deploy, grid.host_nodes.to_a) }
   let(:deploy_rev) { Time.now.utc.to_s }
 
   describe '#selected_nodes' do
     before(:each) do
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-1', node_number: 1, labels: ['foo'])
-      HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-2', node_number: 2, labels: ['foo'])
+      grid.create_node!('node-1', node_id: SecureRandom.uuid, labels: ['foo'])
+      grid.create_node!('node-2', node_id: SecureRandom.uuid, labels: ['foo'])
     end
 
     it 'returns instance_count amount of nodes by default' do
@@ -37,9 +37,9 @@ describe GridServiceDeployer do
 
     context 'with labled nodes' do
       before do
-        HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-1', node_number: 1, labels: ['foo'])
-        HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-2', node_number: 2, labels: ['foo'])
-        HostNode.create!(node_id: SecureRandom.uuid, grid: grid, name: 'node-3', node_number: 3, labels: ['bar'])
+        grid.create_node!('node-1', node_id: SecureRandom.uuid, labels: ['foo'])
+        grid.create_node!('node-2', node_id: SecureRandom.uuid, labels: ['foo'])
+        grid.create_node!('node-3', node_id: SecureRandom.uuid, labels: ['bar'])
       end
 
       it 'returns count based on filtered nodes if strategy is daemon' do
@@ -85,8 +85,8 @@ describe GridServiceDeployer do
 
   context "for a grid with host nodes" do
     before(:each) do
-      grid.host_nodes.create!(name: 'node1', node_id: SecureRandom.uuid)
-      grid.host_nodes.create!(name: 'node2', node_id: SecureRandom.uuid)
+      grid.create_node!('node1', node_id: SecureRandom.uuid)
+      grid.create_node!('node2', node_id: SecureRandom.uuid)
     end
 
     describe '#deploy_service_instance' do

--- a/server/spec/services/grid_service_instance_deployer_spec.rb
+++ b/server/spec/services/grid_service_instance_deployer_spec.rb
@@ -2,7 +2,7 @@
 describe GridServiceInstanceDeployer do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
-  let(:node) { HostNode.create!(name: "node", node_id: SecureRandom.uuid,
+  let(:node) { grid.create_node!("node", node_id: SecureRandom.uuid,
     connected: true,
   ) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
@@ -59,7 +59,7 @@ describe GridServiceInstanceDeployer do
 
         expect(subject).to receive(:deploy_service_instance).once.with(GridServiceInstance, node, deploy_rev, 'running').and_call_original
         expect(subject).to receive(:notify_node).with(node)
-        expect(subject).to receive(:wait_until!).with("service test-grid/null/redis-2 is running on node /node at #{deploy_rev}", timeout: 300) do
+        expect(subject).to receive(:wait_until!).with("service test-grid/null/redis-2 is running on node test-grid/node at #{deploy_rev}", timeout: 300) do
           grid_service.grid_service_instances.first.set(rev: deploy_rev, state: 'running')
         end
 
@@ -114,7 +114,7 @@ describe GridServiceInstanceDeployer do
 
         expect(subject).to receive(:deploy_service_instance).once.with(GridServiceInstance, node, deploy_rev, 'running').and_call_original
         expect(subject).to receive(:notify_node).with(node)
-        expect(subject).to receive(:wait_until!).with("service test-grid/null/redis-2 is running on node /node at #{deploy_rev}", timeout: 300) do
+        expect(subject).to receive(:wait_until!).with("service test-grid/null/redis-2 is running on node test-grid/node at #{deploy_rev}", timeout: 300) do
           grid_service.grid_service_instances.first.set(rev: deploy_rev, state: 'running')
         end
 
@@ -134,7 +134,7 @@ describe GridServiceInstanceDeployer do
 
   context "With an existing deployed instance on a different host node" do
     let(:old_rev) { 1.hours.ago.utc.to_s }
-    let(:old_node) { HostNode.create!(name: "old-node", node_id: SecureRandom.uuid) }
+    let(:old_node) { grid.create_node!("old-node", node_id: SecureRandom.uuid) }
 
     let(:service_instance) {
       grid_service.grid_service_instances.create!(
@@ -171,7 +171,7 @@ describe GridServiceInstanceDeployer do
         expect(subject).to receive(:deploy_service_instance).once.with(service_instance, old_node, deploy_rev, 'stopped')
         expect(subject).to receive(:deploy_service_instance).once.with(service_instance, node, deploy_rev, 'running').and_call_original
         expect(subject).to receive(:notify_node).with(node)
-        expect(subject).to receive(:wait_until!).with("service test-grid/null/redis-2 is running on node /node at #{deploy_rev}", timeout: 300) do
+        expect(subject).to receive(:wait_until!).with("service test-grid/null/redis-2 is running on node test-grid/node at #{deploy_rev}", timeout: 300) do
           grid_service.grid_service_instances.first.set(rev: deploy_rev, state: 'running')
         end
 

--- a/server/spec/services/grid_service_scheduler_spec.rb
+++ b/server/spec/services/grid_service_scheduler_spec.rb
@@ -3,10 +3,11 @@ describe GridServiceScheduler do
 
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
+  let(:grid_nodes) do
+    (1..3).map { |i| HostNode.create!(node_id: SecureRandom.uuid, name: "node-#{i}", node_number: i) }
+  end
   let(:nodes) do
-    nodes = []
-    3.times { nodes << HostNode.create!(node_id: SecureRandom.uuid) }
-    nodes.map { |n| Scheduler::Node.new(n) }
+    grid_nodes.map { |n| Scheduler::Node.new(n) }
   end
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
   let(:subject) { described_class.new(strategy) }

--- a/server/spec/services/logs_helpers_spec.rb
+++ b/server/spec/services/logs_helpers_spec.rb
@@ -18,7 +18,7 @@ describe LogsHelpers do
 
   let(:nodes) do
     {
-      node1: grid.host_nodes.create!(name: 'node-1', node_id: SecureRandom.uuid),
+      node1: grid.create_node!('node-1', node_id: SecureRandom.uuid),
 
     }
   end

--- a/server/spec/services/rpc/container_handler_spec.rb
+++ b/server/spec/services/rpc/container_handler_spec.rb
@@ -54,7 +54,7 @@ describe Rpc::ContainerHandler do
 
   describe '#cleanup' do
     it 'removes given containers ids' do
-      node = grid.host_nodes.create!(node_id: 'aa', name: 'node-1')
+      node = grid.create_node!('node-1', node_id: 'aa')
       containers = []
       containers << grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-1', host_node: node)
       containers << grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-2', host_node: node)
@@ -249,5 +249,5 @@ describe Rpc::ContainerHandler do
 
 
   end
-  
+
 end

--- a/server/spec/services/rpc/container_info_mapper_spec.rb
+++ b/server/spec/services/rpc/container_info_mapper_spec.rb
@@ -1,8 +1,8 @@
 
 describe Rpc::ContainerInfoMapper do
   let(:grid) { Grid.create! }
-  let(:node) { HostNode.create!(name: 'node-1', node_id: 'aaa', grid: grid) }
-  let(:node2) { HostNode.create!(name: 'node-2', node_id: 'bbb', grid: grid) }
+  let(:node) { grid.create_node!('node-1', node_id: 'aaa') }
+  let(:node2) { grid.create_node!('node-2', node_id: 'bbb') }
   let(:service) do
     GridService.create!(
       grid: grid,

--- a/server/spec/services/rpc/node_handler_spec.rb
+++ b/server/spec/services/rpc/node_handler_spec.rb
@@ -1,11 +1,9 @@
 describe Rpc::NodeHandler do
   let(:grid) { Grid.create! }
   let(:subject) { described_class.new(grid) }
-  let(:node) do
-    HostNode.create!(
-      node_id: 'a', grid: grid, name: 'test-node', labels: ['region=ams2'],
-    )
-  end
+  let(:node) { grid.create_node!('test-node',
+      node_id: 'a', labels: ['region=ams2'],
+  ) }
 
   describe '#get' do
     it 'fails if the node_id is not found' do
@@ -13,13 +11,17 @@ describe Rpc::NodeHandler do
     end
 
     it 'returns correct peer ips' do
-      HostNode.create!(
-        node_id: 'b', grid: grid, name: 'test-node-2', labels: ['region=ams2'],
-        private_ip: '10.12.1.3', public_ip: '80.240.128.4'
+      grid.create_node!('test-node-2',
+        node_id: 'b',
+        labels: ['region=ams2'],
+        private_ip: '10.12.1.3',
+        public_ip: '80.240.128.4',
       )
-      HostNode.create!(
-        node_id: 'c', grid: grid, name: 'test-node-3', labels: ['region=ams3'],
-        private_ip: '10.23.1.4', public_ip: '146.185.176.0'
+      grid.create_node!('test-node-3',
+        node_id: 'c',
+        labels: ['region=ams3'],
+        private_ip: '10.23.1.4',
+        public_ip: '146.185.176.0',
       )
       json = subject.get(node.node_id)
       expect(json[:peer_ips]).to include('10.12.1.3')

--- a/server/spec/services/rpc/node_service_pod_handler_spec.rb
+++ b/server/spec/services/rpc/node_service_pod_handler_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 describe Rpc::NodeServicePodHandler do
   let(:grid) { Grid.create! }
   let(:subject) { described_class.new(grid) }
-  let(:node) { HostNode.create!(grid: grid, name: 'test-node', node_id: 'abc') }
+  let(:node) { grid.create_node!('test-node', node_id: 'abc') }
 
   describe '#list' do
     before(:each) do
@@ -31,7 +31,7 @@ describe Rpc::NodeServicePodHandler do
     end
 
     it 'does not return service pods from other node' do
-      other_node = HostNode.create!(grid: grid, name: 'other-node', node_id: 'def')
+      other_node = grid.create_node!('other-node', node_id: 'def')
       service = grid.grid_services.create!(name: 'foo', image_name: 'foo/bar:latest')
       service.grid_service_instances.create!(instance_number: 1, host_node: node, desired_state: 'running')
       list = subject.list(other_node.node_id)

--- a/server/spec/services/rpc/node_volume_handler_spec.rb
+++ b/server/spec/services/rpc/node_volume_handler_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../spec_helper'
 describe Rpc::NodeVolumeHandler, celluloid: true do
   let(:grid) { Grid.create! }
   let(:subject) { described_class.new(grid) }
-  let(:node) { HostNode.create!(grid: grid, name: 'test-node', node_id: 'abc') }
+  let(:node) { grid.create_node!('test-node', node_id: 'abc') }
 
   describe '#list' do
 
@@ -25,7 +25,7 @@ describe Rpc::NodeVolumeHandler, celluloid: true do
     end
 
     it 'does not return volumes from other node' do
-      other_node = HostNode.create!(grid: grid, name: 'other-node', node_id: 'def')
+      other_node = grid.create_node!('other-node', node_id: 'def')
       volume = grid.volumes.create!(driver: 'local', scope: 'instance', name: 'foo')
       volume.volume_instances.create!(host_node: node, name: 'svc.foo-1')
       list = subject.list(other_node.node_id)

--- a/server/spec/services/scheduler/filter/affinity_spec.rb
+++ b/server/spec/services/scheduler/filter/affinity_spec.rb
@@ -2,13 +2,11 @@
 describe Scheduler::Filter::Affinity do
 
   let(:grid) { Grid.create(name: 'test') }
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(grid: grid, node_id: 'node1', name: 'node-1', labels: ['az-1', 'ssd'])
-    nodes << HostNode.create!(grid: grid, node_id: 'node2', name: 'node-2', labels: ['az-1', 'hdd'])
-    nodes << HostNode.create!(grid: grid, node_id: 'node3', name: 'node-3', labels: ['az-2', 'ssd'])
-    nodes
-  end
+  let(:nodes) { [
+    grid.create_node!('node-1', node_id: 'node1', labels: ['az-1', 'ssd']),
+    grid.create_node!('node-2', node_id: 'node2', labels: ['az-1', 'hdd']),
+    grid.create_node!('node-3', node_id: 'node3', labels: ['az-2', 'ssd']),
+  ] }
 
   describe '#split_affinity' do
     it "raises for an invalid comperator" do

--- a/server/spec/services/scheduler/filter/availability_spec.rb
+++ b/server/spec/services/scheduler/filter/availability_spec.rb
@@ -2,13 +2,11 @@
 describe Scheduler::Filter::Availability do
 
   let(:grid) { Grid.create(name: 'test') }
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(grid: grid, node_id: 'node1', name: 'node-1', labels: ['az-1', 'ssd'])
-    nodes << HostNode.create!(grid: grid, node_id: 'node2', name: 'node-2', labels: ['az-1', 'hdd'])
-    nodes << HostNode.create!(grid: grid, node_id: 'node3', name: 'node-3', labels: ['az-2', 'ssd'])
-    nodes
-  end
+  let(:nodes) { [
+    grid.create_node!('node-1', node_id: 'node1', labels: ['az-1', 'ssd']),
+    grid.create_node!('node-2', node_id: 'node2', labels: ['az-1', 'hdd']),
+    grid.create_node!('node-3', node_id: 'node3', labels: ['az-2', 'ssd']),
+  ] }
   let(:service) {double(:service)}
 
 

--- a/server/spec/services/scheduler/filter/dependency_spec.rb
+++ b/server/spec/services/scheduler/filter/dependency_spec.rb
@@ -4,9 +4,9 @@ describe Scheduler::Filter::Dependency do
   let(:grid) { Grid.create(name: 'test') }
   let(:nodes) do
     nodes = []
-    nodes << HostNode.create!(node_id: 'node1', name: 'node-1', labels: ['az-1', 'ssd'], grid: grid)
-    nodes << HostNode.create!(node_id: 'node2', name: 'node-2', labels: ['az-1', 'hdd'], grid: grid)
-    nodes << HostNode.create!(node_id: 'node3', name: 'node-3', labels: ['az-2', 'ssd'], grid: grid)
+    nodes << grid.create_node!('node-1', node_id: 'node1', labels: ['az-1', 'ssd'], grid: grid)
+    nodes << grid.create_node!('node-2', node_id: 'node2', labels: ['az-1', 'hdd'], grid: grid)
+    nodes << grid.create_node!('node-3', node_id: 'node3', labels: ['az-2', 'ssd'], grid: grid)
     nodes
   end
   let(:default_stack) {

--- a/server/spec/services/scheduler/filter/ephemeral_spec.rb
+++ b/server/spec/services/scheduler/filter/ephemeral_spec.rb
@@ -2,22 +2,11 @@
 describe Scheduler::Filter::Ephemeral do
 
   let(:grid) { Grid.create(name: 'test') }
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node1', name: 'node-1',
-      volume_drivers: [{'name' => 'local'}, {'name' => 'foo'}]
-    )
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node2', name: 'node-2',
-      volume_drivers: [{'name' => 'foo'}]
-    )
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node3', name: 'node-3',
-      volume_drivers: [{'name' => 'local'}, {'name' => 'bar'}]
-    )
-    nodes
-  end
+  let(:nodes) { [
+    grid.create_node!('node-1', node_id: 'node1'),
+    grid.create_node!('node-2', node_id: 'node2'),
+    grid.create_node!('node-3', node_id: 'node3'),
+  ] }
 
   let(:stateless_service) do
     grid.grid_services.create!(name: 'nginx', image_name: 'nginx')

--- a/server/spec/services/scheduler/filter/memory_spec.rb
+++ b/server/spec/services/scheduler/filter/memory_spec.rb
@@ -1,15 +1,11 @@
 
 describe Scheduler::Filter::Memory do
-
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(node_id: 'node1', name: 'node-1')
-    nodes << HostNode.create!(node_id: 'node2', name: 'node-2')
-    nodes << HostNode.create!(node_id: 'node3', name: 'node-3')
-    nodes
-  end
-
   let(:grid) { Grid.create(name: 'test') }
+  let(:nodes) { [
+    grid.create_node!('node-1', node_id: 'node1'),
+    grid.create_node!('node-2', node_id: 'node2'),
+    grid.create_node!('node-3', node_id: 'node3'),
+  ] }
 
   let(:test_service) {
     GridService.create(name: 'test-service', grid: grid, image_name: 'test-service:latest')

--- a/server/spec/services/scheduler/filter/port_spec.rb
+++ b/server/spec/services/scheduler/filter/port_spec.rb
@@ -3,9 +3,9 @@ describe Scheduler::Filter::Port do
 
   let(:nodes) do
     nodes = []
-    nodes << HostNode.create!(node_id: 'node1')
-    nodes << HostNode.create!(node_id: 'node2')
-    nodes << HostNode.create!(node_id: 'node3')
+    nodes << HostNode.create!(node_id: 'node1', name: 'node-1', node_number: 1)
+    nodes << HostNode.create!(node_id: 'node2', name: 'node-2', node_number: 2)
+    nodes << HostNode.create!(node_id: 'node3', name: 'node-3', node_number: 3)
     nodes
   end
 

--- a/server/spec/services/scheduler/filter/volume_instance_spec.rb
+++ b/server/spec/services/scheduler/filter/volume_instance_spec.rb
@@ -2,13 +2,11 @@
 describe Scheduler::Filter::VolumeInstance do
 
   let(:grid) { Grid.create(name: 'test') }
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(grid: grid, node_id: 'node1', name: 'node-1', labels: ['az-1', 'ssd'])
-    nodes << HostNode.create!(grid: grid, node_id: 'node2', name: 'node-2', labels: ['az-1', 'hdd'])
-    nodes << HostNode.create!(grid: grid, node_id: 'node3', name: 'node-3', labels: ['az-2', 'ssd'])
-    nodes
-  end
+  let(:nodes) { [
+    grid.create_node!('node-1', node_id: 'node1'),
+    grid.create_node!('node-2', node_id: 'node2'),
+    grid.create_node!('node-3', node_id: 'node3'),
+  ] }
 
   let(:volume) do
     grid.volumes.create!(name: 'foo', driver: 'local', scope: 'instance')

--- a/server/spec/services/scheduler/filter/volume_plugin_spec.rb
+++ b/server/spec/services/scheduler/filter/volume_plugin_spec.rb
@@ -2,22 +2,20 @@
 describe Scheduler::Filter::VolumePlugin do
 
   let(:grid) { Grid.create(name: 'test') }
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node1', name: 'node-1',
+  let(:nodes) { [
+    grid.create_node!('node-1',
+      node_id: 'node1',
       volume_drivers: [{'name' => 'local'}, {'name' => 'foo'}]
-    )
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node2', name: 'node-2',
+    ),
+    grid.create_node!('node-2',
+      node_id: 'node2',
       volume_drivers: [{'name' => 'foo'}]
-    )
-    nodes << HostNode.create!(
-      grid: grid, node_id: 'node3', name: 'node-3',
+    ),
+    grid.create_node!('node-3',
+      node_id: 'node3',
       volume_drivers: [{'name' => 'local'}, {'name' => 'bar'}]
-    )
-    nodes
-  end
+    ),
+  ] }
 
   let(:local_volume) do
     grid.volumes.create!(name: 'local', driver: 'local', scope: 'instance')

--- a/server/spec/services/scheduler/strategy/high_availability_spec.rb
+++ b/server/spec/services/scheduler/strategy/high_availability_spec.rb
@@ -9,11 +9,9 @@ describe Scheduler::Strategy::HighAvailability do
     availability_zones.each do |az|
       2.times do |i|
         instance = i + 1
-        nodes << HostNode.create!(
+        nodes << grid.create_node!("node-#{instance}#{az}",
           node_id: "node#{instance}#{az}",
-          name: "node-#{instance}#{az}",
           connected: true,
-          grid: grid,
           labels: ['region=eu-west-1', "az=#{az}"]
         )
       end
@@ -67,7 +65,7 @@ describe Scheduler::Strategy::HighAvailability do
       end
 
       it 'return nil if data volume node is not available' do
-        node4 = HostNode.create!(node_id: 'node4', name: 'node-4', connected: true, grid: grid)
+        node4 = grid.create_node!('node-4', node_id: 'node4', connected: true)
         stateful_service.grid_service_instances.create!(
           instance_number: 3, host_node: node4
         )

--- a/server/spec/services/scheduler/strategy/random_spec.rb
+++ b/server/spec/services/scheduler/strategy/random_spec.rb
@@ -1,14 +1,12 @@
 describe Scheduler::Strategy::Random do
 
   let(:grid) { Grid.create(name: 'test') }
-
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(node_id: 'node1', name: 'node-1', connected: true, grid: grid)
-    nodes << HostNode.create!(node_id: 'node2', name: 'node-2', connected: true, grid: grid)
-    nodes << HostNode.create!(node_id: 'node3', name: 'node-3', connected: true, grid: grid)
-    nodes.map { |n| Scheduler::Node.new(n) }
-  end
+  let(:grid_nodes) { [
+    grid.create_node!('node-1', node_id: 'node1', connected: true),
+    grid.create_node!('node-2', node_id: 'node2', connected: true),
+    grid.create_node!('node-3', node_id: 'node3', connected: true),
+  ] }
+  let(:nodes) { grid_nodes.map { |n| Scheduler::Node.new(n) } }
 
   let(:stateful_service) do
     GridService.create!(
@@ -23,7 +21,7 @@ describe Scheduler::Strategy::Random do
   end
 
   describe '#find_node' do
-    context 'stateless' do 
+    context 'stateless' do
       it 'returns a node if no previous instance exist' do
         node = subject.find_node(stateless_service, 2, nodes)
         expect(nodes.include?(node)).to be_truthy
@@ -35,7 +33,7 @@ describe Scheduler::Strategy::Random do
         expect(node).to eq(nodes[2])
       end
 
-      it 'returns a node if previously scheduled node has been removed' do 
+      it 'returns a node if previously scheduled node has been removed' do
         stateless_service.grid_service_instances.create!(instance_number: 2, host_node: nodes[2].node)
         nodes.delete(nodes[2]).destroy
         node = subject.find_node(stateless_service, 2, nodes)
@@ -62,7 +60,7 @@ describe Scheduler::Strategy::Random do
         expect(node).to eq(nodes[2])
       end
 
-      it 'returns a node if previously scheduled node has been removed' do 
+      it 'returns a node if previously scheduled node has been removed' do
         stateful_service.grid_service_instances.create!(instance_number: 2, host_node: nodes[2].node)
         nodes.delete(nodes[2]).destroy
         node = subject.find_node(stateful_service, 2, nodes)

--- a/server/spec/services/volume_instance_deployer_spec.rb
+++ b/server/spec/services/volume_instance_deployer_spec.rb
@@ -11,7 +11,7 @@ describe VolumeInstanceDeployer do
     grid.grid_services.create!(name: 'redis', image_name: 'redis')
   end
 
-  let(:node) { HostNode.create!(node_id: SecureRandom.uuid) }
+  let(:node) { HostNode.create!(node_id: SecureRandom.uuid, name: 'node', node_number: 1) }
 
   it 'creates volume instance if needed' do
     expect_any_instance_of(RpcClient).to receive(:request).with('/volumes/notify_update', [])


### PR DESCRIPTION
Fixes #2071, fixes #2542 by creating the nodes with a `node_number` set
Fixes #2558 by always having a node name available for `kontena node list`

* Send and validate both `Kontena-Node-ID` and `Kontena-Node-Name` headers in agent websocket connections
* Use `Grid.create_node!` to allocate the `node_number` before saving, retrying on `node_number` conflicts
* Create new `HostNode`s with the node name set for grid token connections, adding unique suffix if required
* Add validation and unique index on the `HostNode.name` (namespaced per grid)

* Validate the `HostNode.node_number` and change the unique index to be non-sparse

    It was already broken, seemingly failing with duplicate key errors on `node_number: null` with the `grid_id` set?

* Fix specs to use `grid.create_node!`