### PR TITLE
Fix server HostNode::Update/Remove mutations to not use async_thread

### DIFF
--- a/server/app/mutations/host_nodes/remove.rb
+++ b/server/app/mutations/host_nodes/remove.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module HostNodes
   class Remove < Mutations::Command
-    include AsyncHelper
     include Common
 
     required do
@@ -11,9 +10,10 @@ module HostNodes
 
     def execute
       grid = self.host_node.grid
+      
       self.host_node.destroy
 
-      async_thread { notify_grid(grid) } if grid
+      notify_grid(grid) if grid
     end
   end
 end

--- a/server/app/mutations/host_nodes/update.rb
+++ b/server/app/mutations/host_nodes/update.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module HostNodes
   class Update < Mutations::Command
-    include AsyncHelper
     include Common
     include Logging
 
@@ -21,9 +20,7 @@ module HostNodes
 
       self.host_node.save
 
-      async_thread do
-        notify_grid(self.host_node.grid)
-      end
+      notify_grid(self.host_node.grid)
 
       # Update availability if given and trigger appropriate actions
       if self.availability && self.host_node.availability != self.availability

--- a/server/spec/mutations/host_nodes/update_spec.rb
+++ b/server/spec/mutations/host_nodes/update_spec.rb
@@ -1,6 +1,4 @@
 describe HostNodes::Update do
-  include AsyncMock
-
   let(:grid) { Grid.create!(name: 'test') }
   let(:node) { grid.create_node!('node-1', node_id: 'AA') }
   let(:rpc_client) { instance_double(RpcClient) }


### PR DESCRIPTION
The `notify_grid` calls just send RPC notifications, they can be run from the request thread.