### PR TITLE
Fix server NodeVolumeHandler to not be a Celluloid actor

### DIFF
--- a/server/app/services/rpc/node_volume_handler.rb
+++ b/server/app/services/rpc/node_volume_handler.rb
@@ -1,6 +1,5 @@
 module Rpc
   class NodeVolumeHandler
-    include Celluloid
     include Logging
 
     def initialize(grid)

--- a/server/spec/services/rpc/node_volume_handler_spec.rb
+++ b/server/spec/services/rpc/node_volume_handler_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-describe Rpc::NodeVolumeHandler, celluloid: true do
+describe Rpc::NodeVolumeHandler do
   let(:grid) { Grid.create! }
   let(:subject) { described_class.new(grid) }
   let(:node) { grid.create_node!('test-node', node_id: 'abc') }


### PR DESCRIPTION
`NodeVolumeHandler` does NOT need to be an actor. As a side-effect of it being an actor, the errors raised will show up in Rollbar unnecessarily.