### PR TITLE
Initial tls-sni support and new api for domain authorizations

### DIFF
--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -37,7 +37,9 @@ module Kontena::Cli::Certificate
           deployment = client(token).get("services/#{response['linked_service']}/deploys/#{response['service_deploy_id']}")
           wait_for_deploy_to_finish(token, deployment)
         end
-        puts "TLS-SNI certificate is deployed, you can now request the certificate"
+        puts "TLS-SNI challenge certificate is deployed, you can now request the actual certificate"
+      else
+        exit_with_error "Unknown authorization type: #{self.type}"
       end
 
     end

--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Certificate
     parameter "DOMAIN", "Domain to authorize"
 
     option '--type', 'AUTHORIZATION_TYPE', 'Authorization type, either tls-sni-01 or dns-01', default: 'dns-01'
-    option '--linked-service', "LINKED_SERVICE", 'A service (usually LB) where the tls-sni-01 certificate is bundled to'
+    option '--linked-service', "LINKED_SERVICE", 'A service (usually LB) where the tls-sni-01 challenge certificate is bundled to'
 
     def execute
       require_api_url

--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -22,7 +22,7 @@ module Kontena::Cli::Certificate
         domain: domain,
         authorization_type: self.type
       }
-      data['linked_service'] = self.linked_service if self.type == 'tls-sni-01'
+      data['linked_service'] = service_path(self.linked_service) if self.type == 'tls-sni-01'
 
       response = client(token).post("grids/#{current_grid}/domain_authorizations", data)
 
@@ -42,6 +42,14 @@ module Kontena::Cli::Certificate
         exit_with_error "Unknown authorization type: #{self.type}"
       end
 
+    end
+
+    def service_path(linked_service)
+      unless linked_service.include?('/')
+        "null/#{linked_service}"
+      else
+        linked_service
+      end
     end
   end
 end

--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -1,22 +1,45 @@
+require_relative '../services/services_helper'
 
 module Kontena::Cli::Certificate
   class AuthorizeCommand < Kontena::Command
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
+    include Kontena::Cli::Services::ServicesHelper
 
 
     parameter "DOMAIN", "Domain to authorize"
+
+    option '--type', 'AUTHORIZATION_TYPE', 'Authorization type, either tls-sni-01 or dns-01', default: 'dns-01'
+    option '--linked-service', "LINKED_SERVICE", 'A service (usually LB) where the tls-sni-01 certificate is bundled to'
 
     def execute
       require_api_url
       token = require_token
 
-      data = {domain: domain}
-      response = client(token).post("certificates/#{current_grid}/authorize", data)
-      puts "Authorization successfully created. Use the following details to create necessary validations:"
-      puts "Record name: #{response['record_name']}.#{domain}"
-      puts "Record type: #{response['record_type']}"
-      puts "Record content: #{response['record_content']}"
+      exit_with_error "Service link needs to be given with tls-sni-01 auth type" if self.type == 'tls-sni-01' && self.linked_service.nil?
+
+      data = {
+        domain: domain,
+        authorization_type: self.type
+      }
+      data['linked_service'] = self.linked_service if self.type == 'tls-sni-01'
+
+      response = client(token).post("grids/#{current_grid}/domain_authorizations", data)
+
+      case self.type
+      when 'dns-01'
+        puts "Authorization successfully created. Use the following details to create necessary validations:"
+        puts "Record name: #{response.dig('challenge_opts', 'record_name')}.#{domain}"
+        puts "Record type: #{response.dig('challenge_opts', 'record_type')}"
+        puts "Record content: #{response.dig('challenge_opts', 'record_content')}"
+      when 'tls-sni-01'
+        spinner "Waiting for tls-sni-01 certificate to be deployed into #{response['linked_service'].colorize(:cyan)} " do
+          deployment = client(token).get("services/#{response['linked_service']}/deploys/#{response['service_deploy_id']}")
+          wait_for_deploy_to_finish(token, deployment)
+        end
+        puts "TLS-SNI certificate is deployed, you can now request the certificate"
+      end
+
     end
   end
 end

--- a/server/app/models/grid_domain_authorization.rb
+++ b/server/app/models/grid_domain_authorization.rb
@@ -33,7 +33,11 @@ class GridDomainAuthorization
   def service_deploy_state
     if self.grid_service
       deploy = self.grid_service.grid_service_deploys.find_by(id: self.service_deploy_id)
-      deploy.deploy_state
+      if deploy # Could be gone as deploys are on capped collection
+        deploy.deploy_state
+      else
+        :unknown
+      end
     else
       :not_linked
     end

--- a/server/app/models/grid_domain_authorization.rb
+++ b/server/app/models/grid_domain_authorization.rb
@@ -27,6 +27,15 @@ class GridDomainAuthorization
 
   # @return [String]
   def to_path
-    "#{self.grid.try(:name)}/#{self.name}"
+    "#{self.grid.try(:name)}/#{self.domain}"
+  end
+
+  def service_deploy_state
+    if self.grid_service
+      deploy = self.grid_service.grid_service_deploys.find_by(id: self.service_deploy_id)
+      deploy.deploy_state
+    else
+      :not_linked
+    end
   end
 end

--- a/server/app/models/grid_domain_authorization.rb
+++ b/server/app/models/grid_domain_authorization.rb
@@ -30,11 +30,13 @@ class GridDomainAuthorization
     "#{self.grid.try(:name)}/#{self.domain}"
   end
 
-  def computed_state
+  def status
     deploy = find_deploy
     if deploy && !deploy.finished?
       # Deploy still in progress
       :deploying # So that CLI or other clients know to wait before requesting the cert
+    elsif deploy && deploy.finished? && deploy.error?
+      :deploy_error
     else
       self.state
     end

--- a/server/app/models/grid_domain_authorization.rb
+++ b/server/app/models/grid_domain_authorization.rb
@@ -13,7 +13,8 @@ class GridDomainAuthorization
   field :challenge, type: Hash
   field :challenge_opts, type: Hash # TODO encrypt?
   field :authorization_type, type: String, default: 'tls-sni-01'
-  field :service_deploy_id, type: String
+
+  belongs_to :grid_service_deploy
 
   field :encrypted_tls_sni_certificate, type: String, encrypted: true
 
@@ -31,20 +32,14 @@ class GridDomainAuthorization
   end
 
   def status
-    deploy = find_deploy
-    if deploy && !deploy.finished?
+    if self.grid_service_deploy && !self.grid_service_deploy.finished?
       # Deploy still in progress
       :deploying # So that CLI or other clients know to wait before requesting the cert
-    elsif deploy && deploy.finished? && deploy.error?
+    elsif self.grid_service_deploy && self.grid_service_deploy.finished? && self.grid_service_deploy.error?
       :deploy_error
     else
       self.state
     end
-  end
-
-  def find_deploy
-    return self.grid_service.grid_service_deploys.find_by(id: self.service_deploy_id) if self.grid_service
-    nil
   end
 
 end

--- a/server/app/models/grid_domain_authorization.rb
+++ b/server/app/models/grid_domain_authorization.rb
@@ -1,3 +1,5 @@
+require 'symmetric-encryption'
+
 class GridDomainAuthorization
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -5,10 +7,17 @@ class GridDomainAuthorization
 
   belongs_to :grid
 
-  enum :state, [:created, :requested, :validated], default: :created
+  enum :state, [:created, :requested, :validated, :error], default: :created
+
   field :domain, type: String
   field :challenge, type: Hash
   field :challenge_opts, type: Hash # TODO encrypt?
+  field :authorization_type, type: String, default: 'tls-sni-01'
+  field :service_deploy_id, type: String
+
+  field :encrypted_tls_sni_certificate, type: String, encrypted: true
+
+  belongs_to :grid_service # Usually a LB service
 
   index({ grid_id: 1 })
   index({ domain: 1 })

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -50,6 +50,7 @@ class GridService
   has_many :audit_logs
   has_many :grid_service_deploys, dependent: :destroy
   has_many :event_logs
+  has_many :grid_domain_authorizations
   has_and_belongs_to_many :networks
   embeds_many :grid_service_links
   embeds_many :hooks, class_name: 'GridServiceHook'

--- a/server/app/models/grid_service_deploy.rb
+++ b/server/app/models/grid_service_deploy.rb
@@ -30,6 +30,8 @@ class GridServiceDeploy
 
   embeds_many :grid_service_instance_deploys
 
+  has_many :grid_domain_authorizations # Possibility to handle multiple tls-sni cert updates in one deploy
+
   index({ grid_service_id: 1 }, { background: true })
   index({ created_at: 1 }, { background: true })
   index({ queued_at: 1 }, { background: true })

--- a/server/app/mutations/domain_authorizations/authorize.rb
+++ b/server/app/mutations/domain_authorizations/authorize.rb
@@ -35,6 +35,10 @@ module GridDomainAuthorizations
       when 'dns-01'
         debug "creating dns-01 challenge"
         challenge = authorization.dns01
+        if challenge.nil?
+          add_error(:challenge, :dns_01, "LE gave back empty dns-01 challenge!?!?")
+          return
+        end
         challenge_opts = {
           'record_name' => challenge.record_name,
           'record_type' => challenge.record_type,
@@ -43,6 +47,10 @@ module GridDomainAuthorizations
       when 'tls-sni-01'
         debug "creating tls-sni-01 challenge"
         challenge = authorization.tls_sni01
+        if challenge.nil?
+          add_error(:challenge, :tls_sni_01, "LE gave back empty tls-sni-01 challenge!?!?")
+          return
+        end
         verification_cert = [challenge.certificate.to_pem, challenge.private_key.to_pem].join
       end
 

--- a/server/app/mutations/domain_authorizations/authorize.rb
+++ b/server/app/mutations/domain_authorizations/authorize.rb
@@ -74,8 +74,8 @@ module GridDomainAuthorizations
         # We need to deploy the linked service to get the certs in place
         outcome = GridServices::Deploy.run(grid_service: @linked_service, force: true)
         if outcome.success?
-          deploy = outcome.result
-          authz.set(service_deploy_id: deploy.id)
+          authz.grid_service_deploy = outcome.result
+          authz.save
         else
           add_error(:linked_service, :deploy, outcome.errors)
         end

--- a/server/app/mutations/domain_authorizations/authorize.rb
+++ b/server/app/mutations/domain_authorizations/authorize.rb
@@ -20,6 +20,9 @@ module GridDomainAuthorizations
     end
 
     def validate
+      unless grid.grid_secrets.find_by(name: LE_PRIVATE_KEY)
+        add_error(:le_registration, :missing, "Let's Encrypt registration missing")
+      end
       if self.authorization_type == 'tls-sni-01'
         add_error(:linked_service, :missing, "Service link needs to be given for tls-sni-01 authorization type") unless self.linked_service
       end

--- a/server/app/mutations/domain_authorizations/authorize.rb
+++ b/server/app/mutations/domain_authorizations/authorize.rb
@@ -77,7 +77,7 @@ module GridDomainAuthorizations
           deploy = outcome.result
           authz.set(service_deploy_id: deploy.id)
         else
-          add_error(:linked_service, :deploy, outcome.errors.message)
+          add_error(:linked_service, :deploy, outcome.errors)
         end
       end
 

--- a/server/app/mutations/domain_authorizations/authorize.rb
+++ b/server/app/mutations/domain_authorizations/authorize.rb
@@ -1,0 +1,77 @@
+require 'acme-client'
+require 'openssl'
+
+require_relative '../grid_certificates/common'
+require_relative '../../services/logging'
+
+module GridDomainAuthorizations
+  class Authorize < Mutations::Command
+    include GridCertificates::Common
+    include Logging
+
+    required do
+      model :grid, class: Grid
+      string :domain
+      string :authorization_type, in: ['dns-01', 'tls-sni-01'], default: 'dns-01'
+    end
+
+    optional do
+      string :linked_service
+    end
+
+    def validate
+      if self.authorization_type == 'tls-sni-01'
+        add_error(:linked_service, :missing, "Service link needs to be given for tls-sni-01 authorization type") unless self.linked_service
+      end
+      if self.linked_service
+        add_error(:linked_service, :not_found, "Linked service needs to point to existing service") unless @linked_service = resolve_service(self.grid, linked_service)
+      end
+    end
+
+    def execute
+      authorization = acme_client(self.grid).authorize(domain: self.domain)
+      challenge = nil
+      case self.authorization_type
+      when 'dns-01'
+        debug "creating dns-01 challenge"
+        challenge = authorization.dns01
+        challenge_opts = {
+          'record_name' => challenge.record_name,
+          'record_type' => challenge.record_type,
+          'record_content' => challenge.record_content
+        }
+      when 'tls-sni-01'
+        debug "creating tls-sni-01 challenge"
+        challenge = authorization.tls_sni01
+        verification_cert = [challenge.certificate.to_pem, challenge.private_key.to_pem].join
+      end
+
+
+
+      if authz = get_authz_for_domain(self.grid, self.domain)
+        authz.destroy
+      end
+
+      authz = GridDomainAuthorization.create!(
+        grid: self.grid,
+        domain: self.domain,
+        authorization_type: self.authorization_type,
+        challenge: challenge.to_h,
+        challenge_opts: challenge_opts,
+        tls_sni_certificate: verification_cert,
+        grid_service: @linked_service)
+
+      if self.authorization_type == 'tls-sni-01'
+        # We need to deploy the linked service to get the certs in place
+        @linked_service.set(updated_at: Time.now.utc)
+        deploy = GridServiceDeploy.create(grid_service: @linked_service)
+        authz.set(service_deploy_id: deploy.id)
+      end
+
+      authz
+    rescue Acme::Client::Error::Unauthorized
+      add_error(:acme_client, :unauthorized, "Registration probably missing for LE")
+    end
+
+  end
+end

--- a/server/app/mutations/grid_certificates/authorize_domain.rb
+++ b/server/app/mutations/grid_certificates/authorize_domain.rb
@@ -3,7 +3,9 @@ require 'openssl'
 
 require_relative 'common'
 require_relative '../../services/logging'
-
+#
+# Deprecated
+#
 module GridCertificates
   class AuthorizeDomain < Mutations::Command
     include Common

--- a/server/app/mutations/grid_certificates/common.rb
+++ b/server/app/mutations/grid_certificates/common.rb
@@ -46,5 +46,13 @@ module GridCertificates
     def acme_endpoint
       ENV['ACME_ENDPOINT'] || ACME_ENDPOINT
     end
+
+    def resolve_service(grid, service_name)
+      stack_name, service = service_name.split('/')
+      stack = grid.stacks.find_by(name: stack_name)
+      return nil if stack.nil?
+
+      stack.grid_services.find_by(name: service)
+    end
   end
 end

--- a/server/app/routes/v1/certificates_api.rb
+++ b/server/app/routes/v1/certificates_api.rb
@@ -61,12 +61,12 @@ module V1
         load_grid(grid)
 
         r.post do
-
+          # DEPRECATED
           r.on 'authorize' do
             data = parse_json_body
             authorize_domain(data)
           end
-
+          # DEPRECATED
           r.on 'certificate' do
             data = parse_json_body
             get_certificate(data)

--- a/server/app/routes/v1/domain_authorizations_api.rb
+++ b/server/app/routes/v1/domain_authorizations_api.rb
@@ -1,0 +1,29 @@
+module V1
+  class DomainAuthorizationsApi < Roda
+    include TokenAuthenticationHelper
+    include CurrentUser
+    include RequestHelpers
+
+    route do |r|
+
+      validate_access_token
+      require_current_user
+
+      def load_domain_auth(grid_name, domain)
+        grid = load_grid(grid_name) # Handles also access check to grid for current_user
+        grid.grid_domain_authorizations.find_by(domain: domain)
+      end
+
+      r.on ':grid_name/:domain' do |grid_name, domain|
+        r.is do
+          r.get do
+            @domain_authorization = load_domain_auth(grid_name, domain)
+            halt_request(404, {error: "Domain authorization not found)"}) unless @domain_authorization
+
+            render('domain_authorizations/show')
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/app/routes/v1/grids/grid_domain_authorizations.rb
+++ b/server/app/routes/v1/grids/grid_domain_authorizations.rb
@@ -1,0 +1,29 @@
+require_relative '../../../mutations/grid_services/create'
+
+V1::GridsApi.route('grid_domain_authorizations') do |r|
+
+  # POST /v1/grids/:name/domain_authorizations
+  r.post do
+    data = parse_json_body
+    data[:grid] = @grid
+    outcome = GridDomainAuthorizations::Authorize.run(data)
+    if outcome.success?
+      response.status = 201
+      @domain_authorization = outcome.result
+      audit_event(r, @grid, @domain_authorization, 'create', @domain_authorization)
+      render('domain_authorizations/show')
+    else
+      response.status = 422
+      {error: outcome.errors.message}
+    end
+  end
+
+  # GET /v1/grids/:name/domain_authorizations
+  r.get do
+    r.is do
+      @domain_authorizations = @grid.grid_domain_authorizations
+      render('domain_authorizations/index')
+    end
+  end
+
+end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -100,6 +100,11 @@ module V1
           r.route 'grid_event_logs'
         end
 
+        # /v1/grids/:name/domain_authorizations
+        r.on 'domain_authorizations' do
+          r.route 'grid_domain_authorizations'
+        end
+
         r.get do
           r.is do
             render('grids/show')

--- a/server/app/routes/v1_api.rb
+++ b/server/app/routes/v1_api.rb
@@ -20,6 +20,7 @@ module V1
       r.on 'stacks',              proc { r.run StacksApi }
       r.on 'certificates',        proc { r.run CertificatesApi }
       r.on 'volumes',             proc { r.run VolumesApi }
+      r.on 'domain_authorizations', proc { r.run DomainAuthorizationsApi }
     end
   end
 end

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -66,9 +66,9 @@ module Rpc
         secrets << item
       end
 
-      # Inject domain authz as secrets
-      # Why secrets? WEll, secrets are already handled in a way they can be concatenated with same env names
-      service.grid_domain_authorizations.each do |domain_auth|
+      # Inject tls-sni based domain authz as secrets
+      # Why secrets? Well, secrets are already handled in a way they can be concatenated with same env names
+      service.grid_domain_authorizations.select {|d| d.authorization_type == 'tls-sni-01'}.each do |domain_auth|
         secrets << {name: "SSL_CERTS", type: 'env', value: domain_auth.tls_sni_certificate}
       end
 

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -65,6 +65,13 @@ module Rpc
         end
         secrets << item
       end
+
+      # Inject domain authz as secrets
+      # Why secrets? WEll, secrets are already handled in a way they can be concatenated with same env names
+      service.grid_domain_authorizations.each do |domain_auth|
+        secrets << {name: "SSL_CERTS", type: 'env', value: domain_auth.tls_sni_certificate}
+      end
+
       secrets
     end
 
@@ -77,6 +84,7 @@ module Rpc
       env << "KONTENA_STACK_NAME=#{service.stack.try(:name)}"
       env << "KONTENA_NODE_NAME=#{service_instance.host_node.name}"
       env << "KONTENA_SERVICE_INSTANCE_NUMBER=#{service_instance.instance_number}"
+
       env
     end
 

--- a/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
+++ b/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
@@ -1,6 +1,9 @@
+json.id authorization.to_path
 json.domain authorization.domain
 json.challenge authorization.challenge
 json.challenge_opts authorization.challenge_opts
 json.authorization_type authorization.authorization_type
-json.linked_service authorization.grid_service.to_path if authorization.grid_service
-json.service_deploy_id authorization.service_deploy_id if authorization.service_deploy_id
+if authorization.grid_service
+    json.linked_service authorization.grid_service.to_path
+    json.service_deploy_state authorization.service_deploy_state
+end

--- a/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
+++ b/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
@@ -1,0 +1,6 @@
+json.domain authorization.domain
+json.challenge authorization.challenge
+json.challenge_opts authorization.challenge_opts
+json.authorization_type authorization.authorization_type
+json.linked_service authorization.grid_service.to_path if authorization.grid_service
+json.service_deploy_id authorization.service_deploy_id if authorization.service_deploy_id

--- a/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
+++ b/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
@@ -1,9 +1,11 @@
 json.id authorization.to_path
 json.domain authorization.domain
+json.state authorization.computed_state
 json.challenge authorization.challenge
 json.challenge_opts authorization.challenge_opts
 json.authorization_type authorization.authorization_type
-if authorization.grid_service
-    json.linked_service authorization.grid_service.to_path
-    json.service_deploy_state authorization.service_deploy_state
+json.linked_service do
+  if authorization.grid_service
+    json.id authorization.grid_service.to_path
+  end
 end

--- a/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
+++ b/server/app/views/v1/domain_authorizations/_domain_authorization.json.jbuilder
@@ -1,6 +1,6 @@
 json.id authorization.to_path
 json.domain authorization.domain
-json.state authorization.computed_state
+json.status authorization.status
 json.challenge authorization.challenge
 json.challenge_opts authorization.challenge_opts
 json.authorization_type authorization.authorization_type

--- a/server/app/views/v1/domain_authorizations/index.json.jbuilder
+++ b/server/app/views/v1/domain_authorizations/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.domain_authorizations @domain_authorizations do |authorization|
+  json.partial! 'app/views/v1/domain_authorizations/domain_authorization', authorization: authorization
+end

--- a/server/app/views/v1/domain_authorizations/show.json.jbuilder
+++ b/server/app/views/v1/domain_authorizations/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'app/views/v1/domain_authorizations/domain_authorization', authorization: @domain_authorization

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -1489,14 +1489,14 @@ Accept: application/json
 ## Get domain authorization
 
 ```http
-GET /v1/domain_authorizations/foobar.com HTTP/1.1
+GET /v1/domain_authorizations/my-grid/foobar.com HTTP/1.1
 Authorization: Bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
 Accept: application/json
 ```
 
 ### Endpoint
 
-`GET /v1/domain_authorizations/foobar.com`
+`GET /v1/domain_authorizations/my-grid/foobar.com`
 
 
 # Certificates

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -1455,6 +1455,7 @@ Let's Encrypt domain authorization management for certificate handling.
 `status` can be any of the following:
 - `created`: authorization has been created, no firther actions yet taken
 - `deploying`: The related tls-sni certificate is currently being deployed to linked service. Only valid for tls-sni type of authorizations
+- `deploy_error`: The deployment of the linked service has errored out, more details can be found from the linked services event logs
 - `requested`: Authorization has been requested from Let's Encrypt
 - `validated`: Let's Encrypt has succesfully validated the challenge
 - `error`: Error has happened in the validation, re-authorization should be done

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -1426,6 +1426,79 @@ Create an external registry.
 
 `DELETE /v1/grids/{grid_id}/external_registries`
 
+# Domain Authorizations
+
+Let's Encrypt domain authorization management for certificate handling.
+
+## Domain authorization
+
+```json
+{
+  "domain": "web.52.57.23.91.xip.io",
+  "challenge": {
+    "token": "4caq-Qll7ksacYp0Wd_eW4VTQlLp28ODKfBWZrzNbeU",
+    "uri": "https://acme-staging.api.letsencrypt.org/acme/challenge/0GL_fUeZGnbxilMGbcUoAS3UOz_dK8q4TdxDgeCrOs0/55065930",
+    "type": "tls-sni-01"
+  },
+  "challenge_opts": null,
+  "authorization_type": "tls-sni-01",
+  "linked_service": "e2e/null/lb",
+  "service_deploy_id": "599eac26af8cd3000995b36d"
+}
+```
+
+`challenge_opts` are challenge type specific details. For example in `dns-01` challenges there will be some DNS TXT records details.
+
+## Authorize domain
+
+```http
+POST /v1/grids/my-grid/domain_authorizations HTTP/1.1
+Authorization: Bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Accept: application/json
+Content-Type: application/json
+
+{
+    "domain": "foo.domain.com",
+    "authorization_type": "tls-sni-01",
+    "linked_service": "infra/lb"
+}
+```
+
+Authorize a domain with Let's Encrypt.
+
+Authorization types currently supported are `tls-sni-01` and `dns-01`
+
+If `tls-sni-01` authorization type is used, then also `linked_service` attribute must be given as the newly created `tls-sni-01` special purpose certificate is bundled with that service. Usually the linked service is a Kontena loadbalancer exposed to internet.
+
+### Endpoint
+
+`POST /v1/grids/my-grid/domain_authorizations`
+
+## Get domain authorizations
+
+```http
+GET /v1/grids/my-grid/domain_authorizations HTTP/1.1
+Authorization: Bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Accept: application/json
+```
+
+### Endpoint
+
+`GET /v1/grids/my-grid/domain_authorizations`
+
+## Get domain authorization
+
+```http
+GET /v1/domain_authorizations/foobar.com HTTP/1.1
+Authorization: Bearer 8dqAd30DRrzzhJzbcSCG0Lb35csy5w0oNeT+8eDh4q2/NTeK3CmwMHuH4axcaxya+aNfSy1XMsqHP/NsTNy6mg==
+Accept: application/json
+```
+
+### Endpoint
+
+`GET /v1/domain_authorizations/foobar.com`
+
+
 # Certificates
 
 Let's Encrypt certificate management.
@@ -1450,6 +1523,9 @@ Register email to Let's Encrypt.
 `POST /v1/certificates/{grid_id}/register`
 
 ## Authorize a domain
+
+**DEPRECATED**
+Use `POST /v1/grids/my-grid/domain_authorizations` instead.
 
 ```http
 POST /v1/certificates/my-grid/authorize HTTP/1.1

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -1434,20 +1434,30 @@ Let's Encrypt domain authorization management for certificate handling.
 
 ```json
 {
-  "domain": "web.52.57.23.91.xip.io",
-  "challenge": {
-    "token": "4caq-Qll7ksacYp0Wd_eW4VTQlLp28ODKfBWZrzNbeU",
-    "uri": "https://acme-staging.api.letsencrypt.org/acme/challenge/0GL_fUeZGnbxilMGbcUoAS3UOz_dK8q4TdxDgeCrOs0/55065930",
-    "type": "tls-sni-01"
-  },
-  "challenge_opts": null,
-  "authorization_type": "tls-sni-01",
-  "linked_service": "e2e/null/lb",
-  "service_deploy_id": "599eac26af8cd3000995b36d"
+    "id": "e2e/kontena.io",
+    "domain": "kontena.io",
+	"status": "deploying",
+	"challenge": {
+		"token": "Z6Q1SxXphm0WuwU0Khs6nMtQ2HBZGC-kIKCq8g8",
+		"uri": "https://acme-staging.api.letsencrypt.org/acme/challenge/rIxpgCmUlfthUME0an3fjZuxdNyNN0gOirk2lwo/561639",
+		"type": "tls-sni-01"
+	},
+	"challenge_opts": null,
+	"authorization_type": "tls-sni-01",
+	"linked_service": {
+		"id": "e2e/null/lb"
+	}
 }
 ```
 
-`challenge_opts` are challenge type specific details. For example in `dns-01` challenges there will be some DNS TXT records details.
+`challenge_opts` are challenge type specific details. For example in `dns-01` challenges there will be the DNS TXT records details.
+
+`status` can be any of the following:
+- `created`: authorization has been created, no firther actions yet taken
+- `deploying`: The related tls-sni certificate is currently being deployed to linked service. Only valid for tls-sni type of authorizations
+- `requested`: Authorization has been requested from Let's Encrypt
+- `validated`: Let's Encrypt has succesfully validated the challenge
+- `error`: Error has happened in the validation, re-authorization should be done
 
 ## Authorize domain
 

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -435,7 +435,7 @@ describe '/v1/grids', celluloid: true do
 
       it 'returns all domain authorizations' do
         grid.grid_domain_authorizations.create!(domain: 'foo.com', challenge: {:foo => :bar})
-        grid.grid_domain_authorizations.create!(domain: 'foobar.com', challenge: {:foo => :bar}, grid_service: db_service)
+        grid.grid_domain_authorizations.create!(domain: 'foobar.com', challenge: {:foo => :bar}, grid_service: db_service, grid_service_deploy: GridServiceDeploy.create!(grid_service: db_service))
         get "/v1/grids/#{grid.to_path}/domain_authorizations", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['domain_authorizations'].size).to eq(2)

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -439,7 +439,7 @@ describe '/v1/grids', celluloid: true do
         get "/v1/grids/#{grid.to_path}/domain_authorizations", nil, request_headers
         expect(response.status).to eq(200)
         expect(json_response['domain_authorizations'].size).to eq(2)
-        expect(json_response['domain_authorizations'].find {|a| a['domain'] == 'foobar.com'}['linked_service']).to eq(db_service.to_path)
+        expect(json_response['domain_authorizations'].find {|a| a['domain'] == 'foobar.com'}['linked_service']['id']).to eq(db_service.to_path)
       end
     end
   end

--- a/server/spec/api/v1/grids_spec.rb
+++ b/server/spec/api/v1/grids_spec.rb
@@ -423,6 +423,37 @@ describe '/v1/grids', celluloid: true do
         expect(json_response['logs'].size).to eq(2)
       end
     end
+
+    describe '/domain_authorizations' do
+      let(:grid) { david.grids.first }
+
+      it 'returns empty  array by default' do
+        get "/v1/grids/#{grid.to_path}/domain_authorizations", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response['domain_authorizations'].size).to eq(0)
+      end
+
+      it 'returns all domain authorizations' do
+        grid.grid_domain_authorizations.create!(domain: 'foo.com', challenge: {:foo => :bar})
+        grid.grid_domain_authorizations.create!(domain: 'foobar.com', challenge: {:foo => :bar}, grid_service: db_service)
+        get "/v1/grids/#{grid.to_path}/domain_authorizations", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response['domain_authorizations'].size).to eq(2)
+        expect(json_response['domain_authorizations'].find {|a| a['domain'] == 'foobar.com'}['linked_service']).to eq(db_service.to_path)
+      end
+    end
+  end
+
+  describe 'POST /domain_authorizations' do
+    let(:grid) { david.grids.first }
+
+    it 'creates new authorization' do
+      auth = grid.grid_domain_authorizations.create!(domain: 'foobar.com', challenge: {:foo => :bar}, grid_service: db_service)
+      outcome = double(:success? => true, :result => auth)
+      expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(outcome)
+      post "/v1/grids/#{grid.to_path}/domain_authorizations", {'domain' => 'foobar.com'}.to_json, request_headers
+      expect(response.status).to eq(201)
+    end
   end
 
   describe 'GET /metrics' do

--- a/server/spec/mutations/domain_authorizations/authorize_spec.rb
+++ b/server/spec/mutations/domain_authorizations/authorize_spec.rb
@@ -1,0 +1,102 @@
+
+describe GridDomainAuthorizations::Authorize do
+
+  let(:grid) {
+    grid = Grid.create!(name: 'test-grid')
+    grid
+  }
+
+  let(:acme) {
+    instance_double(Acme::Client)
+  }
+
+  before :each do
+    allow(subject).to receive(:acme_client).and_return(acme)
+  end
+
+  describe '#validate' do
+    it 'validates service existence when tls-sni used' do
+      mutation = described_class.new(grid: grid, domain: 'example.com', linked_service: 'non/existing', authorization_type: 'tls-sni-01')
+      expect(mutation.has_errors?).to be_truthy
+    end
+
+    it 'validates service existence when tls-sni used' do
+      GridService.create(grid: grid, name: 'web', image_name: 'web:latest')
+      mutation = described_class.new(grid: grid, domain: 'example.com', linked_service: 'null/web', authorization_type: 'tls-sni-01')
+      expect(mutation.has_errors?).to be_falsey
+    end
+
+  end
+
+  let(:subject) { described_class.new(grid: grid, domain: 'example.com') }
+
+  describe '#execute' do
+    context 'dns-01' do
+
+      let(:authz) {
+        challenge_opts = {
+          'record_name' => '_acme-challenge',
+          'record_content' => '1234567890'
+        }
+        GridDomainAuthorization.create(grid: grid, domain: 'example.com', challenge: {}, challenge_opts: challenge_opts)
+      }
+
+      it 'sends verification request and creates new authorization' do
+        auth = double({dns01: double(
+          {
+            record_name: '_acme_challenge',
+            record_type: 'TXT',
+            record_content: '123456789',
+            to_h: {}
+          })})
+        expect(acme).to receive(:authorize).with(domain: 'example.com').and_return(auth)
+
+
+        subject.execute
+        # Domain authorization is always inserted "fresh"
+        expect(GridDomainAuthorization.find_by(domain: 'example.com').id).not_to eq(authz.id)
+
+      end
+    end
+
+
+    it 'fails gracefully if no LE registration' do
+      expect(acme).to receive(:authorize).and_raise(Acme::Client::Error::Unauthorized)
+
+      expect {
+        outcome = subject.run
+        expect(outcome.success?).to be_falsey
+      }.not_to change{GridDomainAuthorization.count}
+
+    end
+
+
+  end
+
+  context 'tls-sni-01' do
+    let(:web) {
+      GridService.create(grid: grid, name: 'web', image_name: 'web:latest')
+    }
+
+    let(:subject) { described_class.new(grid: grid, domain: 'example.com', linked_service: 'null/web', authorization_type: 'tls-sni-01') }
+
+
+    it 'sends verification request and creates new authorization' do
+      web
+      auth = double(tls_sni01: double(
+        certificate: double(to_pem: 'CERTIFICATE'),
+        private_key: double(to_pem: 'PRIVATE_KEY'),
+        to_h: {}
+      ))
+      expect(acme).to receive(:authorize).with(domain: 'example.com').and_return(auth)
+
+      subject.validate
+      subject.execute
+
+      auth = grid.grid_domain_authorizations.find_by(domain: 'example.com')
+      expect(auth.service_deploy_id).not_to be_nil
+      expect(auth.tls_sni_certificate).to eq('CERTIFICATEPRIVATE_KEY')
+    end
+  end
+
+end

--- a/server/spec/mutations/domain_authorizations/authorize_spec.rb
+++ b/server/spec/mutations/domain_authorizations/authorize_spec.rb
@@ -57,6 +57,17 @@ describe GridDomainAuthorizations::Authorize do
         expect(GridDomainAuthorization.find_by(domain: 'example.com').id).not_to eq(authz.id)
 
       end
+
+      it 'fails if LE gives no challenge' do
+        auth = double(dns01: nil)
+        expect(acme).to receive(:authorize).with(domain: 'example.com').and_return(auth)
+
+        expect {
+          subject.execute
+          expect(subject.has_errors?).to be_truthy
+        }.not_to change{GridDomainAuthorization.count}
+
+      end
     end
 
 
@@ -69,7 +80,6 @@ describe GridDomainAuthorizations::Authorize do
       }.not_to change{GridDomainAuthorization.count}
 
     end
-
 
   end
 
@@ -97,6 +107,17 @@ describe GridDomainAuthorizations::Authorize do
       expect(auth.service_deploy_id).not_to be_nil
       expect(auth.tls_sni_certificate).to eq('CERTIFICATEPRIVATE_KEY')
     end
+
+    it 'fails if LE gives no challenge' do
+        auth = double(tls_sni01: nil)
+        expect(acme).to receive(:authorize).with(domain: 'example.com').and_return(auth)
+
+        expect {
+          subject.execute
+          expect(subject.has_errors?).to be_truthy
+        }.not_to change{GridDomainAuthorization.count}
+
+      end
   end
 
 end

--- a/server/spec/mutations/domain_authorizations/authorize_spec.rb
+++ b/server/spec/mutations/domain_authorizations/authorize_spec.rb
@@ -107,7 +107,7 @@ describe GridDomainAuthorizations::Authorize do
       subject.execute
 
       auth = grid.grid_domain_authorizations.find_by(domain: 'example.com')
-      expect(auth.service_deploy_id).not_to be_nil
+      expect(auth.grid_service_deploy).not_to be_nil
       expect(auth.tls_sni_certificate).to eq('CERTIFICATEPRIVATE_KEY')
     end
 

--- a/server/spec/mutations/domain_authorizations/authorize_spec.rb
+++ b/server/spec/mutations/domain_authorizations/authorize_spec.rb
@@ -26,7 +26,6 @@ describe GridDomainAuthorizations::Authorize do
       GridSecret.find_by(name: 'LE_PRIVATE_KEY').destroy
       outcome = described_class.validate(grid: grid, domain: 'example.com', authorization_type: 'dns-01')
       expect(outcome).not_to be_success
-      puts outcome.errors.message
       expect(outcome.errors.message['le_registration']).to eq('Let\'s Encrypt registration missing')
     end
 

--- a/server/spec/mutations/grid_certificates/get_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/get_certificate_spec.rb
@@ -4,17 +4,15 @@ describe GridCertificates::GetCertificate do
   let(:subject) { described_class.new(grid: grid, secret_name: 'secret', domains: ['example.com']) }
 
   let(:grid) {
-    grid = Grid.create!(name: 'test-grid')
-    grid
+    Grid.create!(name: 'test-grid')
   }
 
   let(:authz) {
-    challenge_opts = {
+    opts = {
       'record_name' => '_acme-challenge',
       'record_content' => '1234567890'
     }
-    authz = GridDomainAuthorization.create(grid: grid, domain: 'example.com', challenge: {}, challenge_opts: challenge_opts)
-    authz
+    GridDomainAuthorization.create!(grid: grid, domain: 'example.com', authorization_type: 'dns-01', challenge: nil, challenge_opts: opts)
   }
 
   describe '#validate' do
@@ -34,18 +32,24 @@ describe GridCertificates::GetCertificate do
       expect(outcome.errors.symbolic).to eq 'cert_type' => :in
     end
 
-    it 'fails validation in domain challenge' do
-      authz
-      expect(subject).to receive(:validate_dns_record).and_return(false)
-      subject.validate
-      expect(subject.has_errors?).to be_truthy
+    context 'dns-01' do
+      it 'fails validation in domain challenge' do
+        authz
+        expect(subject).to receive(:validate_dns_record).and_return(false)
+        subject.validate
+        expect(subject.has_errors?).to be_truthy
+      end
+
+      it 'validates domain challenge' do
+        authz
+        expect(subject).to receive(:validate_dns_record).and_return(true)
+        outcome = subject.validate
+        expect(subject.has_errors?).to be_truthy
+      end
     end
 
-    it 'validates domain challenge' do
-      authz
-      expect(subject).to receive(:validate_dns_record).and_return(true)
-      outcome = subject.validate
-      expect(subject.has_errors?).to be_truthy
+    context 'tls-sni-01' do
+
     end
 
   end
@@ -67,7 +71,7 @@ describe GridCertificates::GetCertificate do
           fullchain_to_pem: 'fullchain'
         }))
       expect(challenge).to receive(:request_verification).and_return(true)
-      expect(challenge).to receive(:verify_status).and_return('valid')
+      expect(challenge).to receive(:verify_status).and_return('valid', 'valid')
       expect(subject).to receive(:upsert_secret).exactly(3).times.and_return(double({success?: true}))
 
       subject.execute
@@ -90,7 +94,7 @@ describe GridCertificates::GetCertificate do
           )
         }))
       expect(challenge).to receive(:request_verification).and_return(true)
-      expect(challenge).to receive(:verify_status).and_return('valid')
+      expect(challenge).to receive(:verify_status).and_return('valid', 'valid')
       expect(subject).to receive(:upsert_secret).exactly(3).times.and_return(double({success?: true}))
 
       subject.execute
@@ -113,7 +117,7 @@ describe GridCertificates::GetCertificate do
           chain_to_pem: 'chain'
         }))
       expect(challenge).to receive(:request_verification).and_return(true)
-      expect(challenge).to receive(:verify_status).and_return('valid')
+      expect(challenge).to receive(:verify_status).and_return('valid', 'valid')
       expect(subject).to receive(:upsert_secret).exactly(3).times.and_return(double({success?: true}))
 
       subject.execute


### PR DESCRIPTION
replaces #2565 

This makes it possible to build better support for certs and automated renewal on top of these.

## TODO

- [ ] API docs
- [x] moar specs