### PR TITLE
Upgrade CLI kontena-websocket-client to 0.1.1 to fix crash on pong

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "liquid", "~> 4.0.0"
   spec.add_runtime_dependency "tty-table", "~> 0.8.0"
-  spec.add_runtime_dependency "kontena-websocket-client", "~> 0.1.0"
+  spec.add_runtime_dependency "kontena-websocket-client", "~> 0.1.1"
 end


### PR DESCRIPTION
The CLI container execs were also affected by https://github.com/kontena/kontena-websocket-client/issues/19, and would crash after the 30s ping interval:

```
DEBUG Running Kontena::Cli::Containers::ExecCommand with ["-i", "core-02/weave", "sh"] -- callback matcher = 'containers exec'
DEBUG websocket exec connect... ws://localhost:9292/v1/containers/development/core-02/weave/exec?interactive=true
D, [2017-08-16T12:14:25.257010 #26954] DEBUG -- Kontena::Websocket::Client: connect_tcp: timeout=10.0
D, [2017-08-16T12:14:25.257523 #26954] DEBUG -- Kontena::Websocket::Client: websocket open...
D, [2017-08-16T12:14:25.264430 #26954] DEBUG -- Kontena::Websocket::Client::Connection: write #buf=302: size=302
D, [2017-08-16T12:14:25.264503 #26954] DEBUG -- Kontena::Websocket::Client: opening
D, [2017-08-16T12:14:25.264556 #26954] DEBUG -- Kontena::Websocket::Client: read (open)
D, [2017-08-16T12:14:25.264621 #26954] DEBUG -- Kontena::Websocket::Client::Connection: wait read: timeout=9.999984219
D, [2017-08-16T12:14:25.392008 #26954] DEBUG -- Kontena::Websocket::Client::Connection: read size=4096: #buf=129
D, [2017-08-16T12:14:25.394689 #26954] DEBUG -- Kontena::Websocket::Client: opened
DEBUG websocket exec open
DEBUG websocket exec write: {"cmd"=>["sh"]}
D, [2017-08-16T12:14:25.395673 #26954] DEBUG -- Kontena::Websocket::Client::Connection: write #buf=20: size=20
D, [2017-08-16T12:14:25.395845 #26954] DEBUG -- Kontena::Websocket::Client: read (ping)
D, [2017-08-16T12:14:25.396060 #26954] DEBUG -- Kontena::Websocket::Client::Connection: wait read: timeout=29.861157834
D, [2017-08-16T12:14:55.286511 #26954] DEBUG -- Kontena::Websocket::Client: ping on read timeout after 29.861157834s
D, [2017-08-16T12:14:55.286613 #26954] DEBUG -- Kontena::Websocket::Client: pinging at 2017-08-16 12:14:55 +0300
D, [2017-08-16T12:14:55.286753 #26954] DEBUG -- Kontena::Websocket::Client::Connection: write #buf=36: size=36
D, [2017-08-16T12:14:55.286812 #26954] DEBUG -- Kontena::Websocket::Client: read (pong)
D, [2017-08-16T12:14:55.286894 #26954] DEBUG -- Kontena::Websocket::Client::Connection: wait read: timeout=9.999793819
D, [2017-08-16T12:14:55.287225 #26954] DEBUG -- Kontena::Websocket::Client::Connection: read size=4096: #buf=32
D, [2017-08-16T12:14:55.287350 #26954] DEBUG -- Kontena::Websocket::Client: pong for 2017-08-16 09:14:55 UTC
D, [2017-08-16T12:14:55.287390 #26954] DEBUG -- Kontena::Websocket::Client: ping-pong at 2017-08-16 09:14:55 UTC in 0.000781456s
D, [2017-08-16T12:14:55.287445 #26954] DEBUG -- Kontena::Websocket::Client: disconnect
ERROR websocket exec error: undefined method `call' for nil:NilClass
Did you mean?  caller
bundler: failed to load command: bin/kontena (bin/kontena)
NoMethodError: undefined method `call' for nil:NilClass
Did you mean?  caller
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:351:in `block (2 levels) in ping'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:376:in `emit_frame'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/hybi.rb:123:in `parse'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/websocket-driver-0.6.5/lib/websocket/driver/client.rb:63:in `parse'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:813:in `block in websocket_read'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:420:in `block in with_driver'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:417:in `synchronize'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:417:in `with_driver'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:811:in `websocket_read'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:761:in `block in read_yield'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:753:in `loop'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:753:in `read_yield'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:286:in `read'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:64:in `websocket_exec_read'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:158:in `block in websocket_exec'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/kontena-websocket-client-0.1.0/lib/kontena/websocket/client.rb:64:in `connect'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:146:in `websocket_exec'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:187:in `container_exec'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/containers/exec_command.rb:20:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:202:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:202:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:202:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
  bin/kontena:18:in `<top (required)>'
```

The `bundle install` would already install the latest 0.1.1 version for `~> 0.1.0`, but this makes it explicit.