### PR TITLE
Fix CLI omnibus liblzma source url

### DIFF
--- a/cli/omnibus/config/software/liblzma.rb
+++ b/cli/omnibus/config/software/liblzma.rb
@@ -24,7 +24,7 @@ skip_transitive_dependency_licensing true
 version("5.2.2") { source md5: "7cf6a8544a7dae8e8106fdf7addfa28c" }
 version("5.2.3") { source md5: "ef68674fb47a8b8e741b34e429d86e9d" }
 
-source url: "https://sourceforge.net/projects/lzmautils/files/xz-#{version}.tar.gz/download",
+source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
        unsafe: true # accept https -> https redirects from sourceforge
 
 relative_path "xz-#{version}"


### PR DESCRIPTION
From #2903: The pre13 CLI omnibus build [failed](https://github.com/kontena/kontena/pull/2905#issuecomment-334156236), presumably because it got confused by the URL ending in `download`, rather than `.tar.gz`: `'./local/omnibus/cache/download' is not an archive - copying to '/home/travis/build/kontena/kontena/cli/omnibus/local/omnibus/src/liblzma/xz-5.2.3'`

Revert the liblzma source url back to what [upstream](https://github.com/chef/omnibus-software/blob/db9cfd23c7ccbdd69a26f53ce52d72362953e8a7/config/software/liblzma.rb#L27) uses, which ends in something that looks like an archive.