### PR TITLE
Fix oneshot hooks; Change post_start hooks to run on start; Add pre_start, pre_stop hooks

### DIFF
--- a/agent/lib/kontena/load_balancers/registrator.rb
+++ b/agent/lib/kontena/load_balancers/registrator.rb
@@ -38,7 +38,7 @@ module Kontena::LoadBalancers
     def on_container_event(topic, event)
       if event.status == 'start'
         container = Docker::Container.get(event.id) rescue nil
-        if container && container.load_balanced?
+        if container && container.service_container? && container.load_balanced?
           self.register_container(container)
         end
       elsif event.status == 'die'

--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -15,8 +15,6 @@ module Kontena
                   :image_name,
                   :image_credentials,
                   :user,
-                  :cmd,
-                  :entrypoint,
                   :memory,
                   :memory_swap,
                   :cpus,
@@ -45,6 +43,7 @@ module Kontena
                   :volume_specs,
                   :read_only,
                   :stop_grace_period
+      attr_accessor :entrypoint, :cmd
 
       # @param [Hash] attrs
       def initialize(attrs = {})

--- a/agent/lib/kontena/rpc/service_pods_api.rb
+++ b/agent/lib/kontena/rpc/service_pods_api.rb
@@ -8,31 +8,13 @@ module Kontena
       # @param instance_number [Integer]
       # @return [Hash]
       def restart(service_id, instance_number)
-        service_pod = find_service_pod(service_id, instance_number)
-        raise Kontena::RpcServer::Error.new(404, "Service instance not found") unless service_pod
-
-        Kontena::ServicePods::Restarter.new(service_pod).perform
+        Kontena::ServicePods::Restarter.new(service_id, instance_number).perform
         {}
       end
 
       def notify_update(reason)
         Celluloid::Notifications.publish('service_pod:update', reason)
         {}
-      end
-
-      private
-
-      # @param service_id [String]
-      # @param instance_number [Integer]
-      def find_service_pod(service_id, instance_number)
-        worker = Celluloid::Actor[:service_pod_manager].workers.find { |w|
-          w.service_pod.service_id == service_id && w.service_pod.instance_number == instance_number
-        }
-        if worker
-          worker.service_pod
-        else
-          nil
-        end
       end
     end
   end

--- a/agent/lib/kontena/rpc/service_pods_api.rb
+++ b/agent/lib/kontena/rpc/service_pods_api.rb
@@ -4,17 +4,35 @@ module Kontena
   module Rpc
     class ServicePodsApi
 
-      # @param [String] service_id
-      # @param [Integer] instance_number
+      # @param service_id [String]
+      # @param instance_number [Integer]
       # @return [Hash]
       def restart(service_id, instance_number)
-        Kontena::ServicePods::Restarter.new(service_id, instance_number).perform
+        service_pod = find_service_pod(service_id, instance_number)
+        raise Kontena::RpcServer::Error.new(404, "Service instance not found") unless service_pod
+
+        Kontena::ServicePods::Restarter.new(service_pod).perform
         {}
       end
 
       def notify_update(reason)
         Celluloid::Notifications.publish('service_pod:update', reason)
         {}
+      end
+
+      private
+
+      # @param service_id [String]
+      # @param instance_number [Integer]
+      def find_service_pod(service_id, instance_number)
+        worker = Celluloid::Actor[:service_pod_manager].workers.find { |w|
+          w.service_pod.service_id == service_id && w.service_pod.instance_number == instance_number
+        }
+        if worker
+          worker.service_pod
+        else
+          nil
+        end
       end
     end
   end

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -16,11 +16,13 @@ module Kontena
 
       attr_reader :service_pod, :image_credentials, :hook_manager
 
-      # @param [ServicePod] service_pod
-      def initialize(service_pod)
+      # @param service_pod [ServicePod]
+      # @param hook_manager [LifecycleHookManager]
+      def initialize(service_pod, hook_manager)
         @service_pod = service_pod
         @image_credentials = service_pod.image_credentials
-        @hook_manager = Kontena::ServicePods::LifecycleHookManager.new(service_pod)
+        @hook_manager = hook_manager
+        @hook_manager.track(service_pod)
       end
 
       # @return [Docker::Container]

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -42,6 +42,7 @@ module Kontena
         wait_network_ready?
 
         if service_container
+          hook_manager.on_pre_stop(service_container)
           info "removing previous version of service: #{service_pod.name_for_humans}"
           cleanup_container(service_container)
           log_service_pod_event("service:create_instance", "removed previous version of service #{service_pod.name_for_humans} instance")

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -89,9 +89,7 @@ module Kontena
           begin
             service_container = create_container(service_config)
             info "running pre_start hook: #{hook['cmd']}"
-            service_container.tap(&:start).attach { |stream, chunk|
-              log_hook_output(service_container.id, [chunk], stream)
-            }
+            service_container.tap(&:start).attach
             if service_container.state['ExitCode'] != 0
               raise "Failed to execute pre_start hook: #{hook['cmd']}, exit code: #{service_container.state['ExitCode']}"
             end

--- a/agent/lib/kontena/service_pods/creator.rb
+++ b/agent/lib/kontena/service_pods/creator.rb
@@ -102,8 +102,7 @@ module Kontena
         true
       rescue => exc
         log_service_pod_event("service:create_instance", exc.message, Logger::ERROR)
-        error exc.message
-        false
+        raise exc
       end
 
       # @param [Docker::Container] service_container

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -66,7 +66,6 @@ module Kontena
       # @return [Array<String>]
       def build_cmd(cmd)
         command = ['/bin/sh', '-c', cmd]
-        command.unshift('/w/w') if service_pod.can_expose_ports?
 
         command
       end

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -1,0 +1,93 @@
+module Kontena
+  module ServicePods
+    class LifecycleHookManager
+      include Kontena::Helpers::RpcHelper
+      include Common
+
+      attr_reader :service_pod
+
+      # @param [ServicePod] service_pod
+      def initialize(service_pod)
+        @service_pod = service_pod
+      end
+
+      # @return [Boolean]
+      def on_pre_start
+        pre_start_hooks = hooks_for('pre_start')
+        return if pre_start_hooks.size == 0
+
+        service_config = config_container(service_pod.dup)
+        service_config['Entrypoint'] = '/bin/sh'
+        service_config['Cmd'] = ['-c', 'sleep 600']
+        service_container = create_container(service_config)
+        service_container.start!
+        pre_start_hooks.each do |hook|
+          info "running pre_start hook: #{hook['cmd']}"
+          command = ['/bin/sh', '-c', hook['cmd']]
+          log_hook_output(service_container.id, ["running pre_start hook: #{hook['cmd']}"], 'stdout')
+          _, _, exit_code = service_container.exec(command) { |stream, chunk|
+            log_hook_output(service_container.id, [chunk], stream)
+          }
+          if exit_code != 0
+            raise "Failed to execute pre_start hook: #{hook['cmd']} (exit code: #{exit_code}"
+          end
+        end
+        true
+      rescue => exc
+        log_service_pod_event("service:create_instance", exc.message, Logger::ERROR)
+        raise exc
+      ensure
+        cleanup_container(service_container) if service_container
+      end
+
+      # @param [Docker::Container] service_container
+      # @return [Boolean]
+      def on_post_start(service_container)
+        hooks_for('post_start').each do |hook|
+          info "running post_start hook: #{hook['cmd']}"
+          command = ['/bin/sh', '-c', hook['cmd']]
+          log_hook_output(service_container.id, ["running post_start hook: #{hook['cmd']}"], 'stdout')
+          _, _, exit_code = service_container.exec(command) { |stream, chunk|
+            log_hook_output(service_container.id, [chunk], stream)
+          }
+          if exit_code != 0
+            raise "Failed to execute post_start hook: #{hook['cmd']} (exit code: #{exit_code}"
+          end
+        end
+        true
+      rescue => exc
+        log_service_pod_event("service:create_instance", exc.message, Logger::ERROR)
+        error exc.message
+        false
+      end
+
+      # @param [String] type
+      # @return [Array<Hash>]
+      def hooks_for(type)
+        service_pod.hooks.select{ |h| h['type'] == type }
+      end
+
+      # @param [String] id
+      # @param [Array<String>] lines
+      # @param [String] type
+      def log_hook_output(id, lines, type)
+        lines.each do |chunk|
+          data = {
+              id: id,
+              time: Time.now.utc.xmlschema,
+              type: type,
+              data: chunk
+          }
+          rpc_client.async.notification('/containers/log', [data])
+        end
+      end
+
+      # @param [String] type
+      # @param [String] data
+      # @param [Integer] severity
+      def log_service_pod_event(type, data, severity = Logger::INFO)
+        super(service_pod.service_id, service_pod.instance_number, type, data, severity)
+      end
+    end
+  end
+end

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -24,7 +24,7 @@ module Kontena
         service_container.start!
         pre_start_hooks.each do |hook|
           info "running pre_start hook: #{hook['cmd']}"
-          command = ['/bin/sh', '-c', hook['cmd']]
+          command = ['/w/w', '/bin/sh', '-c', hook['cmd']]
           log_hook_output(service_container.id, ["running pre_start hook: #{hook['cmd']}"], 'stdout')
           _, _, exit_code = service_container.exec(command) { |stream, chunk|
             log_hook_output(service_container.id, [chunk], stream)
@@ -46,7 +46,7 @@ module Kontena
       def on_post_start(service_container)
         hooks_for('post_start').each do |hook|
           info "running post_start hook: #{hook['cmd']}"
-          command = ['/bin/sh', '-c', hook['cmd']]
+          command = ['/w/w', '/bin/sh', '-c', hook['cmd']]
           log_hook_output(service_container.id, ["running post_start hook: #{hook['cmd']}"], 'stdout')
           _, _, exit_code = service_container.exec(command) { |stream, chunk|
             log_hook_output(service_container.id, [chunk], stream)

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -16,9 +16,10 @@ module Kontena
         pre_start_hooks = hooks_for('pre_start')
         return if pre_start_hooks.size == 0
 
-        service_config = config_container(service_pod.dup)
-        service_config['Entrypoint'] = '/bin/sh'
-        service_config['Cmd'] = ['-c', 'sleep 600']
+        pre_pod = service_pod.dup
+        pre_pod.entrypoint = '/bin/sh'
+        pre_pod.cmd = ['-c', 'sleep 600']
+        service_config = config_container(pre_pod)
         service_container = create_container(service_config)
         service_container.start!
         pre_start_hooks.each do |hook|

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -146,7 +146,7 @@ module Kontena
           service_id: service_pod.service_id,
           instance_number: service_pod.instance_number
         }
-        rpc_client.async.request('/node_service_pods/mark_oneshot_hook', [node.id, pod, hook])
+        rpc_client.request('/node_service_pods/mark_oneshot_hook', [node.id, pod, hook])
         oneshot_cache << hook
       end
 

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -100,7 +100,7 @@ module Kontena
       # @param hook [Hash]
       # @return [Boolean]
       def cached_oneshot_hook?(hook)
-        hook['oneshot'] && oneshot_cache.include?(hook)
+        hook['oneshot'] && oneshot_cache.include?(hook['id'])
       end
 
       # @param [String] cmd
@@ -151,7 +151,7 @@ module Kontena
           instance_number: service_pod.instance_number
         }
         rpc_client.request('/node_service_pods/mark_oneshot_hook', [node.id, pod, hook])
-        oneshot_cache << hook
+        oneshot_cache << hook['id']
       end
 
       # @return [Array<Hash>]

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -146,6 +146,8 @@ module Kontena
 
       # @param hook [Hash]
       def mark_oneshot_hook(hook)
+        return unless hook['oneshot']
+
         pod = {
           service_id: service_pod.service_id,
           instance_number: service_pod.instance_number

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -16,29 +16,23 @@ module Kontena
         pre_start_hooks = hooks_for('pre_start')
         return if pre_start_hooks.size == 0
 
-        pre_pod = service_pod.dup
-        pre_pod.entrypoint = '/bin/sh'
-        pre_pod.cmd = ['-c', 'sleep 600']
-        service_config = config_container(pre_pod)
-        service_container = create_container(service_config)
-        service_container.start!
         pre_start_hooks.each do |hook|
-          info "running pre_start hook: #{hook['cmd']}"
-          command = build_cmd(hook['cmd'])
-          log_hook_output(service_container.id, ["running pre_start hook: #{hook['cmd']}"], 'stdout')
-          _, _, exit_code = service_container.exec(command) { |stream, chunk|
-            log_hook_output(service_container.id, [chunk], stream)
-          }
-          if exit_code != 0
-            raise "Failed to execute pre_start hook: #{hook['cmd']} (exit code: #{exit_code}"
+          begin
+            info "running pre_start hook: #{hook['cmd']}"
+            service_config = config_container(service_pod.dup, hook['cmd'])
+            service_container = create_container(service_config)
+            service_container.tap(&:start).attach
+            if service_container.state['ExitCode'] != 0
+              raise "Failed to execute pre_start hook: #{hook['cmd']}, exit code: #{service_container.state['ExitCode']}"
+            end
+          ensure
+            cleanup_container(service_container) if service_container
           end
         end
         true
       rescue => exc
         log_service_pod_event("service:create_instance", exc.message, Logger::ERROR)
         raise exc
-      ensure
-        cleanup_container(service_container) if service_container
       end
 
       # @param [Docker::Container] service_container
@@ -75,6 +69,18 @@ module Kontena
         command.unshift('/w/w') if service_pod.can_expose_ports?
 
         command
+      end
+
+      # @param [Hash] service_config
+      # @param [String] cmd
+      # @return [Hash]
+      def config_container(service_config, cmd)
+        service_config = super(service_config)
+        service_config['HostConfig'].delete('RestartPolicy')
+        service_config['Labels']['io.kontena.container.type'] = 'service_hook'
+        service_config['Cmd'] = build_cmd(cmd)
+
+        service_config
       end
 
       # @param [String] id

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -100,6 +100,7 @@ module Kontena
       # @return [Hash]
       def config_container(service_pod, cmd)
         service_pod.entrypoint = ['/bin/sh', '-c']
+        service_pod.cmd = cmd
         service_config = super(service_pod)
         service_config['HostConfig'].delete('RestartPolicy')
         service_config['Labels']['io.kontena.container.type'] = 'service_hook'

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -88,15 +88,19 @@ module Kontena
       # @return [Array<Hash>]
       def hooks_for(type)
         hooks = service_pod.hooks.select { |h|
-          h['type'] == type && !h['oneshot'] || (h['oneshot'] && !oneshot_cache.include?(h))
+          h['type'] == type && !cached_oneshot_hook?(h)
         }
-        hooks.each do |h|
-          if h['oneshot'] && !oneshot_cache.include?(h)
-            mark_oneshot_hook(h)
-          end
-        end
+        hooks.each { |h|
+          mark_oneshot_hook(h) if !cached_oneshot_hook?(h)
+        }
 
         hooks
+      end
+
+      # @param hook [Hash]
+      # @return [Boolean]
+      def cached_oneshot_hook?(hook)
+        hook['oneshot'] && oneshot_cache.include?(hook)
       end
 
       # @param [String] cmd
@@ -152,7 +156,7 @@ module Kontena
 
       # @return [Array<Hash>]
       def oneshot_cache
-        @oneshot_cache ||= []
+        @oneshot_cache ||= Set.new
       end
     end
   end

--- a/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
+++ b/agent/lib/kontena/service_pods/lifecycle_hook_manager.rb
@@ -70,14 +70,14 @@ module Kontena
         command
       end
 
-      # @param [Hash] service_config
-      # @param [String] cmd
+      # @param service_pod [ServicePod]
+      # @param cmd [String]
       # @return [Hash]
-      def config_container(service_config, cmd)
-        service_config = super(service_config)
+      def config_container(service_pod, cmd)
+        service_pod.entrypoint = ['/bin/sh', '-c']
+        service_config = super(service_pod)
         service_config['HostConfig'].delete('RestartPolicy')
         service_config['Labels']['io.kontena.container.type'] = 'service_hook'
-        service_config['Cmd'] = build_cmd(cmd)
 
         service_config
       end

--- a/agent/lib/kontena/service_pods/restarter.rb
+++ b/agent/lib/kontena/service_pods/restarter.rb
@@ -8,29 +8,27 @@ module Kontena
       include Kontena::Logging
       include Common
 
-      attr_reader :service_id, :instance_number
+      attr_reader :service_pod
 
-      # @param [String] service_id
-      # @param [Integer] instance_number
-      def initialize(service_id, instance_number)
-        @service_id = service_id
-        @instance_number = instance_number
+      # @param [ServicePod] service_pod
+      def initialize(service_pod)
+        @service_pod = service_pod
       end
 
       # @return [Docker::Container]
       def perform
-        service_container = get_container(self.service_id, self.instance_number)
+        service_container = get_container(service_pod.service_id, service_pod.instance_number)
         if service_container.running?
           info "restarting service: #{service_container.name_for_humans}"
           service_container.restart!('timeout' => service_container.stop_grace_period)
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:restart_instance", "service #{service_container.name_for_humans} instance restarted successfully"
           )
         else
           info "service not running: #{service_container.name_for_humans}"
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:restart_instance", "service #{service_container.name_for_humans} instance not running, restart is ignored"
           )
           return

--- a/agent/lib/kontena/service_pods/restarter.rb
+++ b/agent/lib/kontena/service_pods/restarter.rb
@@ -8,27 +8,29 @@ module Kontena
       include Kontena::Logging
       include Common
 
-      attr_reader :service_pod
+      attr_reader :service_id, :instance_number
 
-      # @param [ServicePod] service_pod
-      def initialize(service_pod)
-        @service_pod = service_pod
+      # @param service_id [String]
+      # @param instance_number [Integer]
+      def initialize(service_id, instance_number)
+        @service_id = service_id
+        @instance_number = instance_number
       end
 
       # @return [Docker::Container]
       def perform
-        service_container = get_container(service_pod.service_id, service_pod.instance_number)
+        service_container = get_container(service_id, instance_number)
         if service_container.running?
           info "restarting service: #{service_container.name_for_humans}"
           service_container.restart!('timeout' => service_container.stop_grace_period)
           log_service_pod_event(
-            service_pod.service_id, service_pod.instance_number,
+            service_id, instance_number,
             "service:restart_instance", "service #{service_container.name_for_humans} instance restarted successfully"
           )
         else
           info "service not running: #{service_container.name_for_humans}"
           log_service_pod_event(
-            service_pod.service_id, service_pod.instance_number,
+            service_id, instance_number,
             "service:restart_instance", "service #{service_container.name_for_humans} instance not running, restart is ignored"
           )
           return

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -28,10 +28,12 @@ module Kontena
           )
           hook_manager.on_pre_start
           service_container.start!
+          hook_manager.on_post_start(service_container)
           log_service_pod_event(
             service_pod.service_id, service_pod.instance_number,
             "service:start_instance", "service instance #{service_container.name_for_humans} started successfully"
           )
+          info "started service: #{service_container.name_for_humans}"
         end
 
         Celluloid::Notifications.publish('service_pod:start', service_container)

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -11,10 +11,12 @@ module Kontena
 
       attr_reader :service_pod, :hook_manager
 
-      # @param [ServicePod] service_pod
-      def initialize(service_pod)
+      # @param service_pod [ServicePod]
+      # @param hook_manager [LifecycleHookManager]
+      def initialize(service_pod, hook_manager)
         @service_pod = service_pod
-        @hook_manager = Kontena::ServicePods::LifecycleHookManager.new(service_pod)
+        @hook_manager = hook_manager
+        @hook_manager.track(service_pod)
       end
 
       # @return [Docker::Container]

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -1,5 +1,6 @@
 require 'docker'
 require_relative 'common'
+require_relative 'lifecycle_hook_manager'
 require_relative '../logging'
 
 module Kontena
@@ -8,28 +9,28 @@ module Kontena
       include Kontena::Logging
       include Common
 
-      attr_reader :service_id, :instance_number
+      attr_reader :service_pod, :hook_manager
 
-      # @param [String] service_id
-      # @param [Integer] instance_number
-      def initialize(service_id, instance_number)
-        @service_id = service_id
-        @instance_number = instance_number
+      # @param [ServicePod] service_pod
+      def initialize(service_pod)
+        @service_pod = service_pod
+        @hook_manager = Kontena::ServicePods::LifecycleHookManager.new(service_pod)
       end
 
       # @return [Docker::Container]
       def perform
-        service_container = get_container(self.service_id, self.instance_number)
+        service_container = get_container(service_pod.service_id, service_pod.instance_number)
         unless service_container.running?
           info "starting service: #{service_container.name_for_humans}"
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:start_instance", "starting service instance #{service_container.name_for_humans}"
           )
-          service_container.restart!('timeout' => service_container.stop_grace_period)
+          hook_manager.on_pre_start(service_container)
+          service_container.start!
           log_service_pod_event(
-            self.service_id, self.instance_number,		
-            "service:start_instance", "service instance #{service_container.name_for_humans} started successfully"		
+            service_pod.service_id, service_pod.instance_number,
+            "service:start_instance", "service instance #{service_container.name_for_humans} started successfully"
           )
         end
 

--- a/agent/lib/kontena/service_pods/starter.rb
+++ b/agent/lib/kontena/service_pods/starter.rb
@@ -26,7 +26,7 @@ module Kontena
             service_pod.service_id, service_pod.instance_number,
             "service:start_instance", "starting service instance #{service_container.name_for_humans}"
           )
-          hook_manager.on_pre_start(service_container)
+          hook_manager.on_pre_start
           service_container.start!
           log_service_pod_event(
             service_pod.service_id, service_pod.instance_number,

--- a/agent/lib/kontena/service_pods/stopper.rb
+++ b/agent/lib/kontena/service_pods/stopper.rb
@@ -11,10 +11,12 @@ module Kontena
 
       attr_reader :service_pod, :hook_manager
 
-      # @param [ServicePod] service_pod
-      def initialize(service_pod)
+      # @param service_pod [ServicePod]
+      # @param hook_manager [LifecycleHookManager]
+      def initialize(service_pod, hook_manager)
         @service_pod = service_pod
-        @hook_manager = Kontena::ServicePods::LifecycleHookManager.new(service_pod)
+        @hook_manager = hook_manager
+        @hook_manager.track(service_pod)
       end
 
       # @return [Docker::Container]

--- a/agent/lib/kontena/service_pods/stopper.rb
+++ b/agent/lib/kontena/service_pods/stopper.rb
@@ -8,32 +8,30 @@ module Kontena
       include Kontena::Logging
       include Common
 
-      attr_reader :service_id, :instance_number
+      attr_reader :service_pod
 
-      # @param [String] service_id
-      # @param [Integer] instance_number
-      def initialize(service_id, instance_number)
-        @service_id = service_id
-        @instance_number = instance_number
+      # @param [ServicePod] service_pod
+      def initialize(service_pod)
+        @service_pod = service_pod
       end
 
       # @return [Docker::Container]
       def perform
-        service_container = get_container(self.service_id, self.instance_number)
+        service_container = get_container(service_pod.service_id, service_pod.instance_number)
         if service_container.running?
           info "stopping service: #{service_container.name_for_humans}"
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:stop_instance", "stopping service instance #{service_container.name_for_humans}"
           )
           service_container.stop!('timeout' => service_container.stop_grace_period)
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:stop_instance", "service instance #{service_container.name_for_humans} stopped succesfully"
           )
         else
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:stop_instance", "service instance #{service_container.name_for_humans} is not running"
           )
         end

--- a/agent/lib/kontena/service_pods/terminator.rb
+++ b/agent/lib/kontena/service_pods/terminator.rb
@@ -8,23 +8,21 @@ module Kontena
       include Kontena::Logging
       include Common
 
-      attr_reader :service_id, :instance_number
+      attr_reader :service_pod
 
-      # @param [String] service_id
-      # @param [Integer] instance_number
+      # @param [ServicePod] service_pod
       # @param [Hash] opts
-      def initialize(service_id, instance_number)
-        @service_id = service_id
-        @instance_number = instance_number
+      def initialize(service_pod)
+        @service_pod = service_pod
       end
 
       # @return [Docker::Container]
       def perform
-        service_container = get_container(self.service_id, self.instance_number)
+        service_container = get_container(service_pod.service_id, service_pod.instance_number)
         if service_container
           info "terminating service: #{service_container.name_for_humans}"
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:remove_instance", "removing service instance #{service_container.name_for_humans}"
           )
           service_container.stop('timeout' => service_container.stop_grace_period)
@@ -32,22 +30,22 @@ module Kontena
           service_container.delete(v: true)
 
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:remove_instance", "service instance #{service_container.name_for_humans} removed successfully"
           )
         end
-        data_container = get_container(self.service_id, self.instance_number, 'volume')
+        data_container = get_container(service_pod.service_id, service_pod.instance_number, 'volume')
         if data_container
           info "cleaning up service volumes: #{data_container.name}"
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:remove_instance", "removing service instance #{service_container.name_for_humans} data volume"
           ) if service_container
 
           data_container.delete(v: true)
 
           log_service_pod_event(
-            self.service_id, self.instance_number,
+            service_pod.service_id, service_pod.instance_number,
             "service:remove_instance", "service instance #{service_container.name_for_humans} data volume removed succesfully"
           ) if service_container
         end

--- a/agent/lib/kontena/service_pods/terminator.rb
+++ b/agent/lib/kontena/service_pods/terminator.rb
@@ -10,11 +10,13 @@ module Kontena
 
       attr_reader :service_pod, :hook_manager
 
-      # @param [ServicePod] service_pod
+      # @param service_pod [ServicePod]
+      # @param hook_manager [LifecycleHookManager]
       # @param [Hash] opts
-      def initialize(service_pod)
+      def initialize(service_pod, hook_manager)
         @service_pod = service_pod
-        @hook_manager = Kontena::ServicePods::LifecycleHookManager.new(service_pod)
+        @hook_manager = hook_manager
+        @hook_manager.track(service_pod)
       end
 
       # @return [Docker::Container]

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -184,9 +184,7 @@ module Kontena::Workers
     end
 
     def ensure_started
-      Kontena::ServicePods::Starter.new(
-        service_pod.service_id, service_pod.instance_number
-      ).perform
+      Kontena::ServicePods::Starter.new(service_pod).perform
     rescue => exc
       log_service_pod_event(
         "service:start_instance",
@@ -197,9 +195,7 @@ module Kontena::Workers
     end
 
     def ensure_stopped
-      Kontena::ServicePods::Stopper.new(
-        service_pod.service_id, service_pod.instance_number
-      ).perform
+      Kontena::ServicePods::Stopper.new(service_pod).perform
     rescue => exc
       log_service_pod_event(
         "service:stop_instance",
@@ -210,9 +206,7 @@ module Kontena::Workers
     end
 
     def ensure_terminated
-      Kontena::ServicePods::Terminator.new(
-        service_pod.service_id, service_pod.instance_number
-      ).perform
+      Kontena::ServicePods::Terminator.new(service_pod).perform
     rescue => exc
       log_service_pod_event(
         "service:remove_instance",

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -84,16 +84,12 @@ module Kontena::Workers
     #
     # @param [Docker::Container] container
     def start_container(container)
-      overlay_cidr = container.overlay_cidr
+      return unless container.service_container?
+      return unless container.overlay_cidr
 
-      if overlay_cidr
-        wait_weave_running?
-
-        register_container_dns(container)
-        attach_overlay(container)
-      else
-        debug "skip start for container=#{container.name} without overlay_cidr"
-      end
+      wait_weave_running?
+      register_container_dns(container)
+      attach_overlay(container)
     rescue Docker::Error::NotFoundError
       debug "skip start for missing container=#{container.id}"
 

--- a/agent/lib/kontena/workers/weave_worker.rb
+++ b/agent/lib/kontena/workers/weave_worker.rb
@@ -84,12 +84,15 @@ module Kontena::Workers
     #
     # @param [Docker::Container] container
     def start_container(container)
-      return unless container.service_container?
-      return unless container.overlay_cidr
+      overlay_cidr = container.overlay_cidr
 
-      wait_weave_running?
-      register_container_dns(container)
-      attach_overlay(container)
+      if overlay_cidr
+        wait_weave_running?
+        register_container_dns(container) if container.service_container?
+        attach_overlay(container)
+      else
+        debug "skip start for container=#{container.name} without overlay_cidr"
+      end
     rescue Docker::Error::NotFoundError
       debug "skip start for missing container=#{container.id}"
 

--- a/agent/spec/lib/kontena/load_balancers/registrator_spec.rb
+++ b/agent/spec/lib/kontena/load_balancers/registrator_spec.rb
@@ -24,6 +24,7 @@ describe Kontena::LoadBalancers::Registrator do
     it 'calls #register_container on start event' do
       allow(Docker::Container).to receive(:get).with(event.id).and_return(container)
       expect(container).to receive(:load_balanced?).and_return(true)
+      expect(container).to receive(:service_container?).and_return(true)
       expect(subject.wrapped_object).to receive(:register_container).once.with(container)
       subject.on_container_event('topic', event)
     end

--- a/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
@@ -9,18 +9,9 @@ describe Kontena::Rpc::ServicePodsApi do
 
   describe '#restart' do
     it 'calls service pod restarter' do
-      service_pod = double(:service_pod)
-      allow(subject).to receive(:find_service_pod).and_return(service_pod)
-      expect(Kontena::ServicePods::Restarter).to receive(:new).with(service_pod).and_return(executor)
+      expect(Kontena::ServicePods::Restarter).to receive(:new).and_return(executor)
       expect(executor).to receive(:perform)
       subject.restart('service_id', 2)
-    end
-
-    it 'raises error if service_pod not found' do
-      allow(subject).to receive(:find_service_pod).and_return(nil)
-      expect {
-        subject.restart('service_id', 2)
-      }.to raise_error(Kontena::RpcServer::Error)
     end
   end
 

--- a/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
+++ b/agent/spec/lib/kontena/rpc/service_pods_api_spec.rb
@@ -9,9 +9,18 @@ describe Kontena::Rpc::ServicePodsApi do
 
   describe '#restart' do
     it 'calls service pod restarter' do
-      expect(Kontena::ServicePods::Restarter).to receive(:new).and_return(executor)
+      service_pod = double(:service_pod)
+      allow(subject).to receive(:find_service_pod).and_return(service_pod)
+      expect(Kontena::ServicePods::Restarter).to receive(:new).with(service_pod).and_return(executor)
       expect(executor).to receive(:perform)
       subject.restart('service_id', 2)
+    end
+
+    it 'raises error if service_pod not found' do
+      allow(subject).to receive(:find_service_pod).and_return(nil)
+      expect {
+        subject.restart('service_id', 2)
+      }.to raise_error(Kontena::RpcServer::Error)
     end
   end
 

--- a/agent/spec/lib/kontena/service_pods/creator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/creator_spec.rb
@@ -29,7 +29,12 @@ describe Kontena::ServicePods::Creator do
   end
 
   let(:service_pod) { Kontena::Models::ServicePod.new(data) }
-  let(:subject) { described_class.new(service_pod) }
+  let(:hook_manager) { double(:hook_manager) }
+  let(:subject) { described_class.new(service_pod, hook_manager) }
+
+  before(:each) do
+    allow(hook_manager).to receive(:track)
+  end
 
   describe '#ensure_data_container' do
     it 'creates data container if it does not exist' do
@@ -45,7 +50,7 @@ describe Kontena::ServicePods::Creator do
       subject.get_container('service_id', 2)
     end
   end
-  
+
 
   describe '#config_container' do
     let(:network_adapter) { instance_double(Kontena::NetworkAdapters::Weave) }
@@ -79,7 +84,7 @@ describe Kontena::ServicePods::Creator do
         )
       }
 
-      subject { described_class.new(service_pod) }
+      subject { described_class.new(service_pod, hook_manager) }
 
       it 'does not include weave-wait' do
         expect(network_adapter).to_not receive(:modify_create_opts)
@@ -116,13 +121,13 @@ describe Kontena::ServicePods::Creator do
         )
       }
 
-      subject { described_class.new(service_pod) }
+      subject { described_class.new(service_pod, hook_manager) }
 
       it 'does not include weave-wait' do
         expect(network_adapter).to receive(:modify_create_opts)
 
         config = subject.config_container(service_pod)
-        
+
       end
     end
   end

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -18,16 +18,10 @@ describe Kontena::ServicePods::LifecycleHookManager do
   end
 
   describe '#build_cmd' do
-    it 'returns array with wait if service pod can expose ports' do
-      allow(service_pod).to receive(:can_expose_ports?).and_return(true)
-      cmd = subject.build_cmd("echo 'hello")
-      expect(cmd[0]).to eq('/w/w')
-    end
-
-    it 'returns array without wait if service pod cannot expose ports' do
-      allow(service_pod).to receive(:can_expose_ports?).and_return(false)
-      cmd = subject.build_cmd("echo 'hello")
-      expect(cmd[0]).not_to eq('/w/w')
+    it 'returns array' do
+      cmd = subject.build_cmd("echo 'hello'")
+      expect(cmd[0]).to eq('/bin/sh')
+      expect(cmd[2]).to eq("echo 'hello'")
     end
   end
 

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -3,7 +3,8 @@ describe Kontena::ServicePods::LifecycleHookManager do
   let(:service_pod) do
     double(:service_pod, hooks: [
       { 'type' => 'pre_start', 'cmd' => 'sleep 1'},
-      { 'type' => 'post_start', 'cmd' => 'sleep 2'}
+      { 'type' => 'post_start', 'cmd' => 'sleep 2'},
+      { 'type' => 'pre_stop', 'cmd' => 'sleep 3'}
     ])
   end
 
@@ -36,6 +37,13 @@ describe Kontena::ServicePods::LifecycleHookManager do
     it 'runs post_start hooks' do
       expect(subject).to receive(:hooks_for).with('post_start').and_return([])
       subject.on_post_start(double(:service_container))
+    end
+  end
+
+  describe '#on_pre_stop' do
+    it 'runs pre_stop hooks' do
+      expect(subject).to receive(:hooks_for).with('pre_stop').and_return([])
+      subject.on_pre_stop(double(:service_container))
     end
   end
 end

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -8,7 +8,11 @@ describe Kontena::ServicePods::LifecycleHookManager do
     ])
   end
 
-  let(:subject) { described_class.new(service_pod) }
+  let(:subject) { described_class.new(double(:node, id: 'asdasd')) }
+
+  before(:each) do
+    subject.track(service_pod)
+  end
 
   describe '#hooks_for' do
     it 'returns only hooks for given type' do

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -1,0 +1,3 @@
+describe Kontena::ServicePods::LifecycleHookManager do
+
+end

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -1,3 +1,33 @@
 describe Kontena::ServicePods::LifecycleHookManager do
 
+  let(:service_pod) do
+    double(:service_pod, hooks: [
+      { 'type' => 'pre_start', 'cmd' => 'sleep 1'},
+      { 'type' => 'post_start', 'cmd' => 'sleep 2'}
+    ])
+  end
+
+  let(:subject) { described_class.new(service_pod) }
+
+  describe '#hooks_for' do
+    it 'returns only hooks for given type' do
+      hooks = subject.hooks_for('pre_start')
+      expect(hooks.size).to eq(1)
+      expect(hooks[0]['cmd']).to eq('sleep 1')
+    end
+  end
+
+  describe '#on_pre_start' do
+    it 'runs pre_start hooks' do
+      expect(subject).to receive(:hooks_for).with('pre_start').and_return([])
+      subject.on_pre_start
+    end
+  end
+
+  describe '#on_post_start' do
+    it 'runs post_start hooks' do
+      expect(subject).to receive(:hooks_for).with('post_start').and_return([])
+      subject.on_post_start(double(:service_container))
+    end
+  end
 end

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -5,9 +5,9 @@ describe Kontena::ServicePods::LifecycleHookManager do
       service_id: 'a',
       instance_number: 2,
       hooks: [
-        { 'type' => 'pre_start', 'cmd' => 'sleep 1'},
-        { 'type' => 'post_start', 'cmd' => 'sleep 2'},
-        { 'type' => 'pre_stop', 'cmd' => 'sleep 3'}
+        { 'id' => '1', 'type' => 'pre_start', 'cmd' => 'sleep 1'},
+        { 'id' => '2', 'type' => 'post_start', 'cmd' => 'sleep 2'},
+        { 'id' => '3', 'type' => 'pre_stop', 'cmd' => 'sleep 3'}
       ]
     )
   end
@@ -30,7 +30,7 @@ describe Kontena::ServicePods::LifecycleHookManager do
       allow(service_pod).to receive(:service_id).and_return('abc')
       allow(service_pod).to receive(:instance_number).and_return(1)
       allow(service_pod).to receive(:hooks).and_return([
-        { 'type' => 'pre_start', 'cmd' => 'sleep 1', 'oneshot' => true }
+        { 'id' => 'a', 'type' => 'pre_start', 'cmd' => 'sleep 1', 'oneshot' => true }
       ])
       allow(subject).to receive(:rpc_client).and_return(spy)
       expect(subject.hooks_for('pre_start').size).to eq(1)
@@ -40,16 +40,16 @@ describe Kontena::ServicePods::LifecycleHookManager do
 
   describe '#cached_oneshot_hook?' do
     it 'returns false if not oneshot' do
-      expect(subject.cached_oneshot_hook?({'oneshot' => false})).to be_falsey
+      expect(subject.cached_oneshot_hook?({ 'id' => 'a', 'oneshot' => false })).to be_falsey
     end
 
     it 'returns false if oneshot but not cached' do
-      expect(subject.cached_oneshot_hook?({'oneshot' => true})).to be_falsey
+      expect(subject.cached_oneshot_hook?({'id' => 'a', 'oneshot' => true })).to be_falsey
     end
 
     it 'returns true if oneshot and cached' do
-      hook = {'oneshot' => true}
-      subject.oneshot_cache << hook
+      hook = { 'id' => 'a', 'oneshot' => true }
+      subject.oneshot_cache << hook['id']
       expect(subject.cached_oneshot_hook?(hook)).to be_truthy
     end
   end

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -17,6 +17,20 @@ describe Kontena::ServicePods::LifecycleHookManager do
     end
   end
 
+  describe '#build_cmd' do
+    it 'returns array with wait if service pod can expose ports' do
+      allow(service_pod).to receive(:can_expose_ports?).and_return(true)
+      cmd = subject.build_cmd("echo 'hello")
+      expect(cmd[0]).to eq('/w/w')
+    end
+
+    it 'returns array without wait if service pod cannot expose ports' do
+      allow(service_pod).to receive(:can_expose_ports?).and_return(false)
+      cmd = subject.build_cmd("echo 'hello")
+      expect(cmd[0]).not_to eq('/w/w')
+    end
+  end
+
   describe '#on_pre_start' do
     it 'runs pre_start hooks' do
       expect(subject).to receive(:hooks_for).with('pre_start').and_return([])

--- a/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/lifecycle_hook_manager_spec.rb
@@ -20,6 +20,17 @@ describe Kontena::ServicePods::LifecycleHookManager do
       expect(hooks.size).to eq(1)
       expect(hooks[0]['cmd']).to eq('sleep 1')
     end
+
+    it 'returns oneshot hooks only once' do
+      allow(service_pod).to receive(:service_id).and_return('abc')
+      allow(service_pod).to receive(:instance_number).and_return(1)
+      allow(service_pod).to receive(:hooks).and_return([
+        { 'type' => 'pre_start', 'cmd' => 'sleep 1', 'oneshot' => true }
+      ])
+      allow(subject).to receive(:rpc_client).and_return(spy)
+      expect(subject.hooks_for('pre_start').size).to eq(1)
+      expect(subject.hooks_for('pre_start').size).to eq(0)
+    end
   end
 
   describe '#build_cmd' do

--- a/agent/spec/lib/kontena/service_pods/restarter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/restarter_spec.rb
@@ -1,8 +1,8 @@
 
 describe Kontena::ServicePods::Restarter do
 
-  let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
-  let(:subject) { described_class.new(service_pod) }
+  let(:service_id) { 'service_id' }
+  let(:subject) { described_class.new(service_id, 1) }
 
   describe '#perform' do
 
@@ -14,7 +14,7 @@ describe Kontena::ServicePods::Restarter do
       allow(subject).to receive(:get_container).and_return(container)
     end
 
-    it 'does notthing if container if not running' do
+    it 'does nothing if container if not running' do
       allow(container).to receive(:running?).and_return(false)
       expect(container).not_to receive(:restart!)
       subject.perform

--- a/agent/spec/lib/kontena/service_pods/restarter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/restarter_spec.rb
@@ -1,8 +1,8 @@
 
 describe Kontena::ServicePods::Restarter do
 
-  let(:service_id) { 'service-id' }
-  let(:subject) { described_class.new(service_id, 1) }
+  let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
+  let(:subject) { described_class.new(service_pod) }
 
   describe '#perform' do
 

--- a/agent/spec/lib/kontena/service_pods/starter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/starter_spec.rb
@@ -24,6 +24,7 @@ describe Kontena::ServicePods::Starter do
 
     it 'starts container if not running' do
       expect(hook_manager).to receive(:on_pre_start).once
+      expect(hook_manager).to receive(:on_post_start).once
       expect(container).to receive(:start!)
       subject.perform
     end

--- a/agent/spec/lib/kontena/service_pods/starter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/starter_spec.rb
@@ -2,8 +2,8 @@
 describe Kontena::ServicePods::Starter do
 
   let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
-  let(:subject) { described_class.new(service_pod) }
   let(:hook_manager) { double(:hook_manager) }
+  let(:subject) { described_class.new(service_pod, hook_manager) }
 
   describe '#perform' do
 
@@ -12,8 +12,8 @@ describe Kontena::ServicePods::Starter do
     end
 
     before(:each) do
+      allow(hook_manager).to receive(:track)
       allow(subject).to receive(:get_container).and_return(container)
-      allow(subject).to receive(:hook_manager).and_return(hook_manager)
     end
 
     it 'does nothing if container is running' do

--- a/agent/spec/lib/kontena/service_pods/starter_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/starter_spec.rb
@@ -1,8 +1,9 @@
 
 describe Kontena::ServicePods::Starter do
 
-  let(:service_id) { 'service-1' }
-  let(:subject) { described_class.new(service_id, 1) }
+  let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
+  let(:subject) { described_class.new(service_pod) }
+  let(:hook_manager) { double(:hook_manager) }
 
   describe '#perform' do
 
@@ -12,6 +13,7 @@ describe Kontena::ServicePods::Starter do
 
     before(:each) do
       allow(subject).to receive(:get_container).and_return(container)
+      allow(subject).to receive(:hook_manager).and_return(hook_manager)
     end
 
     it 'does nothing if container is running' do
@@ -20,15 +22,15 @@ describe Kontena::ServicePods::Starter do
       subject.perform
     end
 
-    it 'restarts container if not running' do
-      expect(container).to receive(:stop_grace_period).and_return(10)
-      expect(container).to receive(:restart!).with({'timeout' => 10})
+    it 'starts container if not running' do
+      expect(hook_manager).to receive(:on_pre_start).once
+      expect(container).to receive(:start!)
       subject.perform
     end
 
-    it 'fails if container restart fails' do
-      expect(container).to receive(:stop_grace_period).and_return(10)
-      expect(container).to receive(:restart!).with({'timeout' => 10}).and_raise(Docker::Error::ServerError, "failed")
+    it 'fails if container start fails' do
+      expect(hook_manager).to receive(:on_pre_start).once
+      expect(container).to receive(:start!).and_raise(Docker::Error::ServerError, "failed")
       expect{subject.perform}.to raise_error(Docker::Error::ServerError)
     end
   end

--- a/agent/spec/lib/kontena/service_pods/stopper_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/stopper_spec.rb
@@ -1,8 +1,8 @@
 
 describe Kontena::ServicePods::Stopper do
 
-  let(:service_id) { 'service-id' }
-  let(:subject) { described_class.new(service_id, 1) }
+  let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
+  let(:subject) { described_class.new(service_pod) }
 
   describe '#perform' do
 

--- a/agent/spec/lib/kontena/service_pods/stopper_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/stopper_spec.rb
@@ -2,8 +2,8 @@
 describe Kontena::ServicePods::Stopper do
 
   let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
-  let(:subject) { described_class.new(service_pod) }
   let(:hook_manager) { double(:hook_manager) }
+  let(:subject) { described_class.new(service_pod, hook_manager) }
 
   describe '#perform' do
 
@@ -12,8 +12,8 @@ describe Kontena::ServicePods::Stopper do
     end
 
     before(:each) do
+      allow(hook_manager).to receive(:track)
       allow(subject).to receive(:get_container).and_return(container)
-      allow(subject).to receive(:hook_manager).and_return(hook_manager)
     end
 
     it 'does nothing if container is not running' do

--- a/agent/spec/lib/kontena/service_pods/stopper_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/stopper_spec.rb
@@ -3,6 +3,7 @@ describe Kontena::ServicePods::Stopper do
 
   let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
   let(:subject) { described_class.new(service_pod) }
+  let(:hook_manager) { double(:hook_manager) }
 
   describe '#perform' do
 
@@ -12,6 +13,7 @@ describe Kontena::ServicePods::Stopper do
 
     before(:each) do
       allow(subject).to receive(:get_container).and_return(container)
+      allow(subject).to receive(:hook_manager).and_return(hook_manager)
     end
 
     it 'does nothing if container is not running' do
@@ -21,17 +23,20 @@ describe Kontena::ServicePods::Stopper do
     end
 
     it 'stops container with a configured timeout' do
+      expect(hook_manager).to receive(:on_pre_stop).once
       expect(container).to receive(:stop_grace_period).and_return(20)
       expect(container).to receive(:stop!).with({'timeout' => 20})
       subject.perform
     end
 
     it 'stops container if running' do
+      expect(hook_manager).to receive(:on_pre_stop).once
       expect(container).to receive(:stop!).with({'timeout' => 10})
       subject.perform
     end
 
     it 'fails if container stop fails' do
+      expect(hook_manager).to receive(:on_pre_stop).once
       expect(container).to receive(:stop!).with({'timeout' => 10}).and_raise(Docker::Error::ServerError, "failed")
       expect{subject.perform}.to raise_error(Docker::Error::ServerError)
     end

--- a/agent/spec/lib/kontena/service_pods/terminator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/terminator_spec.rb
@@ -2,12 +2,12 @@
 describe Kontena::ServicePods::Terminator do
 
   let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
-  let(:subject) { described_class.new(service_pod) }
   let(:hook_manager) { double(:hook_manager) }
+  let(:subject) { described_class.new(service_pod, hook_manager) }
 
   describe '#perform' do
     before(:each) do
-      allow(subject).to receive(:hook_manager).and_return(hook_manager)
+      allow(hook_manager).to receive(:track)
       allow(hook_manager).to receive(:on_pre_stop)
     end
 

--- a/agent/spec/lib/kontena/service_pods/terminator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/terminator_spec.rb
@@ -1,14 +1,14 @@
 
 describe Kontena::ServicePods::Terminator do
 
-  let(:service_id) { 'service-id' }
-  let(:subject) { described_class.new(service_id, 1) }
+  let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
+  let(:subject) { described_class.new(service_pod) }
 
   describe '#perform' do
     it 'terminates service instance' do
       service_container = double(:service, :load_balanced? => false, :name => 'foo.bar-1', :name_for_humans => 'foo/bar-1', :stop_grace_period => 15)
-      allow(subject).to receive(:get_container).with(service_id, 1).and_return(service_container)
-      allow(subject).to receive(:get_container).with(service_id, 1, 'volume')
+      allow(subject).to receive(:get_container).with('service_id', 1).and_return(service_container)
+      allow(subject).to receive(:get_container).with('service_id', 1, 'volume')
 
       expect(service_container).to receive(:stop).with({'timeout' => 15})
       expect(service_container).to receive(:wait)
@@ -19,16 +19,16 @@ describe Kontena::ServicePods::Terminator do
     it 'removes volumes if exist' do
       service_container = spy(:service, :name_for_humans => 'foo/bar-1')
       service_container_volumes = double(:service, name: '/foo-1-volumes')
-      allow(subject).to receive(:get_container).with(service_id, 1).and_return(service_container)
-      allow(subject).to receive(:get_container).with(service_id, 1, 'volume').and_return(service_container_volumes)
+      allow(subject).to receive(:get_container).with('service_id', 1).and_return(service_container)
+      allow(subject).to receive(:get_container).with('service_id', 1, 'volume').and_return(service_container_volumes)
       expect(service_container_volumes).to receive(:delete).with({v: true})
       subject.perform
     end
 
     it 'removes volumes if exist and service_container does not exist' do
       service_container_volumes = double(:service, name: '/foo-volumes')
-      allow(subject).to receive(:get_container).with(service_id, 1).and_return(nil)
-      allow(subject).to receive(:get_container).with(service_id, 1, 'volume').and_return(service_container_volumes)
+      allow(subject).to receive(:get_container).with('service_id', 1).and_return(nil)
+      allow(subject).to receive(:get_container).with('service_id', 1, 'volume').and_return(service_container_volumes)
       expect(service_container_volumes).to receive(:delete).with({v: true})
       subject.perform
     end

--- a/agent/spec/lib/kontena/service_pods/terminator_spec.rb
+++ b/agent/spec/lib/kontena/service_pods/terminator_spec.rb
@@ -3,13 +3,23 @@ describe Kontena::ServicePods::Terminator do
 
   let(:service_pod) { double(:service_pod, service_id: 'service_id', instance_number: 1)}
   let(:subject) { described_class.new(service_pod) }
+  let(:hook_manager) { double(:hook_manager) }
 
   describe '#perform' do
+    before(:each) do
+      allow(subject).to receive(:hook_manager).and_return(hook_manager)
+      allow(hook_manager).to receive(:on_pre_stop)
+    end
+
     it 'terminates service instance' do
-      service_container = double(:service, :load_balanced? => false, :name => 'foo.bar-1', :name_for_humans => 'foo/bar-1', :stop_grace_period => 15)
+      service_container = double(:service,
+        :load_balanced? => false, :name => 'foo.bar-1', :name_for_humans => 'foo/bar-1',
+        :stop_grace_period => 15, :running? => true
+      )
       allow(subject).to receive(:get_container).with('service_id', 1).and_return(service_container)
       allow(subject).to receive(:get_container).with('service_id', 1, 'volume')
 
+      expect(hook_manager).to receive(:on_pre_stop).once
       expect(service_container).to receive(:stop).with({'timeout' => 15})
       expect(service_container).to receive(:wait)
       expect(service_container).to receive(:delete).with({v: true})

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -77,6 +77,14 @@ describe Kontena::Workers::WeaveWorker do
       subject.start_container(container)
     end
 
+    it 'does not attach overlay if container is not service container' do
+      allow(container).to receive(:service_container?).and_return(false)
+      allow(container).to receive(:overlay_cidr).and_return('10.81.1.1/16')
+      allow(subject.wrapped_object).to receive(:register_container_dns)
+      expect(subject.wrapped_object).not_to receive(:attach_overlay).with(container)
+      subject.start_container(container)
+    end
+
     it 'does not attach overlay if container does not have overlay_cidr' do
       allow(container).to receive(:overlay_cidr).and_return(nil)
       allow(subject.wrapped_object).to receive(:register_container_dns)

--- a/agent/spec/lib/kontena/workers/weave_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/weave_worker_spec.rb
@@ -80,8 +80,8 @@ describe Kontena::Workers::WeaveWorker do
     it 'does not attach overlay if container is not service container' do
       allow(container).to receive(:service_container?).and_return(false)
       allow(container).to receive(:overlay_cidr).and_return('10.81.1.1/16')
-      allow(subject.wrapped_object).to receive(:register_container_dns)
-      expect(subject.wrapped_object).not_to receive(:attach_overlay).with(container)
+      expect(subject.wrapped_object).not_to receive(:register_container_dns)
+      expect(subject.wrapped_object).to receive(:attach_overlay).with(container)
       subject.start_container(container)
     end
 

--- a/cli/lib/kontena/cli/stacks/yaml/custom_validators/hooks_validator.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/custom_validators/hooks_validator.rb
@@ -11,13 +11,17 @@ module Kontena::Cli::Stacks::YAML::Validations::CustomValidators
       end
 
       value.keys.each do |hook|
-        unless %w(pre_build post_start).include?(hook)
+        unless %w(pre_build pre_start post_start).include?(hook)
           errors[key] = "invalid hook #{hook}"
         end
       end
 
       if value['pre_build']
         validate_pre_build_hooks(key, value['pre_build'], errors)
+      end
+
+      if value['pre_start']
+        validate_pre_start_hooks(key, value['pre_start'], errors)
       end
 
       if value['post_start']
@@ -37,6 +41,23 @@ module Kontena::Cli::Stacks::YAML::Validations::CustomValidators
       validator = HashValidator.validator_for(pre_build_validation)
       pre_build_hooks.each do |pre_build|
         validator.validate('hooks.pre_build', pre_build, pre_build_validation, errors)
+      end
+    end
+
+    def validate_pre_start_hooks(key, pre_start_hooks, errors)
+      unless pre_start_hooks.is_a?(Array)
+        errors[key] = { 'pre_start' => 'must be an array' }
+        return
+      end
+      pre_start_validation = {
+        'name' => 'string',
+        'instances' => (-> (value) { value.is_a?(Integer) || value == '*' }),
+        'cmd' => 'string',
+        'oneshot' => HashValidator.optional('boolean')
+      }
+      validator = HashValidator.validator_for(post_start_validation)
+      pre_start_hooks.each do |pre_start|
+        validator.validate('hooks.pre_start', pre_start, pre_start_validation, errors)
       end
     end
 

--- a/cli/lib/kontena/cli/stacks/yaml/custom_validators/hooks_validator.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/custom_validators/hooks_validator.rb
@@ -55,7 +55,7 @@ module Kontena::Cli::Stacks::YAML::Validations::CustomValidators
         'cmd' => 'string',
         'oneshot' => HashValidator.optional('boolean')
       }
-      validator = HashValidator.validator_for(post_start_validation)
+      validator = HashValidator.validator_for(pre_start_validation)
       pre_start_hooks.each do |pre_start|
         validator.validate('hooks.pre_start', pre_start, pre_start_validation, errors)
       end

--- a/cli/lib/kontena/cli/stacks/yaml/custom_validators/hooks_validator.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/custom_validators/hooks_validator.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Stacks::YAML::Validations::CustomValidators
       end
 
       value.keys.each do |hook|
-        unless %w(pre_build pre_start post_start).include?(hook)
+        unless %w(pre_build pre_start post_start pre_stop).include?(hook)
           errors[key] = "invalid hook #{hook}"
         end
       end
@@ -26,6 +26,10 @@ module Kontena::Cli::Stacks::YAML::Validations::CustomValidators
 
       if value['post_start']
         validate_post_start_hooks(key, value['post_start'], errors)
+      end
+
+      if value['pre_stop']
+        validate_pre_stop_hooks(key, value['pre_stop'], errors)
       end
     end
 
@@ -75,6 +79,23 @@ module Kontena::Cli::Stacks::YAML::Validations::CustomValidators
       validator = HashValidator.validator_for(post_start_validation)
       post_start_hooks.each do |post_start|
         validator.validate('hooks.post_start', post_start, post_start_validation, errors)
+      end
+    end
+
+    def validate_pre_stop_hooks(key, pre_stop_hooks, errors)
+      unless pre_stop_hooks.is_a?(Array)
+        errors[key] = { 'pre_stop' => 'must be an array' }
+        return
+      end
+      pre_stop_validation = {
+        'name' => 'string',
+        'instances' => (-> (value) { value.is_a?(Integer) || value == '*' }),
+        'cmd' => 'string',
+        'oneshot' => HashValidator.optional('boolean')
+      }
+      validator = HashValidator.validator_for(pre_stop_validation)
+      pre_stop_hooks.each do |pre_stop|
+        validator.validate('hooks.pre_stop', pre_stop, pre_stop_validation, errors)
       end
     end
   end

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -273,6 +273,16 @@ module GridServices
                   end
                 end
               end
+              array :pre_stop do
+                hash do
+                  required do
+                    string :name
+                    string :cmd
+                    string :instances
+                    boolean :oneshot, default: false
+                  end
+                end
+              end
             end
           end
           hash :health_check do

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -253,6 +253,16 @@ module GridServices
           boolean :read_only
           hash :hooks do
             optional do
+              array :pre_start do
+                hash do
+                  required do
+                    string :name
+                    string :cmd
+                    string :instances
+                    boolean :oneshot, default: false
+                  end
+                end
+              end
               array :post_start do
                 hash do
                   required do

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -133,7 +133,7 @@ module Rpc
       service.hooks.each do |hook|
         if hook.instances.include?('*') || hook.instances.include?(instance_number)
           unless hook.done_for?(instance_number)
-            hooks << { type: hook.type, cmd: hook.cmd, oneshot: hook.oneshot }
+            hooks << { id: hook.id.to_s, type: hook.type, cmd: hook.cmd, oneshot: hook.oneshot }
           end
         end
       end

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -133,8 +133,7 @@ module Rpc
       service.hooks.each do |hook|
         if hook.instances.include?('*') || hook.instances.include?(instance_number)
           unless hook.done_for?(instance_number)
-            hooks << {type: hook.type, cmd: hook.cmd}
-            hook.push(:done => instance_number) if hook.oneshot
+            hooks << { type: hook.type, cmd: hook.cmd, oneshot: hook.oneshot }
           end
         end
       end

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -76,7 +76,7 @@ module Rpc
       raise 'Instance not found' unless service_instance
 
       oneshot_hook = service_instance.grid_service.hooks.to_a.find{ |h|
-        h.oneshot && h.type == hook['type'] && h.cmd == hook['cmd']
+        h.oneshot && h.id.to_s == hook['id']
       }
       raise "Hook not found: #{hook}" unless oneshot_hook
       oneshot_hook.push(:done => pod['instance_number'].to_s)

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -499,6 +499,44 @@ describe GridServices::Create do
       expect(outcome).not_to be_success
     end
 
+    context 'hooks' do
+      it 'saves post_start hooks' do
+        outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          hooks: {
+            post_start: [
+              {
+                name: 'sleep', cmd: 'sleep 10', instances: 1, oneshot: true
+              }
+            ]
+          }
+        ).run
+        expect(outcome).to be_success
+        expect(outcome.result.hooks.size).to eq(1)
+      end
+
+      it 'saves pre_start hooks' do
+        outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          hooks: {
+            pre_start: [
+              {
+                name: 'sleep', cmd: 'sleep 10', instances: 1, oneshot: true
+              }
+            ]
+          }
+        ).run
+        expect(outcome).to be_success
+        expect(outcome.result.hooks.size).to eq(1)
+      end
+    end
+
     context 'volumes' do
       let(:volume) do
         Volume.create!(grid: grid, name: 'foo', scope: 'node')

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -535,6 +535,24 @@ describe GridServices::Create do
         expect(outcome).to be_success
         expect(outcome.result.hooks.size).to eq(1)
       end
+
+      it 'saves pre_stop hooks' do
+        outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          hooks: {
+            pre_stop: [
+              {
+                name: 'sleep', cmd: 'sleep 10', instances: 1, oneshot: true
+              }
+            ]
+          }
+        ).run
+        expect(outcome).to be_success
+        expect(outcome.result.hooks.size).to eq(1)
+      end
     end
 
     context 'volumes' do

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -267,10 +267,33 @@ describe Rpc::ServicePodSerializer do
       expect(subject.build_volumes).to eq([{:bind_mount=>nil, :path => '/data', :flags => nil}])
     end
   end
+
   describe '#image_credentials' do
     it 'return nil by default' do
       expect(subject.image_credentials).to be_nil
     end
   end
 
+  describe '#build_hooks' do
+    it 'returns not-executed oneshot hook' do
+      service.hooks.create(
+        type: 'post_start',
+        cmd: 'sleep 1',
+        oneshot: true
+      )
+      hooks = subject.build_hooks
+      expect(hooks[0]).to eq({ type: 'post_start', cmd: 'sleep 1', oneshot: true})
+    end
+
+    it 'does not return oneshot hooks that are already executed' do
+      service.hooks.create(
+        type: 'post_start',
+        cmd: 'sleep 1',
+        oneshot: true
+      )
+      service.hooks.first.push(:done => service_instance.instance_number.to_s)
+      hooks = subject.build_hooks
+      expect(hooks.size).to eq(0)
+    end
+  end
 end

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -276,13 +276,13 @@ describe Rpc::ServicePodSerializer do
 
   describe '#build_hooks' do
     it 'returns not-executed oneshot hook' do
-      service.hooks.create(
+      hook = service.hooks.create!(
         type: 'post_start',
         cmd: 'sleep 1',
         oneshot: true
       )
       hooks = subject.build_hooks
-      expect(hooks[0]).to eq({ type: 'post_start', cmd: 'sleep 1', oneshot: true})
+      expect(hooks[0]).to eq({ id: hook.id.to_s, type: hook.type, cmd: hook.cmd, oneshot: hook.oneshot})
     end
 
     it 'does not return oneshot hooks that are already executed' do

--- a/server/spec/services/rpc/node_service_pod_handler_spec.rb
+++ b/server/spec/services/rpc/node_service_pod_handler_spec.rb
@@ -108,22 +108,61 @@ describe Rpc::NodeServicePodHandler do
   end
 
   describe '#cached_pod' do
+    let(:grid_service) { double(:grid_service) }
+
+    before(:each) do
+      allow(grid_service).to receive(:hooks).and_return([])
+    end
+
     it 'transforms the service instance into pod if not already in cache' do
-      service_instance = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', grid_service: double})
+      service_instance = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', grid_service: grid_service})
       expect(Rpc::ServicePodSerializer).to receive(:new).once.and_return(double(:to_hash => {}))
       subject.cached_pod(service_instance)
       subject.cached_pod(service_instance)
     end
 
     it 'uses instance id, deploy_rev and desired_state as cache key' do
-      service_instance_1 = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', grid_service: double})
+      service_instance_1 = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', grid_service: grid_service})
       expect(Rpc::ServicePodSerializer).to receive(:new).twice.and_return(double(:to_hash => {}))
 
       subject.cached_pod(service_instance_1)
 
-      service_instance_2 = double({id: 'foo', deploy_rev: '12345', desired_state: 'stopped', grid_service: double})
+      service_instance_2 = double({id: 'foo', deploy_rev: '12345', desired_state: 'stopped', grid_service: grid_service})
       subject.cached_pod(service_instance_2)
     end
 
+    it 'does not filter out oneshot hooks if they have not been serialized' do
+      service_instance = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', instance_number: 1, grid_service: grid_service})
+      expect(Rpc::ServicePodSerializer).to receive(:new).once.and_return(double(:to_hash => {
+        hooks: [
+          { type: 'post_start', cmd: 'sleep 1'},
+          { type: 'pre_stop', cmd: 'echo "done"'}
+        ]
+      }))
+      hooks = [
+        double(:hook, type: 'post_start', cmd: 'sleep 1')
+      ]
+      allow(hooks[0]).to receive(:done_for?).and_return(false)
+      allow(grid_service).to receive(:hooks).and_return(hooks)
+      pod_hash = subject.cached_pod(service_instance)
+      expect(pod_hash[:hooks].size).to eq(2)
+    end
+
+    it 'filters out oneshot hooks if they have already been serialized' do
+      service_instance = double({id: 'foo', deploy_rev: '12345', desired_state: 'running', instance_number: 1, grid_service: grid_service})
+      expect(Rpc::ServicePodSerializer).to receive(:new).once.and_return(double(:to_hash => {
+        hooks: [
+          { type: 'post_start', cmd: 'sleep 1'},
+          { type: 'pre_stop', cmd: 'echo "done"'}
+        ]
+      }))
+      hooks = [
+        double(:hook, type: 'post_start', cmd: 'sleep 1')
+      ]
+      allow(hooks[0]).to receive(:done_for?).and_return(true)
+      allow(grid_service).to receive(:hooks).and_return(hooks)
+      pod_hash = subject.cached_pod(service_instance)
+      expect(pod_hash[:hooks]).to eq([{ type: 'pre_stop', cmd: 'echo "done"'}])
+    end
   end
 end

--- a/test/Gemfile
+++ b/test/Gemfile
@@ -4,3 +4,5 @@ gem 'dotenv'
 gem 'rspec'
 gem 'kommando', '~> 0.1.2'
 gem 'kontena-cli', path: '../cli'
+gem 'rake'
+


### PR DESCRIPTION
This PR implements service hooks that are executed before actual service container is started/stopped. Great for db migrations etc.

Other changes/improvements:
- improved `oneshot` hook tracking
- `post_start` is executed always when service instance is started (but not with restart)