### PR TITLE
CLI: Only include PLATFORM in stack default envs when env[PLATFORM] present

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -40,7 +40,7 @@ module Kontena::Cli::Stacks
       end
 
       def dump_variables(reader)
-        vals = reader.variables.to_h(values_only: true).reject {|k,_| k == 'STACK' || k == 'GRID' }
+        vals = reader.variables.to_h(values_only: true).reject {|k,_| k == 'STACK' || k == 'GRID' || k == 'PLATFORM' }
         File.write(values_to, ::YAML.dump(vals))
       end
     end

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -63,8 +63,7 @@ module Kontena::Cli::Stacks
         @default_envs ||= {
           'GRID' => env['GRID'],
           'STACK' => env['STACK'],
-          'PLATFORM' => env['PLATFORM']
-        }
+        }.merge(env['PLATFORM'].to_s.empty? ? {} : { 'PLATFORM' => env['PLATFORM'] })
       end
 
       def internals_interpolated_yaml


### PR DESCRIPTION
Fixes a bug introduced by #2677 and #2667 that made stacks require a PLATFORM in env.

Before:

```
$ bin/kontena stack validate redis.yml
 [error] RuntimeError : Variable validation failed: {"PLATFORM"=>{:presence=>"Required value missing"}}
```

After:

👍 
