### PR TITLE
Fix stack validate command and validity checking when installing

### DIFF
--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -420,7 +420,8 @@ module Kontena
 
         # @param [String] image
         # @return [String]
-        def parse_image(image)
+        def parse_image(image = nil)
+          return if image.nil?
           unless image.include?(":")
             image = "#{image}:latest"
           end

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -28,6 +28,8 @@ module Kontena::Cli::Stacks
 
       install_dependencies unless skip_dependencies?
 
+      stack # runs validations
+
       hint_on_validation_notifications(reader.notifications)
       abort_on_validation_errors(reader.errors)
 

--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -51,6 +51,8 @@ module Kontena::Cli::Stacks
 
       validate_dependencies if dependencies?
 
+      stack # runs validations
+
       hint_on_validation_notifications(reader.notifications, dependencies? ? loader.source : nil)
       abort_on_validation_errors(reader.errors, dependencies? ? loader.source : nil)
 

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -317,7 +317,6 @@ module Kontena::Cli::Stacks
           service_config.delete('extends')
         end
         if name
-          exit_with_error("Image is missing for #{name}. Aborting.") unless service_config['image'] # why isn't this a validation?
           ServiceGeneratorV2.new(service_config).generate.merge('name' => name)
         else
           ServiceGeneratorV2.new(service_config).generate
@@ -443,12 +442,11 @@ module Kontena::Cli::Stacks
       end
 
       def store_failures(data)
-        data['errors'] = data[:errors] unless data['errors']
-        data['notifications'] = data[:notifications] unless data['notifications']
-        errors << { file => data['errors'] || data[:errors] } unless data['errors'].empty?
+        data['errors'] ||= data[:errors] || []
+        data['notifications'] ||= data[:notifications] || []
+        errors << { file => data['errors'] } unless data['errors'].empty?
         notifications << { file => data['notifications'] } unless data['notifications'].empty?
       end
-
 
       # @param [Hash] options - service config
       def normalize_env_vars(options)

--- a/cli/lib/kontena/cli/stacks/yaml/stack_file_loader/file_loader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/stack_file_loader/file_loader.rb
@@ -21,7 +21,7 @@ module Kontena::Cli::Stacks
 
       def initialize(*args)
         super
-        @source = self.class.with_context(@source, parent)
+        @source = self.class.with_context(@source, @parent)
       end
 
       def read_content

--- a/cli/lib/kontena/cli/stacks/yaml/validator_v3.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validator_v3.rb
@@ -75,7 +75,6 @@ module Kontena::Cli::Stacks
               end
               option_errors = validate_options(options)
               result[:errors] << { 'services' => { service => option_errors.errors } } unless option_errors.valid?
-              result[:errors] << { 'services' => { service => { 'image' => "image is missing" } } } unless options['image']
               if options['volumes']
                 mount_path_occurences = Hash.new(0)
                 options['volumes'].each do |volume|

--- a/cli/lib/kontena/cli/stacks/yaml/validator_v3.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validator_v3.rb
@@ -75,6 +75,7 @@ module Kontena::Cli::Stacks
               end
               option_errors = validate_options(options)
               result[:errors] << { 'services' => { service => option_errors.errors } } unless option_errors.valid?
+              result[:errors] << { 'services' => { service => { 'image' => "image is missing" } } } unless options['image']
               if options['volumes']
                 mount_path_occurences = Hash.new(0)
                 options['volumes'].each do |volume|

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -120,17 +120,15 @@ describe Kontena::Cli::Stacks::YAML::Reader do
         it 'merges validation errors' do
           expect(File).to receive(:read).with(fixture_path('docker-compose_v2.yml')).and_return(fixture('docker-compose-invalid.yml'))
           outcome = subject.execute
-          expect(outcome['errors']).to eq([{
-            'docker-compose_v2.yml' =>[
-              {
-                'services' => {
-                  'wordpress' => {
-                    'networks' => 'key not expected'
-                  }
-                }
-              }
-            ]
-          }])
+          expect(subject.errors).to match array_including(
+            hash_including(
+              'docker-compose_v2.yml' => array_including(
+                hash_including(
+                  'services' => { 'wordpress' => { 'networks' => 'key not expected' } }
+                )
+              )
+            )
+          )
         end
       end
 
@@ -312,7 +310,12 @@ describe Kontena::Cli::Stacks::YAML::Reader do
 
     it 'expands build option to absolute path' do
       outcome = subject.execute
-      expect(outcome['services']['webapp']['build']['context']).to eq(fixture_path(''))
+      expect(outcome['services']).to match array_including(
+        hash_including(
+          'name' => 'webapp',
+          'build' => hash_including('context' => fixture_path(''))
+        )
+      )
     end
   end
 
@@ -323,7 +326,12 @@ describe Kontena::Cli::Stacks::YAML::Reader do
 
     it 'expands build context to absolute path' do
       outcome = subject.execute
-      expect(outcome['services']['webapp']['build']['context']).to eq(fixture_path(''))
+      expect(outcome['services']).to match array_including(
+        hash_including(
+          'name' => 'webapp',
+          'build' => hash_including('context' => fixture_path(''))
+        )
+      )
     end
   end
 


### PR DESCRIPTION
Fixes #2806

(from #2707)

Before: 
- Invalid stacks were installed
- Invalid stacks passed `kontena stack validate`

After:
- Invalid stack installation halts before POSTing to master
- Invalid stack fails `kontena stack validate`


