### PR TITLE
Docs: Add stack depends parent/children fields to API documentation

### DIFF
--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -688,7 +688,8 @@ Accept: application/json
     "stack": "my/redis",
     "version": "0.1.0",
     "registry": "file://",
-    "services": []
+    "services": [],
+    "parent_name": "parent-stack-name"
 }
 ```
 

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -582,6 +582,10 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
   "version": "0.1.0",
   "registry": "https://stack-registry.kontena.io",
   "expose": "peer",
+  "parent": { "name": "parent-stack-name" },
+  "children": [
+    { "name": "child-stack-name" }
+  ],
   "services": [
       {
           "name": "arbiter",
@@ -662,6 +666,8 @@ registry | A stack registry where stack schema is originally fetched
 expose | A service that stack exposes to grid level DNS namespace
 services | A list of stack services (see [services](#services) for more info)
 volumes | A list of volumes used in this stack (see [volumes](#volumes) for more info)
+parent | Null or an object with "name" attribute if the stack is part of a dependency chain
+children | An array of objects with "name" attribute if the stack is part of a dependency chain
 
 ### Volume attributes
 
@@ -669,7 +675,6 @@ Attribute | Description
 ---------- | -------
 name  | Name of the volume within the stack
 external | Name of the grid level volume definition to use
-
 
 ## Create a stack
 

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -584,7 +584,7 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
   "expose": "peer",
   "parent": {
     "name": "parent-stack-name",
-    "id": "my-grid/parent-stack-name"
+    "id": "my-grid/parent-stack-name" # null when parent does not exist
   },
   "children": [
     {

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -582,9 +582,15 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
   "version": "0.1.0",
   "registry": "https://stack-registry.kontena.io",
   "expose": "peer",
-  "parent": { "name": "parent-stack-name" },
+  "parent": {
+    "name": "parent-stack-name",
+    "id": "my-grid/parent-stack-name"
+  },
   "children": [
-    { "name": "child-stack-name" }
+    {
+      "name": "child-stack-name",
+      "id": "my-grid/child-stack-name"
+    }
   ],
   "services": [
       {
@@ -666,8 +672,8 @@ registry | A stack registry where stack schema is originally fetched
 expose | A service that stack exposes to grid level DNS namespace
 services | A list of stack services (see [services](#services) for more info)
 volumes | A list of volumes used in this stack (see [volumes](#volumes) for more info)
-parent | Null or an object with "name" attribute if the stack is part of a dependency chain
-children | An array of objects with "name" attribute if the stack is part of a dependency chain
+parent | Null or an object referencing the parent stack in a stack dependency chain
+children | An array of objects referencing the child stacks in a stack dependency chain
 
 ### Volume attributes
 


### PR DESCRIPTION
Adds the new parent and children fields to the stack JSON response documentation.
