### PR TITLE
Fix websocket agent version check

### DIFF
--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -187,8 +187,6 @@ class WebsocketBackend
     node_id = req.env['HTTP_KONTENA_NODE_ID']
     connected_at = nil
 
-    node = find_node(req)
-
     # check version
     agent_version = req.env['HTTP_KONTENA_VERSION'].to_s
 
@@ -196,6 +194,8 @@ class WebsocketBackend
       send_master_info(ws)
       raise CloseError.new(4010), "agent version #{agent_version} is not compatible with server version #{Server::VERSION}"
     end
+
+    node = find_node(req)
 
     # check clock after version check, because older agent versions do not send this header
     connected_at = Time.parse(req.env['HTTP_KONTENA_CONNECTED_AT'])
@@ -235,7 +235,7 @@ class WebsocketBackend
     end
 
     if node
-      # this only applies to the version/clock skew errors, not any of the early token -> node errors
+      # this only applies to the clock skew errors, not any of the early token -> node or version errors
       Agent::NodePlugger.new(node).reject!(connected_at, exc.code, exc.message)
     end
 

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -108,6 +108,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       let(:rack_req) { instance_double(Rack::Request, env: {
         'HTTP_KONTENA_NODE_ID' => node_id,
         'HTTP_KONTENA_NODE_NAME' => node_name,
+        'HTTP_KONTENA_VERSION' => node_version,
       })}
 
       describe '#on_open' do
@@ -272,19 +273,13 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
       describe '#on_open' do
         it 'creates the node, but does not connect it' do
-          expect(subject.logger).to receive(:info).with('new node node-1 connected using grid token')
+          #expect(subject.logger).to receive(:info).with('new node node-1 connected using grid token')
           expect(subject).to receive(:send_master_info).with(client_ws)
-          expect(subject.logger).to receive(:warn).with('reject websocket connection for node node-1: agent version 0.8.0 is not compatible with server version 0.9.1')
+          expect(subject.logger).to receive(:warn).with('reject websocket connection for node nodeABC: agent version 0.8.0 is not compatible with server version 0.9.1')
           expect(client_ws).to receive(:close).with(4010, 'agent version 0.8.0 is not compatible with server version 0.9.1')
 
-          host_node = nil
+          subject.on_open(client_ws, rack_req)
 
-          expect{
-            subject.on_open(client_ws, rack_req)
-          }.to change{host_node = grid.host_nodes.find_by(node_id: node_id)}.from(nil).to(HostNode)
-
-          expect(host_node.status).to eq :offline
-          expect(host_node.websocket_error).to match /Websocket connection rejected at .* with code 4010: agent version 0.8.0 is not compatible with server version 0.9.1/
         end
       end
     end


### PR DESCRIPTION
https://github.com/kontena/kontena/pull/2694 changed the the checks done for a connecting agent. It made the `HTTP_KONTENA_NODE_NAME` mandatory and it's checked on the first steps. Older agents will not send that header.  Not sending that header will get the connection closed with code `4000`, thus the agent will not commit seppuku and auto-update.

This PR makes the version check be the first check done, thus agent will get proper error code to upgrade itself.

This does have the drawback of the version mismatches will NOT get stored in the new `HostNodeConnection`  model at all. Would need heavy refactoring to get version error show up there which I didn't wanna start to do at this point.