### PR TITLE
Fix agent ServicePodWorker to ignore old container events

### DIFF
--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -66,10 +66,8 @@ module Kontena::Workers
     # @param topic [String]
     # @param event [Docker::Event]
     def on_container_event(topic, event)
-      attrs = event.actor.attributes
-      if attrs['io.kontena.service.id'] == @service_pod.service_id &&
-          attrs['io.kontena.container.type'] == 'container'.freeze &&
-          attrs['io.kontena.service.instance_number'].to_i == @service_pod.instance_number
+      if @container && event.id == @container.id
+        debug "container event: #{event.status}"
         @container_state_changed = true
         handle_restart_on_die if event.status == 'die'.freeze
       end

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -167,7 +167,7 @@ module Kontena::Workers
       end
 
       service_container = get_container(service_pod.service_id, service_pod.instance_number)
-      service_container.cached_json
+      service_container.name # trigger cached_json
       service_container
     end
 

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -167,7 +167,7 @@ module Kontena::Workers
       end
 
       service_container = get_container(service_pod.service_id, service_pod.instance_number)
-      service_container.name # trigger cached_json
+      service_container.name if service_container # trigger cached_json
       service_container
     end
 


### PR DESCRIPTION
Fixes #2766

Store the `@container` state in `#apply`, allowing the `ServicePodWorker#on_container_event` handler to accurately identify any events from the managed container, and ignore any queued up events from any previous container.

```
D, [2017-09-06T11:08:16.093978 #1] DEBUG -- Kontena::Workers::ServicePodWorker: state of redis-1: running
I, [2017-09-06T11:08:16.121786 #1]  INFO -- Kontena::Workers::ServicePodWorker: service updated at 2017-09-06T11:08:15+00:00 after service container created at 2017-09-06T10:09:59+00:00
I, [2017-09-06T11:08:16.122948 #1]  INFO -- Kontena::Workers::ServicePodWorker: re-creating redis-1

I, [2017-09-06T11:08:16.123115 #1]  INFO -- Kontena::ServicePods::Creator: creating service: redis-1
I, [2017-09-06T11:08:18.881112 #1]  INFO -- Kontena::ServicePods::Creator: removing previous version of service: redis-1
I, [2017-09-06T11:08:19.644048 #1]  INFO -- Kontena::ServicePods::Creator: service started: redis-1

D, [2017-09-06T11:08:19.756281 #1] DEBUG -- Kontena::Workers::ServicePodWorker: sync state update: {:service_id=>"599bee9bd431ec00137163c7", :instance_number=>1, :rev=>"2017-09-06 11:08:15 UTC", :state=>"running", :error=>nil}
D, [2017-09-06T11:08:19.757256 #1] DEBUG -- Kontena::Workers::ServicePodWorker: container event: create
D, [2017-09-06T11:08:19.766258 #1] DEBUG -- Kontena::Workers::ServicePodWorker: container event: start
```

No more `die` or `stop` events to trigger the restart logic from the old service container that got removed. The `create` and `start` events still cause a second/unnecessary call to `apply` on the next pod manager update loop, but that's okay.