### PR TITLE
CLI: Do not output field names in quiet mode when there is no data

### DIFF
--- a/cli/lib/kontena/cli/table_generator.rb
+++ b/cli/lib/kontena/cli/table_generator.rb
@@ -36,7 +36,8 @@ module Kontena
         end
 
         def print_table(array, fields = nil, &block)
-          puts generate_table(array, fields, &block)
+          output = generate_table(array, fields, &block)
+          puts output unless output.strip.empty?
         end
       end
 
@@ -68,7 +69,7 @@ module Kontena
 
       def render
         if data.empty?
-          fields.map(&method(:format_header_item)).join('  ')
+          fields.size > 1 ? fields.map(&method(:format_header_item)).join('  ') : ''
         else
           table.render(render_mode, render_options).gsub(/\s+$/, '')
         end

--- a/cli/spec/kontena/cli/table_generator_spec.rb
+++ b/cli/spec/kontena/cli/table_generator_spec.rb
@@ -51,6 +51,10 @@ describe Kontena::Cli::TableGenerator do
           ]).without_header
         end
 
+        it 'outputs nothing when table with no data and only one field' do
+          expect{subject.print_table({}, ['a'])}.to output(/\A\z/).to_stdout
+        end
+
         it 'tries to read the fields from #fields method when none given' do
           expect(subject).to receive(:fields).and_return(['a', 'b'])
           expect{subject.print_table(data)}.to output_table([

--- a/test/spec/features/stack/list_spec.rb
+++ b/test/spec/features/stack/list_spec.rb
@@ -1,10 +1,15 @@
 require 'spec_helper'
 
 describe 'stack list' do
-  it "returns an empty list" do
+  after do
+    run('kontena stack rm --force simple')
+  end
+
+  it "returns an empty list with headers" do
     k = run 'kontena stack ls'
     expect(k.code).to eq(0)
     expect(k.out.lines.size).to eq(1)
+    expect(k.out).to match(/NAME.*STACK.*STATE/)
   end
 
   it "returns an installed stack" do
@@ -15,6 +20,23 @@ describe 'stack list' do
     expect(k.code).to eq(0)
     expect(k.out.lines.size).to eq(2)
     expect(k.out.match(/simple.*test\/simple:.*initialized/)).to be_truthy
-    run 'kontena stack rm --force simple'
+  end
+
+  context 'quiet mode' do
+    it "returns an installed stack name" do
+      with_fixture_dir("stack/simple") do
+        run 'kontena stack install --no-deploy'
+      end
+      k = run 'kontena stack ls -q'
+      expect(k.code).to eq(0)
+      expect(k.out.lines.size).to eq(1)
+      expect(k.out.strip).to eq "simple"
+    end
+
+    it "returns nothing when there are no stacks" do
+      k = run 'kontena stack ls -q'
+      expect(k.code).to eq(0)
+      expect(k.out.lines.size).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Fixes #2874

Before this PR:

```console
$ kontena stack ls
NAME  STACK  SERVICES_COUNT  STATE  PORTS
$ kontena stack ls -q
NAME
$ kontena service ls -q
NAME
$ kontena node ls -q
NAME
..etc
```

After this PR:

```console
$ kontena stack ls
NAME  STACK  SERVICES_COUNT  STATE  PORTS
$ kontena stack ls -q
$ kontena service ls -q
$ kontena node ls -q
..etc
```
