### PR TITLE
Return related services in secret json

### DIFF
--- a/server/app/models/grid_secret.rb
+++ b/server/app/models/grid_secret.rb
@@ -16,4 +16,8 @@ class GridSecret
   def to_path
     "#{self.grid.try(:name)}/#{self.name}"
   end
+
+  def services
+    self.grid.grid_services.where(:secrets.elem_match => { secret: self.name })
+  end
 end

--- a/server/app/routes/v1/grids/grid_secrets.rb
+++ b/server/app/routes/v1/grids/grid_secrets.rb
@@ -64,6 +64,7 @@ V1::GridsApi.route('grid_secrets') do |r|
   # GET /v1/grids/:grid/secrets
   r.get do
     r.is do
+      @grid_services = @grid.grid_services.where(:secrets.exists => true)
       @grid_secrets = @grid.grid_secrets.includes(:grid)
       render('grid_secrets/index')
     end

--- a/server/app/views/v1/grid_secrets/index.json.jbuilder
+++ b/server/app/views/v1/grid_secrets/index.json.jbuilder
@@ -3,7 +3,10 @@ json.secrets @grid_secrets do |grid_secret|
   json.name grid_secret.name
   json.created_at grid_secret.created_at
   json.updated_at grid_secret.updated_at
-  json.services grid_secret.services do |grid_service|
+  services_with_secret = @grid_services.find_all do |s|
+    s.secrets.any?{|secret| secret.secret == grid_secret.name}
+  end
+  json.services services_with_secret.each do |grid_service|
     json.id grid_service.to_path
     json.name grid_service.name
   end

--- a/server/app/views/v1/grid_secrets/index.json.jbuilder
+++ b/server/app/views/v1/grid_secrets/index.json.jbuilder
@@ -3,4 +3,8 @@ json.secrets @grid_secrets do |grid_secret|
   json.name grid_secret.name
   json.created_at grid_secret.created_at
   json.updated_at grid_secret.updated_at
+  json.services grid_secret.services do |grid_service|
+    json.id grid_service.to_path
+    json.name grid_service.name
+  end
 end

--- a/server/app/views/v1/grid_secrets/show.json.jbuilder
+++ b/server/app/views/v1/grid_secrets/show.json.jbuilder
@@ -2,3 +2,7 @@ json.id @grid_secret.to_path
 json.name @grid_secret.name
 json.created_at @grid_secret.created_at
 json.value @grid_secret.value
+json.services @grid_secret.services do |grid_service|
+  json.id grid_service.to_path
+  json.name grid_service.name
+end

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -1267,7 +1267,13 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
     "id": "my-grid/SECRET_PWD",
     "name": "SECRET_PWD",
     "created_at": "",
-    "value": "T0Ps3crT"
+    "value": "T0Ps3crT",
+    "services": [
+        {
+          "id": "big-one/null/app",
+          "name": "app"
+        }
+      ]
 }
 ```
 
@@ -1277,6 +1283,7 @@ id | An unique id for the secret
 created_at | A timestamp when the secret was created
 name | A name for the secret (unique within a grid)
 value | A value for the secret (encrypted in the database)
+services | A list of services that are consuming the secret
 
 ## List secrets
 

--- a/server/spec/models/grid_secret_spec.rb
+++ b/server/spec/models/grid_secret_spec.rb
@@ -11,7 +11,7 @@ describe GridSecret do
     described_class.create!(
       grid: grid,
       name: 'test',
-      encrypted_value: '123456'
+      value: '123456'
     )
   end
 

--- a/server/spec/models/grid_secret_spec.rb
+++ b/server/spec/models/grid_secret_spec.rb
@@ -3,4 +3,32 @@ describe GridSecret do
   it { should be_timestamped_document }
   it { should have_fields(:name, :encrypted_value).of_type(String) }
   it { should belong_to(:grid) }
+  let(:grid) do
+    Grid.create!(name: 'terminal-a')
+  end
+
+  let(:secret) do
+    described_class.create!(
+      grid: grid,
+      name: 'test',
+      encrypted_value: '123456'
+    )
+  end
+
+  describe '#services' do
+    it 'returns grid services that are consuming the secret' do
+      secret #create
+      service = GridService.create!(
+        grid: grid,
+        name: 'app',
+        image_name: 'my/app:latest',
+        stateful: false,
+        secrets: [
+          secret: 'test',
+          name: 'test'
+        ]
+      )
+      expect(secret.services).to eq([service])
+    end
+  end
 end


### PR DESCRIPTION
This PR will return related services in secret json
```
{
  "secrets":[
    {  
      "id":"big-one/foo", 
      "name":"foo", 
      "created_at":"2017-09-01T10:28:27.414Z", 
      "updated_at":"2017-09-01T10:28:27.414Z", 
      "services":[
        {
          "id":"big-one/null/app", 
          "name":"app"
        }
      ]
    }
  ]
}
```

Fixes #2545 