### PR TITLE
Fix CLI stack source not found error from "can't determine origin" to generic "no such file"

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/stack_file_loader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/stack_file_loader.rb
@@ -27,7 +27,9 @@ module Kontena::Cli::Stacks
       # @return [StackFileLoader]
       def self.for(source, parent = nil)
         loader = loaders.find { |l| l.match?(source, parent) }
-        raise "Can't determine stack file origin for '#{source}'" if loader.nil?
+        if loader.nil?
+          raise RuntimeError, "Not found: no such file #{source} or invalid uri scheme"
+        end
         loader.new(source, parent)
       end
 


### PR DESCRIPTION
Fixes #2805 

(from #2707)
