### PR TITLE
Make stack logs accept service names as filters

### DIFF
--- a/cli/lib/kontena/cli/stacks/logs_command.rb
+++ b/cli/lib/kontena/cli/stacks/logs_command.rb
@@ -9,13 +9,20 @@ module Kontena::Cli::Stacks
     banner "Shows logs from services in a stack"
 
     parameter "NAME", "Stack name"
+    parameter "[SERVICE] ...", "Service names"
 
     requires_current_master
     requires_current_master_token
 
     def execute
-      show_logs("stacks/#{current_grid}/#{name}/container_logs") do |log|
-        show_log(log)
+      if service_list.empty?
+        show_logs("stacks/#{current_grid}/#{name}/container_logs") do |log|
+          show_log(log)
+        end
+      else
+        show_logs("grids/#{current_grid}/container_logs", services: service_list.map {|s| [name, s].join('/')}.join(',')) do |log|
+          show_log(log)
+        end
       end
     end
 

--- a/cli/spec/kontena/cli/stacks/logs_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/logs_command_spec.rb
@@ -14,13 +14,24 @@ describe Kontena::Cli::Stacks::LogsCommand do
       },
     ]
   end
-  
+
   it "shows stack logs" do
     expect(client).to receive(:get).with('stacks/test-grid/test-stack/container_logs', {
       limit: 100,
     }) { { 'logs' => logs } }
 
     expect{subject.run(['test-stack'])}.to output_lines [
+      "2016-09-07T15:19:04.362690 [test-stack.mysql-1]: mysql log message 1",
+    ]
+  end
+
+  it "shows stack service logs" do
+    expect(client).to receive(:get).with('grids/test-grid/container_logs', {
+      limit: 100,
+      services: 'test-stack/mysql,test-stack/myapp'
+    }) { { 'logs' => logs } }
+
+    expect{subject.run(['test-stack', 'mysql', 'myapp'])}.to output_lines [
       "2016-09-07T15:19:04.362690 [test-stack.mysql-1]: mysql log message 1",
     ]
   end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -127,8 +127,8 @@ module V1
             end
             unless r['services'].nil?
               services = r['services'].split(',').map do |service|
-                @grid.grid_services.find_by(name: service).try(:id)
-              end.delete_if{|s| s.nil?}
+                service.include?('/') ? service : @grid.grid_services.find_by(name: service).try(:id)
+              end.compact
 
               scope = scope.where(grid_service_id: {:$in => services})
             end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -127,7 +127,15 @@ module V1
             end
             unless r['services'].nil?
               services = r['services'].split(',').map do |service|
-                service.include?('/') ? service : @grid.grid_services.find_by(name: service).try(:id)
+                if service.include?('/')
+                  stack_name, service_name = service.split('/', 2)
+                  stack_id = @grid.stacks.where(name: stack_name).first.try(:id)
+                  if stack_id && service_name
+                    @grid.grid_services.where(stack_id: stack_id, name: service_name).first.try(:id)
+                  end
+                else
+                  @grid.grid_services.find_by(name: service).try(:id)
+                end
               end.compact
 
               scope = scope.where(grid_service_id: {:$in => services})

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -340,8 +340,16 @@ describe '/v1/grids', celluloid: true do
         expect(json_response['logs'].first['data']).to eq('foo-1 1')
       end
 
-      it 'returns grid container logs for multiple services' do
+      it 'returns grid container logs for multiple services by service name' do
         get "/v1/grids/#{@grid.to_path}/container_logs?services=foo,bar", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response['logs'].size).to eq(2)
+        expect(json_response['logs'][0]['data']).to eq('foo-1 1')
+        expect(json_response['logs'][1]['data']).to eq('bar-1 1')
+      end
+
+      it 'returns grid container logs for multiple services by service id' do
+        get "/v1/grids/#{@grid.to_path}/container_logs?services=#{@grid.to_path}/foo,#{@grid.to_path}/bar", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['logs'].size).to eq(2)
         expect(json_response['logs'][0]['data']).to eq('foo-1 1')

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -348,12 +348,40 @@ describe '/v1/grids', celluloid: true do
         expect(json_response['logs'][1]['data']).to eq('bar-1 1')
       end
 
-      it 'returns grid container logs for multiple services by service id' do
-        get "/v1/grids/#{@grid.to_path}/container_logs?services=#{@grid.to_path}/foo,#{@grid.to_path}/bar", nil, request_headers
-        expect(response.status).to eq(200)
-        expect(json_response['logs'].size).to eq(2)
-        expect(json_response['logs'][0]['data']).to eq('foo-1 1')
-        expect(json_response['logs'][1]['data']).to eq('bar-1 1')
+      context 'stack service' do
+        let(:stack) do
+          Stacks::Create.run(
+            current_user: david,
+            grid: @grid,
+            name: 'foostack',
+            stack: 'stack',
+            version: '0.1.1',
+            source: '...',
+            variables: { foo: 'bar' },
+            registry: 'file',
+            services: [
+              { name: 'app', image: 'my/app:latest', stateful: false },
+              { name: 'foo', image: 'my/app:latest', stateful: false },
+              { name: 'redis', image: 'redis:2.8', stateful: true }
+            ]
+          ).result
+        end
+
+        before do
+          node = @grid.create_node!('node-2', node_id: SecureRandom.uuid)
+          app_container = stack.grid_services.find_by(name: 'app').containers.create!(name: 'app-1', host_node: node, container_id: 'ddd')
+          app_container.container_logs.create!(name: "app-1", data: 'app-1 1', type: 'stdout', grid: @grid, host_node: node, grid_service: stack.grid_services[0])
+          foo_container = stack.grid_services.find_by(name: 'foo').containers.create!(name: 'foo-1', host_node: node, container_id: 'eee')
+          foo_container.container_logs.create!(name: "foo-1", data: 'foo-1 1', type: 'stdout', grid: @grid, host_node: node, grid_service: stack.grid_services[1])
+        end
+
+        it 'returns grid container logs for multiple services by service id' do
+          get "/v1/grids/#{@grid.to_path}/container_logs?services=foostack/app,foostack/foo,foostack/nonexist,nostack/app", nil, request_headers
+          expect(response.status).to eq(200)
+          expect(json_response['logs'].size).to eq(2)
+          expect(json_response['logs'][0]['data']).to eq('app-1 1')
+          expect(json_response['logs'][1]['data']).to eq('foo-1 1')
+        end
       end
 
       it 'returns grid container logs for a container' do


### PR DESCRIPTION
Fixes #2712

* Makes grid container logs api accept service id's and not just service names as filter
* Makes stack logs command accept service names as filter parameters, like `kontena stack logs stack_name <service_name> <service2_name>`
