### PR TITLE
More descriptive error message when stack YAML has no "stack:"

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/stack_file_loader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/stack_file_loader.rb
@@ -64,7 +64,9 @@ module Kontena::Cli::Stacks
 
       # @return [StackName] an accessor to StackName for the target file
       def stack_name
-        @stack_name ||= Kontena::Cli::Stacks::StackName.new(yaml['stack'], yaml['version'])
+        return @stack_name if @stack_name
+        raise RuntimeError, "The file #{source} does not have the required top level keyword 'stack:'" if yaml['stack'].nil?
+        @stack_name = Kontena::Cli::Stacks::StackName.new(yaml['stack'], yaml['version'])
       end
 
       # @return [Reader] an accessor to YAML::Reader for the target file

--- a/cli/spec/kontena/cli/stacks/common_spec.rb
+++ b/cli/spec/kontena/cli/stacks/common_spec.rb
@@ -41,6 +41,23 @@ describe Kontena::Cli::Stacks::Common do
     end
   end
 
+  describe '#stack_name' do
+    before do
+      allow(File).to receive(:exist?).with(fixture_path('test.yml')).and_return(true)
+    end
+
+    it 'raises if stack file does not have "stack:"' do
+      expect(File).to receive(:read).with(fixture_path('test.yml')).and_return(YAML.dump('services' => { 'abcd' => { 'image' => 'foo' } }))
+      puts YAML.dump('services' => { 'abcd' => { 'image' => 'foo' } })
+      expect{subject.instance([fixture_path('test.yml')]).stack_name}.to raise_error(RuntimeError, /keyword/)
+    end
+
+    it 'reads the stack name from the yaml' do
+      expect(File).to receive(:read).with(fixture_path('test.yml')).and_return(YAML.dump('stack' => 'foo/foostack', 'services' => { 'abcd' => { 'image' => 'foo' } }))
+      expect(subject.instance([fixture_path('test.yml')]).stack_name).to eq 'foostack'
+    end
+  end
+
   describe '#stack' do
     it 'returns a stack result' do
       expect(subject.instance([fixture_path('kontena_v3.yml')]).stack).to respond_to(:[])


### PR DESCRIPTION
When the stack YAML has no `stack: stackname` the current error message is something like: `[error] RuntimeError : Variable validation failed: {"STACK"=>{:presence=>"Required value missing"}}`

This PR changes that to: `The file redis.yml does not have the required top level keyword 'stack:'`
