### PR TITLE
agent: have SIGTTIN handler use Celluloid.dump

### DIFF
--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -119,16 +119,9 @@ module Kontena
     end
 
     def handle_trace
-      info "Dump thread trace..."
+      info "Dump celluloid actor stacks..."
 
-      Thread.list.each do |thread|
-        warn "Thread #{thread.object_id.to_s(36)} #{thread['label']}"
-        if thread.backtrace
-          warn thread.backtrace.join("\n")
-        else
-          warn "no backtrace available"
-        end
-      end
+      Celluloid.dump
     end
 
     def supervise


### PR DESCRIPTION
This results in far more informative output:

```
Celluloid::Actor 0x2af31fb8dc
Celluloid::Cell 0x2af31fbb0c: Kontena::Workers::EventWorker
State: Running (executing tasks)
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `sleep'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `wait'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `block in check'
	/usr/lib/ruby/gems/2.4.0/gems/timers-4.1.1/lib/timers/wait.rb:14:in `for'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:58:in `check'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:155:in `block in run'
	/usr/lib/ruby/gems/2.4.0/gems/timers-4.1.1/lib/timers/group.rb:66:in `wait'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:152:in `run'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:131:in `block in start'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-essentials-0.20.5/lib/celluloid/internals/thread_handle.rb:14:in `block in initialize'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor/system.rb:78:in `block in get_thread'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/group/spawner.rb:50:in `block in instantiate'


	Tasks:
	  1) Celluloid::Task::Fibered[call]: receiving
	      {:dangerous_suspend=>false, :method_name=>:process_events}
		Celluloid::Task::Fibered backtrace unavailable. Please try `Celluloid.task_class = Celluloid::Task::Threaded` if you need backtraces here.


	  2) Celluloid::Task::Fibered[call]: receiving
	      {:dangerous_suspend=>false, :method_name=>:stream_events}
		Celluloid::Task::Fibered backtrace unavailable. Please try `Celluloid.task_class = Celluloid::Task::Threaded` if you need backtraces here.
```