### PR TITLE
Fix server Grids::Update mutation to not use async_thread

### DIFF
--- a/server/app/jobs/grid_scheduler_job.rb
+++ b/server/app/jobs/grid_scheduler_job.rb
@@ -4,10 +4,15 @@ class GridSchedulerJob
   include Celluloid
   include Logging
   include CurrentLeader
-  include Workers
 
   def initialize
     async.perform
+  end
+
+  # @param [Grid] grid
+  def reschedule_grid(grid)
+    info "rescheduling #{grid.name} services"
+    schedule_grid(grid) # XXX: if leader?
   end
 
   def perform

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -28,7 +28,7 @@ module Grids
       end
 
       self.notify_nodes
-      self.reschedule_grid(self.grid)
+      self.reschedule_grid(self.grid) if self.default_affinity
 
       self.grid
     end

--- a/server/app/mutations/grids/update.rb
+++ b/server/app/mutations/grids/update.rb
@@ -2,7 +2,6 @@ require_relative 'common'
 
 module Grids
   class Update < Mutations::Command
-    include AsyncHelper
     include Common
 
     required do
@@ -28,9 +27,8 @@ module Grids
         return
       end
 
-      async_thread do
-        self.notify_nodes
-      end
+      self.notify_nodes
+      self.reschedule_grid(self.grid)
 
       self.grid
     end
@@ -40,7 +38,16 @@ module Grids
         plugger = Agent::NodePlugger.new(node)
         plugger.send_node_info
       end
-      GridScheduler.new(grid).reschedule
+    end
+
+    # @return [Celluloid::Proxy::Cell<GridSchedulerJob>]
+    def grid_scheduler
+      Celluloid::Actor[:grid_scheduler_job]
+    end
+
+    # @param grid [Grid]
+    def reschedule_grid(grid)
+      grid_scheduler.async.reschedule_grid(grid)
     end
   end
 end

--- a/server/app/services/grid_scheduler.rb
+++ b/server/app/services/grid_scheduler.rb
@@ -13,21 +13,6 @@ class GridScheduler
     @grid = grid
   end
 
-  def reschedule
-    self.reschedule_services
-  end
-
-  def reschedule_services
-    grid.grid_services.each do |service|
-      if should_reschedule_service?(service)
-        reschedule_service(service)
-      end
-    end
-  rescue => exc
-    error exc.message
-    debug exc.backtrace.join("\n") if exc.backtrace
-  end
-
   def check_service(service)
     if should_reschedule_service?(service)
       reschedule_service(service)

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -1,16 +1,20 @@
 describe Grids::Update do
-  include AsyncMock
-
   let(:user) { User.create!(email: 'joe@domain.com')}
   let(:grid) {
     grid = Grid.create!(name: 'test-grid')
     grid.users << user
     grid
   }
+  let(:grid_scheduler_job) { instance_double(GridSchedulerJob) }
+
+  before do
+    allow(Celluloid::Actor).to receive(:[]).with(:grid_scheduler_job).and_return(grid_scheduler_job)
+  end
 
   describe '#run' do
     before(:each) do
       allow_any_instance_of(GridAuthorizer).to receive(:updatable_by?).with(user).and_return(true)
+      allow_any_instance_of(described_class).to receive(:reschedule_grid).with(grid)
     end
 
     it 'updates statsd settings' do

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -6,15 +6,16 @@ describe Grids::Update do
     grid
   }
   let(:grid_scheduler_job) { instance_double(GridSchedulerJob) }
+  let(:grid_scheduler_job_async) { instance_double(GridSchedulerJob) }
 
   before do
     allow(Celluloid::Actor).to receive(:[]).with(:grid_scheduler_job).and_return(grid_scheduler_job)
+    allow(grid_scheduler_job).to receive(:async).and_return(grid_scheduler_job_async)
   end
 
   describe '#run' do
     before(:each) do
       allow_any_instance_of(GridAuthorizer).to receive(:updatable_by?).with(user).and_return(true)
-      allow_any_instance_of(described_class).to receive(:reschedule_grid).with(grid)
     end
 
     it 'updates statsd settings' do
@@ -104,6 +105,34 @@ describe Grids::Update do
       outcome = described_class.new(user: user, grid: grid, logs: logs).run
       expect(outcome.success?).to be_falsey
       expect(grid.reload.grid_logs_opts).to be_nil
+    end
+
+    describe 'default_affinity' do
+      it 'updates the grid default affinity and reschedules services' do
+        expect(grid_scheduler_job_async).to receive(:reschedule_grid).with(grid)
+
+        expect{
+          outcome = described_class.new(user: user, grid: grid, default_affinity: ['label!=test']).run
+          expect(outcome).to be_success
+        }.to change{grid.reload.default_affinity}.to(['label!=test'])
+      end
+    end
+
+    context 'with connected grid nodes' do
+      let!(:node) { grid.create_node!('test-node', node_id: 'AAAA', connected: true) }
+      let(:rpc_client) { instance_double(RpcClient) }
+
+      before do
+        allow(RpcClient).to receive(:new).with(node.node_id, Integer).and_return(rpc_client)
+      end
+
+      it 'notifies connected grid nodes' do
+        expect(rpc_client).to receive(:notify).with('/agent/node_info', hash_including(
+
+        ))
+
+        described_class.new(user: user, grid: grid).run!
+      end
     end
   end
 end


### PR DESCRIPTION
The `notify_nodes` just sends RPC notifications, and they can be run from the request thread.

Replace the call to `GridScheduler.new(grid).reschedule` with `Celluloid::Actor[:grid_scheduler_job].async.reschedule_grid(grid)`... it's scary. I suspect it might make sense to just remove it, and let the normal `GridSchedulerJob#perform` loop take care of it? The `reschedule` triggered by the `Grids::Update` doesn't necessary run on the leader.

