### PR TITLE
CLI: Normalize string colorization calls

### DIFF
--- a/cli/lib/kontena/cli/certificate/get_command.rb
+++ b/cli/lib/kontena/cli/certificate/get_command.rb
@@ -24,7 +24,7 @@ module Kontena::Cli::Certificate
       response = client(token).post("certificates/#{current_grid}/certificate", data)
       puts "Certificate successfully received and stored into vault with keys:"
       response.each do |secret|
-        puts secret.colorize(:green)
+        puts pastel.green(secret)
       end
       puts "Use the #{secret}_BUNDLE with Kontena loadbalancer!"
 

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -74,7 +74,7 @@ module Kontena::Cli::Cloud
         exit_with_error "Parsing remote login URL failed."
       end
 
-      puts "Please visit #{verification_uri.to_s.colorize(:cyan)} and enter the code"
+      puts "Please visit #{pastel.cyan(verification_uri.to_s)} and enter the code"
       puts
       puts "#{auth_request_response['user_code']}"
       puts

--- a/cli/lib/kontena/cli/cloud/master/add_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/add_command.rb
@@ -146,7 +146,7 @@ module Kontena::Cli::Cloud::Master
       elsif self.id?
         puts response['data']['id']
       else
-        puts "Registered master.".colorize(:green)
+        puts pastel.green("Registered master.")
         puts "ID: #{response['data']['id']}"
         puts "Client ID: #{response['data']['attributes']['client-id']}"
         puts "Client Secret: #{response['data']['attributes']['client-secret']}"

--- a/cli/lib/kontena/cli/cloud/master/list_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/list_command.rb
@@ -20,7 +20,7 @@ module Kontena::Cli::Cloud::Master
       end
 
       unless response && response.kind_of?(Hash) && response['data'].kind_of?(Array)
-        abort "Listing masters failed".colorize(:red)
+        abort pastel.red("Listing masters failed")
       end
 
       return Array(response['data']) if self.return?

--- a/cli/lib/kontena/cli/cloud/master/remove_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/remove_command.rb
@@ -26,7 +26,7 @@ module Kontena::Cli::Cloud::Master
       spinner "Retrieving a list of registered masters on Kontena Cloud" do
         response = cloud_client.get('user/masters')
         unless response && response.kind_of?(Hash) && response['data'].kind_of?(Array)
-          abort 'Listing masters failed'.colorize(:red)
+          abort pastel.red('Listing masters failed')
         end
       end
 

--- a/cli/lib/kontena/cli/cloud/master/update_command.rb
+++ b/cli/lib/kontena/cli/cloud/master/update_command.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Cloud::Master
     def execute
       attrs = get_attributes
       unless attrs
-        puts "Failed to obtain master credentials".colorize(:red)
+        puts pastel.red("Failed to obtain master credentials")
         exit 1
       end
 

--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -154,7 +154,7 @@ module Kontena
           logger.debug { msg }
           return
         end
-        puts " [#{ success ? 'done'.colorize(:green) : 'fail'.colorize(:red)}] #{msg}"
+        puts " [#{ success ? pastel.green('done') : pastel.red('fail')}] #{msg}"
       end
 
       def warning(msg)

--- a/cli/lib/kontena/cli/external_registries/add_command.rb
+++ b/cli/lib/kontena/cli/external_registries/add_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::ExternalRegistries
       self.url = "https://#{self.url}" unless self.url.start_with?('http')
 
       data = { username: username, password: password, email: email, url: url }
-      spinner "Adding #{url.colorize(:cyan)} to external registries " do
+      spinner "Adding #{pastel.cyan(url)} to external registries " do
         client(token).post("grids/#{current_grid}/external_registries", data)
       end
     end

--- a/cli/lib/kontena/cli/external_registries/remove_command.rb
+++ b/cli/lib/kontena/cli/external_registries/remove_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::ExternalRegistries
       require_api_url
       token = require_token
       confirm_command(name) unless forced?
-      spinner "Removing #{name.colorize(:cyan)} external-registry from #{current_grid.colorize(:cyan)} grid " do
+      spinner "Removing #{pastel.cyan(name)} external-registry from #{pastel.cyan(current_grid)} grid " do
         client(token).delete("external_registries/#{current_grid}/#{name}")
       end
     end

--- a/cli/lib/kontena/cli/grids/events_command.rb
+++ b/cli/lib/kontena/cli/grids/events_command.rb
@@ -37,9 +37,9 @@ module Kontena::Cli::Grids
 
       time = log['created_at']
       if log['severity'] == 2
-        time = time.colorize(:yellow)
+        time = pastel.yellow(time)
       elsif log['severity'] >= 3
-        time = time.colorize(:red)
+        time = pastel.red(time)
       end
 
       puts '%-25s %-25s %-40s %s' % [

--- a/cli/lib/kontena/cli/grids/list_command.rb
+++ b/cli/lib/kontena/cli/grids/list_command.rb
@@ -32,7 +32,7 @@ module Kontena::Cli::Grids
 
       if gridlist.size == 0
         self.verbose? && puts
-        puts "Kontena Master #{config.current_master.name} doesn't have any grids yet. Create one now using 'kontena grid create' command".colorize(:yellow)
+        puts pastel.yellow("Kontena Master #{config.current_master.name} doesn't have any grids yet. Create one now using 'kontena grid create' command")
         self.verbose? && puts
       else
         vputs

--- a/cli/lib/kontena/cli/grids/logs_command.rb
+++ b/cli/lib/kontena/cli/grids/logs_command.rb
@@ -29,7 +29,7 @@ module Kontena::Cli::Grids
         prefix = "#{log['created_at']} #{log['name']}:"
       end
 
-      puts "#{prefix.colorize(color)} #{log['data']}"
+      puts "#{pastel.send(color, prefix)} #{log['data']}"
     end
   end
 end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/add_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Grids::TrustedSubnets
     def execute
       grid = client.get("grids/#{current_grid}")
       data = {trusted_subnets: grid['trusted_subnets'] + [self.subnet]}
-      spinner "Adding #{subnet.colorize(:cyan)} as a trusted subnet in #{current_grid.colorize(:cyan)} grid " do
+      spinner "Adding #{pastel.cyan(subnet)} as a trusted subnet in #{pastel.cyan(current_grid)} grid " do
         client.put("grids/#{current_grid}", data)
       end
     end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -13,10 +13,10 @@ module Kontena::Cli::Grids::TrustedSubnets
       confirm_command(subnet) unless forced?
       trusted_subnets = grid['trusted_subnets'] || []
       unless trusted_subnets.delete(self.subnet)
-        exit_with_error("Grid #{current_grid.colorize(:cyan)} does not have trusted subnet #{subnet.colorize(:cyan)}")
+        exit_with_error("Grid #{pastel.cyan(current_grid)} does not have trusted subnet #{pastel.cyan(subnet)}")
       end
       data = {trusted_subnets: trusted_subnets}
-      spinner "Removing trusted subnet #{subnet.colorize(:cyan)} from #{current_grid.colorize(:cyan)} grid " do
+      spinner "Removing trusted subnet #{pastel.cyan(subnet)} from #{pastel.cyan(current_grid)} grid " do
         client.put("grids/#{current_grid}", data)
       end
     end

--- a/cli/lib/kontena/cli/grids/use_command.rb
+++ b/cli/lib/kontena/cli/grids/use_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Grids
     def execute
       grid = find_grid_by_name(name)
       unless grid
-        exit_with_error "Could not resolve grid by name [#{name}]. For a list of existing grids please run: kontena grid list".colorize(:red)
+        exit_with_error pastel.red("Could not resolve grid by name [#{name}]. For a list of existing grids please run: kontena grid list")
       end
       config.current_master.grid = grid['name']
       config.write

--- a/cli/lib/kontena/cli/helpers/log_helper.rb
+++ b/cli/lib/kontena/cli/helpers/log_helper.rb
@@ -84,7 +84,7 @@ module Kontena::Cli::Helpers
       color = color_for_container(log['name'])
       prefix = "#{log['created_at']} #{log['name']}:"
 
-      puts "#{prefix.colorize(color)} #{log['data']}"
+      puts "#{pastel.send(color, prefix)} #{log['data']}"
     end
 
     # @param [String] container_id

--- a/cli/lib/kontena/cli/logout_command.rb
+++ b/cli/lib/kontena/cli/logout_command.rb
@@ -5,6 +5,6 @@ class Kontena::Cli::LogoutCommand < Kontena::Command
   banner "or 'kontena cloud logout' to log out of the Kontena Cloud", false
 
   def execute
-    exit_with_error("Command removed. Use #{"kontena master logout".colorize(:yellow)} to log out of the Kontena Master")
+    exit_with_error("Command removed. Use #{pastel.yellow("kontena master logout")} to log out of the Kontena Master")
   end
 end

--- a/cli/lib/kontena/cli/master/logout_command.rb
+++ b/cli/lib/kontena/cli/master/logout_command.rb
@@ -9,12 +9,12 @@ module Kontena::Cli::Master
         config.servers.each do |server|
           use_refresh_token(server)
           server.token = nil
-          puts "Logged out of #{server.name.colorize(:green)}"
+          puts "Logged out of #{pastel.green(server.name)}"
         end
       elsif config.current_master
         use_refresh_token(config.current_master)
         config.current_master.token = nil
-        puts "Logged out of #{config.current_master.name.colorize(:green)}"
+        puts "Logged out of #{pastel.green(config.current_master.name)}"
       else
         warn "Current master has not been selected"
         exit 0 # exiting with 0 not 1, it's not really an error situation (kontena logout && kontena master login...)

--- a/cli/lib/kontena/cli/master/user/invite_command.rb
+++ b/cli/lib/kontena/cli/master/user/invite_command.rb
@@ -34,7 +34,7 @@ module Kontena::Cli::Master::User
           elsif self.return?
             return response
           else
-            puts "Invitation created for #{response['email']}".colorize(:green)
+            puts pastel.green("Invitation created for #{response['email']}")
             puts "  * code:    #{response['invite_code']}"
             puts "  * command: kontena master join #{current_master.url} #{response['invite_code']}"
           end

--- a/cli/lib/kontena/cli/nodes/create_command.rb
+++ b/cli/lib/kontena/cli/nodes/create_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::Nodes
       data[:token] = token if token
       data[:labels] = label_list
 
-      spinner "Creating #{name.colorize(:cyan)} node " do
+      spinner "Creating #{pastel.cyan(name)} node " do
         client.post("grids/#{current_grid}/nodes", data)
       end
     end

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -21,7 +21,7 @@ module Kontena::Cli::Nodes
 
       confirm_command(self.node) unless forced?
 
-      spinner "Removing #{self.node.colorize(:cyan)} node from #{current_grid.colorize(:cyan)} grid " do
+      spinner "Removing #{pastel.cyan(self.node)} node from #{pastel.cyan(current_grid)} grid " do
         client(token).delete("nodes/#{node['id']}")
       end
     end

--- a/cli/lib/kontena/cli/nodes/reset_token_command.rb
+++ b/cli/lib/kontena/cli/nodes/reset_token_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::Nodes
     def execute
       confirm("Resetting the node token will disconnect the agent (unless using --no-reset-connection), and require you to reconfigure the kontena-agent using the new `kontena node env` values before it will be able to reconnect. Are you sure?")
 
-      spinner "Resetting node #{self.node.colorize(:cyan)} websocket connection token" do
+      spinner "Resetting node #{pastel.cyan(self.node)} websocket connection token" do
         if self.clear_token?
           client.delete("nodes/#{current_grid}/#{self.node}/token",
             reset_connection: self.reset_connection?,

--- a/cli/lib/kontena/cli/nodes/update_command.rb
+++ b/cli/lib/kontena/cli/nodes/update_command.rb
@@ -20,7 +20,7 @@ module Kontena::Cli::Nodes
       data[:labels] = [] if self.clear_labels?
 
       data[:availability] = availability if availability
-      spinner "Updating #{self.node.colorize(:cyan)} node " do
+      spinner "Updating #{pastel.cyan(self.node)} node " do
         client.put("nodes/#{current_grid}/#{self.node}", data)
       end
     end

--- a/cli/lib/kontena/cli/plugins/install_command.rb
+++ b/cli/lib/kontena/cli/plugins/install_command.rb
@@ -17,7 +17,7 @@ module Kontena::Cli::Plugins
 
     def execute
       if installed?(name)
-        installed = spinner "Upgrading plugin #{name.colorize(:cyan)}" do
+        installed = spinner "Upgrading plugin #{pastel.cyan(name)}" do
           installer.upgrade
         end
 
@@ -25,7 +25,7 @@ module Kontena::Cli::Plugins
           Kontena::PluginManager::Cleaner.new(name).cleanup
         end
       else
-        installed = spinner "Installing plugin #{name.colorize(:cyan)}" do
+        installed = spinner "Installing plugin #{pastel.cyan(name)}" do
           installer.install
         end
       end

--- a/cli/lib/kontena/cli/registry/create_command.rb
+++ b/cli/lib/kontena/cli/registry/create_command.rb
@@ -111,7 +111,7 @@ module Kontena::Cli::Registry
 
       client(token).post("grids/#{current_grid}/stacks", data)
       deployment = client(token).post("stacks/#{current_grid}/registry/deploy", {})
-      spinner "Deploying #{data[:name].colorize(:cyan)} stack " do
+      spinner "Deploying #{pastel.cyan(data[:name])} stack " do
         wait_for_deploy_to_finish(deployment)
       end
       puts "\n"

--- a/cli/lib/kontena/cli/registry/remove_command.rb
+++ b/cli/lib/kontena/cli/registry/remove_command.rb
@@ -11,9 +11,9 @@ module Kontena::Cli::Registry
       name = 'registry'
 
       registry = client(token).get("stacks/#{current_grid}/#{name}") rescue nil
-      exit_with_error("Stack #{name.colorize(:cyan)} does not exist") if registry.nil?
+      exit_with_error("Stack #{pastel.cyan(name)} does not exist") if registry.nil?
 
-      spinner "Removing #{name.colorize(:cyan)} stack " do
+      spinner "Removing #{pastel.cyan(name)} stack " do
         client(token).delete("stacks/#{current_grid}/#{name}")
       end
     end

--- a/cli/lib/kontena/cli/services/containers_command.rb
+++ b/cli/lib/kontena/cli/services/containers_command.rb
@@ -28,7 +28,7 @@ module Kontena::Cli::Services
         puts "  ip: #{container['ip_address']}"
         puts "  public ip: #{container['node']['public_ip']}"
         if container['status'] == 'unknown'
-          puts "  status: #{container['status'].colorize(:yellow)}"
+          puts "  status: #{pastel.yellow(container['status'])}"
         else
           puts "  status: #{container['status']}"
         end

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -58,7 +58,7 @@ module Kontena::Cli::Services
         stateful: stateful?
       }
       data.merge!(parse_service_data_from_options)
-      spinner "Creating #{name.colorize(:cyan)} service " do
+      spinner "Creating #{pastel.cyan(name)} service " do
         create_service(token, current_grid, data)
       end
     end

--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Services
       service_id = name
       data = {}
       data[:force] = true if force?
-      spinner "Deploying service #{name.colorize(:cyan)} " do
+      spinner "Deploying service #{pastel.cyan(name)} " do
         deployment = deploy_service(token, name, data)
         wait_for_deploy_to_finish(token, deployment) if wait?
       end

--- a/cli/lib/kontena/cli/services/envs/add_command.rb
+++ b/cli/lib/kontena/cli/services/envs/add_command.rb
@@ -13,7 +13,7 @@ module Kontena::Cli::Services::Envs
       require_api_url
       token = require_token
       data = {env: env}
-      spinner "Adding env variable to #{name.colorize(:cyan)} service " do
+      spinner "Adding env variable to #{pastel.cyan(name)} service " do
         client(token).post("services/#{parse_service_id(name)}/envs", data)
       end
     end

--- a/cli/lib/kontena/cli/services/envs/remove_command.rb
+++ b/cli/lib/kontena/cli/services/envs/remove_command.rb
@@ -12,7 +12,7 @@ module Kontena::Cli::Services::Envs
     def execute
       require_api_url
       token = require_token
-      spinner "Removing env variable #{env.colorize(:cyan)} from #{name.colorize(:cyan)} service " do
+      spinner "Removing env variable #{pastel.cyan(env)} from #{pastel.cyan(name)} service " do
         client(token).delete("services/#{parse_service_id(name)}/envs/#{env}")
       end
     end

--- a/cli/lib/kontena/cli/services/link_command.rb
+++ b/cli/lib/kontena/cli/services/link_command.rb
@@ -27,7 +27,7 @@ module Kontena::Cli::Services
       links << {name: target_service.to_s, alias: target.to_s}
       links.compact!
       data = {links: links}
-      spinner "Linking #{name.colorize(:cyan)} to #{target.colorize(:cyan)} " do
+      spinner "Linking #{pastel.cyan(name)} to #{pastel.cyan(target)} " do
         update_service(token, name, data)
       end
     end

--- a/cli/lib/kontena/cli/services/logs_command.rb
+++ b/cli/lib/kontena/cli/services/logs_command.rb
@@ -26,7 +26,7 @@ module Kontena::Cli::Services
       color = color_for_container(log['name'])
       instance_number = log['name'].match(/^.+-(\d+)$/)[1]
       name = instance_number.nil? ? log['name'] : instance_number
-      prefix = "#{log['created_at']} [#{name}]:".colorize(color)
+      prefix = pastel.send(color, "#{log['created_at']} [#{name}]:")
       puts "#{prefix} #{log['data']}"
     end
   end

--- a/cli/lib/kontena/cli/services/monitor_command.rb
+++ b/cli/lib/kontena/cli/services/monitor_command.rb
@@ -43,7 +43,7 @@ module Kontena::Cli::Services
             else
               color = :yellow
             end
-            print "■".colorize(color)
+            print pastel.send(color, "■")
           end
           puts ''
         end

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Services
     def remove
       confirm_command(name) unless forced?
 
-      spinner "Removing service #{name.colorize(:cyan)} " do
+      spinner "Removing service #{pastel.cyan(name)} " do
         client.delete("services/#{parse_service_id(name)}")
         removed = false
         until removed == true
@@ -50,7 +50,7 @@ module Kontena::Cli::Services
         i['instance_number'] == instance.to_i
       }
       exit_with_error("Instance not found") unless service_instance
-      spinner "Removing service instance #{instance_name.colorize(:cyan)} " do
+      spinner "Removing service instance #{pastel.cyan(instance_name)} " do
         client.delete("services/#{parse_service_id(name)}/instances/#{service_instance['id']}")
       end
     end

--- a/cli/lib/kontena/cli/services/restart_command.rb
+++ b/cli/lib/kontena/cli/services/restart_command.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Services
     def execute
       require_api_url
       token = require_token
-      spinner "Sending restart signal to service #{name.colorize(:cyan)} " do
+      spinner "Sending restart signal to service #{pastel.cyan(name)} " do
         restart_service(token, name)
       end
     end

--- a/cli/lib/kontena/cli/services/secrets/link_command.rb
+++ b/cli/lib/kontena/cli/services/secrets/link_command.rb
@@ -12,7 +12,7 @@ module Kontena::Cli::Services::Secrets
     def execute
       require_api_url
       token = require_token
-      spinner "Linking #{secret.colorize(:cyan)} from Vault to #{name.colorize(:cyan)} " do
+      spinner "Linking #{pastel.cyan(secret)} from Vault to #{pastel.cyan(name)} " do
         result = client(token).get("services/#{parse_service_id(name)}")
         secrets = result['secrets']
         secrets << parse_secrets([secret])[0]

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -264,7 +264,7 @@ module Kontena
               puts "      health: #{container.dig('health_status', 'status')} (#{health_time.to_i}s ago)"
             end
             if container['status'] == 'unknown'
-              puts "      status: #{container['status'].colorize(:yellow)}"
+              puts "      status: #{pastel.yellow(container['status'])}"
             else
               puts "      status: #{container['status']}"
             end
@@ -547,18 +547,12 @@ module Kontena
         # @param [Symbol] health
         # @return [String]
         def health_status_icon(health)
-          if health == :unhealthy
-            icon = '⊗'.freeze
-            icon.colorize(:red)
-          elsif health == :partial
-            icon = '⊙'.freeze
-            icon.colorize(:yellow)
-          elsif health == :healthy
-            icon = '⊛'.freeze
-            icon.colorize(:green)
+          case health
+          when :unhealthy then pastel.red('⊗')
+          when :partial   then pastel.yellow('⊙')
+          when :healthy   then pastel.green('⊛')
           else
-            icon = '⊝'.freeze
-            icon.colorize(:dim)
+            pastel.dim('⊝')
           end
         end
 

--- a/cli/lib/kontena/cli/services/start_command.rb
+++ b/cli/lib/kontena/cli/services/start_command.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Services
     def execute
       require_api_url
       token = require_token
-      spinner "Sending start signal to #{name.colorize(:cyan)} service " do
+      spinner "Sending start signal to #{pastel.cyan(name)} service " do
         start_service(token, name)
       end
     end

--- a/cli/lib/kontena/cli/services/stop_command.rb
+++ b/cli/lib/kontena/cli/services/stop_command.rb
@@ -11,7 +11,7 @@ module Kontena::Cli::Services
     def execute
       require_api_url
       token = require_token
-      spinner "Sending stop signal to #{name.colorize(:cyan)} service " do
+      spinner "Sending stop signal to #{pastel.cyan(name)} service " do
         stop_service(token, name)
       end
     end

--- a/cli/lib/kontena/cli/services/unlink_command.rb
+++ b/cli/lib/kontena/cli/services/unlink_command.rb
@@ -22,7 +22,7 @@ module Kontena::Cli::Services
       end
       links.delete_if { |l| l['id'] == target_id }
       data = {links: links}
-      spinner "Unlinking #{name.colorize(:cyan)} from #{target.colorize(:cyan)} " do
+      spinner "Unlinking #{pastel.cyan(name)} from #{pastel.cyan(target)} " do
         update_service(token, name, data)
       end
     end

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -50,7 +50,7 @@ module Kontena::Cli::Services
       token = require_token
 
       data = parse_service_data_from_options
-      spinner "Updating #{name.colorize(:cyan)} service " do
+      spinner "Updating #{pastel.cyan(name)} service " do
         update_service(token, name, data)
       end
     end

--- a/cli/lib/kontena/cli/spinner.rb
+++ b/cli/lib/kontena/cli/spinner.rb
@@ -47,7 +47,7 @@ module Kontena
 
       def self.spin_no_tty(msg, &block)
         unless block_given?
-          Kernel.puts "\r [" + "done".colorize(:green) + "] #{msg}"
+          Kernel.puts "\r [" + Kontena.pastel.green("done") + "] #{msg}"
           return
         end
 
@@ -80,7 +80,7 @@ module Kontena
         return spin_no_tty(msg, &block) unless $stdout.tty?
 
         unless block_given?
-          Kernel.puts "\r [" + "done".colorize(:green) + "] #{msg}"
+          Kernel.puts "\r [" + Kontena.pastel.green("done") + "] #{msg}"
           return
         end
 
@@ -89,7 +89,7 @@ module Kontena
           Thread.main['spinners'].each do |thread|
             thread['pause'] = true
           end
-          Kernel.puts "\r [#{'....'.colorize(:yellow)}] #{Thread.main['spinners'].last['msg']}"
+          Kernel.puts "\r [#{Kontena.pastel.yellow('....')}] #{Thread.main['spinners'].last['msg']}"
         end
 
         Thread.main['spinner_msgs'] = []
@@ -139,27 +139,27 @@ module Kontena
           spin_thread.kill
           case spin_status.result
           when :warn
-            Kernel.puts "\r [" + "warn".colorize(:yellow) + "] #{msg}     "
+            Kernel.puts "\r [" + Kontena.pastel.yellow("warn") + "] #{msg}     "
           when :fail
-            Kernel.puts "\r [" + "fail".colorize(:red) + "] #{msg}     "
+            Kernel.puts "\r [" + Kontena.pastel.red("fail") + "] #{msg}     "
           else
-            Kernel.puts "\r [" + "done".colorize(:green) + "] #{msg}     "
+            Kernel.puts "\r [" + Kontena.pastel.green("done") + "] #{msg}     "
           end
         rescue SystemExit => ex
           spin_thread.kill
           if ex.status == 0
-            Kernel.puts "\r [" + "done".colorize(:green)   + "] #{msg}     "
+            Kernel.puts "\r [" + Kontena.pastel.green("done")   + "] #{msg}     "
           else
-            Kernel.puts "\r [" + "fail".colorize(:red)   + "] #{msg}     "
+            Kernel.puts "\r [" + Kontena.pastel.red("fail")   + "] #{msg}     "
           end
           status = ex.status
         rescue SpinAbort
           spin_thread.kill
-          Kernel.puts "\r [" + "fail".colorize(:red)   + "] #{msg}     "
+          Kernel.puts "\r [" + Kontena.pastel.red("fail")   + "] #{msg}     "
           Kontena.logger.debug { "Spin aborted through fail!" }
         rescue Exception => ex
           spin_thread.kill
-          Kernel.puts "\r [" + "fail".colorize(:red)   + "] #{msg}     "
+          Kernel.puts "\r [" + Kontena.pastel.red("fail")   + "] #{msg}     "
           Kontena.logger.error(ex)
           raise ex
         ensure

--- a/cli/lib/kontena/cli/stacks/build_command.rb
+++ b/cli/lib/kontena/cli/stacks/build_command.rb
@@ -35,7 +35,7 @@ module Kontena::Cli::Stacks
       end
 
       if services.none?{ |service| service['build'] }
-        abort 'Not found any service with a build option'.colorize(:red)
+        abort pastel.red('Not found any service with a build option')
       end
       build_docker_images(services)
       push_docker_images(services) unless no_push?
@@ -49,10 +49,10 @@ module Kontena::Cli::Stacks
           abort("'#{service['image']}' is not valid Docker image name") unless valid_image_name?(service['image'])
           abort("'#{service['build']['context']}' does not have #{dockerfile}") unless dockerfile_exist?(service['build']['context'], dockerfile)
           if service['hooks'] && service['hooks']['pre_build']
-            puts "Running pre_build hook".colorize(:cyan)
+            puts pastel.cyan("Running pre_build hook")
             run_pre_build_hook(service['hooks']['pre_build'])
           end
-          puts "Building image #{service['image'].colorize(:cyan)}"
+          puts "Building image #{pastel.cyan(service['image'])}"
           build_docker_image(service)
         end
       end
@@ -62,7 +62,7 @@ module Kontena::Cli::Stacks
     def push_docker_images(services)
       services.each do |service|
         if service['build']
-          puts "Pushing image #{service['image'].colorize(:cyan)}"
+          puts "Pushing image #{pastel.cyan(service['image'])}"
           push_docker_image(service['image'])
         end
       end
@@ -85,7 +85,7 @@ module Kontena::Cli::Stacks
       end
       cmd << build_context
       ret = system(*cmd.flatten)
-      raise ("Failed to build image #{service['image'].colorize(:cyan)}") unless ret
+      raise ("Failed to build image #{pastel.cyan(service['image'])}") unless ret
       ret
     end
 
@@ -95,7 +95,7 @@ module Kontena::Cli::Stacks
       cmd = ['docker', 'push', image]
       cmd.unshift('sudo') if sudo?
       ret = system(*cmd)
-      raise ("Failed to push image #{image.colorize(:cyan)}") unless ret
+      raise ("Failed to push image #{pastel.cyan(image)}") unless ret
       ret
     end
 

--- a/cli/lib/kontena/cli/stacks/logs_command.rb
+++ b/cli/lib/kontena/cli/stacks/logs_command.rb
@@ -28,7 +28,7 @@ module Kontena::Cli::Stacks
 
     def show_log(log)
       color = color_for_container(log['name'])
-      prefix = "#{log['created_at']} [#{log['name']}]:".colorize(color)
+      prefix = pastel.send(color, "#{log['created_at']} [#{log['name']}]:")
       puts "#{prefix} #{log['data']}"
     end
   end

--- a/cli/lib/kontena/cli/stacks/monitor_command.rb
+++ b/cli/lib/kontena/cli/stacks/monitor_command.rb
@@ -45,7 +45,7 @@ module Kontena::Cli::Stacks
         puts "services:"
         services.each do |service|
           color = color_for_service(service['name'])
-          puts "  #{"■".colorize(color)} #{service['name']} (#{service['instances']} instances)"
+          puts "  #{pastel.send(color, "■")} #{service['name']} (#{service['instances']} instances)"
         end
         puts "nodes:"
         node_names = nodes.keys.sort
@@ -59,7 +59,7 @@ module Kontena::Cli::Stacks
               icon = "□"
             end
             color = color_for_service(container['service'])
-            print icon.colorize(color)
+            print pastel.send(color, icon)
           end
           puts ''
         end

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -13,7 +13,7 @@ module Kontena::Cli::Vault
       confirm_command(name) unless forced?
 
       token = require_token
-      vspinner "Removing #{name.colorize(:cyan)} from the vault " do
+      vspinner "Removing #{pastel.cyan(name)} from the vault " do
         client(token).delete("secrets/#{current_grid}/#{name}")
       end
     end

--- a/cli/lib/kontena/cli/vault/update_command.rb
+++ b/cli/lib/kontena/cli/vault/update_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Vault
     end
 
     def execute
-      vspinner "Updating #{name.colorize(:cyan)} value in the vault " do
+      vspinner "Updating #{pastel.cyan(name)} value in the vault " do
         client.put("secrets/#{current_grid}/#{name}", {name: name, value: value, upsert: upsert? })
       end
     end

--- a/cli/lib/kontena/cli/vault/write_command.rb
+++ b/cli/lib/kontena/cli/vault/write_command.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Vault
     end
 
     def execute
-      vspinner "Writing #{name.colorize(:cyan)} to the vault " do
+      vspinner "Writing #{pastel.cyan(name)} to the vault " do
         client.post("grids/#{current_grid}/secrets", { name: name, value: value })
       end
     end

--- a/cli/lib/kontena/cli/vpn/create_command.rb
+++ b/cli/lib/kontena/cli/vpn/create_command.rb
@@ -53,7 +53,7 @@ module Kontena::Cli::Vpn
       spinner "Generating #{pastel.cyan(name)} keys (this will take a while) " do
         wait_for_configuration_to_finish(token)
       end
-      puts "#{name.colorize(:cyan)} service is now started (udp://#{vpn_ip}:1194)."
+      puts "#{pastel.cyan(name)} service is now started (udp://#{vpn_ip}:1194)."
       puts "use 'kontena vpn config' to fetch OpenVPN client config to your machine."
     end
 

--- a/cli/lib/kontena/cli/vpn/remove_command.rb
+++ b/cli/lib/kontena/cli/vpn/remove_command.rb
@@ -14,7 +14,7 @@ module Kontena::Cli::Vpn
       vpn = client(token).get("stacks/#{current_grid}/#{name}") rescue nil
       exit_with_error("VPN stack does not exist") if vpn.nil?
 
-      spinner "Removing #{name.colorize(:cyan)} service " do
+      spinner "Removing #{pastel.cyan(name)} service " do
         client(token).delete("stacks/#{current_grid}/#{name}")
       end
     end

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -169,6 +169,14 @@ module Kontena
   end
 end
 
+# Monkeypatching string to mimick 'colorize' gem
+class String
+  def colorize(color_sym)
+    ::Kontena.pastel.send(color_sym, self)
+  end
+end
+
+
 require 'retriable'
 Retriable.configure do |c|
   c.on_retry = Proc.new do |exception, try, elapsed_time, next_interval|

--- a/cli/lib/kontena_cli.rb
+++ b/cli/lib/kontena_cli.rb
@@ -169,13 +169,6 @@ module Kontena
   end
 end
 
-# Monkeypatching string to mimick 'colorize' gem
-class String
-  def colorize(color_sym)
-    ::Kontena.pastel.send(color_sym, self)
-  end
-end
-
 require 'retriable'
 Retriable.configure do |c|
   c.on_retry = Proc.new do |exception, try, elapsed_time, next_interval|


### PR DESCRIPTION
Replaces remaining occurences of `"string".colorize(:red)` with `pastel.red(string)` 
