### PR TITLE
Fix server MongoPubsub to rescue block errors, and not use async_thread

### DIFF
--- a/server/app/services/mongo_pubsub.rb
+++ b/server/app/services/mongo_pubsub.rb
@@ -160,7 +160,7 @@ class MongoPubsub
           channel = item['channel']
           data = item['data']
 
-          actor.queue_message(channel, data)
+          actor.async.queue_message(channel, data)
         end
       rescue => exc
         error "error while tailing: #{exc.message}"

--- a/server/spec/services/mongo_pubsub_spec.rb
+++ b/server/spec/services/mongo_pubsub_spec.rb
@@ -1,5 +1,5 @@
 
-describe MongoPubsub do
+describe MongoPubsub, :celluloid => true do
 
   describe '.publish' do
     it 'sends message to channel subscribers' do

--- a/server/spec/services/mongo_pubsub_spec.rb
+++ b/server/spec/services/mongo_pubsub_spec.rb
@@ -67,6 +67,27 @@ describe MongoPubsub, :celluloid => true do
       sub2.terminate
     end
 
+    it 'handles subscribers that crash' do
+      @crash = false
+      @done = false
+      sub1 = described_class.subscribe('test') do |msg|
+        if msg[:crash]
+          @crash = true
+          fail msg[:crash]
+        elsif msg[:done]
+          @done = true
+        end
+      end
+
+      described_class.publish('test', crash: false)
+      described_class.publish('test', crash: 'test')
+      WaitHelper.wait_until!("crashed", interval: 0.05) { @crash }
+      described_class.publish('test', done: true)
+      WaitHelper.wait_until!("done", interval: 0.05) { @done }
+
+      sub1.terminate
+    end
+
     it 'cleanups threads' do
       GC.start
 


### PR DESCRIPTION
* Errors raised from `MongoPubsub.subscribe(...) do ...` blocks get logged, and the subscription continues processing messages, rather dying and having messages accumulate in the queue
* Move all `@subscriptions` handling into the `MongoPubsub` actor, don't access the `subscribers` array from outside of the actor thread
* Use a threadsafe `Queue` instead of an `Array`, and `close` it to `stop`