### PR TITLE
Fix agent container exec input RPC hang

### DIFF
--- a/agent/lib/kontena/actors/container_exec.rb
+++ b/agent/lib/kontena/actors/container_exec.rb
@@ -20,11 +20,17 @@ module Kontena::Actors
 
     # @param [String] input
     def input(input)
-      if input.nil?
+      if !@write_pipe
+        warn "stdin write closed"
+      elsif input.nil?
         @write_pipe.close
       else
         @write_pipe.write(input)
       end
+    rescue Errno::EPIPE => exc
+      warn "stdin write error: #{exc}"
+      @write_pipe.close
+      @write_pipe = nil
     end
 
     # @param [String] cmd

--- a/agent/lib/kontena/rpc/docker_container_api.rb
+++ b/agent/lib/kontena/rpc/docker_container_api.rb
@@ -147,8 +147,12 @@ module Kontena
         actor_id = "container_exec_#{id}"
         executor = Celluloid::Actor[actor_id]
         if executor
-          executor.input(input)
+          executor.async.input(input)
+        else
+          raise RpcServer::Error.new(404, "Exec session (#{session_id}) not found")
         end
+
+        {}
       end
 
       # @param [String] id


### PR DESCRIPTION
Fixes #2740 

The `Kontena::Actors::ContainerExec` actor might get stuck on `input` => `@write_pipe.write(...)` if the exec process is not reading from stdin, and the container exec process + Docker engine + Docker API TCP socket + stdin queue buffers all fill up. The `stdin` pipe will remain open when the `docker-api` thread dies and stops reading from it, and if the actor `input` task is stuck on the `@write_pipe.write(...)`, then the `run` task will never see the `defer` error/result value.

Close the `@read_pipe` from the `defer` thread after the `Docker::Container#exec` returns, which unblocks the the `input` task by raising `Errno::EPIPE` from `@write_pipe.write(...)`.

The `Kontena::Actors::ContainerExec` actor now just logs a warning from `input` task and closes the ` @write_pipe`, also discarding any further inputs. There's not much else it can do with the inputs except discard them, after the exec process exits.

The `#run` task then gets the `defer` thread value/error, triggering the `ensure` => `shutdown` , and the CLI sees the `{"exit": 0}`.

## Testing

```
D, [2017-08-28T14:04:15.673317 #1] DEBUG -- Kontena::RpcServer: rpc request: Kontena::Rpc::DockerContainerApi#create_exec ["1095e09b797857263774c9b0d536da78c1e89d67bc2ea805fe81b49087936519"]
I, [2017-08-28T14:04:15.678902 #1]  INFO -- Kontena::Actors::ContainerExec: initialized (session cc2756f6-7b13-4749-bcbf-99b8e2c6d8f1)
D, [2017-08-28T14:04:15.701747 #1] DEBUG -- Kontena::RpcServer: rpc notification: Kontena::Rpc::DockerContainerApi#run_exec ["cc2756f6-7b13-4749-bcbf-99b8e2c6d8f1", ["sleep", "10"], false, true]
I, [2017-08-28T14:04:15.702345 #1]  INFO -- Kontena::Actors::ContainerExec: starting command: ["sleep", "10"] (tty: false, stdin: true)
D, [2017-08-28T14:04:15.727836 #1] DEBUG -- Kontena::RpcServer: rpc notification: Kontena::Rpc::DockerContainerApi#tty_input ["cc2756f6-7b13-4749-bcbf-99b8e2c6d8f1", "spamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspam\n"]
D, [2017-08-28T14:04:15.734591 #1] DEBUG -- Kontena::RpcServer: rpc notification: Kontena::Rpc::DockerContainerApi#tty_input ["cc2756f6-7b13-4749-bcbf-99b8e2c6d8f1", "spamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspam\n"]
...
D, [2017-08-28T14:04:19.392174 #1] DEBUG -- Kontena::RpcServer: rpc notification: Kontena::Rpc::DockerContainerApi#tty_input ["cc2756f6-7b13-4749-bcbf-99b8e2c6d8f1", "spamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspamspam\n"]
D, [2017-08-28T14:04:19.392445 #1] DEBUG -- Kontena::RpcServer: rpc notification: Kontena::Rpc::DockerContainerApi#tty_input ["cc2756f6-7b13-4749-bcbf-99b8e2c6d8f1", nil]



D, [2017-08-28T14:04:21.554856 #1] DEBUG -- Kontena::WebsocketClient: server ping 0.00s of 5.00s timeout
W, [2017-08-28T14:04:25.956915 #1]  WARN -- Kontena::Actors::ContainerExec: stdin write error: Broken pipe
W, [2017-08-28T14:04:25.961359 #1]  WARN -- Kontena::Actors::ContainerExec: stdin write closed
W, [2017-08-28T14:04:25.963801 #1]  WARN -- Kontena::Actors::ContainerExec: stdin write closed
...
W, [2017-08-28T14:04:26.362879 #1]  WARN -- Kontena::Actors::ContainerExec: stdin write closed
W, [2017-08-28T14:04:26.362988 #1]  WARN -- Kontena::Actors::ContainerExec: stdin write closed
W, [2017-08-28T14:04:26.363173 #1]  WARN -- Kontena::Actors::ContainerExec: stdin write closed
I, [2017-08-28T14:04:26.363298 #1]  INFO -- Kontena::Actors::ContainerExec: command finished: ["sleep", "10"] with code 0
D, [2017-08-28T14:04:26.378192 #1] DEBUG -- Kontena::RpcServer: rpc notification: Kontena::Rpc::DockerContainerApi#terminate_exec ["cc2756f6-7b13-4749-bcbf-99b8e2c6d8f1"]
```

The CLI sees the `websocket exec exit: 0`, but all the input spam gets queued up on the server before that.. this causes some severe eventmachine watchdog delays on the server while all the queued up input spam is processed, but in this case the server/agent seem to survive...

However, it can lead to server websocket timeouts... if those hit the CLI, then that stops the spam, but if it hits the agent, then that risks missing the `/container_exec/exit` message... that might end badly if the CLI keeps spamming?