### PR TITLE
Support for stop_signal

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -43,6 +43,7 @@ module Kontena
                   :wait_for_port,
                   :volume_specs,
                   :read_only,
+                  :stop_signal,
                   :stop_grace_period
       attr_accessor :entrypoint, :cmd
 
@@ -88,6 +89,7 @@ module Kontena
         @networks = attrs['networks'] || []
         @wait_for_port = attrs['wait_for_port']
         @read_only = attrs['read_only']
+        @stop_signal = attrs['stop_signal']
         @stop_grace_period = attrs['stop_grace_period']
       end
 
@@ -172,6 +174,7 @@ module Kontena
         docker_opts['User'] = self.user if self.user
         docker_opts['Cmd'] = self.cmd if self.cmd
         docker_opts['Entrypoint'] = self.entrypoint if self.entrypoint
+        docker_opts['StopSignal'] = self.stop_signal if self.stop_signal
 
         if self.can_expose_ports? && self.ports
           docker_opts['ExposedPorts'] = self.build_exposed_ports

--- a/agent/spec/lib/kontena/models/service_pod_spec.rb
+++ b/agent/spec/lib/kontena/models/service_pod_spec.rb
@@ -217,9 +217,18 @@ describe Kontena::Models::ServicePod do
       expect(service_config['Entrypoint']).to be_nil
     end
 
-    it 'does not include Entrypoint if nil' do
+    it 'includes Entrypoint if set' do
       data['entrypoint'] = ['/bin/sh']
       expect(service_config['Entrypoint']).to eq(['/bin/sh'])
+    end
+    
+    it 'does not include StopSignal if nil' do
+      expect(service_config['StopSignal']).to be_nil
+    end
+
+    it 'includes StopSignal if set' do
+      data['stop_signal'] = 'SIGQUIT'
+      expect(service_config['StopSignal']).to eq('SIGQUIT')
     end
 
     it 'includes empty ExposedPorts if no ports are defined' do

--- a/cli/lib/kontena/cli/services/create_command.rb
+++ b/cli/lib/kontena/cli/services/create_command.rb
@@ -45,6 +45,7 @@ module Kontena::Cli::Services
     option "--health-check-initial-delay", "DELAY", "Initial delay for health check"
     option "--health-check-port", "PORT", "Port for health check"
     option "--health-check-protocol", "PROTOCOL", "Protocol of health check"
+    option "--stop-signal", "STOP_SIGNAL", "Alternative signal to stop container"
     option "--stop-timeout", "STOP_TIMEOUT", "Timeout (duration) to stop a container"
     option "--read-only", :flag, "Read-only root fs for the container", default: false
 
@@ -95,6 +96,7 @@ module Kontena::Cli::Services
       health_check = parse_health_check
       data[:health_check] = health_check unless health_check.empty?
       data[:pid] = pid if pid
+      data[:stop_signal] = stop_signal if stop_signal
       data[:stop_grace_period] = stop_timeout if stop_timeout
       data[:read_only] = read_only?
       data

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -53,6 +53,9 @@ module Kontena
           puts "  scaling: #{service['instances'] }"
           puts "  strategy: #{service['strategy']}"
           puts "  read_only: #{service['read_only'] == true ? 'yes' : 'no'}"
+          unless service['stop_signal'].to_s.empty?
+            puts "  stop_signal: #{service['stop_signal']}"
+          end
           puts "  stop_grace_period: #{service['stop_grace_period']}s"
           puts "  deploy_opts:"
           if service['deploy_opts']['min_health']

--- a/cli/lib/kontena/cli/services/update_command.rb
+++ b/cli/lib/kontena/cli/services/update_command.rb
@@ -42,6 +42,7 @@ module Kontena::Cli::Services
     option "--health-check-initial-delay", "DELAY", "Initial for HTTP health check"
     option "--health-check-port", "PORT", "Port for HTTP health check"
     option "--health-check-protocol", "PROTOCOL", "Protocol of health check"
+    option "--stop-signal", "STOP_SIGNAL", "Alternative signal to stop container"
     option "--stop-timeout", "STOP_TIMEOUT", "Timeout (duration) to stop a container"
 
     def execute
@@ -85,6 +86,7 @@ module Kontena::Cli::Services
       health_check = parse_health_check
       data[:health_check] = health_check unless health_check.empty?
       data[:pid] = pid if pid
+      data[:stop_signal] = stop_signal if stop_signal
       data[:stop_grace_period] = stop_timeout if stop_timeout
       data
     end

--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -66,6 +66,7 @@ module Kontena::Cli::Stacks
       data['certificates'] = options['certificates'] if options['certificates']
       data['build'] = parse_build_options(options) if options['build']
       data['health_check'] = parse_health_check(options)
+      data['stop_signal'] = options['stop_signal'] if options['stop_signal']
       data['stop_grace_period'] = options['stop_grace_period'] if options['stop_grace_period']
       data['read_only'] = options['read_only'] || false
       data

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -80,6 +80,7 @@ module Kontena::Cli::Stacks::YAML
           'interval' => optional('integer'),
           'initial_delay' => optional('integer')
         }),
+        'stop_signal' => optional('string'),
         'stop_grace_period' => optional(/(\d+(?:\.\d+)?)([hms])/),
         'read_only' => optional('boolean')
       }

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -40,6 +40,7 @@ class GridService
   field :revision, type: Integer, default: 1
   field :stack_revision, type: Integer
   field :strategy, type: String, default: 'ha'
+  field :stop_signal, type: String
   field :stop_grace_period, type: Fixnum, default: 10
 
   belongs_to :grid

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -352,7 +352,7 @@ module GridServices
               integer :initial_delay, default: 10
             end
           end
-          string :stop_signal, matches: /^((SIG)([A-Z0-9]+|RTMIN\+\d+|RTMAX-\d+)|\d+)$/i
+          string :stop_signal, matches: /\A((SIG)([A-Z0-9]+|RTMIN\+\d+|RTMAX-\d+)|\d+)\z/i
           string :stop_grace_period, matches: Duration::VALIDATION_PATTERN
         end
       end

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -352,7 +352,7 @@ module GridServices
               integer :initial_delay, default: 10
             end
           end
-          string :stop_signal
+          string :stop_signal, matches: /^((SIG)([A-Z0-9]+|RTMIN\+\d+|RTMAX-\d+)|\d+)$/i
           string :stop_grace_period, matches: Duration::VALIDATION_PATTERN
         end
       end

--- a/server/app/mutations/grid_services/common.rb
+++ b/server/app/mutations/grid_services/common.rb
@@ -352,6 +352,7 @@ module GridServices
               integer :initial_delay, default: 10
             end
           end
+          string :stop_signal
           string :stop_grace_period, matches: Duration::VALIDATION_PATTERN
         end
       end

--- a/server/app/mutations/grid_services/update.rb
+++ b/server/app/mutations/grid_services/update.rb
@@ -82,6 +82,7 @@ module GridServices
       attributes[:deploy_opts] = self.deploy_opts if self.deploy_opts
       attributes[:health_check] = self.health_check if self.health_check
       attributes[:volumes_from] = self.volumes_from if self.volumes_from
+      attributes[:stop_signal] = self.stop_signal if self.stop_signal
       attributes[:stop_grace_period] = parse_duration(self.stop_grace_period) if self.stop_grace_period
       attributes[:read_only] = self.read_only unless self.read_only.nil?
 

--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -46,6 +46,7 @@ module Rpc
         log_opts: service.log_opts,
         pid: service.pid,
         wait_for_port: service.deploy_opts.wait_for_port,
+        stop_signal: service.stop_signal,
         stop_grace_period: service.stop_grace_period,
         env: build_env,
         secrets: build_secrets,

--- a/server/app/views/v1/grid_services/_grid_service.json.jbuilder
+++ b/server/app/views/v1/grid_services/_grid_service.json.jbuilder
@@ -67,5 +67,6 @@ if grid_service.health_check && grid_service.health_check.protocol
     end
     json.health_status grid_service.health_status
 end
+json.stop_signal grid_service.stop_signal
 json.stop_grace_period grid_service.stop_grace_period
 json.certificates grid_service.certificates.as_json(only: [:subject, :name, :type])

--- a/server/docs/source/index.html.md
+++ b/server/docs/source/index.html.md
@@ -600,7 +600,8 @@ to | The end date and time (example: `?to=2017-01-01T13:15:00.00Z`) | now
           "stateful": true,
           "replicas": 3,
           "cmd": "--replset kontena --smallfiles",
-        "stop_grace_period": "1m23s",
+          "stop_signal": "SIGTERM",
+          "stop_grace_period": "1m23s",
           "health_check": {
               "protocol": "tcp",
               "port": 27017
@@ -933,6 +934,7 @@ log_driver | Log driver (string)
 log_opts | Log driver options (object)
 hooks | Commands to be executed when service instance is deployed
 instance_counts | Stats about how many instances this service currently has
+stop_signal | Alternative signal to stop the container
 stop_grace_period | How long to wait when attempting to stop a container if it doesn’t handle SIGTERM (or whatever stop signal has been specified with the image), before sending SIGKILL.
 health_status | Health status of the service instances. Only counted if there is a health check defined for the service.
 

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -86,7 +86,7 @@ describe '/v1/services' do
         instances cmd entrypoint ports env memory memory_swap shm_size cpus cpu_shares
         volumes volumes_from cap_add cap_drop state grid links log_driver log_opts
         strategy deploy_opts pid instance_counts net dns hooks secrets revision
-        stack_revision stop_grace_period read_only certificates
+        stack_revision stop_signal stop_grace_period read_only certificates
       ).sort
 
   describe 'GET /:id' do
@@ -142,6 +142,14 @@ describe '/v1/services' do
       expect(response.status).to eq(200)
       expect(json_response['health_status']).to be_nil
       expect(json_response['health_check']).to be_nil
+    end
+
+    it 'returns stop_signal' do
+      redis_service.stop_signal = 'SIGQUIT'
+      redis_service.save
+      get "/v1/services/#{redis_service.to_path}", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['stop_signal']).to eq('SIGQUIT')
     end
 
     it 'returns stop_grace_period' do

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -2,7 +2,7 @@ describe GridService do
   it { should be_timestamped_document }
   it { should be_kind_of(EventStream) }
   it { should have_fields(:image_name, :name, :user, :entrypoint, :state,
-                          :net, :log_driver, :pid).of_type(String) }
+                          :net, :log_driver, :pid, :stop_signal).of_type(String) }
   it { should have_fields(:container_count, :memory,
                           :memory_swap, :cpu_shares,
                           :revision, :stack_revision, :shm_size).of_type(Integer) }

--- a/server/spec/mutations/grid_services/create_spec.rb
+++ b/server/spec/mutations/grid_services/create_spec.rb
@@ -567,6 +567,101 @@ describe GridServices::Create do
       expect(outcome).not_to be_success
     end
 
+    context 'stop_signal' do
+      it 'saves stop_signal' do
+        outcome = described_class.new(
+            grid: grid,
+            image: 'redis:2.8',
+            name: 'redis',
+            stateful: false,
+            stop_signal: 'SIGQUIT'
+        ).run
+        expect(outcome).to be_success
+        expect(outcome.result.stop_signal).to eq('SIGQUIT')
+      end
+
+      it 'validates stop_signal syntax' do
+        outcome = described_class.new(
+          grid: grid,
+          name: 'redis',
+          image: 'redis:2.8',
+          stateful: false,
+          stop_signal: 'invalid'
+        ).run
+        expect(outcome).to_not be_success
+        expect(outcome.errors.message).to eq 'stop_signal' => "Stop Signal isn't in the right format"
+      end
+
+      it 'does not allow empty strings' do
+        outcome = described_class.new(
+          grid: grid,
+          name: 'redis',
+          image: 'redis:2.8',
+          stateful: false,
+          stop_signal: ''
+        ).run
+        expect(outcome).to_not be_success
+        expect(outcome.errors.message.keys).to include('stop_signal')
+      end
+
+      it 'does not allow signal to start with - char' do
+        outcome = described_class.new(
+          grid: grid,
+          name: 'redis',
+          image: 'redis:2.8',
+          stateful: false,
+          stop_signal: '-SIGQUIT'
+        ).run
+        expect(outcome).to_not be_success
+        expect(outcome.errors.message.keys).to include('stop_signal')
+      end
+
+      it 'does not allow signal to end in - char' do
+        outcome = described_class.new(
+          grid: grid,
+          name: 'redis',
+          image: 'redis:2.8',
+          stateful: false,
+          stop_signal: 'SIGRTMIN-'
+        ).run
+        expect(outcome).to_not be_success
+        expect(outcome.errors.message.keys).to include('stop_signal')
+      end
+
+      it 'allows numeric strings as signals' do
+        outcome = described_class.new(
+          grid: grid,
+          name: 'redis',
+          image: 'redis:2.8',
+          stateful: false,
+          stop_signal: '9'
+        ).run
+        expect(outcome).to be_success
+      end
+
+      it 'allows signals with offsets' do
+        outcome = described_class.new(
+          grid: grid,
+          name: 'redis',
+          image: 'redis:2.8',
+          stateful: false,
+          stop_signal: 'SIGRTMIN+2'
+        ).run
+        expect(outcome).to be_success
+      end
+
+      it 'fails to save with invalid stop_signal' do
+        outcome = described_class.new(
+            grid: grid,
+            image: 'redis:2.8',
+            name: 'redis',
+            stateful: false,
+            stop_signal: 'foo'
+        ).run
+        expect(outcome).not_to be_success
+      end
+    end
+
     context 'hooks' do
       it 'saves post_start hooks' do
         outcome = described_class.new(

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -19,6 +19,7 @@ describe Rpc::ServicePodSerializer do
       env: ['FOO=bar'],
       networks: [grid.networks.first],
       service_volumes: [ServiceVolume.new(volume: volume, path:'/data'), ServiceVolume.new(volume: ext_vol, path: '/foo')],
+      stop_signal: 'SIGQUIT',
       stop_grace_period: 20
     )
   end
@@ -158,6 +159,10 @@ describe Rpc::ServicePodSerializer do
 
     it 'includes default network' do
       expect(subject.to_hash).to include(:networks => [{name: 'kontena', subnet: '10.81.0.0/16', multicast: true, internal: false}])
+    end
+
+    it 'stop_signal' do
+      expect(subject.to_hash).to include(:stop_signal => 'SIGQUIT')
     end
 
     it 'stop_grace_period' do

--- a/test/spec/features/service/stop_spec.rb
+++ b/test/spec/features/service/stop_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'json'
 
 describe 'service stop' do
   before(:each) do
@@ -27,5 +28,22 @@ describe 'service stop' do
     sleep 1
     k = run("kontena service show test-2")
     expect(k.out.scan('desired_state: stopped').size).to eq(1)
+  end
+
+  context 'stop_signal set' do
+    after(:each) do
+      run "kontena stack rm --force simple"
+    end
+  
+    it 'sets StopSignal for container' do
+      with_fixture_dir("stack/stop_signal") do
+        k = run 'kontena stack install --deploy'
+        k.wait
+      end
+
+      id = container_id('simple.app-1')
+      k = run "kontena container inspect #{id}"
+      expect(JSON.parse(k.out).dig('Config', 'StopSignal')).to eq('SIGINT')
+    end
   end
 end

--- a/test/spec/fixtures/stack/stop_signal/kontena.yml
+++ b/test/spec/fixtures/stack/stop_signal/kontena.yml
@@ -1,0 +1,7 @@
+stack: simple
+version: 0.1.0
+services:
+  app:
+    image: busybox:latest
+    command: sh -c 'trap "exit 0" SIGINT;trap "exit 1" SIGTERM;while true; do :; done'
+    stop_signal: 'SIGINT'


### PR DESCRIPTION
Closes #2878 
Based implementation on #2767

Added support for `stop_signal`, as in <https://docs.docker.com/compose/compose-file/#stop_signal>

Also fixed apparent typo in `agent/spec/lib/kontena/models/service_pod_spec.rb` `Entrypoint` test case name.

When I ran the specs, there were some errors in `agent` and `server`, but nothing that seemed to relate to this PR.