### PR TITLE
Add --use-defaults to stack install/upgrade/build

### DIFF
--- a/cli/lib/kontena/cli/stacks/build_command.rb
+++ b/cli/lib/kontena/cli/stacks/build_command.rb
@@ -16,6 +16,7 @@ module Kontena::Cli::Stacks
     option ['--[no-]sudo'], :flag, 'Run docker using sudo', hidden: Kontena.on_windows?, environment_variable: 'KONTENA_SUDO', default: false
 
     option ['-n', '--name'], 'NAME', 'Define stack name (by default comes from stack file)'
+    option '--use-defaults', :flag, "Use defaults for all variable prompts"
 
     include Common::StackValuesToOption
     include Common::StackValuesFromOption

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -33,7 +33,8 @@ module Kontena::Cli::Stacks
       @stack ||= reader.execute(
         name: stack_name,
         parent_name: self.respond_to?(:parent_name) ? self.parent_name : nil,
-        values: (self.respond_to?(:values_from_options) ? self.values_from_options : {})
+        values: (self.respond_to?(:values_from_options) ? self.values_from_options : {}),
+        use_defaults_as_values: self.respond_to?(:use_defaults?) ? self.use_defaults? : false
       )
     end
 

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -19,6 +19,7 @@ module Kontena::Cli::Stacks
 
     option '--parent-name', '[PARENT_NAME]', "Set parent stack name", hidden: true
     option '--skip-dependencies', :flag, "Do not install any stack dependencies"
+    option '--use-defaults', :flag, "Use defaults for all variable prompts"
 
     requires_current_master
     requires_current_master_token
@@ -52,6 +53,7 @@ module Kontena::Cli::Stacks
         end
 
         cmd << '--no-deploy' unless deploy?
+        cmd << '--use-defaults' if use_defaults?
 
         cmd << dependency['stack']
         Kontena.run!(cmd)

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -23,6 +23,7 @@ module Kontena::Cli::Stacks
     option '--force', :flag, 'Force upgrade'
     option '--skip-dependencies', :flag, "Do not install any stack dependencies"
     option '--dry-run', :flag, "Simulate upgrade"
+    option '--use-defaults', :flag, "Use defaults for all variable prompts"
 
     requires_current_master
     requires_current_master_token
@@ -89,7 +90,8 @@ module Kontena::Cli::Stacks
           values: data[:variables],
           defaults: old_data[stackname].nil? ? nil : old_data[stackname][:stack_data]['variables'],
           parent_name: data[:parent_name],
-          name: data[:name]
+          name: data[:name],
+          use_defaults_as_values: use_defaults?
         )
         hint_on_validation_notifications(reader.notifications, reader.loader.source)
         abort_on_validation_errors(reader.errors, reader.loader.source)
@@ -191,6 +193,7 @@ module Kontena::Cli::Stacks
         data = changes.new_data[added_stack]
         cmd = ['stack', 'install', '--name', added_stack, '--no-deploy']
         cmd.concat ['--parent-name', data[:parent_name]] if data[:parent_name]
+        cmd << '--use-defaults' if use_defaults?
         data[:variables].each do |k,v|
           cmd.concat ['-v', "#{k}=#{v}"]
         end

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -183,16 +183,25 @@ module Kontena::Cli::Stacks
         loader.origin == 'file'
       end
 
+      def set_variable_defaults_as_values
+        variables.each do |variable|
+          variable.set(variable.default) unless variable.default.nil?
+        end
+      end
+
       # @param [String] service_name (set when using extends)
       # @param name [String] override stackname (default is to parse it from the YAML, but if you set it through -n it needs to be overriden)
       # @param parent_name [String] parent stack name
       # @param skip_validation [Boolean] skip running validations
       # @param values [Hash] force-set variable values using variable_name => variable_value key pairs
       # @param defaults [Hash] set variable defaults from variable_name => variable_value key pairs
+      # @param use_defaults_as_values [TrueClass,FalseClass] set variable values from variable defaults when true
       # @return [Hash]
-      def execute(service_name = nil, name: loader.stack_name.stack, parent_name: nil, skip_validation: false, values: nil, defaults: nil)
+      def execute(service_name = nil, name: loader.stack_name.stack, parent_name: nil, skip_validation: false, values: nil, defaults: nil, use_defaults_as_values: false)
         set_variable_defaults(defaults) if defaults
         set_variable_values(values) if values
+        set_variable_defaults_as_values if use_defaults_as_values
+
         create_dependency_variables(dependencies, name)
         create_parent_variable(parent_name) if parent_name
 

--- a/cli/spec/fixtures/stack-with-prompt-and-default.yml
+++ b/cli/spec/fixtures/stack-with-prompt-and-default.yml
@@ -1,0 +1,16 @@
+stack: user/stackname
+version: 0.1.0
+variables:
+  greeting:
+    type: string
+    default: Hello
+    from:
+      prompt: Greeting
+  target:
+    type: string
+    from:
+      prompt: Target
+services:
+  greeter:
+    image: busybox
+    command: echo "${greeting}, ${target}"

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -62,6 +62,16 @@ describe Kontena::Cli::Stacks::InstallCommand do
       subject.run(['--no-deploy', 'user/stack:1.0.0'])
     end
 
+    context '--use-defaults' do
+      it 'does not prompt for values that have defaults set' do
+        expect(Kontena.prompt).to receive(:ask).once.and_return("foomeister")
+        expect(client).to receive(:post) do |path, data|
+          expect(data['services'].first['cmd']).to match array_including("Hello, foomeister")
+        end
+        subject.run(['--use-defaults', '--no-deploy', fixture_path('stack-with-prompt-and-default.yml')])
+      end
+    end
+
     context '--[no-]deploy' do
       it 'runs deploy for the stack after install by default' do
         expect(client).to receive(:post).with(


### PR DESCRIPTION
Fixes #2406
Replaces #2407

Adds `--use-defaults` flag to `kontena stack install`, `kontena stack upgrade` and `kontena stack build` commands.

When used, any variable default values (or previous values coming from the master when performing an upgrade) will be used as variable values. Can be used to avoid prompts when you have defined defaults for variables.
