### PR TITLE
CLI: Add --no-wait option to kontena service deploy

### DIFF
--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -7,6 +7,7 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
+    option '--[no-]wait', :flag, 'Do not wait for service deployment', default: true
     option '--force', :flag, 'Force deploy even if service does not have any changes'
 
     def execute
@@ -17,7 +18,7 @@ module Kontena::Cli::Services
       data[:force] = true if force?
       spinner "Deploying service #{name.colorize(:cyan)} " do
         deployment = deploy_service(token, name, data)
-        wait_for_deploy_to_finish(token, deployment)
+        wait_for_deploy_to_finish(token, deployment) if wait?
       end
     end
   end

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Stacks
 
     parameter "NAME", "Stack name"
 
-    option '--[no-]wait', :flag, 'Do not wait service deployment', default: true
+    option '--[no-]wait', :flag, 'Do not wait for service deployment', default: true
 
     requires_current_master
     requires_current_master_token


### PR DESCRIPTION
Fixes #2846

Adds a `--no-wait` option that is already found in `kontena stack deploy` to `kontena service deploy`.

Default behavior is to wait for the deployment to finish, by using `--no-wait` you can have the CLI return to shell immediately after sending the deployment start trigger to master.
