### PR TITLE
CLI: Enable anchor/aliases support in YAML parsing

### DIFF
--- a/cli/lib/kontena/cli/master/config/import_command.rb
+++ b/cli/lib/kontena/cli/master/config/import_command.rb
@@ -40,7 +40,7 @@ module Kontena::Cli::Master::Config
         require 'json'
         JSON.parse(data)
       when 'yaml', 'yml'
-        YAML.safe_load(data)
+        ::YAML.safe_load(data, [], [], true)
       else
         exit_with_error "Unknown input format '#{self.format}'"
       end

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -95,7 +95,7 @@ module Kontena::Cli::Stacks
         where.prepend InstanceMethods
 
         where.option '--values-from', '[FILE]', 'Read variable values from YAML' do |filename|
-          values_from_file.merge!(::YAML.safe_load(File.read(filename)))
+          values_from_file.merge!(::YAML.safe_load(File.read(filename)), [], [], true, filename)
           true
         end
 

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -94,14 +94,15 @@ module Kontena::Cli::Stacks
       def self.included(where)
         where.prepend InstanceMethods
 
-        where.option '--values-from', '[FILE]', 'Read variable values from YAML' do |filename|
-          values_from_file.merge!(::YAML.safe_load(File.read(filename)), [], [], true, filename)
-          true
+        where.option '--values-from', '[FILE]', 'Read variable values from YAML', multivalued: true do |filename|
+          values_from_file.merge!(::YAML.safe_load(File.read(filename), [], [], true, filename))
+          filename
         end
 
         where.option '-v', "VARIABLE=VALUE", "Set stack variable values, example: -v domain=example.com. Can be used multiple times.", multivalued: true, attribute_name: :var_option do |var_pair|
           var_name, var_value = var_pair.split('=', 2)
           values_from_value_options.merge!(::YAML.safe_load(::YAML.dump(var_name => var_value)))
+          var_pair
         end
       end
 

--- a/cli/lib/kontena/cli/stacks/registry/show_command.rb
+++ b/cli/lib/kontena/cli/stacks/registry/show_command.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Stacks::Registry
     def execute
       require 'semantic'
       unless versions?
-        stack = ::YAML.safe_load(stacks_client.show(stack_name.stack_name, stack_name.version))
+        stack = ::YAML.safe_load(stacks_client.show(stack_name.stack_name, stack_name.version), [], [], true)
         puts "#{stack['stack']}:"
         puts "  #{"latest_" unless stack_name.version}version: #{stack['version']}"
         puts "  expose: #{stack['expose'] || '-'}"

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -83,7 +83,7 @@ module Kontena::Cli::Stacks
               substitutions: default_envs,
               warnings: false
             )
-          )
+          ), [], [], true, file
         )
       rescue Psych::SyntaxError => ex
         raise ex, "Error while parsing #{file} : #{ex.message}"
@@ -104,7 +104,7 @@ module Kontena::Cli::Stacks
               use_opto: true,
               raise_on_unknown: true
             )
-          )
+          ), [], [], true, file
         )
       rescue Psych::SyntaxError => ex
         raise ex, "Error while parsing #{file} : #{ex.message}"

--- a/cli/lib/kontena/cli/vault/import_command.rb
+++ b/cli/lib/kontena/cli/vault/import_command.rb
@@ -16,7 +16,7 @@ module Kontena::Cli::Vault
 
     def parsed_input
       require "json"
-      json? ? JSON.load(input) : YAML.safe_load(input)
+      json? ? JSON.load(input) : YAML.safe_load(input, [], [], true, path)
     end
 
     def input

--- a/cli/lib/kontena/scripts/completer.rb
+++ b/cli/lib/kontena/scripts/completer.rb
@@ -90,7 +90,7 @@ class Helper
   def yml_services
     require 'yaml'
     if File.exist?('kontena.yml')
-      yaml = YAML.safe_load(File.read('kontena.yml'))
+      yaml = YAML.safe_load(File.read('kontena.yml'), [], [], true, 'kontena.yml')
       services = yaml['services']
       services.keys
     end

--- a/cli/lib/kontena/stacks_cache.rb
+++ b/cli/lib/kontena/stacks_cache.rb
@@ -20,7 +20,7 @@ module Kontena
       end
 
       def load
-        YAML.safe_load(read)
+        ::YAML.safe_load(read, [], [], true, path)
       end
 
       def write(content)
@@ -77,7 +77,7 @@ module Kontena
         else
           dputs "Retrieving #{stack.stack}:#{stack.version} from registry"
           content = client.pull(stack.stack, stack.version)
-          yaml    = ::YAML.safe_load(content)
+          yaml    = ::YAML.safe_load(content, [], [], true, stack.stack)
           new_stack = CachedStack.new(yaml['stack'], yaml['version'])
           if new_stack.cached?
             dputs "Already cached"

--- a/cli/spec/fixtures/stack-with-anchors.yml
+++ b/cli/spec/fixtures/stack-with-anchors.yml
@@ -1,0 +1,13 @@
+stack: user/stackname
+version: 0.1.1
+data:
+  with_affinity: &with_affinity
+    affinity:
+      - abc==dfg
+services:
+  wordpress:
+    <<: *with_affinity
+    image: wordpress
+  mysql:
+    <<: *with_affinity
+    image: mysql

--- a/cli/spec/kontena/cli/stacks/common_spec.rb
+++ b/cli/spec/kontena/cli/stacks/common_spec.rb
@@ -12,10 +12,6 @@ describe Kontena::Cli::Stacks::Common do
       include Kontena::Cli::Stacks::Common::StackNameOption
       include Kontena::Cli::Stacks::Common::StackValuesToOption
       include Kontena::Cli::Stacks::Common::StackValuesFromOption
-
-      def what
-        [source]
-      end
     end
   end
 

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -146,7 +146,6 @@ describe Kontena::Cli::Stacks::YAML::Reader do
         it 'extends services from the same file' do
           app_svc = subject.execute['services'].find { |s| s['name'] == 'app' }
           expect(app_svc).not_to be_nil
-          puts app_svc.inspect
           expect(app_svc).to match hash_including(
             "image" => "base:latest",
             "instances" => 2,
@@ -512,6 +511,13 @@ describe Kontena::Cli::Stacks::YAML::Reader do
       expect(outcome['services']).to match array_including(
         hash_including('name' => 'test', 'env' => ['ASDF=test'])
       )
+    end
+  end
+
+  context "yaml with anchors" do
+    subject { described_class.new(fixture_path('stack-with-anchors.yml')) }
+    it 'parses correctly' do
+      expect(subject.execute['services'].all? { |svc| svc['affinity'] == ['abc==dfg']}).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Fixes #2769 by calling `safe_load` with `content, [], [], true` to set the "aliases" option to true.

This is actually what the allowed stack top level keyword `data` was added for.

This enables something like:

```yaml
stack: foofoo/foo
variables:
  stack_affinity:
    type: string
    required: false
    from: prompt
data:
  with_affinity: &with_affinity
    affinity: $stack_affinity
services:
  foo:
    <<: *with_affinity
    image: foofoo
  bar:
    <<: *with_affinity
    image: barbar
    environment:
      - foofoo=foo
```

Also adds a filename to Psych error message output when applicable
