### PR TITLE
Fix CLI exec --tty for valid non-ASCII unicode input

### DIFF
--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -41,9 +41,9 @@ module Kontena::Cli::Helpers
             chunk = io.readpartial(1024)
 
             # STDIN.raw does not use the ruby external_encoding, it returns binary strings (ASCII-8BIT encoding)
-            # however, we use websocket text frames with JSON, which encodes as UTF-8, and does not handle arbitrary binary data
-            # assume stdin input is valid UTF-8... the JSON.dump will fail if not.
-            chunk.force_encoding(Encoding::UTF_8)
+            # however, we use websocket text frames with JSON, which expects unicode strings encodable as UTF-8, and does not handle arbitrary binary data
+            # assume all stdin input is using ruby's external_encoding... the JSON.dump will fail if not.
+            chunk.force_encoding(Encoding.default_external)
 
             yield chunk
           end

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -113,7 +113,7 @@ module Kontena::Cli::Helpers
             })
           end
           read_stdin(tty: tty) do |stdin|
-            logger.debug "read stdin with encoding=#{stdin.encoding}: #{stdin.inspect}"
+            logger.debug "websocket exec stdin with encoding=#{stdin.encoding}: #{stdin.inspect}"
             websocket_exec_write(ws, 'stdin' => stdin)
           end
           websocket_exec_write(ws, 'stdin' => nil) # EOF

--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -27,7 +27,7 @@ module Kontena::Cli::Helpers
     # @param tty [Boolean] read stdin in raw mode, sending tty escapes for remote pty
     # @raise [ArgumentError] not a tty
     # @yield [data]
-    # @yieldparam data [String] data from stdin
+    # @yieldparam data [String] unicode data from stdin
     # @raise [ArgumentError] not a tty
     # @return EOF on stdin (!tty)
     def read_stdin(tty: nil)
@@ -38,11 +38,18 @@ module Kontena::Cli::Helpers
           # we do not expect EOF on a TTY, ^D sends a tty escape to close the pty instead
           loop do
             # raises EOFError, SyscallError or IOError
-            yield io.readpartial(1024)
+            chunk = io.readpartial(1024)
+
+            # STDIN.raw does not use the ruby external_encoding, it returns binary strings (ASCII-8BIT encoding)
+            # however, we use websocket text frames with JSON, which encodes as UTF-8, and does not handle arbitrary binary data
+            # assume stdin input is valid UTF-8... the JSON.dump will fail if not.
+            chunk.force_encoding(Encoding::UTF_8)
+
+            yield chunk
           end
         }
       else
-        # line-buffered
+        # line-buffered, using the default external_encoding (probably UTF-8)
         while line = STDIN.gets
           yield line
         end
@@ -106,6 +113,7 @@ module Kontena::Cli::Helpers
             })
           end
           read_stdin(tty: tty) do |stdin|
+            logger.debug "read stdin with encoding=#{stdin.encoding}: #{stdin.inspect}"
             websocket_exec_write(ws, 'stdin' => stdin)
           end
           websocket_exec_write(ws, 'stdin' => nil) # EOF

--- a/test/spec/features/service/exec_spec.rb
+++ b/test/spec/features/service/exec_spec.rb
@@ -55,9 +55,9 @@ describe 'service exec' do
       k.out.on("#") do
         k.in << "sleep 10 && echo ok\r"
         sleep 0.1
-        k.in << "\x03"
+        k.in << "\x03" # Ctrl-C -> SIGINT
         sleep 0.1
-        k.in << "\x04"
+        k.in << "\x04" # Ctrl-D -> EOF
       end
 
       expect(k.run).to be_truthy

--- a/test/spec/features/service/exec_spec.rb
+++ b/test/spec/features/service/exec_spec.rb
@@ -77,6 +77,22 @@ describe 'service exec' do
       expect(k.run).to be_truthy
       expect(k.out).to match /\u00e5\u00e5f/
     end
+
+    # RuntimeError : stdin read JSON::GeneratorError: partial character in source, but hit end
+    pending 'runs a command with UTF-8 input across block boundries' do
+      k = kommando("kontena service exec -it test-1 sh")
+
+      k.out.on("#") do
+        # with an odd number of bytes in the 'echo ', the 2-byte UTF-8 chars will get split across the 1024-byte chunk boundary
+        k.in << "echo #{"\u00e5"*512}\r"
+        k.out.on("#") do
+          k.in << "exit\r"
+        end
+      end
+
+      expect(k.run).to be_truthy
+      expect(k.out).to match /^\u00e5{512}$/
+    end
   end
 
   describe '--interactive' do


### PR DESCRIPTION
Fixes #2871

While `STDIN.gets` returns strings using ruby's `external_encoding` (UTF-8), `STDIN.raw {|io| io.readpartial(...) }` returns binary strings (encoding `ASCII-8BIT`). Encoding the input as JSON will also encode the strings to UTF-8, which fails for binary strings, even if they contain valid UTF-8: `"\xC3" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)`

Fixes the JSON encoding by assuming that all `kontena container|service exec -it` input is encoded with ruby's default external encoding (typically UTF-8). This isn't necessarily the case, but it's also similarly broken for non-tty input: `STDIN.gets` will return non-UTF8 input as strings with UTF-8 encoding.

```
$ hd test/latin1.txt 
00000000  66 e5 e5                                          |f..|
00000003
$ kontena service exec -i redis cat < test/latin1.txt 
...
DEBUG websocket exec connect... ws://localhost:9292/v1/containers/development/core-01/redis-1/exec?interactive=true
DEBUG websocket exec open
DEBUG websocket exec write: {"cmd"=>["cat"]}
DEBUG read stdin with encoding=UTF-8: "f\xE5\xE5"
DEBUG websocket exec write: {"stdin"=>"f\xE5\xE5"}
ERROR partial character in source, but hit end (JSON::GeneratorError)
/home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/json-2.0.2/lib/json/common.rb:224:in `generate'
/home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/json-2.0.2/lib/json/common.rb:224:in `generate'
/home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/json-2.0.2/lib/json/common.rb:394:in `dump'
/home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:97:in `websocket_exec_write'
/home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:117:in `block (2 levels) in websocket_exec_write_thread'
/home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:54:in `read_stdin'
/home/kontena/kontena/kontena/cli/lib/kontena/cli/helpers/exec_helper.rb:115:in `block in websocket_exec_write_thread'
```

This will still fail if the input is not actually valid UTF-8, or if the `io.readpartial(1024)` chunk boundary splits a valid UTF-8 character. However, I don't think we can actually fix that case without changing the websocket protocol to either use binary frames with some non-JSON protocol, or use something like base64-encoded strings in JSON. Alternatively, the CLI could buffer up input one byte at a time until it gets a complete UTF-8 character.