### PR TITLE
Check ports from scheduled instances

### DIFF
--- a/server/spec/services/scheduler/filter/port_spec.rb
+++ b/server/spec/services/scheduler/filter/port_spec.rb
@@ -42,29 +42,18 @@ describe Scheduler::Filter::Port do
     end
 
     it 'does not filter out same service instance' do
-      service.containers.create!(
-        name: 'redis-1',
+      service.grid_service_instances.create!(
         host_node: nodes[1],
-        instance_number: 1,
-        network_settings: {
-          'ports' => {
-            '6379/tcp' => [{'node_port' => 6379, 'node_ip' => '0.0.0.0'}]
-          }
-        }
+        instance_number: 1
       )
       filtered = subject.for_service(service, 1, nodes)
       expect(filtered).to eq(nodes)
     end
 
     it 'returns filtered nodes' do
-      service2.containers.create!(
-        name: 'redis2-1',
+      service2.grid_service_instances.create!(
         host_node: nodes[1],
-        network_settings: {
-          'ports' => {
-            '6379/tcp' => [{'node_port' => 6379, 'node_ip' => '0.0.0.0'}]
-          }
-        }
+        instance_number: 1
       )
       filtered = subject.for_service(service, 1, nodes)
       expect(filtered.size).to eq(2)
@@ -73,15 +62,12 @@ describe Scheduler::Filter::Port do
     end
 
     it 'returns empty array if nodes does not have port free' do
+      i = 0
       nodes.each do |node|
-        service2.containers.create!(
-          name: "redis2-#{node.node_id}",
+        i += 1
+        service2.grid_service_instances.create!(
           host_node: node,
-          network_settings: {
-            'ports' => {
-              '6379/tcp' => [{'node_port' => 6379, 'node_ip' => '0.0.0.0'}]
-            }
-          }
+          instance_number: i
         )
       end
 


### PR DESCRIPTION
Currently there is a race condition with the port filter because filter checks reserved ports from actual containers. This PR improves port filtering logic so that ports are checked from scheduled service instances. There is still possibility to hit this race condition if two separate stacks (that have same port exposed) are deployed in parallel.