### PR TITLE
agent: report container exec errors

### DIFF
--- a/agent/lib/kontena/actors/container_exec.rb
+++ b/agent/lib/kontena/actors/container_exec.rb
@@ -32,7 +32,7 @@ module Kontena::Actors
     # @param [Boolean] stdin
     def run(cmd, tty = false, stdin = false)
       info "starting command: #{cmd} (tty: #{tty}, stdin: #{stdin})"
-      exit_code = 0
+      exit_code = 128
       opts = {tty: tty}
       opts[:stdin] = @read_pipe if stdin
       defer {

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -59,6 +59,7 @@ module Kontena::Cli::Helpers
     end
 
     # @param ws [Kontena::Websocket::Client]
+    # @raise [RuntimeError] exec error
     # @return [Integer] exit code
     def websocket_exec_read(ws)
       ws.read do |msg|
@@ -66,7 +67,9 @@ module Kontena::Cli::Helpers
 
         logger.debug "websocket exec read: #{msg.inspect}"
 
-        if msg.has_key?('exit')
+        if msg.has_key?('error')
+          raise msg['error']
+        elsif msg.has_key?('exit')
           # breaks the read loop
           return msg['exit'].to_i
         elsif msg.has_key?('stream')

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -30,9 +30,12 @@ module Docker
 
     def subscribe_to_session
       @subscription = MongoPubsub.subscribe("container_exec:#{@exec_session['id']}") do |data|
-        if data.has_key?('exit')
+        if data.has_key?('error')
+          @ws.send(JSON.dump({ error: data['error'] }))
+          @ws.close(4000)
+        elsif data.has_key?('exit')
           @ws.send(JSON.dump({ exit: data['exit'] }))
-          @ws.close
+          @ws.close(1000)
         else
           @ws.send(JSON.dump({ stream: data['stream'], chunk: data['chunk'] }))
         end

--- a/server/app/services/rpc/container_exec_handler.rb
+++ b/server/app/services/rpc/container_exec_handler.rb
@@ -13,5 +13,9 @@ module Rpc
     def exit(uuid, exit_code)
       MongoPubsub.publish("container_exec:#{uuid}", {exit: exit_code})
     end
+
+    def error(uuid, error)
+      MongoPubsub.publish("container_exec:#{uuid}", {error: error})
+    end
   end
 end


### PR DESCRIPTION
Fixes  #2598

The agent `Kontena::Actors::ContainerExec` would crash on errors from `Docker::Container#exec`, and proceed to send back the default `exit_status = 0`, which is very misleading.

## Testing

Easiest to test with a stopped container:

```
$ kontena service stop redis
 [done] Sending stop signal to redis service      
```

### Before

The CLI just sees `{"exit": 0}`:

```
$ kontena container exec core-01/redis-1 do something && echo "yay it worked, but why did nothing happen? ;("
yay it worked, but why did nothing happen? ;(
```

The agent `Kontena::Actors::ContainerExec` crashes and reports `/container_exec/exit` `[0]`:

```
I, [2017-07-20T10:55:31.276201 #1]  INFO -- Kontena::Actors::ContainerExec: starting command: ["frobnicate"] (tty: false, stdin: false)
I, [2017-07-20T10:55:31.285781 #1]  INFO -- Kontena::Actors::ContainerExec: command finished: ["frobnicate"] with code 0
E, [2017-07-20T10:55:31.286979 #1] ERROR -- : Actor crashed!
Docker::Error::ServerError: Container 2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025 is not running
```

### After

The CLI sees the `{"error": "..."}`:

```
$ kontena container exec core-01/redis-1 do something || echo nay it failed
 [error] RuntimeError : Docker::Error::ServerError: Container 1095e09b797857263774c9b0d536da78c1e89d67bc2ea805fe81b49087936519 is not running

         See /home/kontena/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
nay it failed
```

The agent `Kontena::Actors::ContainerExec` handles the error and reports `/container_exec/error` `["..."]`:

```
I, [2017-08-28T14:44:04.822102 #1]  INFO -- Kontena::Actors::ContainerExec: starting command: ["do", "something"] (tty: false, stdin: false)
W, [2017-08-28T14:44:04.826900 #1]  WARN -- Kontena::Actors::ContainerExec: ["do", "something"] error: Container 1095e09b797857263774c9b0d536da78c1e89d67bc2ea805fe81b49087936519 is not running
```