### PR TITLE
Change "new stacks" color to green in stack upgrade report

### DIFF
--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -150,8 +150,8 @@ module Kontena::Cli::Stacks
       end
 
       unless changes.added_stacks.empty?
-        puts pastel.red("These new stack dependencies #{will} be installed:")
-        changes.added_stacks.each { |stack| puts pastel.red("- #{stack}") }
+        puts pastel.green("These new stack dependencies #{will} be installed:")
+        changes.added_stacks.each { |stack| puts pastel.green("- #{stack}") }
         puts
       end
 


### PR DESCRIPTION
Fixes #2889

Changes the "These new stack dependencies will be installed" -section color from red to green.
