### PR TITLE
Fix server node update grid notify

### DIFF
--- a/server/app/mutations/host_nodes/common.rb
+++ b/server/app/mutations/host_nodes/common.rb
@@ -11,7 +11,7 @@ module HostNodes
     # @param [Grid] grid
     # @param [HostNode] node
     def notify_node(grid, node)
-      plugger = Agent::NodePlugger.new(grid, node)
+      plugger = Agent::NodePlugger.new(node)
       plugger.send_node_info
     end
 

--- a/server/app/mutations/host_nodes/update.rb
+++ b/server/app/mutations/host_nodes/update.rb
@@ -47,13 +47,16 @@ module HostNodes
         if instance.grid_service.stateful?
           info "setting desired state to stopped for instance #{instance.grid_service.to_path}-#{instance.instance_number}"
           instance.set(desired_state: 'stopped')
-          notify_node(instance.host_node) if instance.host_node
+          notify_service_instance(instance, 'stop')
         end
       end
     end
 
-    def notify_node(node)
-      RpcClient.new(node.node_id).notify('/service_pods/notify_update', 'stop')
+    # @param instance [GridServiceInstance]
+    def notify_service_instance(instance, action)
+      if instance.host_node
+        instance.host_node.rpc_client.notify('/service_pods/notify_update', action)
+      end
     end
 
     def start_stateful_services(host_node)
@@ -63,7 +66,7 @@ module HostNodes
         if instance.grid_service.stateful? && instance.grid_service.running? && instance.desired_state == 'stopped'
           info "setting desired state to running for instance #{instance.grid_service.to_path}-#{instance.instance_number}"
           instance.set(desired_state: 'running')
-          notify_node(instance.host_node) if instance.host_node
+          notify_service_instance(instance, 'start')
         end
       end
     end

--- a/server/spec/mutations/host_nodes/common_spec.rb
+++ b/server/spec/mutations/host_nodes/common_spec.rb
@@ -1,21 +1,33 @@
 describe HostNodes::Common do
-  let(:grid) { Grid.create!(name: 'test') }
-  let(:node_a) { grid.create_node!('node-a', node_id: 'AA', connected: true) }
-  let(:node_b) { grid.create_node!('node-b', node_id: 'BB', connected: true) }
-  let(:node_c) { grid.create_node!('node-c', node_id: 'CC', connected: false) }
   let(:described_class) {
     Class.new do
       include HostNodes::Common
     end
   }
 
-  describe '#notify_grid' do
-    it 'notifies all connected nodes' do
-      node_a; node_b; node_c
-      expect(subject).to receive(:notify_node).once.with(grid, node_a)
-      expect(subject).to receive(:notify_node).once.with(grid, node_b)
-      expect(subject).not_to receive(:notify_node).with(grid, node_c)
-      subject.notify_grid(grid)
+  context 'for a grid with three nodes' do
+    let!(:grid) { Grid.create!(name: 'test') }
+    let!(:node_a) { grid.create_node!('node-a', node_id: 'AA', connected: true) }
+    let!(:node_b) { grid.create_node!('node-b', node_id: 'BB', connected: true) }
+    let!(:node_c) { grid.create_node!('node-c', node_id: 'CC', connected: false) }
+
+    describe '#notify_grid' do
+      let(:node1_plugger) { instance_double(Agent::NodePlugger) }
+      let(:node2_plugger) { instance_double(Agent::NodePlugger) }
+      let(:node3_plugger) { instance_double(Agent::NodePlugger) }
+
+      before do
+        allow(Agent::NodePlugger).to receive(:new).with(node_a).and_return(node1_plugger)
+        allow(Agent::NodePlugger).to receive(:new).with(node_b).and_return(node2_plugger)
+        allow(Agent::NodePlugger).to receive(:new).with(node_c).and_return(node3_plugger)
+      end
+
+      it 'notifies all connected nodes' do
+        expect(node1_plugger).to receive(:send_node_info)
+        expect(node2_plugger).to receive(:send_node_info)
+        expect(node3_plugger).to_not receive(:send_node_info)
+        subject.notify_grid(grid)
+      end
     end
   end
 end

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -93,7 +93,7 @@ describe HostNodes::Update do
         end
       end
 
-      context 'for a drained node with a stopped service instance' do
+      context 'for a drained node' do
         before do
           node.set(availability: HostNode::Availability::DRAIN)
         end

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -78,7 +78,7 @@ describe HostNodes::Update do
 
           it 'stops stateful services when draining' do
             expect(rpc_client).to receive(:notify).with('/service_pods/notify_update', 'stop') do
-              expect(stateful_service_instance1.desired_state).to eq 'stopped'
+              expect(stateful_service_instance1.reload.desired_state).to eq 'stopped'
             end
 
             expect{
@@ -116,7 +116,7 @@ describe HostNodes::Update do
 
           it 'starts and notifies the service instance' do
             expect(rpc_client).to receive(:notify).with('/service_pods/notify_update', 'start') do
-              expect(stateful_service_instance1.desired_state).to eq 'running'
+              expect(stateful_service_instance1.reload.desired_state).to eq 'running'
             end
 
             expect {


### PR DESCRIPTION
Fixes #2746

This was broken in 1.3 by #2144, and also in 1.4 by #2306. Shows up in the #2699 logging.

Fix the `notify_node` => `Agent::NodePlugger.new(node)` param, as well as the `start/stop_stateful_services` => `notify_node(...)` method collision.

Adds specs that now actually test that this actually works.