### PR TITLE
Add Agent reconnect backoff

### DIFF
--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -55,6 +55,8 @@ describe Kontena::WebsocketClient, :celluloid => true do
   describe '#start' do
     it 'connects' do
       expect(subject).to receive(:connect!)
+      expect(subject).to receive(:backoff_reconnect!)
+      expect(subject).to receive(:loop).and_yield
 
       actor.start
     end
@@ -220,6 +222,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
     describe '#start' do
       it 'does not connect' do
         expect(subject).not_to receive(:connect!)
+        expect(subject).to receive(:loop).and_yield
 
         actor.start
       end
@@ -490,6 +493,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
     describe '#start' do
       it 'does not connect' do
         expect(subject).not_to receive(:connect!)
+        expect(subject).to receive(:loop).and_yield
 
         actor.start
       end

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -36,10 +36,8 @@ describe Kontena::WebsocketClient, :celluloid => true do
   end
 
   before do
-    # run timers immediately, once
-    allow(subject.wrapped_object).to receive(:every) do |&block|
-      block.call
-    end
+    # run connect loop immediately, once
+    allow(subject).to receive(:loop).and_yield
   end
 
   describe '#initialize' do
@@ -56,7 +54,6 @@ describe Kontena::WebsocketClient, :celluloid => true do
     it 'connects' do
       expect(subject).to receive(:connect!)
       expect(subject).to receive(:backoff_reconnect!)
-      expect(subject).to receive(:loop).and_yield
 
       actor.start
     end
@@ -222,7 +219,6 @@ describe Kontena::WebsocketClient, :celluloid => true do
     describe '#start' do
       it 'does not connect' do
         expect(subject).not_to receive(:connect!)
-        expect(subject).to receive(:loop).and_yield
 
         actor.start
       end
@@ -493,7 +489,6 @@ describe Kontena::WebsocketClient, :celluloid => true do
     describe '#start' do
       it 'does not connect' do
         expect(subject).not_to receive(:connect!)
-        expect(subject).to receive(:loop).and_yield
 
         actor.start
       end


### PR DESCRIPTION
This PR adds increasing backoff for agent reconnects.

Didn't implement it as exponential as exponential would make the backoff time quite long with only few attempts.

fixes #2027 