### PR TITLE
Fix missing certificates validation on service update

### DIFF
--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -32,6 +32,7 @@ module GridServices
         add_error(:health_check, :invalid, 'Interval has to be bigger than timeout')
       end
       validate_secrets
+      validate_certificates
       if self.grid_service.stateful?
         if self.volumes_from && self.volumes_from.size > 0
           add_error(:volumes_from, :invalid, 'Cannot combine stateful & volumes_from')

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -495,6 +495,18 @@ describe GridServices::Create do
         )]
       end
 
+      it 'fails to create service with invalid certificates' do
+        outcome = described_class.new(
+          grid: grid,
+          image: 'redis:2.8',
+          name: 'redis',
+          stateful: false,
+          certificates: [
+            {subject: 'kotnena.io', name: 'SSL_CERT'}
+          ]
+        ).run
+        expect(outcome).to_not be_success
+      end
     end
 
     it 'validates env syntax' do

--- a/server/spec/mutations/grid_services/update_spec.rb
+++ b/server/spec/mutations/grid_services/update_spec.rb
@@ -318,6 +318,7 @@ describe GridServices::Update do
           expect(outcome = subject.run).to be_success
         }.to change{service.reload.revision}.and change{service.reload.updated_at}
       end
+
       it 'removes certificate' do
         subject = described_class.new(
             grid_service: service,
@@ -330,6 +331,20 @@ describe GridServices::Update do
         }.to change{service.reload.revision}.and change{service.reload.updated_at}
 
         expect(service.reload.certificates.map{|c| c.subject}).to eq ['kontena.io']
+      end
+
+      it 'fails with invalid certificate' do
+        subject = described_class.new(
+            grid_service: service,
+            certificates: [
+              {subject: 'www.kotnena.io', name: 'SSL_CERT'},
+            ]
+        )
+        expect {
+          expect(outcome = subject.run).to_not be_success
+        }.to not_change{service.reload.revision}.and not_change{service.reload.updated_at}
+
+        expect(service.reload.certificates.map{|c| c.subject}).to eq ['kontena.io', 'www.kontena.io']
       end
     end
 


### PR DESCRIPTION
The service update mutation was not validating the updated certificates. Some typoing of the opto list prompt syntax lead to `[#<GridServiceCertificate _id: 59bbdb45a040b50011f5b205, subject: "test.188.226.131.23.nip.io test.188.226.131.23.xip.io", name: "SSL_CERTS", type: "env">]`.

### Testing
```
$ kontena stack upgrade ingress-lb test/lb-certificates.yaml 
 [done] Parsing test/lb-certificates.yaml     
 [done] Reading stack ingress-lb from master     
> Affinity : label!=no-ingress-lb
> SSL certificate subjects : (["test.188.226.131.23.nip.io test.188.226.131.23.xip.io"]) test.188.226.131.23.nip.io test.188.226.131.23.xip.> SSL certificate subjects : test.188.226.131.23.nip.io test.188.226.131.23.xip.io
> Custom port mappings (comma separated, eg 2022:2022,25:25) : []
 [fail] Upgrading stack ingress-lb     
 [error] 422 : Unprocessable Entity:
	services:
	  lb:
	    certificates:
	    - Certificate test.188.226.131.23.nip.io test.188.226.131.23.xip.io does not exist
```