### PR TITLE
Make travis gem deploy idempotent

### DIFF
--- a/build/travis/deploy_gem.sh
+++ b/build/travis/deploy_gem.sh
@@ -9,7 +9,7 @@ echo "Checking for deployed kontena-cli gem version $VERSION..."
 if gem fetch -v $VERSION kontena-cli 2>&1 | tee /tmp/gem-fetch.log | grep -q "ERROR:  Could not find a valid gem 'kontena-cli' (= $VERSION) in any repository"; then
   echo "gem version $VERSION has not yet been deployed"
 elif test -e ./kontena-cli-$VERSION.gem; then
-  echo "gem version $VERSION already deployed"
+  echo "skipping deploy because gem version $VERSION was already deployed:"
   ls -l kontena-cli-$VERSION.gem
   sha256sum kontena-cli-$VERSION.gem
   exit 0

--- a/build/travis/deploy_gem.sh
+++ b/build/travis/deploy_gem.sh
@@ -2,6 +2,15 @@
 
 set -ue
 
+VERSION=$(cat ./VERSION)
+
+if gem fetch -v $VERSION kontena-cli; then
+  echo "gem version $VERSION already deployed:"
+  ls -l kontena-cli-$VERSION.gem
+  sha256sum kontena-cli-$VERSION.gem
+  exit 0
+fi
+
 # login
 curl -u $RUBYGEMS_USER https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials; chmod 0600 ~/.gem/credentials
 

--- a/build/travis/deploy_gem.sh
+++ b/build/travis/deploy_gem.sh
@@ -4,11 +4,18 @@ set -ue
 
 VERSION=$(cat ./VERSION)
 
-if gem fetch -v $VERSION kontena-cli; then
-  echo "gem version $VERSION already deployed:"
+echo "Checking for deployed kontena-cli gem version $VERSION..."
+
+if gem fetch -v $VERSION kontena-cli 2>&1 | tee /tmp/gem-fetch.log | grep -q "ERROR:  Could not find a valid gem 'kontena-cli' (= $VERSION) in any repository"; then
+  echo "gem version $VERSION has not yet been deployed"
+elif test -e ./kontena-cli-$VERSION.gem; then
+  echo "gem version $VERSION already deployed"
   ls -l kontena-cli-$VERSION.gem
   sha256sum kontena-cli-$VERSION.gem
   exit 0
+else
+  echo "WARNING: unknown gem fetch error, continuing anyways"
+  cat /tmp/gem-fetch.log
 fi
 
 # login


### PR DESCRIPTION
Allow restarting the travis CLI deploy job to retry omnibus builds by skipping the gem deploy if the gem has already been deployed.

## Testing
### For an already released version
```
+ cat ./VERSION
+ VERSION=1.4.0.pre12
+ echo Checking for deployed kontena-cli gem version 1.4.0.pre12...
Checking for deployed kontena-cli gem version 1.4.0.pre12...
+ gem fetch -v 1.4.0.pre12 kontena-cli
+ tee /tmp/gem-fetch.log
+ grep -q ERROR:  Could not find a valid gem 'kontena-cli' (= 1.4.0.pre12) in any repository
+ test -e ./kontena-cli-1.4.0.pre12.gem
+ echo gem version 1.4.0.pre12 already deployed
gem version 1.4.0.pre12 already deployed
+ ls -l kontena-cli-1.4.0.pre12.gem
-rw-rw-r-- 1 kontena kontena 193536 loka   4 12:21 kontena-cli-1.4.0.pre12.gem
+ sha256sum kontena-cli-1.4.0.pre12.gem
c0e14ee7c822befde94fc8be1f3192f72b605f5814d9db328a6351eb53de370a  kontena-cli-1.4.0.pre12.gem
+ exit 0
```

### For an unreleased version
```
+ set -ue
+ cat ./VERSION
+ VERSION=1.4.0.pre13
+ echo Checking for deployed kontena-cli gem version 1.4.0.pre13...
Checking for deployed kontena-cli gem version 1.4.0.pre13...
+ gem fetch -v 1.4.0.pre13 kontena-cli
+ grep -q ERROR:  Could not find a valid gem 'kontena-cli' (= 1.4.0.pre13) in any repository
+ tee /tmp/gem-fetch.log
+ echo gem version 1.4.0.pre13 has not yet been deployed
gem version 1.4.0.pre13 has not yet been deployed
build/travis/deploy_gem.sh: 22: build/travis/deploy_gem.sh: RUBYGEMS_USER: parameter not set
```

### With random rubygems errors
```
+ set -ue
+ cat ./VERSION
+ VERSION=1.4.0.pre13
+ echo Checking for deployed kontena-cli gem version 1.4.0.pre13...
Checking for deployed kontena-cli gem version 1.4.0.pre13...
+ gem fetch -v 1.4.0.pre13 kontena-cli
+ + tee /tmp/gem-fetch.log
grep -q ERROR:  Could not find a valid gem 'kontena-cli' (= 1.4.0.pre13) in any repository
+ test -e ./kontena-cli-1.4.0.pre13.gem
+ echo WARNING: unknown gem fetch error, continuing anyways
WARNING: unknown gem fetch error, continuing anyways
+ cat /tmp/gem-fetch.log
ERROR:  Could not find a valid gem 'kontena-cli' (= 1.4.0.pre13), here is why:
          Unable to download data from https://rubygems.org/ - no such name (https://rubygems.org/specs.4.8.gz)
build/travis/deploy_gem.sh: 22: build/travis/deploy_gem.sh: RUBYGEMS_USER: parameter not set
```

