### PR TITLE
Fix server GridServices::Start/Stop to not use async_thread

### DIFF
--- a/server/app/mutations/grid_services/start.rb
+++ b/server/app/mutations/grid_services/start.rb
@@ -14,13 +14,16 @@ module GridServices
     def start_service_instances
       self.grid_service.grid_service_instances.each do |i|
         i.set(desired_state: 'running')
-        notify_node(i.host_node) if i.host_node
+        notify_service_instance(i, 'start')
       end
     end
 
     # @param node [HostNode]
-    def notify_node(node)
-      node.rpc_client.notify('/service_pods/notify_update', 'start')
+    # @param action [String]
+    def notify_service_instance(service_instance, action)
+      if service_instance.host_node
+        service_instance.host_node.rpc_client.notify('/service_pods/notify_update', action)
+      end
     end
   end
 end

--- a/server/app/mutations/grid_services/stop.rb
+++ b/server/app/mutations/grid_services/stop.rb
@@ -1,33 +1,29 @@
 module GridServices
   class Stop < Mutations::Command
-    include AsyncHelper
-
     required do
       model :grid_service
     end
 
     def execute
-      prev_state = self.grid_service.state
-      async_thread do
-        begin
-          self.grid_service.set_state('stopped')
-          self.stop_service_instances
-        rescue => exc
-          self.grid_service.set_state(prev_state)
-          raise exc
-        end
-      end
+      self.grid_service.set_state('stopped')
+      self.stop_service_instances
+    rescue => exc
+      add_error(:stop, :error, exc.message)
     end
 
     def stop_service_instances
       self.grid_service.grid_service_instances.each do |i|
         i.set(desired_state: 'stopped')
-        notify_node(i.host_node) if i.host_node
+        notify_service_instance(i, 'stop')
       end
     end
 
-    def notify_node(node)
-      RpcClient.new(node.node_id).notify('/service_pods/notify_update', 'stop')
+    # @param node [HostNode]
+    # @param action [String]
+    def notify_service_instance(service_instance, action)
+      if service_instance.host_node
+        service_instance.host_node.rpc_client.notify('/service_pods/notify_update', action)
+      end
     end
   end
 end

--- a/server/spec/mutations/grid_services/start_spec.rb
+++ b/server/spec/mutations/grid_services/start_spec.rb
@@ -1,38 +1,49 @@
 describe GridServices::Start do
-  include AsyncMock
-
-  let(:grid) {
-    grid = Grid.create!(name: 'test-grid')
-    grid
-  }
-  let(:redis_service) { GridService.create(grid: grid, name: 'redis', image_name: 'redis:2.8')}
-  let(:subject) { described_class.new(grid_service: redis_service)}
+  let(:grid) { Grid.create!(name: 'test-grid') }
+  let(:service) { GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8') }
+  let(:subject) { described_class.new(grid_service: service) }
 
   describe '#run' do
-    it 'starts service containers' do
-      redis_service.containers.create!(name: 'redis-1-volume', container_id: '12', container_type: 'volume')
-      container = redis_service.containers.create!(name: 'redis-1', container_id: '34')
-      expect(subject).to receive(:start_service_instances).and_return(true)
-
-      outcome = subject.run
-    end
-
     it 'sets service state to running' do
-      redis_service.containers.create!(name: 'redis-1', container_id: '34')
       allow(subject).to receive(:start_service_instances).and_return(true)
-      outcome = subject.run
-      expect(redis_service.reload.state).to eq('running')
+
+      expect{
+        subject.run!
+      }.to change{service.reload.state}.to('running')
     end
 
-    it 'returns service to previous state if exception is raised' do
-      prev_state = redis_service.state
-      redis_service.containers.create!(name: 'redis-1', container_id: '34')
-      subject = described_class.new(grid_service: redis_service)
-      expect(subject).to receive(:start_service_instances).and_raise(StandardError.new('error'))
-      expect {
-        outcome = subject.run
-      }.to raise_exception(StandardError)
-      expect(redis_service.state).to eq(prev_state)
+    context 'with a service instance' do
+      let(:node) { nil }
+      let!(:service_instance) { GridServiceInstance.create!(grid_service: service, instance_number: 1, host_node: node ) }
+
+      it 'starts the service instance' do
+        expect{
+          subject.run!
+        }.to change{service_instance.reload.desired_state}.to('running')
+      end
+
+      context 'with a host node' do
+        let!(:node) { grid.create_node!('test-node') }
+        let(:rpc_client) { instance_double(RpcClient) }
+
+        before do
+          allow(node).to receive(:rpc_client).and_return(rpc_client)
+        end
+
+        it 'notifies the host node' do
+          expect(rpc_client).to receive(:notify).with('/service_pods/notify_update', 'start')
+
+          outcome = subject.run!
+        end
+      end
+    end
+
+    it 'fails on errors' do
+      expect(subject).to receive(:start_service_instances).and_raise(StandardError.new('test'))
+
+      expect(outcome = subject.run).to_not be_success
+      expect(outcome.errors.message).to eq 'start' => 'test'
+      expect(outcome.errors.symbolic).to eq 'start' => :error
     end
   end
 end


### PR DESCRIPTION
Fixes #2777 by stopping the stack services before destroying them from the `StackDeployWorker`

Don't use `async_thread` for the `GridServices::Start` / `GridServices::Stop` mutations. They only set the `GridService` / `GridServiceInstance` states, and publish async `RpcClient.notify` RPC notifications. That can be done right from the request thread.

Also remove the `prev_state` rollback. The service state can end up being be somewhat indeterminate if some individual instance start/stop fails?

Fix the specs - `GridServices::Stop` was missing any, and the `GridServices::Start` specs were still in the pre-`GridServiceInstance` age and didn't actually test the RPC notifications.