### PR TITLE
Fix stack variables to not write to env by default

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
   spec.add_runtime_dependency "hash_validator", "~> 0.7.1"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
-  spec.add_runtime_dependency "opto", "1.8.5"
+  spec.add_runtime_dependency "opto", "1.8.7"
   spec.add_runtime_dependency "semantic", "~> 1.5"
   spec.add_runtime_dependency "liquid", "~> 4.0.0"
   spec.add_runtime_dependency "tty-table", "~> 0.8.0"

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -131,7 +131,7 @@ module Kontena::Cli::Stacks
       def variables
         @variables ||= ::Opto::Group.new(
           internals_interpolated_yaml.fetch('variables', {}).merge(default_envs_to_options),
-          defaults: { from: :env, to: :env }
+          defaults: { from: :env }
         )
       end
 


### PR DESCRIPTION
Fixes #2798

Before this PR stacks had these defaults applied to all variables:

```yaml
from:
  env: <same_as_variable_name>
to:
  env: <same_as_variable_name>
```

After this PR the variables are no longer sent to local env to avoid leaking stack variables from parent stacks to child stacks when using stack dependencies.

The default becomes:
```yaml
from:
  env: <same_as_variable_name>
```

### Breaking change

After this PR something like this no longer works:

```yaml
variables:
   db_host:
     type: string
     from:
       prompt: Enter DB_HOST
  backup_db_host:
     type: string
     from:
       prompt: Enter backup DB_HOST or leave blank to use the DB_HOST
       env: db_host
```

To fix, change to:

```diff
-       env: db_host
+       variable: db_host
```

or send the value to env manually:

```diff
     from:
       prompt: Enter DB_HOST
+     to:
+       env: db_host
```


Opto has been updated to 1.8.7 to bring in the `variable` resolver.
