### PR TITLE
CLI: Add --values-from-stack option to stack commands for reading values from an installed stack

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -102,8 +102,8 @@ module Kontena::Cli::Stacks
         where.option '--values-from-stack', '[STACK_NAME]', 'Read variable values from an installed stack', multivalued: true do |stackname|
           response = client.get("stacks/#{current_grid}/#{stackname}")
           variables = response['variables']
-          Kontena.logger.debug { "Received variables from stack #{filename} on Master: #{variables.inspect}" }
-          warn "Stack #{filename} does not have any values for variables" if variables.empty?
+          Kontena.logger.debug { "Received variables from stack #{stackname} on Master: #{variables.inspect}" }
+          warn "Stack #{stackname} does not have any values for variables" if variables.empty?
           values_from_installed_stack.merge!(variables)
           stackname
         end

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -45,6 +45,10 @@ module Kontena::Cli::Stacks
         caret "Installing dependency #{pastel.cyan(dependency[:stack])} as #{pastel.cyan(target_name)}"
         cmd = ['stack', 'install', '-n', target_name, '--parent-name', stack_name]
 
+        values_from_list.each do |vals_from|
+          cmd.concat ['--values-from', vals_from + "-" + dependency['name']]
+        end
+
         dependency['variables'].merge(dependency_values_from_options(dependency['name'])).each do |key, value|
           next if key == 'PARENT_STACK'
           cmd.concat ['-v', "#{key}=#{value}"]

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -45,12 +45,7 @@ module Kontena::Cli::Stacks
         caret "Installing dependency #{pastel.cyan(dependency[:stack])} as #{pastel.cyan(target_name)}"
         cmd = ['stack', 'install', '-n', target_name, '--parent-name', stack_name]
 
-        values_from_list.each do |vals_from|
-          cmd.concat ['--values-from', vals_from + "-" + dependency['name']]
-        end
-
         dependency['variables'].merge(dependency_values_from_options(dependency['name'])).each do |key, value|
-          next if key == 'PARENT_STACK'
           cmd.concat ['-v', "#{key}=#{value}"]
         end
 

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -140,14 +140,11 @@ module Kontena::Cli::Stacks
           cmd = ['stack', 'install', '--name', stackname]
           cmd.concat ['--parent-name', stack['parent_name']] if stack['parent_name']
 
-          values_from_stack_list.each do |vals_from|
-            cmd.concat ['--values-from-stack', stackname.sub(name, vals_from)]
-          end
-
           stack['variables'].merge(dependency_values_from_options(stackname)).each do |k, v|
             next if k == 'PARENT_STACK'
             cmd.concat ['-v', "#{k}=#{v}"]
           end
+
           cmd << '--no-deploy'
           cmd << data[:local][:loader].source
           caret "Installing new dependency #{cmd.last} as #{stackname}"

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -139,6 +139,11 @@ module Kontena::Cli::Stacks
         else
           cmd = ['stack', 'install', '--name', stackname]
           cmd.concat ['--parent-name', stack['parent_name']] if stack['parent_name']
+
+          values_from_list.each do |vals_from|
+            cmd.concat ['--values-from', stackname.sub(name, vals_from)]
+          end
+
           stack['variables'].merge(dependency_values_from_options(stackname)).each do |k, v|
             next if k == 'PARENT_STACK'
             cmd.concat ['-v', "#{k}=#{v}"]

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -140,8 +140,8 @@ module Kontena::Cli::Stacks
           cmd = ['stack', 'install', '--name', stackname]
           cmd.concat ['--parent-name', stack['parent_name']] if stack['parent_name']
 
-          values_from_list.each do |vals_from|
-            cmd.concat ['--values-from', stackname.sub(name, vals_from)]
+          values_from_stack_list.each do |vals_from|
+            cmd.concat ['--values-from-stack', stackname.sub(name, vals_from)]
           end
 
           stack['variables'].merge(dependency_values_from_options(stackname)).each do |k, v|

--- a/cli/spec/kontena/cli/stacks/common_spec.rb
+++ b/cli/spec/kontena/cli/stacks/common_spec.rb
@@ -3,6 +3,10 @@ require "kontena/cli/stacks/yaml/reader"
 
 describe Kontena::Cli::Stacks::Common do
   include FixturesHelpers
+  include RequirementsHelper
+  include ClientHelpers
+
+  mock_current_master
 
   let(:klass) do
     Class.new(Kontena::Command) do
@@ -12,10 +16,6 @@ describe Kontena::Cli::Stacks::Common do
       include Kontena::Cli::Stacks::Common::StackNameOption
       include Kontena::Cli::Stacks::Common::StackValuesToOption
       include Kontena::Cli::Stacks::Common::StackValuesFromOption
-
-      def what
-        [source]
-      end
     end
   end
 
@@ -57,7 +57,7 @@ describe Kontena::Cli::Stacks::Common do
       expect(subject.instance(['-v', 'foo=bar', '-v', 'bar=baz', fixture_path('kontena_v3.yml')]).values_from_options).to match hash_including('foo' => 'bar', 'bar' => 'baz')
     end
 
-    context '--values-from' do
+    describe '--values-from' do
       before do
         allow(File).to receive(:exist?).with('vars.yml').and_return(true)
         expect(File).to receive(:read).with('vars.yml').and_return(::YAML.dump('baz' => 'bag', 'bar' => 'boo'))
@@ -70,6 +70,30 @@ describe Kontena::Cli::Stacks::Common do
       it 'includes values read from --values-from file, overriden by -v values' do
         expect(subject.instance(['-v', 'foo=bar', '-v', 'bar=baz', '--values-from', 'vars.yml', fixture_path('kontena_v3.yml')]).values_from_options).to match hash_including('foo' => 'bar', 'bar' => 'baz', 'baz' => 'bag')
       end
+    end
+
+    describe '--values-from-stack' do
+      let(:instance) { subject.instance(['--values-from-stack', 'redisproxy', fixture_path('kontena_v3.yml')]) }
+
+      it 'reads all dependent stack variables' do
+        expect(client).to receive(:get).with('stacks/test-grid/redisproxy').and_return(
+          'variables' => { 'foo' => 'bar' },
+          'children' => [ { 'name' => 'redisproxy-redis1' } ]
+        )
+
+        expect(client).to receive(:get).with('stacks/test-grid/redisproxy-redis1').and_return(
+          'variables' => { 'redisvar' => 'test' },
+          'children' => [ { 'name' => 'redisproxy-redis1-monitor' } ]
+        )
+
+        expect(client).to receive(:get).with('stacks/test-grid/redisproxy-redis1-monitor').and_return(
+          'variables' => { 'monitorvar' => 'test2' },
+          'children' => []
+        )
+
+        expect(instance.values_from_options).to match hash_including('foo' => 'bar', 'redis1.redisvar' => 'test', 'redis1.monitor.monitorvar' => 'test2')
+      end
+
     end
   end
 end

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -42,120 +42,6 @@ describe Kontena::Cli::Stacks::InstallCommand do
       subject.run(['--no-deploy', fixture_path('kontena_v3.yml')])
     end
 
-    context 'variable value input' do
-      describe '--values-from' do
-        it 'sends stack to master, loading values from a file' do
-          expect(File).to receive(:exist?).with('values.yml').and_return(true)
-          expect(File).to receive(:read).with('values.yml').and_return(
-            YAML.dump('TEST_ENV_VAR' => 'abc', 'MYSQL_IMAGE' => 'mysqlimage', 'tag' => 'def')
-          )
-          expect(client).to receive(:post) do |path, data|
-            expect(path).to eq 'grids/test-grid/stacks'
-            expect(data).to match hash_including(
-              'services' => array_including(
-                hash_including(
-                  'name' => 'mysql',
-                  'image' => 'mysqlimage:latest',
-                  'env' => array_including(
-                    'TEST_VAR=abc'
-                  )
-                ),
-                hash_including(
-                  'name' => 'wordpress',
-                  'image' => 'wordpress:def'
-                )
-              )
-            )
-          end.and_return({})
-          subject.run(['--no-deploy', '--values-from', 'values.yml', fixture_path('stack-with-variables.yml')])
-        end
-
-        it 'sends stack to master, loading values from another stack on master' do
-          expect(File).to receive(:exist?).with('foostack').and_return(false)
-          allow(client).to receive(:get).with('stacks/test-grid/foostack').and_return(
-            'variables' => {
-              'TEST_ENV_VAR' => 'abc', 'MYSQL_IMAGE' => 'mysqlimage', 'tag' => 'def'
-            }
-          )
-          expect(client).to receive(:post) do |path, data|
-            expect(path).to eq 'grids/test-grid/stacks'
-            expect(data).to match hash_including(
-              'services' => array_including(
-                hash_including(
-                  'name' => 'mysql',
-                  'image' => 'mysqlimage:latest',
-                  'env' => array_including(
-                    'TEST_VAR=abc'
-                  )
-                ),
-                hash_including(
-                  'name' => 'wordpress',
-                  'image' => 'wordpress:def'
-                )
-              )
-            )
-          end.and_return({})
-          subject.run(['--no-deploy', '--values-from', 'foostack', fixture_path('stack-with-variables.yml')])
-        end
-
-        it 'can combine multiple inputs' do
-          expect(File).to receive(:exist?).with('values.yml').and_return(true)
-          expect(File).to receive(:read).with('values.yml').and_return(
-            YAML.dump('TEST_ENV_VAR' => 'abc')
-          )
-          expect(File).to receive(:exist?).with('foostack').and_return(false)
-          allow(client).to receive(:get).with('stacks/test-grid/foostack').and_return(
-            'variables' => { 'MYSQL_IMAGE' => 'mysqlimage' }
-          )
-          expect(client).to receive(:post) do |path, data|
-            expect(path).to eq 'grids/test-grid/stacks'
-            expect(data).to match hash_including(
-              'services' => array_including(
-                hash_including(
-                  'name' => 'mysql',
-                  'image' => 'mysqlimage:latest',
-                  'env' => array_including(
-                    'TEST_VAR=abc'
-                  )
-                ),
-                hash_including(
-                  'name' => 'wordpress',
-                  'image' => 'wordpress:def'
-                )
-              )
-            )
-          end.and_return({})
-          subject.run(['--no-deploy', '--values-from', 'foostack', '--values-from', 'values.yml', '-v', 'tag=def', fixture_path('stack-with-variables.yml')])
-
-        end
-      end
-
-      describe '-v' do
-        it 'sends stack to master, loading values from command line' do
-          expect(client).to receive(:post) do |path, data|
-            expect(path).to eq 'grids/test-grid/stacks'
-            expect(data).to match hash_including(
-              'services' => array_including(
-                hash_including(
-                  'name' => 'mysql',
-                  'image' => 'mysqlimage:latest',
-                  'env' => array_including(
-                    'TEST_VAR=abc'
-                  )
-                ),
-                hash_including(
-                  'name' => 'wordpress',
-                  'image' => 'wordpress:def'
-                )
-              )
-            )
-          end.and_return({})
-            YAML.dump('TEST_ENV_VAR' => 'abc', 'MYSQL_IMAGE' => 'mysqlimage', 'tag' => 'def')
-          subject.run(['--no-deploy', '-v', 'TEST_ENV_VAR=abc', '-v', 'MYSQL_IMAGE=mysqlimage', '-v', 'tag=def', fixture_path('stack-with-variables.yml')])
-        end
-      end
-    end
-
     it 'allows to override stack name' do
       expect(client).to receive(:post) do |path, data|
         expect(path).to eq 'grids/test-grid/stacks'
@@ -179,7 +65,7 @@ describe Kontena::Cli::Stacks::InstallCommand do
     context '--[no-]deploy' do
       it 'runs deploy for the stack after install by default' do
         expect(client).to receive(:post).with(
-           'grids/test-grid/stacks', hash_including(stack_expectation)
+          'grids/test-grid/stacks', hash_including(stack_expectation)
         )
         expect(Kontena).to receive(:run!).with(['stack', 'deploy', 'stackname']).and_return(true)
         subject.run([fixture_path('kontena_v3.yml')])
@@ -193,6 +79,83 @@ describe Kontena::Cli::Stacks::InstallCommand do
         expect(Kontena).to receive(:run!).with(["stack", "install", "-n", "deptest-dep_2", "--parent-name", "deptest", "-v", "dep_var=1", '--no-deploy', fixture_path('stack-with-dependencies-dep-2.yml')])
         expect(client).to receive(:post).with('grids/test-grid/stacks', hash_including('stack' => 'user/depstack1', 'name' => 'deptest'))
         subject.run(['-n', 'deptest', '--no-deploy', '-v', 'dep_1.dep_1.dep_var=1', fixture_path('stack-with-dependencies.yml')])
+      end
+    end
+  end
+
+  context 'variable value input' do
+    let(:expectation) do
+      {
+        'services' => array_including(
+          hash_including(
+            'name' => 'mysql',
+            'image' => 'mysqlimage:latest',
+            'env' => array_including(
+              'TEST_VAR=abc'
+            )
+          ),
+          hash_including(
+            'name' => 'wordpress',
+            'image' => 'wordpress:def'
+          )
+        )
+      }
+    end
+
+    describe '--values-from' do
+      it 'sends stack to master, loading values from a file' do
+        allow(File).to receive(:exist?).with('values.yml').and_return(true)
+        expect(File).to receive(:read).with('values.yml').and_return(
+          YAML.dump('TEST_ENV_VAR' => 'abc', 'MYSQL_IMAGE' => 'mysqlimage', 'tag' => 'def')
+        )
+        expect(client).to receive(:post) do |path, data|
+          expect(path).to eq 'grids/test-grid/stacks'
+          expect(data).to match hash_including(expectation)
+        end.and_return({})
+        subject.run(['--no-deploy', '--values-from', 'values.yml', fixture_path('stack-with-variables.yml')])
+      end
+    end
+
+    describe '--values-from-stack' do
+      it 'sends stack to master, loading values from another stack on master' do
+        allow(client).to receive(:get).with('stacks/test-grid/foostack').and_return(
+          'variables' => {
+            'TEST_ENV_VAR' => 'abc', 'MYSQL_IMAGE' => 'mysqlimage', 'tag' => 'def'
+          }
+        )
+        expect(client).to receive(:post) do |path, data|
+          expect(path).to eq 'grids/test-grid/stacks'
+          expect(data).to match hash_including(expectation)
+        end.and_return({})
+        subject.run(['--no-deploy', '--values-from-stack', 'foostack', fixture_path('stack-with-variables.yml')])
+      end
+    end
+
+    describe '-v' do
+      it 'sends stack to master, loading values from command line' do
+        expect(client).to receive(:post) do |path, data|
+          expect(path).to eq 'grids/test-grid/stacks'
+          expect(data).to match hash_including(expectation)
+        end.and_return({})
+        YAML.dump('TEST_ENV_VAR' => 'abc', 'MYSQL_IMAGE' => 'mysqlimage', 'tag' => 'def')
+        subject.run(['--no-deploy', '-v', 'TEST_ENV_VAR=abc', '-v', 'MYSQL_IMAGE=mysqlimage', '-v', 'tag=def', fixture_path('stack-with-variables.yml')])
+      end
+    end
+
+    describe 'combination of value inputs' do
+      it 'can combine multiple inputs' do
+        allow(File).to receive(:exist?).with('values.yml').and_return(true)
+        expect(File).to receive(:read).with('values.yml').and_return(
+          YAML.dump('TEST_ENV_VAR' => 'abc')
+        )
+        allow(client).to receive(:get).with('stacks/test-grid/foostack').and_return(
+          'variables' => { 'MYSQL_IMAGE' => 'mysqlimage' }
+        )
+        expect(client).to receive(:post) do |path, data|
+          expect(path).to eq 'grids/test-grid/stacks'
+          expect(data).to match hash_including(expectation)
+        end.and_return({})
+        subject.run(['--no-deploy', '--values-from-stack', 'foostack', '--values-from', 'values.yml', '-v', 'tag=def', fixture_path('stack-with-variables.yml')])
       end
     end
   end


### PR DESCRIPTION
Fixes #2739
Fixes #2515

Adds `--values-from-stack` to stack install/upgrade/show/validate that reads stack variable values from an installed stack from the master. It's also possible to give the same name as the current stack during upgrade to avoid answering any questions.

It also makes `--values-from` be multivalued, meaning that you can read from multiple files.
