### PR TITLE
Fix missing stack and grid variables when running validate with --online flag

### DIFF
--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -38,7 +38,9 @@ module Kontena::Cli::Stacks
     end
 
     def execute
-      unless online?
+      if online?
+        set_env_variables(stack_name, require_current_grid)
+      else
         config.current_master = nil
         set_env_variables(stack_name, 'validate', 'validate-platform')
       end

--- a/cli/spec/kontena/cli/stacks/validate_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/validate_command_spec.rb
@@ -18,6 +18,13 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
       expect{Kontena.run!('stack', 'validate', fixture_path('kontena_v3.yml'))}.not_to exit_with_error
       expect{Kontena.run!('stack', 'validate', fixture_path('kontena_v3.yml'))}.to output(/stack:.*version:.*services:.*variables:/m).to_stdout
     end
+
+    context '--online' do
+      it 'validates a yaml file' do
+        expect{Kontena.run!('stack', 'validate', '--online', fixture_path('kontena_v3.yml'))}.to output(/stack:.*version:.*services:.*variables:/m).to_stdout
+      end
+    end
+
   end
 
   context 'with dependencies' do


### PR DESCRIPTION
Fixes #2880

Before this PR `kontena stack validate --online` would always fail with:
```
Variable validation failed: {"GRID"=>{:presence=>"Required value missing"}, "STACK"=>{:presence=>"Required value missing"}, "PLATFORM"=>{:presence=>"Required value missing"}}
```
