### PR TITLE
Fix agent websocket disconnected notifications

### DIFF
--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -24,8 +24,6 @@ module Kontena
     CLOSE_TIMEOUT = 10.0
     WRITE_TIMEOUT = 10.0 # this one is a little odd
 
-    attr_reader :api_uri
-
     # @param [String] api_uri
     # @param [String] node_id
     # @param [String] node_name
@@ -84,7 +82,7 @@ module Kontena
     def connect!
       @connecting = true
 
-      info "connecting to master at #{api_uri}"
+      info "connecting to master at #{@api_uri}"
       headers = {
           'Kontena-Node-Id' => @node_id.to_s,
           'Kontena-Node-Name' => @node_name,

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -7,6 +7,7 @@ require_relative 'rpc_client'
 #   websocket:connect [nil] connecting, not yet connected
 #   websocket:open [nil] connected, websocket open
 #   websocket:connected [nil] received /agent/master_info from server
+#   websocket:disconnected [nil] websocket disconnected
 module Kontena
   class WebsocketClient
     include Celluloid
@@ -223,6 +224,9 @@ module Kontena
       @ws = nil # prevent further send_message calls until reconnected
       @connected = false
       @connecting = false
+
+      # any queued up send_message calls will fail
+      publish('websocket:disconnected', nil)
     end
 
     # Called from RpcServer, does not crash the Actor on errors.

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -16,6 +16,7 @@ module Kontena
 
     STRFTIME = '%F %T.%NZ'
 
+    CONNECT_INTERVAL = 1.0
     CONNECT_TIMEOUT = 10.0
     OPEN_TIMEOUT = 10.0
     PING_INTERVAL = 30.0 # seconds
@@ -23,10 +24,7 @@ module Kontena
     CLOSE_TIMEOUT = 10.0
     WRITE_TIMEOUT = 10.0 # this one is a little odd
 
-    attr_reader :api_uri,
-                :ws,
-                :rpc_server,
-                :ping_timer
+    attr_reader :api_uri
 
     # @param [String] api_uri
     # @param [String] node_id
@@ -78,7 +76,7 @@ module Kontena
     end
 
     def start
-      every(1.0) do
+      every(CONNECT_INTERVAL) do
         connect! if !connected? unless connecting?
       end
     end

--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -25,8 +25,6 @@ module Kontena::Workers
       @etcd = Etcd.client(host: '127.0.0.1', port: 2379)
       subscribe('container:event', :on_container_event)
       subscribe('websocket:connected', :on_connect) # from master_info RPC
-      subscribe('websocket:disconnect', :on_disconnect)
-      subscribe('websocket:close', :on_disconnect)
       info 'initialized'
 
       async.start if autostart

--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -25,6 +25,7 @@ module Kontena::Workers
       @etcd = Etcd.client(host: '127.0.0.1', port: 2379)
       subscribe('container:event', :on_container_event)
       subscribe('websocket:connected', :on_connect) # from master_info RPC
+      subscribe('websocket:disconnected', :on_disconnect)
       info 'initialized'
 
       async.start if autostart

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -54,7 +54,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
 
   describe '#start' do
     it 'connects' do
-      expect(subject).to receive(:connect)
+      expect(subject).to receive(:connect!)
 
       actor.start
     end
@@ -65,7 +65,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
       expect(async).to receive(:connect_client)
       expect(subject).to receive(:publish).with('websocket:connect', nil)
 
-      actor.connect
+      actor.connect!
 
       expect(subject).to be_connecting
       expect(subject).to_not be_connected
@@ -89,7 +89,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
       it 'creates a websocket client with Kontena-Node-Token header' do
         expect(async).to receive(:connect_client)
 
-        actor.connect
+        actor.connect!
 
         expect(subject).to be_connecting
         expect(subject).to_not be_connected
@@ -140,7 +140,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
           expect(err.message).to eq 'Invalid websocket URL: http://api.example.com'
         end
 
-        actor.connect
+        actor.connect!
 
         expect(subject.connecting?).to be false
       end
@@ -154,7 +154,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
       it 'creates a websocket client with ssl, and ssl_verify' do
         expect(async).to receive(:connect_client)
 
-        actor.connect
+        actor.connect!
 
         expect(subject.ws).to be_a Kontena::Websocket::Client
         expect(subject.ws.url).to eq 'wss://socket.example.com'
@@ -172,7 +172,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
       it 'creates a websocket client with ssl and no ssl_verify' do
         expect(async).to receive(:connect_client)
 
-        actor.connect
+        actor.connect!
 
         expect(subject.ws).to be_a Kontena::Websocket::Client
         expect(subject.ws.url).to eq 'wss://socket.example.com'
@@ -186,11 +186,11 @@ describe Kontena::WebsocketClient, :celluloid => true do
     let(:url) { 'wss://socket.example.com' }
     let(:options) { { ssl_hostname: 'test'} }
 
-    describe '#connect' do
+    describe '#connect!' do
       it 'creates a websocket client with ssl and ssl_hostname' do
         expect(async).to receive(:connect_client)
 
-        actor.connect
+        actor.connect!
 
         expect(subject.ws).to be_a Kontena::Websocket::Client
         expect(subject.ws.url).to eq 'wss://socket.example.com'
@@ -219,7 +219,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
 
     describe '#start' do
       it 'does not connect' do
-        expect(subject).not_to receive(:connect)
+        expect(subject).not_to receive(:connect!)
 
         actor.start
       end
@@ -489,7 +489,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
 
     describe '#start' do
       it 'does not connect' do
-        expect(subject).not_to receive(:connect)
+        expect(subject).not_to receive(:connect!)
 
         actor.start
       end


### PR DESCRIPTION
The rewrite in #2560 broke the existing `websocket:close` and `websocket:disconnect` notifications used by the `LogWorker`, and it would no longer see any notification if the websocket was disconnected with an error.

This replaces the `websocket:close` and `websocket:disconnect` notifications with a single `websocket:disconnected` notification.

The `websocket:disconnect` notification is removed, because ping timeouts will now result in immediate `Kontena::Websocket::Client` errors, instead of having to wait for the close timeout to expire.

The `websocket:close` notification is removed, because support for agent-initiated websocket closes does not exist yet: the agent shold stop queueing up more messages, and wai  for any queued up messages to get flushed out before shutting down.