### PR TITLE
Fix e2e plugin uninstall spec to not use --force

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     environment:
       - KONTENA_URI=ws://localhost:9292
       - KONTENA_TOKEN=e2etoken
+      - LOG_LEVEL=0
     network_mode: "host"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/test/spec/features/plugin/uninstall_spec.rb
+++ b/test/spec/features/plugin/uninstall_spec.rb
@@ -8,8 +8,9 @@ describe 'plugin uninstall' do
   it 'removes installed plugin' do
     k = run('kontena plugin uninstall aws')
     expect(k.code).to eq(0)
-    
+
     k = run('kontena plugin ls')
+    expect(k.code).to eq(0)
     expect(k.out).to_not match(/aws/)
   end
 end

--- a/test/spec/features/plugin/uninstall_spec.rb
+++ b/test/spec/features/plugin/uninstall_spec.rb
@@ -8,5 +8,8 @@ describe 'plugin uninstall' do
   it 'removes installed plugin' do
     k = run('kontena plugin uninstall aws')
     expect(k.code).to eq(0)
+    
+    k = run('kontena plugin ls')
+    expect(k.out).to_not match(/aws/)
   end
 end

--- a/test/spec/features/plugin/uninstall_spec.rb
+++ b/test/spec/features/plugin/uninstall_spec.rb
@@ -6,7 +6,7 @@ describe 'plugin uninstall' do
   end
 
   it 'removes installed plugin' do
-    k = run('kontena plugin uninstall --force aws')
+    k = run('kontena plugin uninstall aws')
     expect(k.code).to eq(0)
   end
 end


### PR DESCRIPTION
Fixes #2810 

The `kontena plugin uninstall` command no longer requires or even accepts `--force`, so fix the e2e spec to not pass `--force`.

```

plugin uninstall
 [done] Installing plugin aws     
Installed dependency aws-sdk version 2.10.61
Installed dependency aws-sdk-core version 2.10.61
Installed dependency aws-sdk-resources version 2.10.61
Installed dependency aws-sigv4 version 1.0.2
Installed dependency jmespath version 1.3.1
Installed dependency kontena-cli version 1.3.4
Installed plugin aws version 0.3.0
Installed dependency opto version 1.8.5
Installed dependency tty-cursor version 0.4.0
Installed dependency tty-prompt version 0.12.0
Installed dependency websocket-driver-kontena version 0.6.5
Installed dependency wisper version 1.6.1
 [done] Uninstalling plugin aws     
NAME  VERSION  DESCRIPTION
  removes installed plugin

Finished in 10.54 seconds (files took 0.27723 seconds to load)
1 example, 0 failures
```