### PR TITLE
Add rake to e2e suite Gemfile

### DIFF
--- a/test/Gemfile
+++ b/test/Gemfile
@@ -4,3 +4,5 @@ gem 'dotenv'
 gem 'rspec'
 gem 'kommando', '~> 0.1.2'
 gem 'kontena-cli', path: '../cli'
+gem 'rake'
+


### PR DESCRIPTION
This PR adds `rake` to the e2e suite's Gemfile.

![image](https://user-images.githubusercontent.com/224971/30200727-c78106f8-9480-11e7-8859-175bbe30f468.png)

