### PR TITLE
New certificate model, API, service YAML

### DIFF
--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -4,16 +4,29 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
+    BANNER = "This command is now deprecated in favor of 'kontena certificate request' command".colorize(:red)
+
+    banner BANNER
+
+    option '--secret-name', 'SECRET_NAME', 'The name for the secret to store the certificate in'
+    option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain, chain or cert', default: 'fullchain'
     parameter "DOMAIN ...", "Domain(s) to get certificate for"
 
+
     def execute
+      puts BANNER
+
       require_api_url
       token = require_token
-      data = {domains: domain_list}
+      secret = secret_name || "LE_CERTIFICATE_#{domain_list[0].gsub('.', '_')}"
+      data = {domains: domain_list, secret_name: secret}
 
-      spinner "Requesting certificate for #{domain_list.join(',').colorize(:cyan)} " do
-        response = client(token).post("grids/#{current_grid}/certificates", data)
+      response = client(token).post("certificates/#{current_grid}/certificate", data)
+      puts "Certificate successfully received and stored into vault with keys:"
+      response.each do |secret|
+        puts secret.colorize(:green)
       end
+      puts "Use the #{secret}_BUNDLE with Kontena loadbalancer!"
 
     end
   end

--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -4,23 +4,19 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-
-    option '--secret-name', 'SECRET_NAME', 'The name for the secret to store the certificate in'
-    option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain, chain or cert', default: 'fullchain'
+    option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain or cert', default: 'fullchain'
     parameter "DOMAIN ...", "Domain(s) to get certificate for"
 
 
     def execute
       require_api_url
       token = require_token
-      secret = secret_name || "LE_CERTIFICATE_#{domain_list[0].gsub('.', '_')}"
-      data = {domains: domain_list, secret_name: secret}
-      response = client(token).post("certificates/#{current_grid}/certificate", data)
-      puts "Certificate successfully received and stored into vault with keys:"
-      response.each do |secret|
-        puts secret.colorize(:green)
+      data = {domains: domain_list, cert_type: cert_type}
+
+      spinner "Requesting certificate for #{domain_list.join(',').colorize(:cyan)} " do
+        response = client(token).post("grids/#{current_grid}/certificates", data)
       end
-      puts "Use the #{secret}_BUNDLE with Kontena loadbalancer!"
+
     end
   end
 end

--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -4,14 +4,12 @@ module Kontena::Cli::Certificate
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    option '--cert-type', 'CERT_TYPE', 'The type of certificate to get: fullchain or cert', default: 'fullchain'
     parameter "DOMAIN ...", "Domain(s) to get certificate for"
-
 
     def execute
       require_api_url
       token = require_token
-      data = {domains: domain_list, cert_type: cert_type}
+      data = {domains: domain_list}
 
       spinner "Requesting certificate for #{domain_list.join(',').colorize(:cyan)} " do
         response = client(token).post("grids/#{current_grid}/certificates", data)

--- a/cli/lib/kontena/cli/certificate/list_command.rb
+++ b/cli/lib/kontena/cli/certificate/list_command.rb
@@ -1,0 +1,75 @@
+require_relative '../services/services_helper'
+
+module Kontena::Cli::Certificate
+  class ListCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Kontena::Cli::TableGenerator::Helper
+    include Kontena::Util
+
+    requires_current_master
+    requires_current_master_token
+    requires_current_grid
+
+    SEVEN_DAYS = 7 * 24 * 60 * 60
+    THREE_DAYS = 3 * 24 * 60 * 60
+
+    def fields
+      quiet? ? ['subject'] : {subject: 'subject', "expiration" => 'expires_in'}
+    end
+
+    def certificates
+      client.get("grids/#{current_grid}/certificates")['certificates']
+    end
+
+    def status_icon(expires_in)
+      icon = '⊛'.freeze
+
+      if expires_in < 0
+        icon.colorize(:red)
+      else
+        icon.colorize(:green)
+      end
+
+    end
+
+    def status_color(expires_in)
+
+      if expires_in < 0
+        :red
+      elsif expires_in < THREE_DAYS
+        :bright_yellow
+      elsif expires_in < SEVEN_DAYS
+        :yellow
+      else
+        :green
+      end
+
+    end
+
+    def expires_in(certificate)
+      valid_until = Time.parse(certificate['valid_until'])
+      (valid_until - Time.now).to_i
+    end
+
+    def expires_in_human(expires_in)
+      if expires_in > 0
+        text = seconds_to_human(expires_in)
+      else
+        text = seconds_to_human(-1 * expires_in) + ' ago'
+      end
+
+      text.colorize(status_color(expires_in))
+    end
+
+    def execute
+      print_table(certificates) do |certificate|
+        expires_in = expires_in(certificate)
+        certificate['subject'] = status_icon(expires_in) + " " + certificate['subject'] unless quiet?
+        next if quiet? # No need to fiddle with colors when they will not get printed
+        certificate['expires_in'] = expires_in_human(expires_in)
+      end
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/certificate/request_command.rb
+++ b/cli/lib/kontena/cli/certificate/request_command.rb
@@ -1,0 +1,20 @@
+
+module Kontena::Cli::Certificate
+  class RequestCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+
+    parameter "DOMAIN ...", "Domain(s) to get certificate for"
+
+    def execute
+      require_api_url
+      token = require_token
+      data = {domains: domain_list}
+
+      spinner "Requesting certificate for #{domain_list.join(',').colorize(:cyan)} " do
+        response = client(token).post("grids/#{current_grid}/certificates", data)
+      end
+
+    end
+  end
+end

--- a/cli/lib/kontena/cli/certificate/show_command.rb
+++ b/cli/lib/kontena/cli/certificate/show_command.rb
@@ -1,0 +1,19 @@
+require_relative '../services/services_helper'
+
+module Kontena::Cli::Certificate
+  class ShowCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+
+    parameter "SUBJECT", "Certificate subject"
+
+    requires_current_master
+    requires_current_master_token
+    requires_current_grid
+
+    def execute
+      certificate = client.get("certificates/#{current_grid}/#{self.subject}")
+      puts YAML.dump(certificate)
+    end
+  end
+end

--- a/cli/lib/kontena/cli/certificate_command.rb
+++ b/cli/lib/kontena/cli/certificate_command.rb
@@ -1,10 +1,12 @@
 
 class Kontena::Cli::CertificateCommand < Kontena::Command
 
-
+  subcommand ["list", "ls"], "List certificates", load_subcommand('certificate/list_command')
+  subcommand "show", "Show certificate details", load_subcommand('certificate/show_command')
   subcommand "register", "Register to LetsEncrypt", load_subcommand('certificate/register_command')
   subcommand "authorize", "Create DNS authorization for domain", load_subcommand('certificate/authorize_command')
   subcommand "get", "Get certificate for domain", load_subcommand('certificate/get_command')
+
 
   def execute
   end

--- a/cli/lib/kontena/cli/certificate_command.rb
+++ b/cli/lib/kontena/cli/certificate_command.rb
@@ -5,6 +5,7 @@ class Kontena::Cli::CertificateCommand < Kontena::Command
   subcommand "show", "Show certificate details", load_subcommand('certificate/show_command')
   subcommand "register", "Register to LetsEncrypt", load_subcommand('certificate/register_command')
   subcommand "authorize", "Create DNS authorization for domain", load_subcommand('certificate/authorize_command')
+  subcommand "request", "Request certificate for domain", load_subcommand('certificate/request_command')
   subcommand "get", "Get certificate for domain", load_subcommand('certificate/get_command')
 
 

--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -62,6 +62,7 @@ module Kontena::Cli::Stacks
       data['deploy_opts'] = deploy
       data['hooks'] = options['hooks'] || {}
       data['secrets'] = options['secrets'] if options['secrets']
+      data['certificates'] = options['certificates'] if options['certificates']
       data['build'] = parse_build_options(options) if options['build']
       data['health_check'] = parse_health_check(options)
       data['stop_grace_period'] = options['stop_grace_period'] if options['stop_grace_period']

--- a/cli/lib/kontena/cli/stacks/yaml/custom_validators/certificates_validator.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/custom_validators/certificates_validator.rb
@@ -1,0 +1,22 @@
+module Kontena::Cli::Stacks::YAML::Validations::CustomValidators
+  class CertificatesValidator < HashValidator::Validator::Base
+    def initialize
+      super('stacks_valid_certificates')
+    end
+
+    def validate(key, value, validations, errors)
+      unless value.is_a?(Array)
+        errors[key] = 'certificates must be array'
+        return
+      end
+      certificate_item_validation = {
+        'subject' => 'string',
+        'name' => 'string',
+        'type' => 'string'
+      }
+      value.each do |certificate|
+        HashValidator.validator_for(certificate_item_validation).validate(key, certificate, certificate_item_validation, errors)
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -6,6 +6,7 @@ module Kontena::Cli::Stacks::YAML
      require_relative 'custom_validators/extends_validator'
      require_relative 'custom_validators/hooks_validator'
      require_relative 'custom_validators/secrets_validator'
+     require_relative 'custom_validators/certificates_validator'
 
      def self.load
        return if @loaded
@@ -13,6 +14,7 @@ module Kontena::Cli::Stacks::YAML
        HashValidator.append_validator(BuildValidator.new)
        HashValidator.append_validator(ExtendsValidator.new)
        HashValidator.append_validator(SecretsValidator.new)
+       HashValidator.append_validator(CertificatesValidator.new)
        HashValidator.append_validator(HooksValidator.new)
        @loaded = true
      end
@@ -59,6 +61,7 @@ module Kontena::Cli::Stacks::YAML
         'volumes' => optional('array'),
         'volumes_from' => optional('array'),
         'secrets' => optional('stacks_valid_secrets'),
+        'certificates' => optional('stacks_valid_certificates'),
         'hooks' => optional('stacks_valid_hooks'),
         'only_if' => optional(-> (value) { value.is_a?(String) || value.is_a?(Hash) || value.is_a?(Array) }),
         'skip_if' => optional(-> (value) { value.is_a?(String) || value.is_a?(Hash) || value.is_a?(Array) }),

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -335,6 +335,25 @@ describe Kontena::Cli::Stacks::YAML::ValidatorV3 do
         end
       end
     end
+
+    context 'certificates' do
+      it 'validates certificates is array' do
+        result = subject.validate_options('certificates' => 'kontena.io')
+        expect(result.errors.key?('certificates')).to be_truthy
+
+        result = subject.validate_options('certificates' => [])
+        expect(result.errors.key?('certificates')).to be_falsey
+      end
+
+      it 'validates certificates has all needed keys' do
+        result = subject.validate_options('certificates' => [{}])
+        expect(result.errors.key?('certificates')).to be_truthy
+        expect(result.errors['certificates'].has_key?('subject')).to be_truthy
+        expect(result.errors['certificates'].has_key?('name')).to be_truthy
+        expect(result.errors['certificates'].has_key?('type')).to be_truthy
+      end
+
+    end
   end
 
   describe '#validate' do

--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -1,0 +1,24 @@
+class Certificate
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :subject, type: String
+  field :valid_until, type: DateTime
+  field :alt_names, type: Array
+  field :encrypted_private_key, type: String, encrypted: true # PEM encoded
+  field :certificate, type: String # PEM encoded certificate, no need to encrypt
+
+  belongs_to :grid
+
+  validates_presence_of :subject, :valid_until
+  validates_uniqueness_of :subject, scope: [:grid_id]
+
+  index({ grid_id: 1 })
+  index({ subject: 1 })
+  index({ grid_id: 1, subject: 1 }, {unique: true})
+
+  def to_path
+    "#{self.grid.name}/#{self.subject}"
+  end
+
+end

--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -7,6 +7,8 @@ class Certificate
   field :alt_names, type: Array
   field :encrypted_private_key, type: String, encrypted: true # PEM encoded
   field :certificate, type: String # PEM encoded certificate, no need to encrypt
+  field :chain, type: String
+  field :full_chain, type: String
 
   belongs_to :grid
 

--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -7,8 +7,7 @@ class Certificate
   field :alt_names, type: Array
   field :encrypted_private_key, type: String, encrypted: true # PEM encoded
   field :certificate, type: String # PEM encoded certificate, no need to encrypt
-  field :chain, type: String
-  field :full_chain, type: String
+  field :chain, type: String # Trust chain
 
   belongs_to :grid
 
@@ -21,6 +20,14 @@ class Certificate
 
   def to_path
     "#{self.grid.name}/#{self.subject}"
+  end
+
+  def full_chain
+    self.certificate + self.chain
+  end
+
+  def bundle
+    self.full_chain + self.private_key
   end
 
 end

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -35,6 +35,7 @@ class Grid
   has_many :grid_domain_authorizations, dependent: :delete
   has_many :networks, dependent: :delete
   has_many :volumes, dependent: :destroy
+  has_many :certificates
   has_and_belongs_to_many :users
   embeds_one :grid_logs_opts, class_name: 'GridLogsOpts'
 

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -57,6 +57,7 @@ class GridService
   embeds_many :hooks, class_name: 'GridServiceHook'
   embeds_many :secrets, class_name: 'GridServiceSecret'
   embeds_many :service_volumes, class_name: 'ServiceVolume'
+  embeds_many :certificates, class_name: 'GridServiceCertificate'
   embeds_one :deploy_opts, class_name: 'GridServiceDeployOpt', autobuild: true
   embeds_one :health_check, class_name: 'GridServiceHealthCheck'
 

--- a/server/app/models/grid_service_certificate.rb
+++ b/server/app/models/grid_service_certificate.rb
@@ -1,0 +1,9 @@
+class GridServiceCertificate
+  include Mongoid::Document
+
+  field :subject, type: String # To identify the cert object
+  field :name, type: String, default: 'SSL_CERTS'
+  field :type, type: String, default: 'env' # For future use where we could expose certs as files
+
+  embedded_in :grid_service
+end

--- a/server/app/mutations/grid_certificates/common.rb
+++ b/server/app/mutations/grid_certificates/common.rb
@@ -54,5 +54,15 @@ module GridCertificates
 
       stack.grid_services.find_by(name: service)
     end
+
+    def validate_dns_record(domain, expected_record)
+      resolv = Resolv::DNS.new()
+      info "validating domain:_acme-challenge.#{domain}"
+      resource = resolv.getresource("_acme-challenge.#{domain}", Resolv::DNS::Resource::IN::TXT)
+      info "got record: #{resource.strings}, expected: #{expected_record}"
+      expected_record == resource.strings[0]
+    rescue
+      false
+    end
   end
 end

--- a/server/app/mutations/grid_certificates/get_certificate.rb
+++ b/server/app/mutations/grid_certificates/get_certificate.rb
@@ -3,6 +3,11 @@ require 'timeout'
 require_relative 'common'
 require_relative '../../services/logging'
 
+# DEPRECATED
+#
+# This mutation deals with the "legacy" mode of operation and stores certs as secrets.
+# As the old API will still be around for some time so will this mutation.
+#
 module GridCertificates
   class GetCertificate < Mutations::Command
     include Common
@@ -116,16 +121,6 @@ module GridCertificates
         return
       end
       outcome.result
-    end
-
-    def validate_dns_record(domain, expected_record)
-      resolv = Resolv::DNS.new()
-      info "validating domain:_acme-challenge.#{domain}"
-      resource = resolv.getresource("_acme-challenge.#{domain}", Resolv::DNS::Resource::IN::TXT)
-      info "got record: #{resource.strings}, expected: #{expected_record}"
-      expected_record == resource.strings[0]
-    rescue
-      false
     end
   end
 end

--- a/server/app/mutations/grid_certificates/request_certificate.rb
+++ b/server/app/mutations/grid_certificates/request_certificate.rb
@@ -94,7 +94,6 @@ module GridCertificates
         certificate_model.private_key = certificate.request.private_key.to_pem
         certificate_model.certificate = certificate.to_pem
         certificate_model.chain = certificate.chain_to_pem
-        certificate_model.full_chain = certificate.fullchain_to_pem
 
         certificate_model.save
       else
@@ -105,8 +104,7 @@ module GridCertificates
           valid_until: certificate.x509.not_after,
           private_key: certificate.request.private_key.to_pem,
           certificate: certificate.to_pem,
-          chain: certificate.chain_to_pem,
-          full_chain: certificate.fullchain_to_pem
+          chain: certificate.chain_to_pem
         )
       end
 

--- a/server/app/mutations/grid_certificates/request_certificate.rb
+++ b/server/app/mutations/grid_certificates/request_certificate.rb
@@ -1,0 +1,128 @@
+require 'timeout'
+
+require_relative 'common'
+require_relative '../../services/logging'
+
+module GridCertificates
+  class RequestCertificate < Mutations::Command
+    include Common
+    include Logging
+    include WaitHelper
+
+    required do
+      model :grid, class: Grid
+
+      array :domains do
+        string
+      end
+      string :cert_type, in: ['cert', 'fullchain'], default: 'fullchain'
+    end
+
+    optional do
+      array :linked_services do
+        string
+      end
+    end
+
+    def validate
+      self.domains.each do |domain|
+        domain_authz = get_authz_for_domain(self.grid, domain)
+
+        if domain_authz
+          if domain_authz.authorization_type == 'dns-01'
+            # Check that the expected DNS record is already in place
+            unless validate_dns_record(domain, domain_authz.challenge_opts['record_content'])
+              add_error(:dns_record, :invalid, "Expected DNS record not present for domain #{domain}")
+            end
+          end
+        else
+          add_error(:authorization, :not_found, "Domain authorization not found for domain #{domain}")
+        end
+
+      end
+    end
+
+    def verify_domain(domain)
+      domain_authorization = get_authz_for_domain(self.grid, domain)
+      challenge = le_client.challenge_from_hash(domain_authorization.challenge)
+      if domain_authorization.state == :created
+        info 'requesting verification for domain #{domain}'
+        success = challenge.request_verification
+        if success
+          domain_authorization.state = :requested
+          domain_authorization.save
+        else
+          add_error(:request_verification, :failed, "Requesting verification failed")
+        end
+      end
+
+      wait_until!("domain verification for #{domain} is valid", interval: 1, timeout: 30, threshold: 10) {
+        challenge.verify_status != 'pending'
+      }
+
+      case challenge.verify_status
+      when 'valid'
+        domain_authorization.state = :validated
+      when 'invalid'
+        domain_authorization.state = :invalid
+        add_error(:challenge, :invalid, challenge.error['detail'])
+      end
+
+      domain_authorization.save
+    rescue Timeout::Error
+      warn 'timeout while waiting for DNS verfication status'
+      add_error(:challenge_verify, :timeout, 'Challenge verification timeout')
+    rescue Acme::Client::Error => exc
+      error exc
+      add_error(:acme_client, :error, exc.message)
+    end
+
+    def has_errors?
+      return true if @errors && @errors.size > 0
+      false
+    end
+
+    def execute
+
+      self.domains.each do |domain|
+        verify_domain(domain)
+      end
+
+      # some domain verifications has failed, errors already added
+      return if has_errors?
+
+      csr = Acme::Client::CertificateRequest.new(names: self.domains)
+      certificate = le_client.new_certificate(csr)
+      cert_priv_key = certificate.request.private_key.to_pem
+      certificate_pem = nil
+      case self.cert_type
+        when 'fullchain'
+          certificate_pem = certificate.fullchain_to_pem
+        when 'cert'
+          certificate_pem = certificate.to_pem
+      end
+
+      certificate_model = Certificate.create!(
+        grid: self.grid,
+        subject: self.domains[0],
+        alt_names: self.domains[1..-1],
+        valid_until: certificate.x509.not_after,
+        private_key: cert_priv_key,
+        certificate: certificate_pem
+      )
+
+      certificate_model
+
+    rescue Acme::Client::Error => exc
+      error exc
+      add_error(:acme_client, :error, exc.message)
+    end
+
+
+    def le_client
+      @le_client ||= acme_client(self.grid)
+    end
+
+  end
+end
+

--- a/server/app/mutations/grid_certificates/request_certificate.rb
+++ b/server/app/mutations/grid_certificates/request_certificate.rb
@@ -11,14 +11,7 @@ module GridCertificates
 
     required do
       model :grid, class: Grid
-
       array :domains do
-        string
-      end
-    end
-
-    optional do
-      array :linked_services do
         string
       end
     end
@@ -45,7 +38,7 @@ module GridCertificates
       domain_authorization = get_authz_for_domain(self.grid, domain)
       challenge = le_client.challenge_from_hash(domain_authorization.challenge)
       if domain_authorization.state == :created
-        info 'requesting verification for domain #{domain}'
+        info "requesting verification for domain #{domain}"
         success = challenge.request_verification
         if success
           domain_authorization.state = :requested

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -96,7 +96,7 @@ module GridServices
       service_certificates = []
       self.certificates.each do |certificate|
         service_certificate = existing_certificates.find{ |c|
-          c.subject == secret['subject'] && c.name == secret['name']
+          c.subject == certificate['subject'] && c.name == certificate['name']
         }
         unless service_certificate
           service_certificate = GridServiceCertificate.new(

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -91,6 +91,25 @@ module GridServices
       service_secrets
     end
 
+    # @return [Array<GridServiceCertificate>]
+    def build_grid_service_certificates(existing_certificates)
+      service_certificates = []
+      self.certificates.each do |certificate|
+        service_certificate = existing_certificates.find{ |c|
+          c.subject == secret['subject'] && c.name == secret['name']
+        }
+        unless service_certificate
+          service_certificate = GridServiceCertificate.new(
+              subject: certificate['subject'],
+              name: certificate['name']
+          )
+        end
+        service_certificates << service_certificate
+      end
+
+      service_certificates
+    end
+
     def build_service_volumes(existing_volumes, grid, stack)
       service_volumes = []
       self.volumes.each do |vol|
@@ -147,6 +166,18 @@ module GridServices
       end
     end
 
+    # Validates that the defined certificates exist
+    def validate_certificates
+      validate_each :certificates do |c|
+        cert = self.grid.certificates.find_by(subject: c[:subject])
+        unless cert
+          [:not_found, "Certificate #{c[:subject]} does not exist"]
+        else
+          nil
+        end
+      end
+    end
+
     # @param volume [String]
     # @return [Array{Symbol, String}] for validate_each
     def validate_volume(volume, stateful_volumes: nil)
@@ -192,6 +223,14 @@ module GridServices
             hash do
               required do
                 string :secret
+                string :name
+              end
+            end
+          end
+          array :certificates do
+            hash do
+              required do
+                string :subject
                 string :name
               end
             end

--- a/server/app/mutations/grid_services/create.rb
+++ b/server/app/mutations/grid_services/create.rb
@@ -32,6 +32,7 @@ module GridServices
         add_error(:health_check, :invalid, 'Interval has to be bigger than timeout')
       end
       validate_secrets
+      validate_certificates
       validate_volumes
     end
 
@@ -55,6 +56,12 @@ module GridServices
       if self.secrets
         attributes[:secrets] = self.build_grid_service_secrets([])
       end
+
+      attributes.delete(:certificates)
+      if self.certificates
+        attributes[:certificates] = self.build_grid_service_certificates([])
+      end
+
       # Attach to default network
       if self.net == 'bridge' || self.net.nil?
         default_net = self.grid.networks.find_by(name: 'kontena')

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -104,6 +104,12 @@ module GridServices
         )
         embeds_changed ||= attributes[:service_volumes] != self.grid_service.service_volumes.to_a
       end
+      if self.certificates
+        attributes[:certificates] = self.build_grid_service_certificates(self.grid_service.certificates.to_a)
+        embeds_changed ||= attributes[:certificates] != self.grid_service.certificates.to_a
+      end
+
+
       grid_service.attributes = attributes
 
       if grid_service.changed? || embeds_changed

--- a/server/app/routes/v1/certificates_api.rb
+++ b/server/app/routes/v1/certificates_api.rb
@@ -60,6 +60,19 @@ module V1
 
         load_grid(grid)
 
+        r.get do
+          r.on ':subject' do |subject|
+            @certificate = @grid.certificates.find_by(subject: subject)
+            if @certificate
+              response.status = 200
+              render('certificates/show')
+            else
+              response.status = 404
+              {error: 'Not found'}
+            end
+          end
+        end
+
         r.post do
           # DEPRECATED
           r.on 'authorize' do

--- a/server/app/routes/v1/grids/grid_certificates.rb
+++ b/server/app/routes/v1/grids/grid_certificates.rb
@@ -1,0 +1,28 @@
+
+V1::GridsApi.route('grid_certificates') do |r|
+
+  # POST /v1/grids/:name/certificates
+  r.post do
+    data = parse_json_body
+    data[:grid] = @grid
+    outcome = GridCertificates::RequestCertificate.run(data)
+    if outcome.success?
+      response.status = 201
+      @certificate = outcome.result
+      audit_event(r, @grid, @certificate, 'create', @certificate)
+      render('certificates/show')
+    else
+      response.status = 422
+      {error: outcome.errors.message}
+    end
+  end
+
+  # GET /v1/grids/:name/certificates
+  r.get do
+    r.is do
+      @certificates = @grid.certificates
+      render('certificates/index')
+    end
+  end
+
+end

--- a/server/app/routes/v1/grids_api.rb
+++ b/server/app/routes/v1/grids_api.rb
@@ -105,6 +105,11 @@ module V1
           r.route 'grid_domain_authorizations'
         end
 
+        # /v1/grids/:name/certificates
+        r.on 'certificates' do
+          r.route 'grid_certificates'
+        end
+
         r.get do
           r.is do
             render('grids/show')

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -78,7 +78,7 @@ module Rpc
         grid_cert = grid.certificates.find_by(subject: certificate.subject)
         item = {name: certificate.name, type: certificate.type, value: nil}
         if grid_cert
-          item[:value] = [grid_cert.certificate, grid_cert.private_key].join
+          item[:value] = [grid_cert.full_chain, grid_cert.private_key].join
         end
         secrets << item
       end

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -78,7 +78,7 @@ module Rpc
         grid_cert = grid.certificates.find_by(subject: certificate.subject)
         item = {name: certificate.name, type: certificate.type, value: nil}
         if grid_cert
-          item[:value] = [grid_cert.full_chain, grid_cert.private_key].join
+          item[:value] = grid_cert.bundle
         end
         secrets << item
       end

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -73,6 +73,16 @@ module Rpc
         secrets << {name: "SSL_CERTS", type: 'env', value: domain_auth.tls_sni_certificate}
       end
 
+      # Inject certificates as secrets
+      service.certificates.each do |certificate|
+        grid_cert = grid.certificates.find_by(subject: certificate.subject)
+        item = {name: certificate.name, type: certificate.type, value: nil}
+        if grid_cert
+          item[:value] = [grid_cert.certificate, grid_cert.private_key].join
+        end
+        secrets << item
+      end
+
       secrets
     end
 

--- a/server/app/views/v1/certificates/_certificate.json.jbuilder
+++ b/server/app/views/v1/certificates/_certificate.json.jbuilder
@@ -1,0 +1,4 @@
+json.id certificate.to_path
+json.subject certificate.subject
+json.valid_until certificate.valid_until
+json.alt_names certificate.alt_names

--- a/server/app/views/v1/certificates/index.json.jbuilder
+++ b/server/app/views/v1/certificates/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.certificates @certificates do |certificate|
+  json.partial! 'app/views/v1/certificates/certificate', certificate: certificate
+end

--- a/server/app/views/v1/certificates/show.json.jbuilder
+++ b/server/app/views/v1/certificates/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'app/views/v1/certificates/certificate', certificate: @certificate

--- a/server/spec/api/v1/certificates_spec.rb
+++ b/server/spec/api/v1/certificates_spec.rb
@@ -1,0 +1,90 @@
+describe '/v1/containers' do
+
+  let(:request_headers) do
+    {
+        'HTTP_AUTHORIZATION' => "Bearer #{valid_token.token_plain}"
+    }
+  end
+
+  let(:grid) do
+    Grid.create!(name: 'terminal-a')
+  end
+
+  let(:david) do
+    user = User.create!(email: 'david@domain.com', external_id: '123456')
+    grid.users << user
+
+    user
+  end
+
+  let(:valid_token) do
+    AccessToken.create!(user: david, scopes: ['user'])
+  end
+
+  let(:certificate) do
+    Certificate.create!(
+        grid: grid,
+        subject: 'kontena.io',
+        alt_names: [],
+        valid_until: Time.now + 90.days,
+        private_key: 'private_key',
+        certificate: 'certificate_pem'
+      )
+  end
+
+  describe 'POST /v1/grids/<grid>/certificates' do
+    it 'requests new certificate' do
+      outcome = double(
+        :success? => true,
+        :result => certificate
+      )
+
+      expect(GridCertificates::RequestCertificate).to receive(:run).and_return(outcome)
+      data = {
+        domains: ['kontena.io']
+      }
+      post "/v1/grids/#{grid.name}/certificates", data.to_json, request_headers
+      expect(response.status).to eq(201), response.body
+      expect(json_response['subject']).to eq('kontena.io')
+    end
+
+    it 'fails in requesting new certificate' do
+      outcome = double(
+        :success? => false,
+        :result => certificate,
+        :errors => double(:message => 'kaboom')
+      )
+      expect(GridCertificates::RequestCertificate).to receive(:run).and_return(outcome)
+      post "/v1/grids/#{grid.name}/certificates", {}, request_headers
+      expect(response.status).to eq(422), response.body
+      expect(json_response['error']).to eq('kaboom')
+    end
+  end
+
+  describe 'GET /v1/grids/<grid>/certificates' do
+    it 'gets all certs' do
+      certificate
+      get "/v1/grids/#{grid.name}/certificates", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['certificates'].size).to eq(1)
+      expect(json_response['certificates'][0]['subject']).to eq('kontena.io')
+    end
+  end
+
+  describe 'GET /v1/certificates/<grid>/<subject>' do
+    it 'gets a certificate' do
+      certificate
+      get "/v1/certificates/#{grid.name}/kontena.io", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['subject']).to eq('kontena.io')
+      expect(json_response['id']).to eq("#{grid.name}/kontena.io")
+    end
+
+    it '404 for non-existing cert' do
+      get "/v1/certificates/#{grid.name}/foobar.io", nil, request_headers
+      expect(response.status).to eq(404)
+    end
+  end
+
+
+end

--- a/server/spec/api/v1/certificates_spec.rb
+++ b/server/spec/api/v1/certificates_spec.rb
@@ -1,4 +1,4 @@
-describe '/v1/containers' do
+describe '/v1/certificates' do
 
   let(:request_headers) do
     {

--- a/server/spec/mutations/grid_certificates/request_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/request_certificate_spec.rb
@@ -29,17 +29,6 @@ describe GridCertificates::RequestCertificate do
       expect(subject.has_errors?).to be_truthy
     end
 
-    it 'rejects invalid cert type' do
-      outcome = described_class.run(grid: grid, secret_name: 'secret', domains: ['example.com'], cert_type: 'foo')
-      expect(outcome).to_not be_success
-      expect(outcome.errors.symbolic).to eq 'cert_type' => :in
-    end
-    it 'rejects invalid multi-line cert type ' do
-      outcome = described_class.run(grid: grid, secret_name: 'secret', domains: ['example.com'], cert_type: "cert\nfoobar")
-      expect(outcome).to_not be_success
-      expect(outcome.errors.symbolic).to eq 'cert_type' => :in
-    end
-
     context 'dns-01' do
 
       it 'fails validation in domain challenge' do
@@ -58,7 +47,7 @@ describe GridCertificates::RequestCertificate do
     end
 
     context 'tls-sni-01' do
-      # As of now there no specific validations for tls-sni verification
+      # As of now there's no specific validations for tls-sni verification
     end
 
   end
@@ -113,7 +102,7 @@ describe GridCertificates::RequestCertificate do
             private_key: double({to_pem: 'private_key'})
           }
         ),
-        chain_to_pem: 'chain_certificate',
+        chain_to_pem: 'chain',
         fullchain_to_pem: 'fullchain',
         to_pem: 'certificate_only',
         x509: double(:not_after => Time.now + 90.days)
@@ -127,7 +116,9 @@ describe GridCertificates::RequestCertificate do
         expect(c.valid_until).not_to be_nil
         expect(c.alt_names).to be_empty
         expect(c.private_key).to eq('private_key')
-        expect(c.certificate).to eq('fullchain')
+        expect(c.certificate).to eq('certificate_only')
+        expect(c.chain).to eq('chain')
+        expect(c.full_chain).to eq('fullchain')
       }.to change {grid.certificates.count}.by (1)
     end
 

--- a/server/spec/mutations/grid_certificates/request_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/request_certificate_spec.rb
@@ -122,17 +122,12 @@ describe GridCertificates::RequestCertificate do
       }.to change {grid.certificates.count}.by (1)
     end
 
-    it 'get only cert' do
-      subject = described_class.new(grid: grid, secret_name: 'secret', domains: ['example.com'], cert_type: 'cert')
-
+    it 'updates cert' do
+      subject = described_class.new(grid: grid, secret_name: 'secret', domains: ['example.com'])
+      certificate = Certificate.create!(grid: grid, subject: 'example.com', valid_until: Time.now)
       expect {
-        c = subject.execute
-        expect(c.subject).to eq('example.com')
-        expect(c.valid_until).not_to be_nil
-        expect(c.alt_names).to be_empty
-        expect(c.private_key).to eq('private_key')
-        expect(c.certificate).to eq('certificate_only')
-      }.to change {grid.certificates.count}.by (1)
+        subject.execute
+      }.to not_change{grid.certificates.count}.and change{certificate.reload.updated_at}
     end
   end
 

--- a/server/spec/mutations/grid_certificates/request_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/request_certificate_spec.rb
@@ -1,0 +1,175 @@
+
+describe GridCertificates::RequestCertificate do
+
+  let(:subject) { described_class.new(grid: grid, secret_name: 'secret', domains: ['example.com']) }
+
+  let(:grid) {
+    Grid.create!(name: 'test-grid')
+  }
+
+  let(:acme_client) do
+    double()
+  end
+
+  before :each do
+    allow_any_instance_of(described_class).to receive(:acme_client).and_return(acme_client)
+  end
+
+  let(:authz) {
+    opts = {
+      'record_name' => '_acme-challenge',
+      'record_content' => '1234567890'
+    }
+    GridDomainAuthorization.create!(grid: grid, domain: 'example.com', authorization_type: 'dns-01', challenge: {}, challenge_opts: opts)
+  }
+
+  describe '#validate' do
+    it 'validates domain authorization existence' do
+      subject.validate
+      expect(subject.has_errors?).to be_truthy
+    end
+
+    it 'rejects invalid cert type' do
+      outcome = described_class.run(grid: grid, secret_name: 'secret', domains: ['example.com'], cert_type: 'foo')
+      expect(outcome).to_not be_success
+      expect(outcome.errors.symbolic).to eq 'cert_type' => :in
+    end
+    it 'rejects invalid multi-line cert type ' do
+      outcome = described_class.run(grid: grid, secret_name: 'secret', domains: ['example.com'], cert_type: "cert\nfoobar")
+      expect(outcome).to_not be_success
+      expect(outcome.errors.symbolic).to eq 'cert_type' => :in
+    end
+
+    context 'dns-01' do
+
+      it 'fails validation in domain challenge' do
+        authz
+        expect(subject).to receive(:validate_dns_record).and_return(false)
+        subject.validate
+        expect(subject.has_errors?).to be_truthy
+      end
+
+      it 'validates domain challenge' do
+        authz
+        expect(subject).to receive(:validate_dns_record).and_return(true)
+        outcome = subject.validate
+        expect(subject.has_errors?).to be_truthy
+      end
+    end
+
+    context 'tls-sni-01' do
+      # As of now there no specific validations for tls-sni verification
+    end
+
+  end
+
+  describe '#verify_domain' do
+    let(:challenge) do
+      double()
+    end
+
+    before :each do
+      authz
+      expect(acme_client).to receive(:challenge_from_hash).and_return(challenge)
+    end
+
+    it 'verifies domain succesfully' do
+      expect(challenge).to receive(:request_verification).and_return(true)
+      expect(challenge).to receive(:verify_status).and_return('valid', 'valid')
+
+      subject.verify_domain('example.com')
+    end
+
+    it 'adds error if verification timeouts' do
+      expect(challenge).to receive(:request_verification).and_return(true)
+      expect(challenge).to receive(:verify_status).and_raise(Timeout::Error)
+      expect(subject).to receive(:add_error)
+
+      subject.verify_domain('example.com')
+    end
+
+    it 'adds error if acme client errors' do
+      expect(challenge).to receive(:request_verification).and_raise(Acme::Client::Error)
+      expect(subject).to receive(:add_error)
+
+      subject.verify_domain('example.com')
+    end
+
+
+  end
+
+  describe '#execute' do
+    before :each do
+      authz
+      allow_any_instance_of(described_class).to receive(:verify_domain)
+      allow_any_instance_of(described_class).to receive(:validate_dns_record).and_return(true)
+      allow(acme_client).to receive(:new_certificate).and_return(certificate)
+    end
+
+    let(:certificate) do
+      double({
+        request: double(
+          {
+            private_key: double({to_pem: 'private_key'})
+          }
+        ),
+        chain_to_pem: 'chain_certificate',
+        fullchain_to_pem: 'fullchain',
+        to_pem: 'certificate_only',
+        x509: double(:not_after => Time.now + 90.days)
+      })
+    end
+
+    it 'get fullchain cert by default' do
+      expect {
+        c = subject.execute
+        expect(c.subject).to eq('example.com')
+        expect(c.valid_until).not_to be_nil
+        expect(c.alt_names).to be_empty
+        expect(c.private_key).to eq('private_key')
+        expect(c.certificate).to eq('fullchain')
+      }.to change {grid.certificates.count}.by (1)
+    end
+
+    it 'get only cert' do
+      subject = described_class.new(grid: grid, secret_name: 'secret', domains: ['example.com'], cert_type: 'cert')
+
+      expect {
+        c = subject.execute
+        expect(c.subject).to eq('example.com')
+        expect(c.valid_until).not_to be_nil
+        expect(c.alt_names).to be_empty
+        expect(c.private_key).to eq('private_key')
+        expect(c.certificate).to eq('certificate_only')
+      }.to change {grid.certificates.count}.by (1)
+    end
+  end
+
+
+  describe '#validate_dns_record' do
+    it 'returns false when wrong content in DNS record' do
+      resolv = double
+      allow(Resolv::DNS).to receive(:new).and_return(resolv)
+      expect(resolv).to receive(:getresource).with("_acme-challenge.example.com", Resolv::DNS::Resource::IN::TXT).and_return(double(strings: ['dsdsdsdsds']))
+      expect(subject.validate_dns_record('example.com', '1234567890')).to be_falsey
+
+    end
+
+    it 'returns false when DNS Failure' do
+      resolv = double
+      allow(Resolv::DNS).to receive(:new).and_return(resolv)
+      expect(resolv).to receive(:getresource).with("_acme-challenge.example.com", Resolv::DNS::Resource::IN::TXT).and_raise(Resolv::ResolvError)
+      expect(subject.validate_dns_record('example.com', '1234567890')).to be_falsey
+
+    end
+
+    it 'returns true when correct content in DNS record' do
+      resolv = double
+      allow(Resolv::DNS).to receive(:new).and_return(resolv)
+      expect(resolv).to receive(:getresource).with("_acme-challenge.example.com", Resolv::DNS::Resource::IN::TXT).and_return(double(strings: ['1234567890']))
+      expect(subject.validate_dns_record('example.com', '1234567890')).to be_truthy
+
+    end
+  end
+
+end

--- a/server/spec/mutations/grid_certificates/request_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/request_certificate_spec.rb
@@ -118,7 +118,8 @@ describe GridCertificates::RequestCertificate do
         expect(c.private_key).to eq('private_key')
         expect(c.certificate).to eq('certificate_only')
         expect(c.chain).to eq('chain')
-        expect(c.full_chain).to eq('fullchain')
+        expect(c.full_chain).to eq('certificate_onlychain')
+        expect(c.bundle).to eq('certificate_onlychainprivate_key')
       }.to change {grid.certificates.count}.by (1)
     end
 

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -464,6 +464,40 @@ describe GridServices::Create do
       end
     end
 
+    context 'with service_certificate' do
+      let :certificate do
+        Certificate.create!(grid: grid,
+          subject: 'kontena.io',
+          valid_until: Time.now + 90.days,
+          private_key: 'private_key',
+          certificate: 'certificate',
+          full_chain: 'full_chain')
+      end
+
+      before do
+        certificate
+      end
+
+      it 'saves service cert' do
+        outcome = described_class.new(
+            grid: grid,
+            image: 'redis:2.8',
+            name: 'redis',
+            stateful: false,
+            certificates: [
+              {subject: 'kontena.io', name: 'SSL_CERT'}
+            ]
+        ).run
+        expect(outcome.success?).to be(true)
+        expect(outcome.result.certificates.map{|s| s.attributes}).to match [hash_including(
+            'subject' => 'kontena.io',
+            'type' => 'env',
+            'name' => 'SSL_CERT',
+        )]
+      end
+
+    end
+
     it 'validates env syntax' do
       outcome = described_class.new(
         grid: grid,

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -470,8 +470,7 @@ describe GridServices::Create do
           subject: 'kontena.io',
           valid_until: Time.now + 90.days,
           private_key: 'private_key',
-          certificate: 'certificate',
-          full_chain: 'full_chain')
+          certificate: 'certificate')
       end
 
       before do

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -282,8 +282,7 @@ describe GridServices::Update do
           subject: 'kontena.io',
           valid_until: Time.now + 90.days,
           private_key: 'private_key',
-          certificate: 'certificate',
-          full_chain: 'full_chain')
+          certificate: 'certificate')
       end
 
       let :certificate2 do
@@ -291,8 +290,7 @@ describe GridServices::Update do
           subject: 'www.kontena.io',
           valid_until: Time.now + 90.days,
           private_key: 'private_key',
-          certificate: 'certificate',
-          full_chain: 'full_chain')
+          certificate: 'certificate')
       end
 
       it 'does not change existing certs' do

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -266,6 +266,75 @@ describe GridServices::Update do
       end
     end
 
+    context 'for a service with certificates' do
+      let(:service) {
+        GridService.create(grid: grid, stack: stack, name: 'redis',
+          image_name: 'redis:2.8',
+          certificates: [
+            {subject: certificate.subject, name: 'SSL_CERT'},
+            {subject: certificate2.subject, name: 'SSL_CERT2'}
+          ],
+        )
+      }
+
+      let :certificate do
+        Certificate.create!(grid: grid,
+          subject: 'kontena.io',
+          valid_until: Time.now + 90.days,
+          private_key: 'private_key',
+          certificate: 'certificate',
+          full_chain: 'full_chain')
+      end
+
+      let :certificate2 do
+        Certificate.create!(grid: grid,
+          subject: 'www.kontena.io',
+          valid_until: Time.now + 90.days,
+          private_key: 'private_key',
+          certificate: 'certificate',
+          full_chain: 'full_chain')
+      end
+
+      it 'does not change existing certs' do
+        subject = described_class.new(
+            grid_service: service,
+            certificates: [
+              {subject: certificate.subject, name: 'SSL_CERT'},
+              {subject: certificate2.subject, name: 'SSL_CERT2'}
+            ]
+        )
+        expect {
+          expect(outcome = subject.run).to be_success
+        }.to not_change{service.reload.revision}.and not_change{service.reload.updated_at}
+      end
+
+      it 'changes existing certs' do
+        subject = described_class.new(
+            grid_service: service,
+            certificates: [
+              {subject: certificate.subject, name: 'SSL_CERT'},
+              {subject: certificate2.subject, name: 'SSL_CERT2_FOO'}
+            ]
+        )
+        expect {
+          expect(outcome = subject.run).to be_success
+        }.to change{service.reload.revision}.and change{service.reload.updated_at}
+      end
+      it 'removes certificate' do
+        subject = described_class.new(
+            grid_service: service,
+            certificates: [
+              {subject: certificate.subject, name: 'SSL_CERT'}
+            ]
+        )
+        expect {
+          expect(outcome = subject.run).to be_success
+        }.to change{service.reload.revision}.and change{service.reload.updated_at}
+
+        expect(service.reload.certificates.map{|c| c.subject}).to eq ['kontena.io']
+      end
+    end
+
     context 'hooks' do
       context 'for a service with hooks' do
         let(:service) {

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -175,6 +175,19 @@ describe Rpc::ServicePodSerializer do
       end
     end
 
+    describe '[:secrets]' do
+      it 'includes certificates as secrets' do
+        Certificate.create!(grid: grid, subject: 'kontena.io', valid_until: Time.now + 90.days, private_key: 'private_key', certificate: 'certificate')
+        service.certificates.create!(subject: 'kontena.io', name: 'CERT')
+        subject = described_class.new(service_instance)
+        secrets = subject.to_hash[:secrets]
+
+        expect(secrets.size).to eq(2) # There's also the tls domain auth secret
+
+        expect(secrets.find{ |s| s[:name] == 'CERT'}[:value]).to eq('certificateprivate_key')
+      end
+    end
+
     describe '[:labels]' do
       let(:labels) { subject.to_hash[:labels] }
 

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -182,14 +182,14 @@ describe Rpc::ServicePodSerializer do
           valid_until: Time.now + 90.days,
           private_key: 'private_key',
           certificate: 'certificate',
-          full_chain: 'full_chain')
+          chain: 'chain')
         service.certificates.create!(subject: 'kontena.io', name: 'CERT')
         subject = described_class.new(service_instance)
         secrets = subject.to_hash[:secrets]
 
         expect(secrets.size).to eq(2) # There's also the tls domain auth secret
 
-        expect(secrets.find{ |s| s[:name] == 'CERT'}[:value]).to eq('full_chainprivate_key')
+        expect(secrets.find{ |s| s[:name] == 'CERT'}[:value]).to eq('certificatechainprivate_key')
       end
     end
 

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -177,14 +177,19 @@ describe Rpc::ServicePodSerializer do
 
     describe '[:secrets]' do
       it 'includes certificates as secrets' do
-        Certificate.create!(grid: grid, subject: 'kontena.io', valid_until: Time.now + 90.days, private_key: 'private_key', certificate: 'certificate')
+        Certificate.create!(grid: grid,
+          subject: 'kontena.io',
+          valid_until: Time.now + 90.days,
+          private_key: 'private_key',
+          certificate: 'certificate',
+          full_chain: 'full_chain')
         service.certificates.create!(subject: 'kontena.io', name: 'CERT')
         subject = described_class.new(service_instance)
         secrets = subject.to_hash[:secrets]
 
         expect(secrets.size).to eq(2) # There's also the tls domain auth secret
 
-        expect(secrets.find{ |s| s[:name] == 'CERT'}[:value]).to eq('certificateprivate_key')
+        expect(secrets.find{ |s| s[:name] == 'CERT'}[:value]).to eq('full_chainprivate_key')
       end
     end
 


### PR DESCRIPTION
follows #2732 

Certificates are "promoted" as first-class citizens in both API and in model level also.

Certificates can be bundled to a service much like secrets:
```
stack: jussi/certs
version: 0.1.0
services:
  certs:
    image: nginx:alpine
    certificates:
      - subject: kontena.io
        name: CERTIFICATE
        type: env
```

By doing so, during the next deployment the certificate will be "injected" into container envs:
```
$ docker exec certs.certs-1 env | grep CERTIFICATE
CERTIFICATE=certificateprivate_key
```

The actual injection happens through secrets in server-agent RPC API.

One of the goals of this PR is to also enable building automatic-renewal of certs that are for domain that are authorized with tls-sni-01


## TODO

- [x] fix specs
- [x]  Finalize CLI side for highlighting certs that are to expire soon
- [ ]  API docs
- [ ]  usage docs
- [x]  change merge-to branch when #2732 merged