### PR TITLE
Change travis cli omnibus deploy to run as separate job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ deploy:
     on:
       tags: true
       condition: $TEST_DIR = cli && $TRAVIS_OS_NAME = linux
-      rvm: 2.3.3
+      rvm: 2.4.1 # separate from deploy_gem, ideally after
       repo: kontena/kontena
   - provider: script
     script: "rvm $TRAVIS_RUBY_VERSION do $TRAVIS_BUILD_DIR/build/travis/deploy.sh"


### PR DESCRIPTION
Run the omnibus deploy as part of the CLI rvm 2.4.1 job, separately from the CLI gem deploy that runs as part of the CLI rvm 2.3.3 job.

This assumes that the rvm 2.4.1 job doesn't run before the rvm 2.3.3 job, as the omnibus build will fail if the kontena-cli gem is not yet available. But at least the omnibus job can now be restarted manually in this case.