### PR TITLE
Add --no-prompt for disabling prompts in stack commands

### DIFF
--- a/cli/lib/kontena/cli/stacks/build_command.rb
+++ b/cli/lib/kontena/cli/stacks/build_command.rb
@@ -22,6 +22,8 @@ module Kontena::Cli::Stacks
 
     parameter "[SERVICE] ...", "Services to build"
 
+    include Common::NoPromptOption
+
     requires_current_master # the stack may use a vault resolver
     requires_current_master_token
 

--- a/cli/lib/kontena/cli/stacks/common.rb
+++ b/cli/lib/kontena/cli/stacks/common.rb
@@ -33,13 +33,20 @@ module Kontena::Cli::Stacks
       @stack ||= reader.execute(
         name: stack_name,
         parent_name: self.respond_to?(:parent_name) ? self.parent_name : nil,
-        values: (self.respond_to?(:values_from_options) ? self.values_from_options : {})
+        values: (self.respond_to?(:values_from_options) ? self.values_from_options : {}),
+        prompt: self.respond_to?(:use_prompt?) ? self.use_prompt? : $stdin.tty?
       )
     end
 
     # @return [Class] an accessor to StackFileLoader constant, for testing purposes
     def loader_class
       ::Kontena::Cli::Stacks::YAML::StackFileLoader
+    end
+
+    module NoPromptOption
+      def self.included(where)
+        where.option '--[no-]prompt', :flag, "Prompt for variables, uses defaults when available", default: $stdin.tty?, attribute_name: :use_prompt
+      end
     end
 
     module RegistryNameParam

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -16,6 +16,7 @@ module Kontena::Cli::Stacks
 
     include Common::StackValuesToOption
     include Common::StackValuesFromOption
+    include Common::NoPromptOption
 
     option '--parent-name', '[PARENT_NAME]', "Set parent stack name", hidden: true
     option '--skip-dependencies', :flag, "Do not install any stack dependencies"
@@ -52,6 +53,7 @@ module Kontena::Cli::Stacks
         end
 
         cmd << '--no-deploy' unless deploy?
+        cmd << '--no-prompt' unless use_prompt?
 
         cmd << dependency['stack']
         Kontena.run!(cmd)

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -90,7 +90,8 @@ module Kontena::Cli::Stacks
           values: data[:variables],
           defaults: old_data[stackname].nil? ? nil : old_data[stackname][:stack_data]['variables'],
           parent_name: data[:parent_name],
-          name: data[:name]
+          name: data[:name],
+          prompt: use_prompt?
         )
         hint_on_validation_notifications(reader.notifications, reader.loader.source)
         abort_on_validation_errors(reader.errors, reader.loader.source)

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -17,6 +17,7 @@ module Kontena::Cli::Stacks
 
     include Common::StackValuesToOption
     include Common::StackValuesFromOption
+    include Common::NoPromptOption
 
     option '--[no-]deploy', :flag, 'Trigger deploy after upgrade', default: true
 
@@ -194,6 +195,7 @@ module Kontena::Cli::Stacks
         data[:variables].each do |k,v|
           cmd.concat ['-v', "#{k}=#{v}"]
         end
+        cmd << '--no-prompt' unless use_prompt?
         cmd << data[:loader].source
         caret "Installing new dependency #{cmd.last} as #{added_stack}"
         deployable_stacks << added_stack

--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -14,6 +14,7 @@ module Kontena::Cli::Stacks
 
     include Common::StackValuesToOption
     include Common::StackValuesFromOption
+    include Common::NoPromptOption
 
     option '--online', :flag, "Enable connections to current master", default: false
     option '--dependency-tree', :flag, "Show dependency tree"

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -180,8 +180,9 @@ module Kontena::Cli::Stacks
 
       # Removes any `from: prompt` entries from variables
       def disable_prompts
+        prompts = Set.new(%w(prompt service_link vault_cert_prompt))
         variables.each do |option|
-          option.from.delete_if { |k,_| k.to_s == 'prompt' }
+          option.from.delete_if { |k,_| prompts.include?(k.to_s) }
         end
       end
 

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -178,6 +178,13 @@ module Kontena::Cli::Stacks
         variables.build_option(name: 'PARENT_STACK', type: :string, value: parent_name)
       end
 
+      # Removes any `from: prompt` entries from variables
+      def disable_prompts
+        variables.each do |option|
+          option.from.delete_if { |k,_| k.to_s == 'prompt' }
+        end
+      end
+
       # @return [Boolean] did this stack come from a local file?
       def from_file?
         loader.origin == 'file'
@@ -189,8 +196,10 @@ module Kontena::Cli::Stacks
       # @param skip_validation [Boolean] skip running validations
       # @param values [Hash] force-set variable values using variable_name => variable_value key pairs
       # @param defaults [Hash] set variable defaults from variable_name => variable_value key pairs
+      # @param prompt [Boolean] set to false to disable prompting
       # @return [Hash]
-      def execute(service_name = nil, name: loader.stack_name.stack, parent_name: nil, skip_validation: false, values: nil, defaults: nil)
+      def execute(service_name = nil, name: loader.stack_name.stack, parent_name: nil, skip_validation: false, values: nil, defaults: nil, prompt: true)
+        disable_prompts if !prompt
         set_variable_defaults(defaults) if defaults
         set_variable_values(values) if values
         create_dependency_variables(dependencies, name)

--- a/cli/spec/fixtures/stack-with-prompt-and-default.yml
+++ b/cli/spec/fixtures/stack-with-prompt-and-default.yml
@@ -1,0 +1,17 @@
+stack: user/stackname
+version: 0.1.0
+variables:
+  greeting:
+    type: string
+    default: Hello
+    from:
+      prompt: Greeting
+  target:
+    type: string
+    from:
+      prompt: Target
+services:
+  greeter:
+    image: busybox
+    command: echo "${greeting}, ${target}"
+

--- a/cli/spec/kontena/cli/stacks/install_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/install_command_spec.rb
@@ -62,6 +62,21 @@ describe Kontena::Cli::Stacks::InstallCommand do
       subject.run(['--no-deploy', 'user/stack:1.0.0'])
     end
 
+    context '--no-prompt' do
+      it 'exits with error when there is no default value' do
+        expect(Kontena).not_to receive(:prompt)
+        expect{subject.run(['--no-prompt', '--no-deploy', fixture_path('stack-with-prompt-and-default.yml')])}.to exit_with_error.and output(/Required value/).to_stderr
+      end
+
+      it 'does not prompt when there are default values' do
+        expect(Kontena).not_to receive(:prompt)
+        expect(client).to receive(:post) do |path, data|
+          expect(data['services'].first['cmd']).to match array_including("Hello, foomeister")
+        end
+        subject.run(['--no-prompt', '-v', 'target=foomeister', '--no-deploy', fixture_path('stack-with-prompt-and-default.yml')])
+      end
+    end
+
     context '--[no-]deploy' do
       it 'runs deploy for the stack after install by default' do
         expect(client).to receive(:post).with(


### PR DESCRIPTION
Replaces #2884
Replaces #2407
Fixes #2406

Adds a `--no-prompt` option to `kontena stack [install|upgrade|validate|build]` which will disable any prompting. If there is a default value, it will be used instead of prompting, this happens when running an upgrade to a stack that has already been installed.

**Note:** If your stack relied on a default value coming from the prompt during an upgrade, after this it will break.

For example, something like:

```yaml
variables:
  pass:
    type: string
    from:
      prompt: Enter password
      random_string: 16
services:
  app:
    image: app
    environment:
      - "SECRET_PASSWORD=$pass"
```

will always generate a new random string during an upgrade when `--no-prompt` is used.

You should use vault instead:

```yaml
variables:
  pass:
    type: string
    from:
      vault: APP_PASSWORD
      prompt: Enter password
      random_string: 16
    to:
      vault: APP_PASSWORD

services:
  app:
    image: app
    secrets:
      - name: SECRET_PASSWORD
        secret: APP_PASSWORD
        type: env
```
