### PR TITLE
Certificate auto renewal

### DIFF
--- a/server/app/jobs/certificate_renew_job.rb
+++ b/server/app/jobs/certificate_renew_job.rb
@@ -5,7 +5,7 @@ class CertificateRenewJob
   include WaitHelper
   include DistributedLocks
 
-  RENEW_INTERVAL = 1.day.to_i
+  RENEW_INTERVAL = 1.hour.to_i
 
   RENEW_TRESHOLD = 7.days
 

--- a/server/app/jobs/certificate_renew_job.rb
+++ b/server/app/jobs/certificate_renew_job.rb
@@ -4,7 +4,7 @@ class CertificateRenewJob
   include CurrentLeader
   include WaitHelper
 
-  RENEW_INTERVAL = 5 * 60 # Run the renew check every 5 mins
+  RENEW_INTERVAL = 1.day.to_i
 
   RENEW_TRESHOLD = 7.days
 
@@ -69,6 +69,7 @@ class CertificateRenewJob
         wait_until!("deployment of tls-sni secret is finished", timeout: 300, threshold: 20) {
           domain_auth.reload.status != :deploying
         }
+        raise "Deployment of tls-sni secret failed" if domain_auth.reload.status == :deploy_error
       else
         # No point to continue, cert renewal not gonna succeed
         raise "Domain authorization failed: #{outcome.errors.message}"

--- a/server/app/jobs/certificate_renew_job.rb
+++ b/server/app/jobs/certificate_renew_job.rb
@@ -1,0 +1,83 @@
+class CertificateRenewJob
+  include Celluloid
+  include Logging
+  include CurrentLeader
+
+  RENEW_INTERVAL = 5 * 60 # Run the renew check every 5 mins
+
+  def initialize(perform = true)
+    async.perform if perform
+  end
+
+  def perform
+    # TODO Maybe sleep a while first to allow everything else to start up before running this loop?
+    info 'starting to watch certificate renewals'
+    every(RENEW_INTERVAL) do
+      if leader?
+        renew_certificates
+      end
+    end
+  end
+
+  def renew_certificates
+    Grid.each do |grid|
+      grid.certificates.each do |cert|
+        renew_certificate(cert)
+      end
+    end
+  end
+
+  def renew_certificate(certificate)
+    if should_renew?(certificate) && can_renew?(certificate)
+      info "certificate renewal needed for #{certificate.subject}"
+      begin
+        authorize_domains(certificate)
+        request_new_cert(certificate)
+      rescue => exc
+        error "Failed to renew certificate for #{certificate.subject}"
+        error exc
+      end
+    end
+  end
+
+  def should_renew?(certificate)
+    certificate.valid_until > Time.now + 7.days
+  end
+
+  # Checks if all domain are authorized with tls-sni, we can't automate anything else for now
+  def can_renew?(certificate)
+    certificate.all_domains.each do |domain|
+      domain_auth = certificate.grid.grid_domain_authorizations.find_by(domain: domain)
+      unless domain_auth && domain_auth.authorization_type == 'tls-sni-01'
+        return false
+      end
+    end
+
+    true
+  end
+
+  def authorize_domains(certificate)
+    certificate.all_domains.each do |domain|
+      info "authorizing domain #{domain}"
+      domain_auth = certificate.grid.grid_domain_authorizations.find_by(domain: domain)
+      outcome = GridDomainAuthorizations::Authorize.run(
+        grid: certificate.grid,
+        domain: domain,
+        authorization_type: 'tls-sni-01',
+        linked_service: "#{domain_auth.grid_service.stack.name}/#{domain_auth.grid_service.name}"
+      )
+      unless outcome.success
+        # No point to continue, cert renewal not gonna succeed
+        raise "Domain authorization failed: #{outcome.errors.message}"
+      end
+    end
+  end
+
+  def request_new_cert(certificate)
+    info "requesting certificate for #{certificate.subject}"
+    outcome = GridCertificates::RequestCertificate.run(grid: grid, domains: certificate.all_domains)
+    unless outcome.success?
+      raise "Certificate request failed: #{outcome.errors.message}"
+    end
+  end
+end

--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -30,4 +30,8 @@ class Certificate
     self.full_chain + self.private_key
   end
 
+  def all_domains
+    [self.subject] + self.alt_names.to_a
+  end
+
 end

--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -22,14 +22,17 @@ class Certificate
     "#{self.grid.name}/#{self.subject}"
   end
 
+  # @return [String] Actual certificate and the trust chain bundled together
   def full_chain
     self.certificate + self.chain
   end
 
+  # @return [String] Fullchain and private key bundle, mainly for HAProxy
   def bundle
     self.full_chain + self.private_key
   end
 
+  # @return [Array<String>]
   def all_domains
     [self.subject] + self.alt_names.to_a
   end

--- a/server/app/services/job_supervisor.rb
+++ b/server/app/services/job_supervisor.rb
@@ -7,4 +7,5 @@ class JobSupervisor < Celluloid::Supervision::Container
   supervise type: TelemetryJob, as: :telemetry_job
   supervise type: GridServiceHealthMonitorJob, as: :service_health_monitor_job
   supervise type: CloudWebsocketClientManager, as: :cloud_websocket_client_manager
+  supervise type: CertificateRenewJob, as: :certificate_renew_job
 end

--- a/server/spec/jobs/certificate_renew_job_spec.rb
+++ b/server/spec/jobs/certificate_renew_job_spec.rb
@@ -1,0 +1,59 @@
+
+describe CertificateRenewJob, celluloid: true do
+
+  let(:subject) { described_class.new(false) }
+
+  let(:grid) { Grid.create!(name: 'test-grid') }
+
+  let(:service) { GridService.create!(grid: grid, name: 'lb', image_name: 'lb')}
+
+  let(:certificate) {
+    Certificate.create!(grid: grid,
+      subject: 'kontena.io',
+      valid_until: Time.now + 90.days,
+      private_key: 'private_key',
+      certificate: 'certificate',
+      chain: 'chain')
+  }
+
+  describe '#should_renew?' do
+    it 'returns false if no need to renew' do
+      expect(subject.should_renew?(certificate)).to be_falsey
+    end
+
+    it 'returns true when need to renew' do
+      certificate.valid_until = Time.now + 6.days
+      expect(subject.should_renew?(certificate)).to be_truthy
+    end
+  end
+
+  describe '#can_renew?' do
+    it 'returns false if some domain not tls-sni authorized' do
+      GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'dns-01')
+      expect(subject.can_renew?(certificate)).to be_falsey
+    end
+
+    it 'returns true when all domains tls-sni authorized' do
+      GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01')
+      expect(subject.can_renew?(certificate)).to be_truthy
+    end
+  end
+
+  describe '#authorize_domains' do
+    it 'authorises domain succesfully' do
+      domain_auth = GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: service)
+      expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => true, :result => domain_auth))
+      expect(subject.wrapped_object).to receive(:wait_until!)
+      subject.authorize_domains(certificate)
+    end
+
+    it 'raises if domain auth fails' do
+      domain_auth = GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: service)
+      expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => false, :errors => double(:message => 'boom')))
+      expect {
+        subject.authorize_domains(certificate)
+      }.to raise_error "Domain authorization failed: boom"
+    end
+  end
+
+end

--- a/server/spec/jobs/certificate_renew_job_spec.rb
+++ b/server/spec/jobs/certificate_renew_job_spec.rb
@@ -16,14 +16,16 @@ describe CertificateRenewJob, celluloid: true do
       chain: 'chain')
   }
 
-  describe '#should_renew?' do
-    it 'returns false if no need to renew' do
-      expect(subject.should_renew?(certificate)).to be_falsey
-    end
-
-    it 'returns true when need to renew' do
-      certificate.valid_until = Time.now + 6.days
-      expect(subject.should_renew?(certificate)).to be_truthy
+  describe '#renew_certificates' do
+    it 'renews only those that are going old within 7 days' do
+      cert2 = Certificate.create!(grid: grid,
+          subject: 'www.kontena.io',
+          valid_until: Time.now + 5.days,
+          private_key: 'private_key',
+          certificate: 'certificate',
+          chain: 'chain')
+      expect(subject.wrapped_object).to receive(:renew_certificate).with(cert2)
+      subject.renew_certificates
     end
   end
 

--- a/server/spec/jobs/certificate_renew_job_spec.rb
+++ b/server/spec/jobs/certificate_renew_job_spec.rb
@@ -56,6 +56,15 @@ describe CertificateRenewJob, celluloid: true do
         subject.authorize_domains(certificate)
       }.to raise_error "Domain authorization failed: boom"
     end
+
+    it 'raises if tls-sni deployment fails' do
+      domain_auth = GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: service)
+      expect(domain_auth).to receive(:status).twice.and_return(:deploy_error) #once in the wait loop and once after it
+      expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => true, :result => domain_auth))
+      expect {
+        subject.authorize_domains(certificate)
+      }.to raise_error "Deployment of tls-sni secret failed"
+    end
   end
 
 end


### PR DESCRIPTION
Now with TLS-SNI domain verifications it's possible to renew certificates fully automatically.

Tested to actually work locally with some SSH tunnel magic, tunneling the LE tls-sni request from DO ubuntu to local dev box. :)

Maybe some of the logic like `should_renew?` should move to `Certificate` model?

In for 1.4 still? 