### PR TITLE
Send & store logs in batches

### DIFF
--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -208,8 +208,11 @@ module Kontena::Workers
     def finalize
       stop_streaming if streaming?
       pause_processing
-      if @queue.size > 0 && rpc_client && rpc_client.alive?
-        rpc_client.notification('/containers/log_batch', [@queue])
+      if @queue.size > 0 && rpc_client
+        while @queue.size > 0 do
+          batch = @queue.shift(BATCH_SIZE * 10)
+          rpc_client.async.notification('/containers/log_batch', [batch])
+        end
       end
     end
   end

--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -211,6 +211,7 @@ module Kontena::Workers
       if @queue.size > 0 && rpc_client
         while @queue.size > 0 do
           batch = @queue.shift(BATCH_SIZE * 10)
+          info "flushing #{batch.size} log items from queue"
           rpc_client.async.notification('/containers/log_batch', [batch])
         end
       end

--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -207,8 +207,10 @@ module Kontena::Workers
 
     def finalize
       stop_streaming if streaming?
-      sleep 1 until @queue.empty?
       pause_processing
+      if @queue.size > 0 && rpc_client && rpc_client.alive?
+        rpc_client.notification('/containers/log_batch', [@queue])
+      end
     end
   end
 end

--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -60,8 +60,9 @@ module Kontena::Workers
 
     # Process items from @queue
     def process_queue
-      while buffer = @queue.shift(BATCH_SIZE)
+      loop do
         sleep 1 until processing?
+        buffer = @queue.shift(BATCH_SIZE)
         if buffer.size > 0
           rpc_client.notification('/containers/log_batch', [buffer])
           sleep 0.01

--- a/agent/spec/lib/kontena/workers/log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/log_worker_spec.rb
@@ -166,4 +166,25 @@ describe Kontena::Workers::LogWorker, :celluloid => true do
       end
     end
   end
+
+  describe '#force_flush_buffer?' do
+    it 'returns false by default' do
+      expect(subject.force_flush_buffer?).to be_falsey
+    end
+  end
+
+  describe '#flush_buffer' do
+    before(:each) do
+      allow(rpc_client).to receive(:notification)
+    end
+
+    it 'sends buffer to master' do
+      expect(rpc_client).to receive(:notification).once
+      subject.flush_buffer
+    end
+
+    it 'returns flush unix timestamp' do
+      expect(subject.flush_buffer).to be_instance_of(Fixnum)
+    end
+  end
 end

--- a/agent/spec/lib/kontena/workers/log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/log_worker_spec.rb
@@ -95,7 +95,7 @@ describe Kontena::Workers::LogWorker, :celluloid => true do
 
       it 'creates new container_log_worker actor' do
         worker = spy(:container_log_worker)
-        expect(Kontena::Workers::ContainerLogWorker).to receive(:new).with(container, Queue).and_return(worker)
+        expect(Kontena::Workers::ContainerLogWorker).to receive(:new).with(container, Array).and_return(worker)
         subject.stream_container_logs(container)
       end
     end
@@ -164,27 +164,6 @@ describe Kontena::Workers::LogWorker, :celluloid => true do
 
         subject.on_container_event('topic', double(:event, id: 'foo', status: 'create'))
       end
-    end
-  end
-
-  describe '#force_flush_buffer?' do
-    it 'returns false by default' do
-      expect(subject.force_flush_buffer?).to be_falsey
-    end
-  end
-
-  describe '#flush_buffer' do
-    before(:each) do
-      allow(rpc_client).to receive(:notification)
-    end
-
-    it 'sends buffer to master' do
-      expect(rpc_client).to receive(:notification).once
-      subject.flush_buffer
-    end
-
-    it 'returns flush unix timestamp' do
-      expect(subject.flush_buffer).to be_instance_of(Fixnum)
     end
   end
 end

--- a/agent/spec/lib/kontena/workers/log_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/log_worker_spec.rb
@@ -67,6 +67,22 @@ describe Kontena::Workers::LogWorker, :celluloid => true do
 
       expect(subject).to_not be_streaming
     end
+
+    it 'marks timestamp from queue' do
+      time = Time.now.utc - 60
+      subject.queue << {
+        id: 'id1',
+        time: time.xmlschema
+      }
+      worker1 = subject.workers['id1'] = double(:worker1, alive?: true)
+
+      expect(Celluloid::Actor).to receive(:kill).with(worker1)
+      expect(etcd).to receive(:set).with('/kontena/log_worker/containers/id1', {value: time.to_i, ttl: Integer})
+
+      subject.stop_streaming
+
+      expect(subject).to_not be_streaming
+    end
   end
 
   describe '#mark_timestamp' do

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -45,6 +45,7 @@ module Rpc
       batch_size = batch.size
       if batch_size > 0
         flush_logs(batch)
+        batch.clear
         gc_cache
       end
       { count: batch_size }
@@ -130,7 +131,6 @@ module Rpc
     # @param [Array<Hash>]
     def flush_logs(logs)
       @db_session[:container_logs].insert_many(logs)
-      logs.clear
     end
 
     def flush_stats

--- a/server/app/services/rpc/container_handler.rb
+++ b/server/app/services/rpc/container_handler.rb
@@ -4,15 +4,12 @@ module Rpc
   class ContainerHandler
     include Logging
 
-    attr_accessor :logs_buffer_size
     attr_accessor :stats_buffer_size
 
     def initialize(grid)
       @grid = grid
-      @logs = []
       @stats = []
       @cached_containers = {}
-      @logs_buffer_size = 5
       @stats_buffer_size = 5
       @containers_cache_size = 50
       @db_session = ContainerLog.collection.client.with(
@@ -42,31 +39,39 @@ module Rpc
       end
     end
 
-    # @param [Hash] data
-    def log(data)
-      container = cached_container(data['id'])
-      if container
-        if data['time']
-          created_at = Time.parse(data['time'])
-        else
-          created_at = Time.now.utc
-        end
-        @logs << {
-          grid_id: @grid.id,
-          host_node_id: container['host_node_id'],
-          grid_service_id: container['grid_service_id'],
-          instance_number: container['instance_number'],
-          container_id: container['_id'],
-          created_at: created_at,
-          name: container['name'],
-          type: data['type'],
-          data: data['data']
-        }
-        if @logs.size >= @logs_buffer_size
-          flush_logs
-          gc_cache
-        end
+    # @param [Array<Hash>] logs
+    def log_batch(logs)
+      batch = logs.map { |data| self.build_log_item(data) }.compact
+      batch_size = batch.size
+      if batch_size > 0
+        flush_logs(batch)
+        gc_cache
       end
+      { count: batch_size }
+    end
+
+    # @param [Hash] data
+    # @return [Hash,NilClass]
+    def build_log_item(data)
+      container = cached_container(data['id'])
+      return nil unless container
+
+      if data['time']
+        created_at = Time.parse(data['time'])
+      else
+        created_at = Time.now.utc
+      end
+      {
+        grid_id: @grid.id,
+        host_node_id: container['host_node_id'],
+        grid_service_id: container['grid_service_id'],
+        instance_number: container['instance_number'],
+        container_id: container['_id'],
+        created_at: created_at,
+        name: container['name'],
+        type: data['type'],
+        data: data['data']
+      }
     end
 
     # @param [Hash] data
@@ -122,9 +127,10 @@ module Rpc
       {}
     end
 
-    def flush_logs
-      @db_session[:container_logs].insert_many(@logs)
-      @logs.clear
+    # @param [Array<Hash>]
+    def flush_logs(logs)
+      @db_session[:container_logs].insert_many(logs)
+      logs.clear
     end
 
     def flush_stats


### PR DESCRIPTION
It's more efficient to send logs from agent to master in batches.