### PR TITLE
Fix agent ServicePodWorker to not block on wait_for_port

### DIFF
--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -76,6 +76,11 @@ module Docker
       false
     end
 
+    # @return DatetTime
+    def started_at
+      DateTime.parse(cached_json['State']['StartedAt'])
+    end
+
     # @return [Boolean]
     def finished?
       DateTime.parse(self.state['FinishedAt']).year > 1

--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -76,7 +76,7 @@ module Docker
       false
     end
 
-    # @return DatetTime
+    # @return [DateTime]
     def started_at
       DateTime.parse(cached_json['State']['StartedAt'])
     end

--- a/agent/lib/kontena/helpers/port_helper.rb
+++ b/agent/lib/kontena/helpers/port_helper.rb
@@ -1,8 +1,10 @@
   module Kontena
     module Helpers
       module PortHelper
-
-        def container_port_open?(ip, port, timeout = 2.0)
+        # @param ip [String]
+        # @param port [Integer]
+        # @param timeout [Float]
+        def port_open?(ip, port, timeout: 2.0)
           Timeout::timeout(timeout) do
             begin
               TCPSocket.new(ip, port).close
@@ -14,7 +16,6 @@
         rescue Timeout::Error
           false
         end
-
       end
     end
   end

--- a/agent/lib/kontena/workers/container_health_check_worker.rb
+++ b/agent/lib/kontena/workers/container_health_check_worker.rb
@@ -96,7 +96,7 @@ module Kontena::Workers
         'id' => @container.id
       }
       begin
-        response = container_port_open?(ip, port, timeout)
+        response = port_open?(ip, port, timeout: timeout)
         debug "got status: #{response}"
         data['status'] = response ? 'healthy' : 'unhealthy'
         data['status_code'] = response ? 'open' : 'closed'

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -26,7 +26,7 @@ module Kontena::Workers
     def initialize(node, service_pod)
       @node = node
       @service_pod = service_pod
-      @prev_state = nil # sync'd to master
+      @prev_state = nil # last state sent to master; do not go backwards in time
       @container_state_changed = true
       @deploy_rev_changed = false
       @restarts = 0
@@ -117,64 +117,75 @@ module Kontena::Workers
     end
 
     def apply
-      cancel_restart_timers
-      exclusive {
-        begin
-          @container = ensure_desired_state
-          # reset restart counter if instance stays up 10s
-          @restart_counter_reset_timer = after(10) {
-            info "#{@service_pod.name_for_humans} stayed up 10s, resetting restart backoff counter" if restarting?
-            @restarts = 0
-          }
-        rescue => error
-          warn "failed to sync #{service_pod.name} at #{service_pod.deploy_rev}: #{error}"
-          warn error
-          sync_state_to_master(@container, error)
-          return
-        else
-          @container_state_changed = false
-        end
+      service_pod = nil
+      container = nil
 
-        if service_pod.terminated?
-          # Only terminate this actor after we have succesfully ensure_terminated the Docker container
-          # Otherwise, stick around... the manager will notice we're still there and re-signal to destroy
-          self.terminate
-        elsif service_pod.running? && service_pod.wait_for_port
-          # delay sync_state_to_master until started
-          # XXX: apply() gets called twice for each deploy_rev, and this launches two wait_for_port tasks...
-          async.wait_for_port(service_pod, @container)
-        else
-          sync_state_to_master(@container)
-        end
+      exclusive {
+        # make sure we sync the correct service_pod rev back to the master, if it changes later during the apply
+        service_pod = @service_pod
+
+        cancel_restart_timers
+
+        container = @container = ensure_desired_state
+
+        # reset restart counter if instance stays up 10s
+        @restart_counter_reset_timer = after(10) {
+          info "#{@service_pod.name_for_humans} stayed up 10s, resetting restart backoff counter" if restarting?
+          @restarts = 0
+        }
+        @container_state_changed = false
       }
+
+      if service_pod.running? && service_pod.wait_for_port
+        wait_for_port(service_pod, container)
+
+      elsif service_pod.terminated?
+        # Only terminate this actor after we have succesfully ensure_terminated the Docker container
+        # Otherwise, stick around... the manager will notice we're still there and re-signal to destroy
+        self.terminate
+        return # skip sync_state_to_master
+      end
+
+    rescue => error
+      warn "failed to sync #{service_pod.name} at #{service_pod.deploy_rev}: #{error}"
+      warn error
+      sync_state_to_master(service_pod, container, error) # XXX: unknown container?
+    else
+      sync_state_to_master(service_pod, container)
     end
 
+    # Check that the given container is still running for the given service pod revision.
+    #
+    # @raise [RuntimeError] service stopped
+    # @raise [RuntimeError] service redeployed
+    # @raise [RuntimeError] container recreated
+    # @raise [RuntimeError] container restarted
+    def check_starting!(service_pod, container)
+      raise "service stopped" if !@service_pod.running?
+      raise "service redeployed" if @service_pod.deploy_rev != service_pod.deploy_rev
+      raise "container recreated" if @container.id != container.id
+      raise "container restarted" if @container.started_at != container.started_at
+    end
+
+    # @param service_pod [Kontena::Models::ServicePod]
+    # @param container [Docker::Container]
+    # @param timeout [Float]
+    # @raise [RuntimeError] service or container changed
+    # @raise [Timeout::Error] service did not become ready
+    # @return container is ready
     def wait_for_port(service_pod, container, timeout: 300.0)
       name = container.name
       ip = container.overlay_ip
       port = service_pod.wait_for_port
 
-      info "waiting for container #{name} port #{ip}:#{port} to respond"
+      info "waiting until container #{name} port #{ip}:#{port} is responding"
 
       wait_until!("container #{name} port #{ip}:#{port} is responding", interval: 1.0, timeout: timeout) {
-         raise "service stopped" if !@service_pod.running?
-         raise "service redeployed" if @service_pod.deploy_rev != service_pod.deploy_rev
-         raise "container recreated" if @container.id != container.id
-         raise "container restarted" if @container.started_at != container.started_at
+        check_starting!(service_pod, container) # raises
+        port_open?(ip, port, timeout: 1.0)
+      }
 
-         port_open?(ip, port, timeout: 1.0)
-       }
-
-    rescue RuntimeError, Timeout::Error => exc
-      if @service_pod.deploy_rev == service_pod.deploy_rev
-        warn "wait_for_port failed: #{exc}"
-        sync_state_to_master(container, exc)
-      else
-        warn "wait_for_port aborted: #{exc}"
-      end
-    else
       info "container #{name} port #{ip}:#{port} is responding"
-      sync_state_to_master(container)
     end
 
     # @return [Docker::Container, nil]
@@ -351,9 +362,10 @@ module Kontena::Workers
       end
     end
 
+    # @param service_pod [Kontena::Models::ServicePod]
     # @param service_container [Docker::Container]
     # @param error [Exception]
-    def sync_state_to_master(service_container, error = nil)
+    def sync_state_to_master(service_pod, service_container, error = nil)
       state = {
         service_id: service_pod.service_id,
         instance_number: service_pod.instance_number,
@@ -362,11 +374,17 @@ module Kontena::Workers
         error: error ? "#{error.class}: #{error}" : nil,
       }
 
-      if state != @prev_state
-        debug "sync state update: #{state}"
-        rpc_client.async.request('/node_service_pods/set_state', [node.id, state])
-        @prev_state = state
-      end
+      exclusive {
+        if @prev_state && @prev_state[:rev] && service_pod.deploy_rev < @prev_state[:rev]
+          warn "skip #{service_pod.name_for_humans} state sync at #{service_pod.deploy_rev}: stale, last sync at #{@prev_state[:rev]}"
+        elsif state == @prev_state
+          debug "skip #{service_pod.name_for_humans} state sync at #{service_pod.deploy_rev}: unchanged"
+        else
+          debug "sync #{service_pod.name_for_humans} state at #{service_pod.deploy_rev}: #{state}"
+          rpc_client.async.request('/node_service_pods/set_state', [node.id, state])
+          @prev_state = state
+        end
+      }
     end
 
     # @param type [String]

--- a/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
@@ -12,6 +12,92 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
   end
   let(:subject) { described_class.new(node, service_pod) }
 
+  describe '#apply' do
+    let(:container_id) { '8919f1a9fd05a0730a4b36549771e25895d71b9dd54c426bd6f5be969d39773c' }
+    let(:overlay_ip) { '10.81.128.1' }
+    let(:container_started_at) { Time.now }
+    let(:container) {double(:container, id: container_id,
+      name: 'foo-2',
+      overlay_ip: overlay_ip,
+      started_at: container_started_at,
+    ) }
+    let(:restarted_container) {double(:container, id: container_id,
+      name: 'foo-2',
+      overlay_ip: overlay_ip,
+      started_at: container_started_at + 1.0,
+    ) }
+
+    it 'ensures the container, and syncs to master' do
+      expect(subject.wrapped_object).to receive(:ensure_desired_state).and_return(container)
+      expect(subject.wrapped_object).to receive(:sync_state_to_master).with(service_pod, container)
+
+      subject.apply
+    end
+
+    it 'ensures the container, and syncs errors to master' do
+      expect(subject.wrapped_object).to receive(:ensure_desired_state).and_raise(RuntimeError.new('test'))
+      expect(subject.wrapped_object).to receive(:sync_state_to_master).with(service_pod, nil, RuntimeError)
+
+      subject.apply
+    end
+
+    context 'with wait_for_port' do
+      let(:service_pod) do
+        Kontena::Models::ServicePod.new(
+          'id' => 'foo/2',
+          'instance_number' => 2,
+          'updated_at' => Time.now.to_s,
+          'deploy_rev' => Time.now.to_s,
+          'desired_state' => 'running',
+          'wait_for_port' => 1337,
+        )
+      end
+
+      it 'syncs state after waiting for the port' do
+        expect(subject.wrapped_object).to receive(:ensure_desired_state).and_return(container)
+        expect(subject.wrapped_object).to receive(:port_open?).with(overlay_ip, 1337, timeout: 1.0).and_return(true)
+        expect(subject.wrapped_object).to receive(:sync_state_to_master).with(service_pod, container)
+
+        subject.apply
+      end
+
+      it 'aborts if the container crashes and restarts' do
+        expect(subject.wrapped_object).to receive(:ensure_desired_state).once.and_return(container)
+        expect(subject.wrapped_object).to receive(:port_open?).with(overlay_ip, 1337, timeout: 1.0).once do
+          expect(subject.wrapped_object).to receive(:ensure_desired_state).once.and_return(restarted_container)
+          expect(subject.wrapped_object).to receive(:wait_for_port)
+          # XXX: in this case both the failing initial wait_for_port, and the restart will report state...
+          expect(subject.wrapped_object).to receive(:sync_state_to_master).with(service_pod, restarted_container)
+
+          subject.on_container_event('container:event', double(id: container_id, status: 'die'))
+
+          false
+        end
+        allow(subject.wrapped_object).to receive(:sleep)
+        allow(subject.wrapped_object).to receive(:port_open?).with(overlay_ip, 1337, timeout: 1.0).and_return(false)
+        expect(subject.wrapped_object).to receive(:sync_state_to_master).with(service_pod, container, RuntimeError) do |pod, container, error|
+          expect(error.message).to match /container restarted/
+        end
+
+
+        subject.apply
+      end
+    end
+
+    describe 'when terminating a service pod' do
+      it 'ensures the container, and terminates' do
+        expect(subject.wrapped_object).to receive(:ensure_desired_state) do
+          expect(service_pod).to be_terminated
+          nil
+        end
+        expect(subject.wrapped_object).to receive(:terminate)
+        expect(subject.wrapped_object).to_not receive(:sync_state_to_master)
+
+        subject.destroy
+      end
+    end
+  end
+
   describe '#ensure_desired_state' do
     it 'calls ensure_running if container does not exist and service_pod desired_state is running' do
       container = double(:container, :running? => true, :restarting? => false, name: 'foo-2')
@@ -152,8 +238,15 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
         subject.sync_state_to_master(service_pod, container)
       end
 
+      it 'updates again with a newer rev' do
+        allow(service_pod).to receive(:deploy_rev).and_return((Time.now + 1.0).to_s)
+
+        expect(rpc_client).to receive(:request)
+        subject.sync_state_to_master(service_pod, container)
+      end
+
       it 'does not send an update for an older rev' do
-        allow(service_pod).to receive(:deploy_rev).and_return(Time.now.to_s)
+        allow(service_pod).to receive(:deploy_rev).and_return((Time.now - 1.0).to_s)
 
         expect(rpc_client).to_not receive(:request)
         subject.sync_state_to_master(service_pod, container)


### PR DESCRIPTION
Fixes #2775 by having the deploy fail if the container restarts during `wait_for_port`
Fixes #2415 by allowing the `ServicePodWorker` actor to terminate during `wait_for_port`
Maybe fixes #2625?
Mitigates #2710 by allowing deploys pending on `wait_for_port` to be aborted by stopping the service

Splits apart the `apply` `exclusive { ensure_desired_state; sync_state_to_master }` block, with an optional `wait_for_port` in between. The `wait_for_port` -> `wait_until!` -> `sleep` in the actor class allows the actor to see later `update` calls, and the `wait_for_port` `wait_until!` -> `check_starting!` can pick these up to cancel the wait.

Needs extra logic to protect `sync_state_to_master` against sending stale state from a suspended `apply` task, after a new `update` state has been applied and sent.

## Workaround for cancelling a deploy stuck on `wait_for_port`

This allows interrupting a service deploy with a broken `wait_for_port` by using `kontena service stop`, which will immediately fail the ongoing deploy, as the agent will sync the `service_pod` state with the current `deploy_rev` and `state: stopped` - although there's also a race here with the `wait_for_port` task syncing its `error` state:

```
I, [2017-09-06T16:03:37.567719 #18]  INFO -- GridServiceInstanceDeployer: waited 13.7s of 300.0s until: service development/null/redis-waitforport-1 is running on node development/core-01 at 2017-09-06 16:03:23 UTC yielded GridServiceInstance
W, [2017-09-06T16:03:37.568076 #18]  WARN -- GridServiceInstanceDeployer: Failed to deploy service instance development/null/redis-waitforport-1 to node core-01: GridServiceInstanceDeployer::StateError: Service instance is not running, but stopped
```

```
W, [2017-09-06T16:03:37.600901 #1]  WARN -- Kontena::Workers::ServicePodWorker: wait_for_port failed: service stopped
```

# TODO
- [ ] fix dual-`async.wait_for_port`?
- [x] specs
- [ ] more specs?