### PR TITLE
Fix stack deploy to not raise RuntimeError on deploy errors

### DIFF
--- a/cli/lib/kontena/cli/stacks/stacks_helper.rb
+++ b/cli/lib/kontena/cli/stacks/stacks_helper.rb
@@ -9,10 +9,10 @@ module Kontena::Cli::Stacks
           deployment = client.get("stacks/#{deployment['stack_id']}/deploys/#{deployment['id']}")
         end
         if deployment['state'] == 'error'
-          $stderr.puts "Stack deploy failed"
+          puts "Stack deploy failed"
           deployment['service_deploys'].each do |service_deploy|
             if service_deploy['state'] == 'error'
-              $stderr.puts " - #{service_deploy['reason']}"
+              puts " - #{service_deploy['reason']}"
             end
           end
 

--- a/cli/lib/kontena/cli/stacks/stacks_helper.rb
+++ b/cli/lib/kontena/cli/stacks/stacks_helper.rb
@@ -9,9 +9,10 @@ module Kontena::Cli::Stacks
           deployment = client.get("stacks/#{deployment['stack_id']}/deploys/#{deployment['id']}")
         end
         if deployment['state'] == 'error'
+          $stderr.puts "Stack deploy failed"
           deployment['service_deploys'].each do |service_deploy|
             if service_deploy['state'] == 'error'
-              puts "        #{service_deploy['reason']}"
+              $stderr.puts " - #{service_deploy['reason']}"
             end
           end
 

--- a/cli/lib/kontena/cli/stacks/stacks_helper.rb
+++ b/cli/lib/kontena/cli/stacks/stacks_helper.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Stacks
             end
           end
 
-          raise 'deploy failed'
+          abort
         end
       end
 

--- a/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/deploy_command_spec.rb
@@ -43,6 +43,6 @@ describe Kontena::Cli::Stacks::DeployCommand do
     })
     expect(subject).to receive(:sleep).once
 
-    expect{subject.run(['test-stack'])}.to exit_with_error.and output(/deploy failed/).to_stderr
+    expect{subject.run(['test-stack'])}.to exit_with_error.and output(/Stack deploy failed/).to_stdout
   end
 end


### PR DESCRIPTION
See https://github.com/kontena/kontena/issues/2114#issuecomment-335724117

The instance errors in `wait_for_deployment_to_start` result in an unhandled `RuntimeError` exception, which results in `run the command again with environment DEBUG=true set to see the full exception`. 

Change the `wait_for_deployment_to_start` to just `puts` + `abort` instead, as the CLI handles the resulting `SystemExit` properly within the spinner and `Kontena.run!`. The `wait_for_deploy_to_finish` also aborts in a similar fashion, although that happens outside of any `spinner`.

## Testing
### Before
```
 [done] Creating stack affinity-fail      
 [done] Triggering deployment of stack affinity-fail     
 [fail] Waiting for deployment to start     
        Cannot find applicable node for service instance development/affinity-fail/redis-1: Did not find any nodes for affinity filter: node==nonexist
 [error] RuntimeError : deploy failed
         See /home/kontena/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
```

### After

The `puts` get queued up within the `spinner`, and thus get output after the `[fail] Waiting for deployment to start`

```
 [done] Creating stack affinity-fail      
 [done] Triggering deployment of stack affinity-fail     
 [fail] Waiting for deployment to start     
Stack deploy failed
 - Cannot find applicable node for service instance development/affinity-fail/redis-1: Did not find any nodes for affinity filter: node==nonexist
```