### PR TITLE
Fix server websocket exec error handling

### DIFF
--- a/server/app/helpers/request_helpers.rb
+++ b/server/app/helpers/request_helpers.rb
@@ -6,16 +6,14 @@ module RequestHelpers
     base.plugin :default_headers, 'Content-Type'=>'application/json'
     base.plugin :render, cache: true, engine: 'json.jbuilder', views: 'app/views/v1'
     base.plugin :error_handler do |e|
+      log_message = "\n#{e.class} (#{e.message}):\n"
+      log_message << "  " << e.backtrace.join("\n  ") << "\n\n" if e.backtrace
+      puts log_message
+
       if e.is_a?(RpcClient::Error)
         { code: e.code, message: e.message, backtrace: e.backtrace }
       else
-        response.status = 500
-        log_message = "\n#{e.class} (#{e.message}):\n"
-        log_message << "  " << e.backtrace.join("\n  ") << "\n\n" if e.backtrace
-        puts log_message
-        json = { message: 'Internal server error' }
-
-        json
+        { message: 'Internal server error' }
       end
     end
   end

--- a/server/app/routes/v1/containers_api.rb
+++ b/server/app/routes/v1/containers_api.rb
@@ -55,15 +55,15 @@ module V1
           end
 
           r.on 'exec' do
+            interactive = r['interactive'].to_s == 'true'
+            tty = r['tty'].to_s == 'true'
+            shell = r['shell'].to_s == 'true'
+
+            audit_event(r, container.grid, container, interactive ? 'exec_interactive' : 'exec')
+
             r.websocket do |ws|
               executor = Docker::StreamingExecutor.new(container, ws)
-              if r['interactive'].to_s == 'true'
-                audit_event(r, container.grid, container, 'exec_interactive')
-                executor.start(r['shell'].to_s == 'true', true, r['tty'].to_s == 'true')
-              else
-                audit_event(r, container.grid, container, 'exec')
-                executor.start(r['shell'].to_s == 'true', false, r['tty'].to_s == 'true')
-              end
+              executor.start(shell, interactive, tty)
             end
           end
         end

--- a/server/app/routes/v1/containers_api.rb
+++ b/server/app/routes/v1/containers_api.rb
@@ -61,9 +61,9 @@ module V1
               tty: r['tty'].to_s == 'true',
             )
             audit_event(r, container.grid, container, executor.interactive? ? 'exec_interactive' : 'exec')
-            executor.setup
 
             begin
+              executor.setup
               r.websocket do |ws|
                 # this is not allowed to fail
                 executor.start(ws)

--- a/server/app/routes/v1/containers_api.rb
+++ b/server/app/routes/v1/containers_api.rb
@@ -69,6 +69,7 @@ module V1
                 executor.start(ws)
               end
             ensure
+              # only relevant if the request wasn't actually a websocket request
               executor.teardown unless executor.started?
             end
           end

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -76,6 +76,8 @@ module Docker
       debug { "exec #{self.exec_id} run with shell=#{shell} tty=#{tty} stdin=#{stdin}: #{cmd.inspect}" }
 
       @rpc_client.notify('/containers/run_exec', self.exec_id, cmd, tty, stdin)
+
+      running!
     end
 
     # @param width [Integer]
@@ -172,9 +174,8 @@ module Docker
       debug { "websocket message: #{data.inspect}"}
 
       if data.has_key?('cmd')
-        fail "already running" if running?
+        fail "unexpected cmd: already running" if running?
         exec_run(data['cmd'], shell: @shell, tty: @tty, stdin: @interactive)
-        running!
       end
 
       if data.has_key?('stdin')

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -186,14 +186,14 @@ module Docker
     #
     # Can be called multiple times (abort -> on_websocket_close)
     def teardown
-      if @exec_session
-        exec_terminate
-        @exec_session = nil
-      end
-
       if @subscription
         @subscription.terminate
         @subscription = nil
+      end
+
+      if @exec_session
+        exec_terminate
+        @exec_session = nil
       end
     end
   end

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -31,6 +31,13 @@ module Docker
       @started
     end
 
+    def running!
+      @running = true
+    end
+    def running?
+      @running
+    end
+
     def exec_id
       @exec_session['id']
     end
@@ -144,14 +151,18 @@ module Docker
       debug { "websocket message: #{data.inspect}"}
 
       if data.has_key?('cmd')
+        fail "already running" if running?
         exec_run(data['cmd'], shell: @shell, tty: @tty, stdin: @interactive)
+        running!
       end
 
       if data.has_key?('stdin')
+        fail "not running" unless running?
         exec_input(data['stdin'])
       end
 
       if data.has_key?('tty_size')
+        fail "not running" unless running?
         exec_resize(data['tty_size'])
       end
     rescue JSON::ParserError => exc

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -51,7 +51,7 @@ module Docker
     end
 
     # Valid after setup()
-
+    #
     # @return [String] container exec RPC UUID
     def exec_id
       @exec_session['id']

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -38,7 +38,7 @@ module Docker
     # Setup RPC state
     def setup
       @exec_session = exec_create
-      @subscription = subscribe_to_exec
+      @subscription = subscribe_to_exec(@exec_session['id'])
     end
 
     # @return [Hash{:id => String}]
@@ -82,11 +82,9 @@ module Docker
     end
 
     # @return [MongoPubsub::Subscription]
-    def subscribe_to_exec
-      channel = "container_exec:#{self.exec_id}"
-
-      MongoPubsub.subscribe(channel) do |data|
-        debug { "subscribe #{channel}: #{data.inspect}" }
+    def subscribe_to_exec(id)
+      MongoPubsub.subscribe("container_exec:#{id}") do |data|
+        debug { "subscribe exec #{id}: #{data.inspect}" }
 
         if data.has_key?('error')
           websocket_write(error: data['error'])

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -144,7 +144,7 @@ module Docker
       debug { "websocket message: #{data.inspect}"}
 
       if data.has_key?('cmd')
-        exec_run(data['cmd'], shell: @shell, tty: @tty, stdin: @stdin)
+        exec_run(data['cmd'], shell: @shell, tty: @tty, stdin: @interactive)
       end
 
       if data.has_key?('stdin')

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -24,6 +24,11 @@ module Docker
       !!@interactive
     end
 
+    # @return [Boolean]
+    def tty?
+      !!@tty
+    end
+
     def started!
       @started = true
     end
@@ -179,12 +184,14 @@ module Docker
       end
 
       if data.has_key?('stdin')
-        fail "not running" unless running?
+        fail "unexpected stdin: not interactive" unless interactive?
+        fail "unexpected stdin: not running" unless running?
         exec_input(data['stdin'])
       end
 
       if data.has_key?('tty_size')
-        fail "not running" unless running?
+        fail "unexpected tty_size: not a tty" unless tty?
+        fail "unexpected tty_size: not running" unless running?
         exec_resize(data['tty_size']['width'], data['tty_size']['height'])
       end
     rescue JSON::ParserError => exc

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -27,6 +27,9 @@ module Docker
     def started!
       @started = true
     end
+
+    # start() was successful
+    # @return [Boolean]
     def started?
       @started
     end
@@ -34,10 +37,17 @@ module Docker
     def running!
       @running = true
     end
+
+    # exec is running, and ready to accept input/tty_resize
+    #
+    # @return [Boolean]
     def running?
       @running
     end
 
+    # Valid after setup()
+
+    # @return [String] container exec RPC UUID
     def exec_id
       @exec_session['id']
     end

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -134,6 +134,10 @@ module Docker
         on_websocket_message(event.data)
       end
 
+      @ws.on(:error) do |exc|
+        warn exc
+      end
+
       @ws.on(:close) do |event|
         on_websocket_close(event.code, event.reason)
       end

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -126,7 +126,7 @@ module Docker
         elsif data.has_key?('stream')
           websocket_write(stream: data['stream'], chunk: data['chunk'])
         else
-          error "invalid container exec #{channel} RPC: #{data.inspect}"
+          error "invalid container exec #{id} RPC: #{data.inspect}"
         end
       end
     end

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -81,7 +81,9 @@ module Docker
     # @param width [Integer]
     # @param height [Integer]
     def exec_resize(width, height)
-      raise ArgumentError "width and height must be integers > 0" unless width > 0 && height > 0 
+      raise ArgumentError, "width must be integer" unless Integer === width
+      raise ArgumentError, "height must be integer" unless Integer === height
+      raise ArgumentError, "width and height must be integers > 0" unless width > 0 && height > 0
 
       tty_size = { 'width' => width, 'height' => height }
 

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -3,110 +3,197 @@ module Docker
     include Logging
 
     # @param [Container] container
-    # @param [#send,#close] ws
-    def initialize(container, ws)
-      @container = container
-      @ws = ws
-      @client = RpcClient.new(container.host_node.node_id)
-    end
-
-    # Starts normal exec session (without tty)
     # @param [Boolean] shell
     # @param [Boolean] stdin
     # @param [Boolean] tty
-    def start(shell, stdin, tty)
-      create_session
-      subscribe_to_session
-      if stdin
-        register_stdin_ws_events(shell, tty)
-      else
-        register_run_ws_events(shell, tty)
+    def initialize(container, shell: false, interactive: false, tty: false)
+      @container = container
+      @shell = shell
+      @interactive = interactive
+      @tty = tty
+
+      @rpc_client = container.host_node.rpc_client
+
+      @exec_session = nil
+      @subscription = nil
+      @started = false
+    end
+
+    # @return [Boolean]
+    def interactive?
+      !!@interactive
+    end
+
+    def started!
+      @started = true
+    end
+    def started?
+      @started
+    end
+
+    def exec_id
+      @exec_session['id']
+    end
+
+    # Setup RPC state
+    def setup
+      @exec_session = exec_create
+      @subscription = subscribe_to_exec
+    end
+
+    # @return [Hash{:id => String}]
+    def exec_create
+      @rpc_client.request('/containers/create_exec', @container.container_id).tap do |session|
+        debug { "exec create: #{session.inspect}" }
       end
     end
 
-    def create_session
-      @exec_session = @client.request('/containers/create_exec', @container.container_id)
+    # @param cmd [Array<String>]
+    # @param tty [Boolean]
+    # @param stdin [Boolean]
+    def exec_run(cmd, shell: false, tty: false, stdin: false)
+      if shell
+        cmd = ['/bin/sh', '-c', cmd.join(' ')]
+      end
+
+      debug { "exec #{self.exec_id} run with shell=#{shell} tty=#{tty} stdin=#{stdin}: #{cmd.inspect}" }
+
+      @rpc_client.notify('/containers/run_exec', self.exec_id, cmd, tty, stdin)
     end
 
-    def subscribe_to_session
-      @subscription = MongoPubsub.subscribe("container_exec:#{@exec_session['id']}") do |data|
+    # @param tty_size [Hash{'width' => Integer, 'height' => Integer}]
+    def exec_resize(tty_size)
+      debug { "exec #{self.exec_id} resize: #{tty_size.inspect}" }
+
+      @rpc_client.notify('/containers/tty_resize', self.exec_id, tty_size)
+    end
+
+    # @param stdin [String]
+    def exec_input(stdin)
+      debug { "exec #{self.exec_id} input: #{stdin.inspect}" }
+
+      @rpc_client.notify('/containers/tty_input', self.exec_id, stdin)
+    end
+
+    def exec_terminate
+      debug { "exec #{self.exec_id} terminate" }
+
+      @rpc_client.notify('/containers/terminate_exec', self.exec_id)
+    end
+
+    # @return [MongoPubsub::Subscription]
+    def subscribe_to_exec
+      channel = "container_exec:#{self.exec_id}"
+
+      MongoPubsub.subscribe(channel) do |data|
+        debug { "subscribe #{channel}: #{data.inspect}" }
+
         if data.has_key?('error')
-          @ws.send(JSON.dump({ error: data['error'] }))
-          @ws.close(4000)
+          websocket_write(error: data['error'])
+          websocket_close(4000)
         elsif data.has_key?('exit')
-          @ws.send(JSON.dump({ exit: data['exit'] }))
-          @ws.close(1000)
+          websocket_write(exit: data['exit'])
+          websocket_close(1000)
+        elsif data.has_key?('stream')
+          websocket_write(stream: data['stream'], chunk: data['chunk'])
         else
-          @ws.send(JSON.dump({ stream: data['stream'], chunk: data['chunk'] }))
+          error "invalid container exec #{channel} RPC: #{data.inspect}"
         end
       end
     end
 
-    # @param [Boolean] shell
-    # @param [Boolean] tty
-    def register_stdin_ws_events(shell, tty)
-      init = true
+    # Does not raise.
+    #
+    # @param ws [Faye::Websocket]
+    def start(ws)
+      @ws = ws
+
       @ws.on(:message) do |event|
-        if init == true
-          begin
-            data = JSON.parse(event.data)
-            if data.has_key?('cmd')
-              if shell
-                cmd = ['/bin/sh', '-c', data['cmd'].join(' ')]
-              else
-                cmd = data['cmd']
-              end
-              @client.notify('/containers/run_exec', @exec_session['id'], cmd, tty, true)
-              init = false
-            end
-          rescue JSON::ParserError
-            error "invalid handshake json"
-            @ws.close
-          end
-        else
-          begin
-            input = JSON.parse(event.data)
-            if input.has_key?('stdin')
-              @client.notify('/containers/tty_input', @exec_session['id'], input['stdin'])
-            elsif input.has_key?('tty_size')
-              @client.notify('/containers/tty_resize', @exec_session['id'], input['tty_size'])
-            end
-          rescue JSON::ParserError
-            error "invalid tty_input json"
-            @ws.close
-          end
-        end
+        on_websocket_message(event.data)
       end
 
       @ws.on(:close) do |event|
-        @client.notify('/containers/terminate_exec', @exec_session['id'])
-        @subscription.terminate if @subscription
+        on_websocket_close(event.code, event.reason)
       end
+
+      started!
     end
 
-    # @param [Boolean] shell
-    # @param [Boolean] tty
-    def register_run_ws_events(shell, tty)
-      @ws.on(:message) do |event|
-        begin
-          data = JSON.parse(event.data)
-          if data.has_key?('cmd')
-            if shell
-              cmd = ['/bin/sh', '-c', data['cmd'].join(' ')]
-            else
-              cmd = data['cmd']
-            end
-            @client.notify('/containers/run_exec', @exec_session['id'], cmd, tty, false)
-          end
-        rescue JSON::ParserError
-          error "invalid json"
-          @ws.close
-        end
+    # @param data [Hash] Write websocket JSON frame
+    def websocket_write(data)
+      debug { "websocket write: #{data.inspect}" }
+
+      msg = JSON.dump(data)
+
+      EventMachine.schedule {
+        @ws.send(msg)
+      }
+    end
+
+    # @param code [Integer]
+    # @param reason [String]
+    def websocket_close(code, reason = nil)
+      debug { "websocket close with code #{code}: #{reason}"}
+
+      EventMachine.schedule {
+        @ws.close(code, reason)
+      }
+    end
+
+    def on_websocket_message(msg)
+      data = JSON.parse(msg)
+
+      debug { "websocket message: #{data.inspect}"}
+
+      if data.has_key?('cmd')
+        exec_run(data['cmd'], shell: @shell, tty: @tty, stdin: @stdin)
       end
 
-      @ws.on(:close) do |event|
-        @client.notify('/containers/terminate_exec', @exec_session['id'])
-        @subscription.terminate if @subscription
+      if data.has_key?('stdin')
+        exec_input(data['stdin'])
+      end
+
+      if data.has_key?('tty_size')
+        exec_resize(data['tty_size'])
+      end
+    rescue JSON::ParserError => exc
+      warn "invalid websocket JSON: #{exc}"
+      abort exc
+    rescue => exc
+      error exc
+      abort exc
+    end
+
+    # @param code [Integer]
+    # @param reason [String]
+    def on_websocket_close(code, reason)
+      debug "websocket closed with code #{code}: #{reason}"
+
+      self.teardown
+    end
+
+    # Abort exec on error.
+    #
+    # Closes client websocket, terminates the exec RPC.
+    #
+    # @param exc [Exception]
+    def abort(exc)
+      websocket_close(4000, "#{exc.class}: #{exc}")
+      self.teardown
+    end
+
+    # Release resources from #setup()
+    #
+    # Can be called multiple times (abort -> on_websocket_close)
+    def teardown
+      if @exec_session
+        exec_terminate
+        @exec_session = nil
+      end
+
+      if @subscription
+        @subscription.terminate
+        @subscription = nil
       end
     end
   end

--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -78,8 +78,13 @@ module Docker
       @rpc_client.notify('/containers/run_exec', self.exec_id, cmd, tty, stdin)
     end
 
-    # @param tty_size [Hash{'width' => Integer, 'height' => Integer}]
-    def exec_resize(tty_size)
+    # @param width [Integer]
+    # @param height [Integer]
+    def exec_resize(width, height)
+      raise ArgumentError "width and height must be integers > 0" unless width > 0 && height > 0 
+
+      tty_size = { 'width' => width, 'height' => height }
+
       debug { "exec #{self.exec_id} resize: #{tty_size.inspect}" }
 
       @rpc_client.notify('/containers/tty_resize', self.exec_id, tty_size)
@@ -173,7 +178,7 @@ module Docker
 
       if data.has_key?('tty_size')
         fail "not running" unless running?
-        exec_resize(data['tty_size'])
+        exec_resize(data['tty_size']['width'], data['tty_size']['height'])
       end
     rescue JSON::ParserError => exc
       warn "invalid websocket JSON: #{exc}"

--- a/server/spec/services/docker/streaming_executor_spec.rb
+++ b/server/spec/services/docker/streaming_executor_spec.rb
@@ -215,6 +215,13 @@ describe Docker::StreamingExecutor do
           subject.on_websocket_message('invalid json data')
         end
 
+        it 'aborts on random server errors' do
+          expect(rpc_client).to receive(:notify).and_raise(Celluloid::DeadActorError)
+          expect(subject).to receive(:abort).with(Celluloid::DeadActorError)
+
+          subject.on_websocket_message('{"cmd":["echo", "test"]}')
+        end
+
         describe 'for a non-interactive exec' do
           it 'accepts a command frame' do
             expect(subject).to receive(:exec_run).with(['echo', 'test'], shell: false, tty: false, stdin: false)

--- a/server/spec/services/docker/streaming_executor_spec.rb
+++ b/server/spec/services/docker/streaming_executor_spec.rb
@@ -1,0 +1,77 @@
+describe Docker::StreamingExecutor do
+  let(:grid) { Grid.create!(name: 'test-grid') }
+  let(:node) { grid.create_node!('test-node', node_id: 'TEST', connected: true) }
+  let(:service) { GridService.create!(grid: grid, name: 'redis', image_name: 'redis:3.0', container_count: 1) }
+  let(:container_id) { 'e78dc44810960911098286c234216d4b5e837537628acc6bbcfd8cafd789b160' }
+  let(:container) { Container.create!(grid: grid, grid_service: service, host_node: node, container_id: container_id, name: 'redis-1' ) }
+
+  let(:rpc_client) { instance_double(RpcClient) }
+  let(:exec_id) { '70720f99-19aa-4d6b-bd1d-5cd9b430ae8b' }
+  let(:pubsub_subscription) { instance_double(MongoPubsub::Subscription) }
+
+  subject { described_class.new(container) }
+
+  before do
+    allow(node).to receive(:rpc_client).and_return(rpc_client)
+  end
+
+  describe '#setup' do
+    it 'requests an exec session from the agent' do
+      expect(rpc_client).to receive(:request).with('/containers/create_exec', container_id).and_return({'id' => exec_id})
+      expect(subject).to receive(:subscribe_to_exec).with(exec_id).and_return(pubsub_subscription)
+
+      subject.setup
+
+      expect(subject.exec_id).to eq exec_id
+    end
+
+    it 'subscribes to the exec pubsub channel' do
+      expect(subject).to receive(:exec_create).and_return({'id' => '70720f99-19aa-4d6b-bd1d-5cd9b430ae8b'})
+      expect(MongoPubsub).to receive(:subscribe).with("container_exec:70720f99-19aa-4d6b-bd1d-5cd9b430ae8b").and_return(pubsub_subscription)
+
+      subject.setup
+    end
+  end
+
+  describe '#teardown' do
+    context 'when not setup' do
+      it 'does nothing' do
+        subject.teardown
+      end
+    end
+  end
+
+  context 'after setup' do
+    before do
+      expect(rpc_client).to receive(:request).with('/containers/create_exec', container_id).and_return({'id' => exec_id})
+      expect(MongoPubsub).to receive(:subscribe).with("container_exec:70720f99-19aa-4d6b-bd1d-5cd9b430ae8b").and_return(pubsub_subscription)
+
+      subject.setup
+    end
+
+    describe '#teardown' do
+      it 'terminates the subscription and agent RPC exec' do
+        expect(pubsub_subscription).to receive(:terminate)
+        expect(rpc_client).to receive(:notify).with('/containers/terminate_exec', exec_id)
+
+        subject.teardown
+      end
+
+    end
+
+    context 'after teardown' do
+      before do
+        expect(pubsub_subscription).to receive(:terminate).once
+        expect(rpc_client).to receive(:notify).with('/containers/terminate_exec', exec_id).once
+
+        subject.teardown
+      end
+
+      describe '#teardown' do
+        it 'does nothing' do
+          subject.teardown
+        end
+      end
+    end
+  end
+end

--- a/server/spec/services/docker/streaming_executor_spec.rb
+++ b/server/spec/services/docker/streaming_executor_spec.rb
@@ -81,6 +81,24 @@ describe Docker::StreamingExecutor do
 
         subject.exec_resize(80, 24)
       end
+
+      it 'fails on invalid width' do
+        expect{
+          subject.exec_resize(nil, 24)
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'fails on invalid height' do
+        expect{
+          subject.exec_resize(80, nil)
+        }.to raise_error(ArgumentError)
+      end
+
+      it 'fails on invalid width/height' do
+        expect{
+          subject.exec_resize(-1, -1)
+        }.to raise_error(ArgumentError)
+      end
     end
 
     describe '#exec_input' do

--- a/server/spec/services/docker/streaming_executor_spec.rb
+++ b/server/spec/services/docker/streaming_executor_spec.rb
@@ -49,6 +49,56 @@ describe Docker::StreamingExecutor do
       subject.setup
     end
 
+    describe '#exec_run' do
+      it 'sends RPC notify' do
+        expect(rpc_client).to receive(:notify).with('/containers/run_exec', exec_id, ['echo', 'test'], false, false)
+
+        subject.exec_run(['echo', 'test'])
+      end
+
+      it 'execs with interactive' do
+        expect(rpc_client).to receive(:notify).with('/containers/run_exec', exec_id, ['echo', 'test'], false, true)
+
+        subject.exec_run(['echo', 'test'], stdin: true)
+      end
+
+      it 'execs with interactive tty' do
+        expect(rpc_client).to receive(:notify).with('/containers/run_exec', exec_id, ['echo', 'test'], true, true)
+
+        subject.exec_run(['echo', 'test'], tty: true, stdin: true)
+      end
+
+      it 'execs with shell' do
+        expect(rpc_client).to receive(:notify).with('/containers/run_exec', exec_id, ['/bin/sh', '-c', 'echo test'], false, false)
+
+        subject.exec_run(['echo test'], shell: true)
+      end
+    end
+
+    describe '#exec_resize' do
+      it 'sends RPC notify' do
+        expect(rpc_client).to receive(:notify).with('/containers/tty_resize', exec_id, {'width' => 80, 'height' => 24})
+
+        subject.exec_resize(80, 24)
+      end
+    end
+
+    describe '#exec_input' do
+      it 'sends RPC notify' do
+        expect(rpc_client).to receive(:notify).with('/containers/tty_input', exec_id, "echo test\r")
+
+        subject.exec_input("echo test\r")
+      end
+    end
+
+    describe '#exec_terminate' do
+      it 'sends RPC notify' do
+        expect(rpc_client).to receive(:notify).with('/containers/terminate_exec', exec_id)
+
+        subject.exec_terminate
+      end
+    end
+
     describe '#teardown' do
       it 'terminates the subscription and agent RPC exec' do
         expect(pubsub_subscription).to receive(:terminate)


### PR DESCRIPTION
Fixes #2605

Change the roda request handler to run the RPC `/containers/create_exec` request outside of the `r.websocket` block, allowing it to fail via the normal roda error handling. The `r.websocket` block only registers the websocket handlers, which is not expected to fail.

Rewrite the `Docker::StreamingExecutor`:

* Split up `setup` vs `start(ws)` for error handling purposes

* Deduplicate the `register_stdin_ws_events` vs `register_run_ws_events`

* Better debug logging

* Fix `MongoPubsub.subscribe do ...` to use `EventMachine.schedule { @ws.write(...) }`

    The socket is owned by EventMachine, and the pubsub subscription thread should not be doing concurrent writes to the websocket.

* Fix the `@ws.on :message` handler to abort the websocket on any errors, not just `JSON::ParserError`

* Add specs