### PR TITLE
Fix agent LogWorker start/stop

### DIFF
--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -1,5 +1,6 @@
 require_relative 'container_log_worker'
 require_relative '../helpers/rpc_helper'
+require_relative '../helpers/wait_helper'
 
 module Kontena::Workers
   class LogWorker
@@ -7,6 +8,7 @@ module Kontena::Workers
     include Celluloid::Notifications
     include Kontena::Logging
     include Kontena::Helpers::RpcHelper
+    include Kontena::Helpers::WaitHelper
 
     attr_reader :queue, :etcd, :workers
 
@@ -17,70 +19,69 @@ module Kontena::Workers
     ETCD_PREFIX = '/kontena/log_worker/containers'
     QUEUE_MAX_SIZE = 2000
     QUEUE_THROTTLE = (QUEUE_MAX_SIZE * 0.8)
+    WATCH_INTERVAL = 10.0
 
     # @param [Boolean] autostart
     def initialize(autostart = true)
       @queue = Queue.new
       @workers = {}
       @etcd = Etcd.client(host: '127.0.0.1', port: 2379)
+      @running = nil
       subscribe('container:event', :on_container_event)
       subscribe('websocket:connected', :on_connect) # from master_info RPC
       subscribe('websocket:disconnected', :on_disconnect)
       info 'initialized'
 
-      async.start if autostart
+      if autostart
+        async.watch_queue
+        async.start
+      end
+    end
+
+    # @return [Boolean]
+    def running?
+      !!@running
     end
 
     # @param [String] topic
     # @param [Object] data
     def on_connect(topic, data)
-      @queue_processing = true
-      async.start
-      info 'started log streaming'
+      start unless running?
     end
 
     # @param [String] topic
     # @param [Object] data
     def on_disconnect(topic, data)
-      @queue_processing = false
-      async.stop
-      info 'stopped log streaming'
-    end
-
-    def queue_processing?
-      @queue_processing == true
+      stop if running?
     end
 
     def start
-      sleep 1 until Actor[:etcd_launcher].running?
-      Docker::Container.all.each do |container|
-        begin
-          self.stream_container_logs(container) unless container.skip_logs?
-        rescue Docker::Error::NotFoundError
-          # Could be thrown since container.skip_logs? actually loads the container details
-        end
-      end
+      @running = true
 
-      async.watch_queue
-      async.process_queue
+      exclusive {
+        info 'start log streaming'
+
+        wait_until!("etcd running") { Actor[:etcd_launcher].running? }
+
+        Docker::Container.all.each do |container|
+          begin
+            self.stream_container_logs(container) unless container.skip_logs?
+          rescue Docker::Error::NotFoundError => exc
+            # Could be thrown since container.skip_logs? actually loads the container details
+            warn exc.message
+          rescue => exc
+            error exc
+          end
+        end
+
+        async.process_queue
+      }
     end
 
-    def watch_queue
-      loop do
-        sleep 10
-        if @queue.size > QUEUE_MAX_SIZE
-          warn "queue is full (size is #{@queue.size}), log lines are dropped until queue has free space"
-        elsif @queue.size > QUEUE_THROTTLE
-          warn "queue size is #{@queue.size}, log streams are throttled and some log lines may be dropped"
-        elsif @queue.size > (QUEUE_MAX_SIZE / 2)
-          warn "queue size is #{@queue.size}"
-        end
-      end
-    end
-
+    # Process items from @queue until nil
     def process_queue
       defer {
-        while queue_processing? && data = @queue.pop
+        while data = @queue.pop
           rpc_client.async.notification('/containers/log', [data])
           if @queue.size > 100
             sleep 0.001
@@ -92,14 +93,29 @@ module Kontena::Workers
     end
 
     def stop
-      return unless queue_processing?
+      @running = false
 
-      @workers.keys.dup.each do |id|
-        self.stop_streaming_container_logs(id)
-        self.mark_timestamp(id, Time.now.to_i)
+      exclusive {
+        info 'stop log streaming'
+
+        @workers.keys.dup.each do |id|
+          self.stop_streaming_container_logs(id)
+          self.mark_timestamp(id, Time.now.to_i)
+        end
+        @queue << nil # stop process_queue loop
+      }
+    end
+
+    def watch_queue
+      every(WATCH_INTERVAL) do
+        if @queue.size > QUEUE_MAX_SIZE
+          warn "queue is full (size is #{@queue.size}), log lines are dropped until queue has free space"
+        elsif @queue.size > QUEUE_THROTTLE
+          warn "queue size is #{@queue.size}, log streams are throttled and some log lines may be dropped"
+        elsif @queue.size > (QUEUE_MAX_SIZE / 2)
+          warn "queue size is #{@queue.size}"
+        end
       end
-    rescue => exc
-      error "#{exc.class.name}: #{exc.message}"
     end
 
     def mark_timestamps
@@ -119,20 +135,16 @@ module Kontena::Workers
 
     # @param [Docker::Container] container
     def stream_container_logs(container)
-      exclusive {
-        unless workers[container.id]
-          workers[container.id] = ContainerLogWorker.new(container, queue)
-          since = 0
-          key = etcd.get("#{ETCD_PREFIX}/#{container.id}") rescue nil
-          if key
-            etcd.delete("#{ETCD_PREFIX}/#{container.id}")
-            since = key.value.to_i
-          end
-          workers[container.id].async.start(since.to_i)
+      unless workers[container.id]
+        workers[container.id] = ContainerLogWorker.new(container, queue)
+        since = 0
+        key = etcd.get("#{ETCD_PREFIX}/#{container.id}") rescue nil
+        if key
+          etcd.delete("#{ETCD_PREFIX}/#{container.id}")
+          since = key.value.to_i
         end
-      }
-    rescue => exc
-      error "#{exc.class.name}: #{exc.message}"
+        workers[container.id].async.start(since.to_i)
+      end
     end
 
     # @param [String] container_id
@@ -143,7 +155,7 @@ module Kontena::Workers
         Celluloid::Actor.kill(worker) if worker.alive?
       end
     rescue => exc
-      error exc.message
+      error exc
     end
 
     # @param [String] topic
@@ -154,12 +166,16 @@ module Kontena::Workers
       elsif START_EVENTS.include?(event.status)
         container = Docker::Container.get(event.id) rescue nil
         debug "#{container.name}/#{container.labels}"
-        if container && queue_processing? && !container.skip_logs?
-          stream_container_logs(container)
+        if container && running? && !container.skip_logs?
+          exclusive {
+            stream_container_logs(container)
+          }
         elsif container
           mark_timestamp(container.id, Time.now.to_i)
         end
       end
+    rescue => exc
+      error exc
     end
 
     def finalize

--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -30,7 +30,8 @@ module Kontena::Workers
       @queue = Queue.new
       @workers = {}
       @etcd = Etcd.client(host: '127.0.0.1', port: 2379)
-      @running = nil
+      @processing = false
+      @streaming = false
       subscribe('container:event', :on_container_event)
       subscribe('websocket:connected', :on_connect) # from master_info RPC
       subscribe('websocket:disconnected', :on_disconnect)

--- a/agent/spec/lib/kontena/workers/log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/log_worker_spec.rb
@@ -3,8 +3,7 @@ describe Kontena::Workers::LogWorker, :celluloid => true do
   include RpcClientMocks
 
   let(:subject) { described_class.new(false) }
-  let(:container) { spy(:container, id: 'foo', labels: {}) }
-  let(:etcd) { spy(:etcd) }
+  let(:etcd) { instance_double(Etcd::Client) }
 
   before(:each) do
     mock_rpc_client
@@ -54,77 +53,115 @@ describe Kontena::Workers::LogWorker, :celluloid => true do
     end
   end
 
-  describe '#mark_timestamps' do
+  describe '#stop_streaming' do
     it 'calls mark_timestamp for each worker' do
-      subject.workers['id1'] = true
-      subject.workers['id2'] = true
-      expect(subject.wrapped_object).to receive(:mark_timestamp).twice
-      subject.mark_timestamps
+      worker1 = subject.workers['id1'] = double(:worker1, alive?: true)
+      worker2 = subject.workers['id2'] = double(:worker2, alive?: true)
+
+      expect(Celluloid::Actor).to receive(:kill).with(worker1)
+      expect(etcd).to receive(:set).with('/kontena/log_worker/containers/id1', {value: Integer, ttl: Integer})
+      expect(Celluloid::Actor).to receive(:kill).with(worker2)
+      expect(etcd).to receive(:set).with('/kontena/log_worker/containers/id2', {value: Integer, ttl: Integer})
+
+      subject.stop_streaming
+
+      expect(subject).to_not be_streaming
     end
   end
 
   describe '#mark_timestamp' do
     it 'saves timestamp to etcd' do
-      etcd = spy(:etcd)
-      allow(subject.wrapped_object).to receive(:etcd).and_return(etcd)
-      expect(etcd).to receive(:set)
+      expect(etcd).to receive(:set).with('/kontena/log_worker/containers/id', {value: Integer, ttl: Integer})
+
       subject.mark_timestamp('id', Time.now.to_i)
     end
   end
 
   describe '#stream_container_logs' do
+    let(:container) { double(:container,
+      id: 'foo',
+    ) }
+
     it 'does nothing if worker actor exist' do
-      allow(subject.wrapped_object).to receive(:etcd).and_return(spy)
       expect(Kontena::Workers::ContainerLogWorker).not_to receive(:new)
       subject.workers[container.id] = spy(:container_log_worker)
       subject.stream_container_logs(container)
     end
 
-    it 'creates new container_log_worker actor' do
-      allow(subject.wrapped_object).to receive(:etcd).and_return(spy)
-      worker = spy(:container_log_worker)
-      expect(Kontena::Workers::ContainerLogWorker).to receive(:new).and_return(worker)
-      subject.stream_container_logs(container)
+    context 'without any etcd key' do
+      before do
+        allow(etcd).to receive(:get).with('/kontena/log_worker/containers/foo').and_raise(Etcd::KeyNotFound)
+      end
+
+      it 'creates new container_log_worker actor' do
+        worker = spy(:container_log_worker)
+        expect(Kontena::Workers::ContainerLogWorker).to receive(:new).with(container, Queue).and_return(worker)
+        subject.stream_container_logs(container)
+      end
     end
   end
 
   describe '#stop_streaming_container_logs' do
     it 'terminates worker if it exist' do
-      worker = spy(:worker, :alive? => true)
-      subject.workers[container.id] = worker
+      worker = double(:worker, :alive? => true)
+      subject.workers['foo'] = worker
       expect(Celluloid::Actor).to receive(:kill).with(worker).once
-      subject.stop_streaming_container_logs(container.id)
+      subject.stop_streaming_container_logs('foo')
     end
   end
 
   describe '#on_container_event' do
-    it 'stops streaming on die' do
-      expect(subject.wrapped_object).to receive(:stop_streaming_container_logs).once.with('foo')
-      subject.on_container_event('topic', double(:event, id: 'foo', status: 'die'))
+    let(:skip_logs?) { false }
+    let(:container) { double(:container,
+      id: 'foo',
+      name: 'test-1',
+      labels: {'io.kontena.container.type' => 'test'},
+      skip_logs?: skip_logs?,
+    ) }
+
+    before do
+      allow(Docker::Container).to receive(:get).with('foo').and_return(container)
     end
 
-    context 'when running' do
+    context 'when not streaming' do
+      it 'marks start time' do
+        expect(subject.wrapped_object).to receive(:mark_timestamp).with('foo', Integer)
+
+        subject.on_container_event('topic', double(:event, id: 'foo', status: 'start'))
+      end
+
+      it 'stops streaming on die' do
+        expect(subject.wrapped_object).to receive(:stop_streaming_container_logs).once.with('foo')
+
+        subject.on_container_event('topic', double(:event, id: 'foo', status: 'die'))
+      end
+    end
+
+    context 'when streaming' do
       before do
-        allow(subject.wrapped_object).to receive(:running?).and_return(true)
+        allow(subject.wrapped_object).to receive(:streaming?).and_return(true)
       end
 
       it 'starts streaming on start' do
-        allow(Docker::Container).to receive(:get).and_return(container)
-        expect(container).to receive(:skip_logs?).and_return(false)
         expect(subject.wrapped_object).to receive(:stream_container_logs).once.with(container)
+
         subject.on_container_event('topic', double(:event, id: 'foo', status: 'start'))
       end
 
-      it 'does not start streaming on start if logs should be skipped' do
-        allow(Docker::Container).to receive(:get).and_return(container)
-        expect(container).to receive(:skip_logs?).and_return(true)
-        expect(subject.wrapped_object).not_to receive(:stream_container_logs)
-        subject.on_container_event('topic', double(:event, id: 'foo', status: 'start'))
+      context 'with skip_logs' do
+        let(:skip_logs?) { true }
+
+        it 'does not start streaming on start if logs should be skipped' do
+          expect(subject.wrapped_object).not_to receive(:stream_container_logs)
+          expect(subject.wrapped_object).to receive(:mark_timestamp).with('foo', Integer) # XXX: why?
+
+          subject.on_container_event('topic', double(:event, id: 'foo', status: 'start'))
+        end
       end
 
       it 'does not start streaming on create' do
-        allow(Docker::Container).to receive(:get).and_return(container)
         expect(subject.wrapped_object).not_to receive(:stream_container_logs)
+
         subject.on_container_event('topic', double(:event, id: 'foo', status: 'create'))
       end
     end


### PR DESCRIPTION
Fixes #2232, fixes  #2661

* Only run one `async.watch_queue` task from `initialize`
* Fix `start unless running?` and `stop if running?` to not race and launch duplicate tasks
* Shut down `process_queue` from `stop`

Not 100% sure about the `exclusive { ... }` blocks.