### PR TITLE
Server: Replace use of Celluloid::Future for async threads 

### DIFF
--- a/server/app/helpers/async_helper.rb
+++ b/server/app/helpers/async_helper.rb
@@ -1,0 +1,17 @@
+module AsyncHelper
+  include Logging
+
+  # Run block in a new thread. Log exceptions.
+  #
+  # @yield
+  # @return [Thread] don't care about it
+  def async_thread(&block)
+    Thread.new {
+      begin
+        yield
+      rescue Exception => exc
+        error exc
+      end
+    }
+  end
+end

--- a/server/app/mutations/grid_services/restart.rb
+++ b/server/app/mutations/grid_services/restart.rb
@@ -1,13 +1,15 @@
 module GridServices
   class Restart < Mutations::Command
+    include AsyncHelper
+
     required do
       model :grid_service
     end
 
     def execute
-      Celluloid::Future.new{
+      async_thread do
         self.restart_service_instances
-      }
+      end
     end
 
     def restart_service_instances

--- a/server/app/mutations/grid_services/start.rb
+++ b/server/app/mutations/grid_services/start.rb
@@ -1,12 +1,14 @@
 module GridServices
   class Start < Mutations::Command
+    include AsyncHelper
+
     required do
       model :grid_service
     end
 
     def execute
       prev_state = self.grid_service.state
-      Celluloid::Future.new {
+      async_thread do
         begin
           self.grid_service.set_state('running')
           self.start_service_instances
@@ -14,7 +16,7 @@ module GridServices
           self.grid_service.set_state(prev_state)
           raise exc
         end
-      }
+      end
     end
 
     def start_service_instances

--- a/server/app/mutations/grid_services/stop.rb
+++ b/server/app/mutations/grid_services/stop.rb
@@ -1,12 +1,14 @@
 module GridServices
   class Stop < Mutations::Command
+    include AsyncHelper
+
     required do
       model :grid_service
     end
 
     def execute
       prev_state = self.grid_service.state
-      Celluloid::Future.new{
+      async_thread do
         begin
           self.grid_service.set_state('stopped')
           self.stop_service_instances
@@ -14,7 +16,7 @@ module GridServices
           self.grid_service.set_state(prev_state)
           raise exc
         end
-      }
+      end
     end
 
     def stop_service_instances

--- a/server/app/mutations/host_nodes/common.rb
+++ b/server/app/mutations/host_nodes/common.rb
@@ -3,11 +3,9 @@ module HostNodes
 
     # @param [Grid] grid
     def notify_grid(grid)
-      Celluloid::Future.new {
-        grid.host_nodes.connected.each do |node|
-          notify_node(grid, node)
-        end
-      }
+      grid.host_nodes.connected.each do |node|
+        notify_node(grid, node)
+      end
     end
 
     # @param [Grid] grid

--- a/server/app/mutations/host_nodes/remove.rb
+++ b/server/app/mutations/host_nodes/remove.rb
@@ -2,7 +2,7 @@ require_relative 'common'
 
 module HostNodes
   class Remove < Mutations::Command
-    include Workers
+    include AsyncHelper
     include Common
 
     required do
@@ -13,9 +13,7 @@ module HostNodes
       grid = self.host_node.grid
       self.host_node.destroy
 
-      if grid
-        notify_grid(grid)
-      end
+      async_thread { notify_grid(grid) } if grid
     end
   end
 end

--- a/server/app/mutations/host_nodes/update.rb
+++ b/server/app/mutations/host_nodes/update.rb
@@ -2,7 +2,7 @@ require_relative 'common'
 
 module HostNodes
   class Update < Mutations::Command
-
+    include AsyncHelper
     include Common
     include Logging
 
@@ -21,7 +21,9 @@ module HostNodes
 
       self.host_node.save
 
-      notify_grid(self.host_node.grid)
+      async_thread do
+        notify_grid(self.host_node.grid)
+      end
 
       # Update availability if given and trigger appropriate actions
       if self.availability && self.host_node.availability != self.availability

--- a/server/app/services/mongo_pubsub.rb
+++ b/server/app/services/mongo_pubsub.rb
@@ -1,10 +1,13 @@
 require_relative 'logging'
+require_relative '../helpers/async_helper.rb'
 
 class MongoPubsub
   include Celluloid
   include Logging
 
   class Subscription
+    include AsyncHelper
+
     attr_reader :channel
 
     # @param [String] channel
@@ -45,7 +48,7 @@ class MongoPubsub
 
     def process
       @process = true
-      Celluloid::Future.new {
+      async_thread do
         while @process == true && @stopped == false
           data = @queue.shift
           if data
@@ -54,7 +57,7 @@ class MongoPubsub
             @process = false
           end
         end
-      }
+      end
     end
 
     # @param [Hash] data

--- a/server/spec/mutations/grid_services/restart_spec.rb
+++ b/server/spec/mutations/grid_services/restart_spec.rb
@@ -1,5 +1,6 @@
+describe GridServices::Restart do
+  include AsyncMock
 
-describe GridServices::Restart, celluloid: true do
   let(:grid) { Grid.create!(name: 'test-grid') }
   let(:redis_service) { GridService.create(grid: grid, name: 'redis', image_name: 'redis:2.8')}
   let(:node) { HostNode.create!(name: 'node-1', grid: grid)}
@@ -11,7 +12,7 @@ describe GridServices::Restart, celluloid: true do
       )
       subject = described_class.new(grid_service: redis_service)
       expect(subject).to receive(:restart_service_instance).with(node, container.instance_number).once
-      subject.run.result.value
+      outcome = subject.run
     end
 
     it 'sets service state to running' do
@@ -19,20 +20,17 @@ describe GridServices::Restart, celluloid: true do
       subject = described_class.new(grid_service: redis_service)
       allow(subject).to receive(:restart_service_instance)
       outcome = subject.run
-      outcome.result.value
       expect(redis_service.state).to eq('running')
     end
+  end
 
+  describe '#restart_service_instances' do
     it 'returns service to previous state if exception is raised' do
       prev_state = redis_service.state
       redis_service.containers.create!(name: 'redis-1', container_id: '34')
       subject = described_class.new(grid_service: redis_service)
       expect(subject).to receive(:restart_service_instance).and_raise(StandardError.new('error'))
-      outcome = subject.run
-      expect(outcome.success?).to be_truthy
-      expect {
-        outcome.result.value
-      }.to raise_exception(StandardError)
+      expect{subject.restart_service_instances}.to raise_exception(StandardError)
       expect(redis_service.state).to eq(prev_state)
     end
   end

--- a/server/spec/mutations/grid_services/start_spec.rb
+++ b/server/spec/mutations/grid_services/start_spec.rb
@@ -1,5 +1,6 @@
+describe GridServices::Start do
+  include AsyncMock
 
-describe GridServices::Start, celluloid: true do
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
     grid
@@ -13,14 +14,13 @@ describe GridServices::Start, celluloid: true do
       container = redis_service.containers.create!(name: 'redis-1', container_id: '34')
       expect(subject).to receive(:start_service_instances).and_return(true)
 
-      subject.run.result.value
+      outcome = subject.run
     end
 
     it 'sets service state to running' do
       redis_service.containers.create!(name: 'redis-1', container_id: '34')
       allow(subject).to receive(:start_service_instances).and_return(true)
       outcome = subject.run
-      outcome.result.value
       expect(redis_service.reload.state).to eq('running')
     end
 
@@ -29,10 +29,8 @@ describe GridServices::Start, celluloid: true do
       redis_service.containers.create!(name: 'redis-1', container_id: '34')
       subject = described_class.new(grid_service: redis_service)
       expect(subject).to receive(:start_service_instances).and_raise(StandardError.new('error'))
-      outcome = subject.run
-      expect(outcome.success?).to be_truthy
       expect {
-        outcome.result.value
+        outcome = subject.run
       }.to raise_exception(StandardError)
       expect(redis_service.state).to eq(prev_state)
     end

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -1,11 +1,17 @@
-
-describe Grids::Update, celluloid: true do
+describe Grids::Update do
   let(:user) { User.create!(email: 'joe@domain.com')}
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
     grid.users << user
     grid
   }
+
+  before do
+    # test async blocks by running them sync
+    allow(subject).to receive(:async_thread) do |&block|
+      block.call
+    end
+  end
 
   describe '#run' do
     before(:each) do

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -1,17 +1,12 @@
 describe Grids::Update do
+  include AsyncMock
+
   let(:user) { User.create!(email: 'joe@domain.com')}
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
     grid.users << user
     grid
   }
-
-  before do
-    # test async blocks by running them sync
-    allow(subject).to receive(:async_thread) do |&block|
-      block.call
-    end
-  end
 
   describe '#run' do
     before(:each) do

--- a/server/spec/mutations/host_nodes/common_spec.rb
+++ b/server/spec/mutations/host_nodes/common_spec.rb
@@ -1,5 +1,4 @@
-
-describe HostNodes::Common, celluloid: true do
+describe HostNodes::Common do
   let(:grid) { Grid.create!(name: 'test') }
   let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA', connected: true) }
   let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB', connected: true) }
@@ -11,17 +10,12 @@ describe HostNodes::Common, celluloid: true do
   }
 
   describe '#notify_grid' do
-    it 'returns future' do
-      expect(subject.notify_grid(grid).class).to eq(Celluloid::Future)
-    end
-
     it 'notifies all connected nodes' do
       node_a; node_b; node_c
       expect(subject).to receive(:notify_node).once.with(grid, node_a)
       expect(subject).to receive(:notify_node).once.with(grid, node_b)
       expect(subject).not_to receive(:notify_node).with(grid, node_c)
-      future = subject.notify_grid(grid)
-      future.value
+      subject.notify_grid(grid)
     end
   end
 end

--- a/server/spec/mutations/host_nodes/remove_spec.rb
+++ b/server/spec/mutations/host_nodes/remove_spec.rb
@@ -1,14 +1,9 @@
 describe HostNodes::Remove do
+  include AsyncMock
+
   let(:grid) { Grid.create!(name: 'test') }
   let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA') }
   let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB') }
-
-  before do
-    # test async blocks by running them sync
-    allow(subject).to receive(:async_thread) do |&block|
-      block.call
-    end
-  end
 
   describe '#run' do
     let(:subject) { described_class.new(host_node: node_a) }

--- a/server/spec/mutations/host_nodes/remove_spec.rb
+++ b/server/spec/mutations/host_nodes/remove_spec.rb
@@ -1,12 +1,17 @@
-
-describe HostNodes::Remove, celluloid: true do
+describe HostNodes::Remove do
   let(:grid) { Grid.create!(name: 'test') }
   let(:node_a) { HostNode.create!(name: 'node-a', grid: grid, node_id: 'AA') }
   let(:node_b) { HostNode.create!(name: 'node-b', grid: grid, node_id: 'BB') }
 
+  before do
+    # test async blocks by running them sync
+    allow(subject).to receive(:async_thread) do |&block|
+      block.call
+    end
+  end
+
   describe '#run' do
     let(:subject) { described_class.new(host_node: node_a) }
-    before(:each) { allow(subject).to receive(:worker).and_return(spy(:worker)) }
 
     it 'removes node' do
       node_a; node_b

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -1,13 +1,8 @@
 describe HostNodes::Update do
+  include AsyncMock
+
   let(:grid) { Grid.create!(name: 'test') }
   let(:node) { HostNode.create!(name: 'node-1', grid: grid, node_id: 'AA') }
-
-  before do
-    # test async blocks by running them sync
-    allow(subject).to receive(:async_thread) do |&block|
-      block.call
-    end
-  end
 
   describe '#run' do
     context 'labels' do

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -1,7 +1,13 @@
-
-describe HostNodes::Update, celluloid: true do
+describe HostNodes::Update do
   let(:grid) { Grid.create!(name: 'test') }
   let(:node) { HostNode.create!(name: 'node-1', grid: grid, node_id: 'AA') }
+
+  before do
+    # test async blocks by running them sync
+    allow(subject).to receive(:async_thread) do |&block|
+      block.call
+    end
+  end
 
   describe '#run' do
     context 'labels' do

--- a/server/spec/support/async_mock.rb
+++ b/server/spec/support/async_mock.rb
@@ -1,0 +1,10 @@
+module AsyncMock
+  def self.included(cls)
+    cls.before do
+      # test async blocks by running them sync
+      allow_any_instance_of(described_class).to receive(:async_thread) do |&block|
+        block.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2126 to log any errors raised by the async thread blocks

Using `Celluloid::Future` to execute async blocks in threads without actually checking the future `value` is broken, in that it silently ignores any resulting errors. This results in bugs like #2584 which are very hard to notice.

Fix the server to just use a simple `AsyncHelper#async_thread do ... end` which at least logs the errors, making them slightly more likely to be noticed during development. It does not actually handle the errors, though.