### PR TITLE
Fix interpolation of stack variables declared by `to: env`

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -368,7 +368,11 @@ module Kontena::Cli::Stacks
               if use_opto
                 opt = variables.option(var)
                 if opt.nil?
-                  raise RuntimeError, "Undeclared variable '#{var}' in #{file}:#{line_num} -- #{row}" if raise_on_unknown
+                  if variables.find { |opt| opt.to[:env][var] }
+                    val = env[var]
+                  else
+                    raise RuntimeError, "Undeclared variable '#{var}' in #{file}:#{line_num} -- #{row}" if raise_on_unknown
+                  end
                 else
                   val = opt.value
                   if opt.to['env']

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -368,8 +368,9 @@ module Kontena::Cli::Stacks
               if use_opto
                 opt = variables.option(var)
                 if opt.nil?
-                  if variables.find { |opt| opt.to[:env][var] }
-                    val = env[var]
+                  to_env = variables.find { |opt| opt.to[:env][var] }
+                  if to_env
+                    val = to_env.value
                   else
                     raise RuntimeError, "Undeclared variable '#{var}' in #{file}:#{line_num} -- #{row}" if raise_on_unknown
                   end

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -376,9 +376,6 @@ module Kontena::Cli::Stacks
                   end
                 else
                   val = opt.value
-                  if opt.to['env']
-                    Array(opt.to['env']).each { |env_var| env[env_var] = val.to_s }
-                  end
                 end
               else
                 val = substitutions[var]

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -368,7 +368,7 @@ module Kontena::Cli::Stacks
               if use_opto
                 opt = variables.option(var)
                 if opt.nil?
-                  to_env = variables.find { |opt| opt.to[:env][var] }
+                  to_env = variables.find { |opt| Array(opt.to[:env]).include?(var) }
                   if to_env
                     val = to_env.value
                   else

--- a/cli/spec/fixtures/stack-with-variables.yml
+++ b/cli/spec/fixtures/stack-with-variables.yml
@@ -38,7 +38,7 @@ services:
     extends:
       file: docker-compose_v2.yml
       service: wordpress
-    image: "wordpress:$tag"
+    image: "wordpress:$TAG"
     stateful: true
     environment:
       - WORDPRESS_DB_PASSWORD=${STACK}_secret

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -234,6 +234,18 @@ describe Kontena::Cli::Stacks::YAML::Reader do
           hash_including('name' => 'mysql', 'env' => array_including('INTERNAL_VAR=$INTERNAL_VAR'))
         )
       end
+
+      it 'raises runtime error for undeclared variables' do
+        subject.variables.delete(subject.variables.option('test_var'))
+        expect{subject.execute}.to raise_error(RuntimeError, /Undeclared variable 'test_var'/)
+      end
+
+      it 'considers variables declared when they are listed as to: env targets' do
+        subject.variables.option('tag').to[:env] = "BAG"
+        expect{subject.execute}.to raise_error(RuntimeError, /Undeclared variable 'TAG'/)
+        subject.variables.option('tag').to[:env] = "TAG"
+        expect{subject.execute}.not_to raise_error
+      end
     end
 
     context 'environment variables' do


### PR DESCRIPTION
Fixes #2815

#2707 removed this functionality but seems like it is still needed.

When you have something like:

```yaml
stack: test/to-env
variables:
  foo:
    type: string
    value: hello
    to:
      env: FOO
services:
  redis:
    image: redis
    environment:
      - FOO=${FOO}
```

Then without this PR you would get "Undeclared variable FOO". This PR makes any environment variables that are listed in "to: env: " to be considered "declared".
