### PR TITLE
Add --dry-run to simulate kontena stack upgrade

### DIFF
--- a/cli/lib/kontena/cli/stacks/change_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/change_resolver.rb
@@ -66,11 +66,7 @@ module Kontena::Cli::Stacks
 
       removed_stacks.each do |removed_stack|
         removed_services.concat(
-          begin
-            old_data[removed_stack][:stack_data]['services'].map { |svc| "#{removed_stack}/#{svc['name']}"}
-        rescue
-          require 'byebug'; byebug
-        end
+          old_data[removed_stack][:stack_data]['services'].map { |svc| "#{removed_stack}/#{svc['name']}"}
         )
       end
 

--- a/cli/lib/kontena/cli/stacks/change_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/change_resolver.rb
@@ -1,0 +1,100 @@
+require_relative 'yaml/stack_file_loader'
+
+module Kontena::Cli::Stacks
+  class ChangeResolver
+
+    def self.common
+      @common ||= Class.new { include Kontena::Cli::Common }.new
+    end
+
+    attr_reader :old_data, :new_data
+
+    # Creates a change analysis from two sets of stack data.
+    # The format is a flat hash of all related stacks.
+    #
+    # @param old_data [Hash]
+    # @param new_data [Hash]
+    def initialize(old_data, new_data)
+      @old_data = old_data
+      @new_data = new_data
+      analyze
+    end
+
+    # @return [Array<String>] an array of services that should be added
+    def added_services
+      @added_services ||= []
+    end
+
+    # @return [Array<String>] an array of services that should be removed
+    def removed_services
+      @removed_services ||= []
+    end
+
+    # @return [Array<String>] an array of services that should be upgraded
+    def upgraded_services
+      @upgraded_services ||= []
+    end
+
+    # @return [Array<String>] an array of stack installation names that should be removed
+    def removed_stacks
+      @removed_stacks ||= []
+    end
+
+    # @return [Array<String>] an array of stack installation names that should be removed
+    def added_stacks
+      @added_stacks ||= []
+    end
+
+    # @return [Array<String>] an array of stack installation names that should be upgraded
+    def upgraded_stacks
+      @upgraded_stacks ||= []
+    end
+
+    # @return [Hash] a hash of "installed-stack-name" => { :from => 'stackname', :to => 'new-stackname' }
+    def replaced_stacks
+      @replaced_stacks ||= {}
+    end
+
+    # @return [Array<String>] an array of installed stack names that should exist after upgrade
+    def remaining_stacks
+      @remaining_stacks ||= added_stacks + upgraded_stacks
+    end
+
+    def analyze
+      old_names = old_data.keys
+      new_names = new_data.keys
+
+      removed_stacks.concat(old_names - new_names)
+      added_stacks.concat(new_names - old_names)
+      upgraded_stacks.concat(new_names - added_stacks)
+
+      removed_stacks.each do |removed_stack|
+        removed_services.concat(
+          old_data[removed_stack][:stack_data]['services'].map { |svc| "#{removed_stack}/#{svc['name']}"}
+        )
+      end
+
+      added_stacks.each do |added_stack|
+        added_services.concat(
+          new_data[added_stack][:stack_data]['services'].map { |svc| "#{added_stack}/#{svc['name']}"}
+        )
+      end
+
+      upgraded_stacks.each do |upgraded_stack|
+        old_stack = old_data[upgraded_stack][:stack_data]['stack']
+        new_stack = new_data[upgraded_stack][:stack_data]['stack']
+
+        unless old_stack == new_stack
+          replaced_stacks[upgraded_stack] = { from: old_stack, to: new_stack }
+        end
+
+        old_services = old_data[upgraded_stack][:stack_data]['services'].map { |svc| "#{upgraded_stack}/#{svc['name']}" }
+        new_services = new_data[upgraded_stack][:stack_data]['services'].map { |svc| "#{upgraded_stack}/#{svc['name']}" }
+
+        removed_services.concat(old_services - new_services)
+        added_services.concat(new_services - old_services)
+        upgraded_services.concat(new_services - added_services)
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/stacks/change_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/change_resolver.rb
@@ -62,7 +62,7 @@ module Kontena::Cli::Stacks
 
       removed_stacks.concat(old_names - new_names)
       added_stacks.concat(new_names - old_names)
-      upgraded_stacks.concat(new_names - added_stacks)
+      upgraded_stacks.concat(new_names & old_names)
 
       removed_stacks.each do |removed_stack|
         removed_services.concat(
@@ -89,7 +89,7 @@ module Kontena::Cli::Stacks
 
         removed_services.concat(old_services - new_services)
         added_services.concat(new_services - old_services)
-        upgraded_services.concat(new_services & added_services)
+        upgraded_services.concat(new_services & old_services)
       end
     end
   end

--- a/cli/lib/kontena/cli/stacks/change_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/change_resolver.rb
@@ -70,7 +70,11 @@ module Kontena::Cli::Stacks
 
       removed_stacks.each do |removed_stack|
         removed_services.concat(
-          old_data[removed_stack][:stack_data]['services'].map { |svc| "#{removed_stack}/#{svc['name']}"}
+          begin
+            old_data[removed_stack][:stack_data]['services'].map { |svc| "#{removed_stack}/#{svc['name']}"}
+        rescue
+          require 'byebug'; byebug
+        end
         )
       end
 

--- a/cli/lib/kontena/cli/stacks/change_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/change_resolver.rb
@@ -3,10 +3,6 @@ require_relative 'yaml/stack_file_loader'
 module Kontena::Cli::Stacks
   class ChangeResolver
 
-    def self.common
-      @common ||= Class.new { include Kontena::Cli::Common }.new
-    end
-
     attr_reader :old_data, :new_data
 
     # Creates a change analysis from two sets of stack data.
@@ -97,7 +93,7 @@ module Kontena::Cli::Stacks
 
         removed_services.concat(old_services - new_services)
         added_services.concat(new_services - old_services)
-        upgraded_services.concat(new_services - added_services)
+        upgraded_services.concat(new_services & added_services)
       end
     end
   end

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -44,7 +44,7 @@ module Kontena::Cli::Stacks
       return if dependencies.nil?
       dependencies.each do |dependency|
         target_name = "#{stack_name}-#{dependency['name']}"
-        caret "Installing dependency #{pastel.cyan(dependency[:stack])} as #{pastel.cyan(target_name)}"
+        caret "Installing dependency #{pastel.cyan(dependency['stack'])} as #{pastel.cyan(target_name)}"
         cmd = ['stack', 'install', '-n', target_name, '--parent-name', stack_name]
 
         dependency['variables'].merge(dependency_values_from_options(dependency['name'])).each do |key, value|

--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -76,6 +76,7 @@ module Kontena::Cli::Stacks
     end
 
     def tree_icon(row)
+      return '' unless $stdout.tty?
       parent = row['parent']
       children = row['children'] || []
       if parent.nil? && children.empty?

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -80,8 +80,8 @@ module Kontena::Cli::Stacks
     # @param new_data [Hash] data from files
     # @return [Kontena::Cli::Stacks::ChangeRsolver]
     def process_data(old_data, new_data)
-      caret "Analyzing upgrade" # not a spinner, because the stack executes can create prompts
-      # Execute the local stacks
+      logger.debug { "Master stacks: #{old_data.keys.join(",")} YAML stacks: #{new_data.keys.join(",")}" }
+
       new_data.reverse_each do |stackname, data|
         reader = data[:loader].reader
         set_env_variables(stackname, current_grid) # set envs for execution time
@@ -97,7 +97,9 @@ module Kontena::Cli::Stacks
 
       set_env_variables(stack_name, current_grid) # restore envs
 
-      Kontena::Cli::Stacks::ChangeResolver.new(old_data, new_data)
+      spinner "Analyzing upgrade" do
+        Kontena::Cli::Stacks::ChangeResolver.new(old_data, new_data)
+      end
     end
 
     def display_report(changes)

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -103,6 +103,10 @@ module Kontena::Cli::Stacks
     end
 
     def display_report(changes)
+      if !dry_run? && changes.removed_stacks.empty? && changes.replaced_stacks.empty? && changes.upgraded_stacks.size == 1 && changes.removed_services.empty?
+        return
+      end
+
       will = dry_run? ? "would" : "will"
 
       puts "SERVICES:"
@@ -156,7 +160,6 @@ module Kontena::Cli::Stacks
         changes.upgraded_stacks.each { |stack| puts pastel.cyan("- #{stack}") }
         puts
       end
-
 
       puts
     end

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -50,13 +50,13 @@ module Kontena::Cli::Stacks
 
       get_confirmation(changes)
 
-      run_removes(changes.removed_stacks)
-
       deployable_stacks = []
       deployable_stacks.concat run_installs(changes)
       deployable_stacks.concat run_upgrades(changes)
 
       run_deploys(deployable_stacks) if deploy?
+
+      run_removes(changes.removed_stacks)
 
       changes
     end

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -153,6 +153,7 @@ module Kontena::Cli::Stacks
           if dry_run?
             caret "Would install new dependency #{cmd.last} as #{stackname} without --dry-run", dots: false
           else
+            caret "Installing new dependency #{cmd.last} as #{stackname}"
             Kontena.run!(cmd)
           end
         end

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -162,11 +162,9 @@ module Kontena::Cli::Stacks
     # requires heavier confirmation when something very dangerous is going to happen
     def get_confirmation(changes)
       unless force?
-        if changes.removed_services.empty? && changes.removed_stacks.empty? && changes.replaced_stacks.empty?
-          confirm
-        else
+        unless changes.removed_services.empty? && changes.removed_stacks.empty? && changes.replaced_stacks.empty?
           puts "#{pastel.red('Warning:')} This can not be undone, data will be lost."
-          confirm_command(stack_name)
+          confirm
         end
       end
     end

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -86,20 +86,20 @@ module Kontena::Cli::Stacks
 
       unless changes.removed_services.empty?
         puts pastel.yellow("These services #{will} be removed from master:")
-        changes.removed_services.each { |svc| puts " - #{svc}" }
+        changes.removed_services.each { |svc| puts pastel.yellow(" - #{svc}") }
         puts
       end
 
       unless changes.added_services.empty?
-        puts "These new services #{will} be created to master:"
-        changes.added_services.each { |svc| puts " - #{svc}" }
+        puts pastel.green("These new services #{will} be created to master:")
+        changes.added_services.each { |svc| puts pastel.green(" - #{svc}") }
         puts
       end
 
       unless changes.upgraded_services.empty?
-        puts "These services #{will} be upgraded:"
+        puts pastel.cyan("These services #{will} be upgraded:")
         changes.upgraded_services.each do |svc|
-          puts "- #{svc}"
+          puts pastel.cyan("- #{svc}")
         end
         puts
       end
@@ -109,28 +109,27 @@ module Kontena::Cli::Stacks
 
       unless changes.removed_stacks.empty?
         puts pastel.red("These stacks #{will} be removed because they are no longer depended on:")
-        changes.removed_stacks.each { |stack| puts "- #{stack}" }
+        changes.removed_stacks.each { |stack| puts pastel.red("- #{stack}") }
         puts
       end
 
       unless changes.replaced_stacks.empty?
-        puts pastel.yellow("These stacks #{will} be replaced with other stacks:")
+        puts pastel.yellow("These stacks #{will} be replaced by other stacks:")
         changes.replaced_stacks.each do |installed_name, data|
-          puts "- #{installed_name} from #{pastel.cyan(data[:from])} to #{pastel.cyan(data[:to])}"
-          logger.debug { "- #{installed_name} from #{pastel.cyan(data[:from])} to #{pastel.cyan(data[:to])}" }
+          puts "- #{pastel.yellow(installed_name)} from #{pastel.cyan(data[:from])} to #{pastel.cyan(data[:to])}"
         end
         puts
       end
 
       unless changes.added_stacks.empty?
         puts pastel.red("These new stack dependencies #{will} be installed:")
-        changes.added_stacks.each { |stack| puts "- #{stack}" }
+        changes.added_stacks.each { |stack| puts pastel.red("- #{stack}") }
         puts
       end
 
       unless changes.upgraded_stacks.empty?
-        puts "These stacks #{will} be upgraded#{' and deployed' if deploy?}:"
-        changes.upgraded_stacks.each { |stack| puts "- #{stack}" }
+        puts pastel.cyan("These stacks #{will} be upgraded#{' and deployed' if deploy?}:")
+        changes.upgraded_stacks.each { |stack| puts pastel.cyan("- #{stack}") }
         puts
       end
 

--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -30,7 +30,6 @@ module Kontena::Cli::Stacks
         cmd.concat ['--parent-name', stack_name]
 
         dependency['variables'].merge(dependency_values_from_options(dependency['name'])).each do |key, value|
-          next if key == 'PARENT_STACK'
           cmd.concat ['-v', "#{key}=#{value}"]
         end
         cmd << dependency['stack']
@@ -58,8 +57,11 @@ module Kontena::Cli::Stacks
 
       dump_variables if values_to
 
-      result = reader.fully_interpolated_yaml.merge(
-        'variables' => Kontena::Util.stringify_keys(reader.variables.to_h(with_values: true, with_errors: true))
+      result = stack.reject { |k, _| k == 'source' }
+      result.merge!(
+        'variables' => Kontena::Util.stringify_keys(
+          reader.variable_values(without_defaults: true, without_vault: true, with_errors: true)
+        )
       )
       if dependencies?
         puts ::YAML.dump(result).sub(/\A---$/, "---\n# #{loader.source}")

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -49,8 +49,8 @@ module Kontena::Cli::Stacks
       # @param without_defaults [TrueClass,FalseClass] strip the GRID, STACK, etc from response
       # @param without_vault [TrueClass,FalseClass] strip out any values that are going to or coming from VAULT
       # @return [Hash] a hash of key value pairs representing the values of stack variables
-      def variable_values(without_defaults: false, without_vault: false)
-        result = variables.to_h(values_only: true)
+      def variable_values(without_defaults: false, without_vault: false, with_errors: false)
+        result = variables.to_h(values_only: true, with_errors: with_errors)
         if without_defaults
           result.delete_if { |k, _| default_envs.key?(k.to_s) || k.to_s == 'PARENT_STACK' }
         end

--- a/cli/lib/kontena/cli/stacks/yaml/stack_file_loader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/stack_file_loader.rb
@@ -85,7 +85,7 @@ module Kontena::Cli::Stacks
         else
           @dependencies = depends.map do |name, dependency|
             loader = StackFileLoader.for(dependency['stack'], self)
-            deps = { 'name' => name, 'stack' => loader.source, 'variables' => dependency.fetch('variables', Hash.new), :loader => self }
+            deps = { 'name' => name, 'stack' => loader.source, 'variables' => dependency.fetch('variables', Hash.new) }
             if recurse
               child_deps = loader.dependencies
               deps['depends'] = child_deps unless child_deps.nil?

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -51,13 +51,13 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
     it 'sends stack to master' do
       expect(client).to receive(:get).with('stacks/test-grid/stack-a').and_return(stack_response)
       expect(client).to receive(:put).with('stacks/test-grid/stack-a', hash_including(stack_expectation.merge('name' => 'stack-a'))).and_return(true)
-      subject.run(['--no-deploy', 'stack-a', fixture_path('kontena_v3.yml')])
+      subject.run(['--no-deploy', '--force', 'stack-a', fixture_path('kontena_v3.yml')])
     end
 
     it 'requires confirmation when master stack is different than input stack' do
       expect(client).to receive(:get).with('stacks/test-grid/stack-b').and_return(stack_response.merge('stack' => 'foo/otherstack'))
-      expect(subject).to receive(:confirm).with(/Replacing stack foo\/otherstack on master with user\/stackname/).and_call_original
-      expect{subject.run(['stack-b',  fixture_path('kontena_v3.yml')])}.to exit_with_error
+      expect(subject).to receive(:confirm_command).and_call_original
+      expect{subject.run(['stack-b', fixture_path('kontena_v3.yml')])}.to exit_with_error.and output(/- stack-b from foo\/otherstack to user\/stackname/).to_stdout
     end
 
     it 'triggers deploy by default' do
@@ -66,7 +66,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
         'stacks/test-grid/stack-a', anything
       ).and_return({})
       expect(Kontena).to receive(:run!).with(['stack', 'deploy', 'stack-a']).once
-      subject.run(['stack-a', fixture_path('kontena_v3.yml')])
+      subject.run(['--force', 'stack-a', fixture_path('kontena_v3.yml')])
     end
 
     context '--no-deploy option' do
@@ -83,13 +83,13 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
     context 'with a stack including dependencies' do
 
       let(:expectation)     {{ 'name' => 'deptest', 'stack' => 'user/depstack1' }}
-      let(:expectation_1)   {{ 'name' => 'deptest-dep_1', 'stack' => 'user/depstack1child1' }}
+      let(:expectation_1)   {{ 'name' => 'deptest-dep_1', 'stack' => 'user/depstack1child1'}}
       let(:expectation_1_1) {{ 'name' => 'deptest-dep_1-dep_1', 'stack' => 'user/depstack1child1child1', 'services' => array_including(hash_including('image' => 'image:2')) }}
       let(:expectation_2)   {{ 'name' => 'deptest-dep_2', 'stack' => 'user/depstack1child2', 'services' => array_including(hash_including('image' => 'image:1')), 'variables' => hash_including('dep_var' => 1) }}
 
-      let(:response)     { expectation.merge('parent' => nil, 'children' => [{'name' => 'deptest-dep_1'}, {'name' => 'deptest-dep_2'}]) }
-      let(:response_1)   { expectation_1.merge('parent' => { 'name' => 'deptest' }, 'children' => [{'name' => 'deptest-dep_1-dep_1'}]) }
-      let(:response_1_1) { expectation_1_1.merge('parent' => { 'name' => 'deptest-dep_1' }, 'children' => []) }
+      let(:response)     { expectation.merge('parent' => nil, 'children' => [{'name' => 'deptest-dep_1'}, {'name' => 'deptest-dep_2'}], 'services' => [])  }
+      let(:response_1)   { expectation_1.merge('parent' => { 'name' => 'deptest' }, 'children' => [{'name' => 'deptest-dep_1-dep_1'}], 'services' => []) }
+      let(:response_1_1) { expectation_1_1.merge('parent' => { 'name' => 'deptest-dep_1' }, 'children' => [], 'services' => []) }
       let(:response_2)   { expectation_2.merge('parent' => { 'name' => 'deptest' }, 'children' => [], 'variables' => {}, 'services' => []) }
 
       before  do
@@ -104,12 +104,12 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
         expect(client).to receive(:put).with('stacks/test-grid/deptest-dep_1-dep_1', hash_including(expectation_1_1)).and_return(true)
         expect(client).to receive(:put).with('stacks/test-grid/deptest-dep_1', hash_including(expectation_1)).and_return(true)
         expect(client).to receive(:put).with('stacks/test-grid/deptest', hash_including(expectation)).and_return(true)
-        subject.run(['--no-deploy', '-v', 'dep_2.dep_var=1', 'deptest', fixture_path('stack-with-dependencies.yml')])
+        subject.run(['--force', '--no-deploy', '-v', 'dep_2.dep_var=1', 'deptest', fixture_path('stack-with-dependencies.yml')])
       end
 
       context 'when a dependency has been removed' do
         it 'warns if a stack no longer in the dependency chain would be removed' do
-          expect(subject).to receive(:confirm).and_call_original
+          expect(subject).to receive(:confirm_command).and_call_original
           expect{subject.run(['--no-deploy', 'deptest', fixture_path('stack-with-dependencies-dep_2-removed.yml')])}.to exit_with_error.and output(/- deptest-dep_2.*data will be lost/m).to_stdout
         end
       end
@@ -117,8 +117,8 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       context 'when a dependency has been added' do
         it 'installs any new stacks in the dependency chain' do
           allow(client).to receive(:put).and_return(true)
-          expect(Kontena).to receive(:run!).with(["stack", "install", "--name", "deptest-dep_3", "--parent-name", "deptest", "--no-deploy", fixture_path('stack-with-dependencies-dep-3.yml')]).and_return(true)
-          subject.run(['--no-deploy', '-v', 'dep_2.dep_var=1', 'deptest', fixture_path('stack-with-dependencies-dep_3-added.yml')])
+          expect(Kontena).to receive(:run!).with(["stack", "install", "--name", "deptest-dep_3", "--no-deploy", "--parent-name", "deptest", fixture_path('stack-with-dependencies-dep-3.yml')]).and_return(true)
+          subject.run(['--no-deploy', '--force', '-v', 'dep_2.dep_var=1', 'deptest', fixture_path('stack-with-dependencies-dep_3-added.yml')])
         end
       end
     end

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -56,7 +56,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
 
     it 'requires confirmation when master stack is different than input stack' do
       expect(client).to receive(:get).with('stacks/test-grid/stack-b').and_return(stack_response.merge('stack' => 'foo/otherstack'))
-      expect(subject).to receive(:confirm_command).and_call_original
+      expect(subject).to receive(:confirm).and_call_original
       expect{subject.run(['stack-b', fixture_path('kontena_v3.yml')])}.to exit_with_error.and output(/- stack-b from foo\/otherstack to user\/stackname/).to_stdout
     end
 
@@ -109,7 +109,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
 
       context 'when a dependency has been removed' do
         it 'warns if a stack no longer in the dependency chain would be removed' do
-          expect(subject).to receive(:confirm_command).and_call_original
+          expect(subject).to receive(:confirm).and_call_original
           expect{subject.run(['--no-deploy', 'deptest', fixture_path('stack-with-dependencies-dep_2-removed.yml')])}.to exit_with_error.and output(/- deptest-dep_2.*data will be lost/m).to_stdout
         end
       end


### PR DESCRIPTION
Fixes #2819

Adds `--dry-run` option to stack upgrade and also gives better output before asking for confirmation when running without `--dry-run`.

In the future the report could show some finer diff of the changes to upgraded services.
