### PR TITLE
Don't fetch too many log items in stream loop

### DIFF
--- a/server/app/helpers/logs_helpers.rb
+++ b/server/app/helpers/logs_helpers.rb
@@ -1,6 +1,7 @@
 module LogsHelpers
   LOGS_LIMIT_DEFAULT = 100
   LOGS_LIMIT_MAX = 10000
+  LOGS_STREAM_CHUNK = LOGS_LIMIT_DEFAULT * 3
 
   # @param r [Roda::RodaRequest]
   # @param scope [Mongoid::CriteriaMongoid::Criteria] of ContainerLog
@@ -21,7 +22,7 @@ module LogsHelpers
       stream(loop: true) do |out|
         if from
           # all items following a specific item
-          logs  = scope.where(:id.gt => from).order(:id => 1).limit(LOGS_LIMIT_MAX).to_a
+          logs  = scope.where(:id.gt => from).order(:id => 1).limit(LOGS_STREAM_CHUNK).to_a
         else
           # limit most recent logs
           logs = scope.order(:id => -1).limit(limit).to_a.reverse
@@ -32,6 +33,7 @@ module LogsHelpers
             out << render('container_logs/_container_log', locals: {log: log})
           end
           from = logs.last.id
+          sleep 0.1
         else
           # idle keepalive, trigger write errors on timeout
           out << ' '
@@ -71,7 +73,7 @@ module LogsHelpers
       stream(loop: true) do |out|
         if from
           # all items following a specific item
-          logs  = scope.where(:id.gt => from).order(:id => 1).limit(LOGS_LIMIT_MAX).to_a
+          logs  = scope.where(:id.gt => from).order(:id => 1).limit(LOGS_STREAM_CHUNK).to_a
         else
           # limit most recent logs
           logs = scope.order(:id => -1).limit(limit).to_a.reverse
@@ -82,6 +84,7 @@ module LogsHelpers
             out << render('event_logs/_event_log', locals: {event_log: log})
           end
           from = logs.last.id
+          sleep 0.1
         else
           # idle keepalive, trigger write errors on timeout
           out << ' '

--- a/server/spec/services/logs_helpers_spec.rb
+++ b/server/spec/services/logs_helpers_spec.rb
@@ -90,6 +90,7 @@ describe LogsHelpers do
     before do
       stub_const('LogsHelpers::LOGS_LIMIT_DEFAULT', 10)
       stub_const('LogsHelpers::LOGS_LIMIT_MAX', 20)
+      stub_const('LogsHelpers::LOGS_STREAM_CHUNK', 20)
 
       allow(subject).to receive(:sleep)
     end


### PR DESCRIPTION
Fetching max 10k items in a tight stream loop will exhaust server too easily.