### PR TITLE
agent: have SIGTTIN handler also dump non-celluloid threads

### DIFF
--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -119,9 +119,21 @@ module Kontena
     end
 
     def handle_trace
-      info "Dump celluloid actor stacks..."
+      info "Dump celluloid actor and thread stacks..."
 
       Celluloid.dump
+
+      Thread.list.each do |thread|
+        next if thread[:celluloid_actor_system]
+
+        puts "Thread 0x#{thread.object_id.to_s(16)} <#{thread.name}>"
+        if backtrace = thread.backtrace
+          puts "\t#{thread.backtrace.join("\n\t")}"
+        end
+        puts
+      end
+
+      info "Dump cellulooid actor and thread stacks: done"
     end
 
     def supervise

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -128,7 +128,7 @@ module Kontena
 
         puts "Thread 0x#{thread.object_id.to_s(16)} <#{thread.name}>"
         if backtrace = thread.backtrace
-          puts "\t#{thread.backtrace.join("\n\t")}"
+          puts "\t#{backtrace.join("\n\t")}"
         end
         puts
       end


### PR DESCRIPTION
Fixes #2727 to also dump non-celluloid threads

Example from  #2740:

```
Thread 0x5f8612ccf4 (future):
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/util.rb:90:in `join'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/util.rb:90:in `each'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/util.rb:90:in `block in hijack_for'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/excon/middlewares/hijack.rb:42:in `response_call'
	/usr/lib/ruby/gems/2.4.0/gems/excon-0.58.0/lib/excon/connection.rb:389:in `response'
	/usr/lib/ruby/gems/2.4.0/gems/excon-0.58.0/lib/excon/connection.rb:253:in `request'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/connection.rb:40:in `request'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/connection.rb:65:in `block (2 levels) in <class:Connection>'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/exec.rb:73:in `start!'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/container.rb:92:in `exec'
	/app/lib/kontena/actors/container_exec.rb:44:in `block in run'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:16:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/future.rb:18:in `block in new'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-essentials-0.20.5/lib/celluloid/internals/thread_handle.rb:14:in `block in initialize'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor/system.rb:78:in `block in get_thread'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/group/spawner.rb:50:in `block in instantiate'


Thread 0x5f852eeffc <>
	/app/lib/kontena/agent.rb:131:in `backtrace'
	/app/lib/kontena/agent.rb:131:in `block in handle_trace'
	/app/lib/kontena/agent.rb:126:in `each'
	/app/lib/kontena/agent.rb:126:in `handle_trace'
	/app/lib/kontena/agent.rb:111:in `handle_signal'
	/app/lib/kontena/agent.rb:98:in `run!'
	/app/bin/kontena-agent:45:in `<main>'

Thread 0x5f85a3f6e4 <>
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/util.rb:68:in `copy_stream'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/util.rb:68:in `block (2 levels) in hijack_for'

Thread 0x5f85a3f590 <>
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/util.rb:79:in `readpartial'
	/usr/lib/ruby/gems/2.4.0/gems/docker-api-1.33.6/lib/docker/util.rb:79:in `block (2 levels) in hijack_for'
```