### PR TITLE
Fix CLI output hang after exceptions raised in spinners

### DIFF
--- a/cli/lib/kontena/cli/spinner.rb
+++ b/cli/lib/kontena/cli/spinner.rb
@@ -168,6 +168,7 @@ module Kontena
               Kernel.puts msg
             end
           end
+          Thread.main['spinners'].delete(spin_thread)
         end
 
         exit(status) if status


### PR DESCRIPTION
Spinners may leave behind their spinner-threads making [`Kontena::Cli::Common#puts`](https://github.com/kontena/kontena/blob/master/cli/lib/kontena/cli/common.rb#L91) eat all the messages.

Normally this does not matter because usually the command exits and nobody notices. But when running through `Kontena.run!` or the way KOSH does it, the threads are left behind and prevent any further `puts`ing.

As a sidenote, the selfmade spinner implementation is far from excellent and should probably be replaced with something like `tty-spinner`