### PR TITLE
CLI: Allow referencing child stack variables from parent

### DIFF
--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -148,7 +148,7 @@ module Kontena::Cli::Stacks
         end
 
         def values_from_options
-          @values_from_options ||= values_from_installed_stacks.merge(values_from_file).merge(values_from_value_options)
+          values_from_installed_stacks.merge(values_from_file).merge(values_from_value_options)
         end
 
         # Transforms a hash

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -173,11 +173,14 @@ module Kontena::Cli::Stacks
       # This variable can be used to interpolate for example a hostname to some environment variable:
       # environment:
       #   - "REDIS_HOST=redis.${REDIS}"
-      def create_dependency_variables(dependencies, name)
+      def create_dependency_variables(dependencies, name, prefix = "")
         return if dependencies.nil?
         dependencies.each do |options|
-          variables.build_option(name: options['name'].to_s, type: :string, value: "#{name}-#{options['name']}")
-          create_dependency_variables(options['depends'], "#{name}.#{options['name']}")
+          variables.build_option(
+            name: "#{"#{prefix}." unless prefix.empty?}#{options['name']}",
+            type: :string,
+            value: "#{name}-#{options['name']}")
+          create_dependency_variables(options['depends'], "#{name}-#{options['name']}", options['name'])
         end
       end
 
@@ -375,7 +378,7 @@ module Kontena::Cli::Stacks
           if row.strip.start_with?('interpolate:') || row.strip.start_with?('evaluate:')
             row
           else
-            row.gsub(/(?<!\$)\$(?!\$)\{?\w+\}?/) do |v| # searches $VAR and ${VAR} and not $$VAR
+            row.gsub(/(?<!\$)\$(?!\$)\{?(?:\w|\.)+\}?/) do |v| # searches $VAR and ${VAR} and not $$VAR
               var = v.tr('${}', '')
 
               if use_opto

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -151,7 +151,16 @@ module Kontena::Cli::Stacks
       def set_variable_values(values)
         values.each do |key, val|
           var = variables.option(key.to_s)
-          var.set(val) if var
+          if var
+            var.set(val)
+          else
+            type = case val
+                   when Integer then :integer
+                   when TrueClass, FalseClass then :boolean
+                   else :string
+                   end
+            variables.build_option(type: type, name: key, value: val)
+          end
         end
       end
 

--- a/cli/lib/kontena/cli/stacks/yaml/stack_file_loader/raw_content_loader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/stack_file_loader/raw_content_loader.rb
@@ -1,0 +1,32 @@
+module Kontena::Cli::Stacks
+  module YAML
+    class RawContentLoader < StackFileLoader
+      # For loading from a string directly, probably mostly useful in specs
+      def self.match?(source, parent = nil)
+        source.kind_of?(String) && source.count("\n") > 0 && source.include?("stack: ")
+      end
+
+      def inspect
+        super.gsub(/@content=".+?[^\\]"/m, "@content=\"...\"")
+      end
+
+      def initialize(*args)
+        super
+        @content = source.dup
+        @source = "string"
+      end
+
+      def read_content
+        @content
+      end
+
+      def origin
+        "string"
+      end
+
+      def registry
+        "file://"
+      end
+    end
+  end
+end

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -244,6 +244,16 @@ describe Kontena::Cli::Stacks::YAML::Reader do
         subject.variables.option('tag').to[:env] = "TAG"
         expect{subject.execute}.not_to raise_error
       end
+
+      it 'considers variables declared when they are sent in via the values: hash' do
+        instance = described_class.new(YAML.dump('stack' => 'foo/foo', 'services' => { 'foo' => { 'environment' => ["BAR=${baz}"] } } ))
+        expect(instance.execute(values: { baz: 'foo' })).to match hash_including(
+          'variables' => hash_including('baz' => 'foo'),
+          'services' => array_including(
+            hash_including('name' => 'foo', 'env' => array_including('BAR=foo'))
+          )
+        )
+      end
     end
 
     context 'environment variables' do


### PR DESCRIPTION
Makes it possible to reference child stack variable values from a parent stack.

After this PR, something like this can be done:

```yaml
stack: user/stack
version: 0.1.0
depends:
  mysql:
    stack: zontena/mysql

services:
  app:
     image: myawesomeapp
     environment:
       - "DB_USERNAME=${mysql.username}" # <--- !!!
```

