### PR TITLE
Fix certificates to not auto-renew if missing the linked service

### DIFF
--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -42,7 +42,7 @@ class Certificate
   def auto_renewable?
     self.all_domains.each do |domain|
       domain_auth = self.grid.grid_domain_authorizations.find_by(domain: domain)
-      unless domain_auth && domain_auth.authorization_type == 'tls-sni-01'
+      unless domain_auth && domain_auth.authorization_type == 'tls-sni-01' && domain_auth.grid_service
         return false
       end
     end

--- a/server/spec/jobs/certificate_renew_job_spec.rb
+++ b/server/spec/jobs/certificate_renew_job_spec.rb
@@ -67,6 +67,7 @@ describe CertificateRenewJob, celluloid: true do
 
         subject.renew_certificate(certificate)
       end
+
     end
 
     describe '#authorize_domains' do
@@ -89,6 +90,22 @@ describe CertificateRenewJob, celluloid: true do
         expect {
           subject.authorize_domains(certificate)
         }.to raise_error "Deployment of tls-sni secret failed"
+      end
+    end
+
+    context 'with the linked service having been removed' do
+      before do
+        linked_service.destroy
+        certificate.reload
+      end
+
+      describe '#renew_certificate' do
+        it 'does not renew the cert' do
+          expect(subject.wrapped_object).to_not receive(:request_new_cert)
+          expect(subject.wrapped_object).to_not receive(:error)
+
+          subject.renew_certificate(certificate)
+        end
       end
     end
   end

--- a/server/spec/jobs/certificate_renew_job_spec.rb
+++ b/server/spec/jobs/certificate_renew_job_spec.rb
@@ -5,7 +5,7 @@ describe CertificateRenewJob, celluloid: true do
 
   let(:grid) { Grid.create!(name: 'test-grid') }
 
-  let(:service) { GridService.create!(grid: grid, name: 'lb', image_name: 'lb')}
+  let(:linked_service) { GridService.create!(grid: grid, name: 'lb', image_name: 'lb')}
 
   let(:certificate) {
     Certificate.create!(grid: grid,
@@ -29,30 +29,67 @@ describe CertificateRenewJob, celluloid: true do
     end
   end
 
-  describe '#authorize_domains' do
-    it 'authorises domain succesfully' do
-      domain_auth = GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: service)
-      expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => true, :result => domain_auth))
-      expect(subject.wrapped_object).to receive(:wait_until!)
-      subject.authorize_domains(certificate)
-    end
+  context 'without any domain authz' do
+    describe '#renew_certificate' do
+      it 'does not renew the certificate' do
+        expect(subject.wrapped_object).to_not receive(:authorize_domains)
+        expect(subject.wrapped_object).to_not receive(:request_new_cert)
 
-    it 'raises if domain auth fails' do
-      domain_auth = GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: service)
-      expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => false, :errors => double(:message => 'boom')))
-      expect {
-        subject.authorize_domains(certificate)
-      }.to raise_error "Domain authorization failed: boom"
-    end
-
-    it 'raises if tls-sni deployment fails' do
-      domain_auth = GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: service)
-      expect(domain_auth).to receive(:status).twice.and_return(:deploy_error) #once in the wait loop and once after it
-      expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => true, :result => domain_auth))
-      expect {
-        subject.authorize_domains(certificate)
-      }.to raise_error "Deployment of tls-sni secret failed"
+        subject.renew_certificate(certificate)
+      end
     end
   end
 
+  context 'with a non-renewable domain authz' do
+    let(:domain_auth) { GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'dns-01') }
+
+    describe '#renew_certificate' do
+      it 'does not renew the certificate' do
+        expect(subject.wrapped_object).to_not receive(:authorize_domains)
+        expect(subject.wrapped_object).to_not receive(:request_new_cert)
+
+        subject.renew_certificate(certificate)
+      end
+    end
+  end
+
+  context 'with an auto-renewable domain authz' do
+    let!(:domain_auth) { GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: linked_service) }
+
+    describe '#renew_certificate' do
+      before do
+        expect(certificate).to be_auto_renewable
+      end
+
+      it 're-authorizes and renews the cert' do
+        expect(subject.wrapped_object).to receive(:authorize_domains).with(certificate)
+        expect(subject.wrapped_object).to receive(:request_new_cert).with(certificate)
+
+        subject.renew_certificate(certificate)
+      end
+    end
+
+    describe '#authorize_domains' do
+      it 'authorises domain succesfully' do
+        expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => true, :result => domain_auth))
+        expect(subject.wrapped_object).to receive(:wait_until!)
+        subject.authorize_domains(certificate)
+      end
+
+      it 'raises if domain auth fails' do
+        expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => false, :errors => double(:message => 'boom')))
+        expect {
+          subject.authorize_domains(certificate)
+        }.to raise_error "Domain authorization failed: boom"
+      end
+
+      it 'raises if tls-sni deployment fails' do
+        expect(domain_auth).to receive(:status).twice.and_return(:deploy_error) #once in the wait loop and once after it
+        expect(GridDomainAuthorizations::Authorize).to receive(:run).and_return(double(:success? => true, :result => domain_auth))
+        expect {
+          subject.authorize_domains(certificate)
+        }.to raise_error "Deployment of tls-sni secret failed"
+      end
+    end
+  end
 end

--- a/server/spec/models/certificate_spec.rb
+++ b/server/spec/models/certificate_spec.rb
@@ -41,9 +41,20 @@ describe Certificate do
       end
     end
 
-    context 'with tls-sni domain authorizations' do
+    context 'with tls-sni domain authorizations missing any linked service' do
       let!(:authz1) { GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01') }
       let!(:authz2) { GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'tls-sni-01') }
+
+      it 'is not auto-renewable' do
+        expect(certificate).to_not be_auto_renewable
+      end
+    end
+
+    context 'with tls-sni domain authorizations having a linked service' do
+      let(:linked_service) { GridService.create!(grid: grid, name: 'lb', image_name: 'lb')}
+
+      let!(:authz1) { GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01', grid_service: linked_service) }
+      let!(:authz2) { GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'tls-sni-01', grid_service: linked_service) }
 
       it 'is auto-renewable' do
         expect(certificate).to be_auto_renewable

--- a/server/spec/models/certificate_spec.rb
+++ b/server/spec/models/certificate_spec.rb
@@ -1,34 +1,53 @@
 describe Certificate do
   it { should be_timestamped_document }
-
   it { should belong_to(:grid) }
 
+  let(:grid) { Grid.create!(name: 'test-grid') }
+
+  let(:certificate) {
+    Certificate.create!(grid: grid,
+      subject: 'kontena.io',
+      valid_until: Time.now + 90.days,
+      private_key: 'private_key',
+      certificate: 'certificate',
+      alt_names: ['www.kontena.io'],
+      chain: 'chain',
+    )
+  }
 
   describe '#auto_renewable?' do
+    context 'with missing subject domain authorizations' do
+      let!(:authz1) { GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'tls-sni-01') }
 
-    let(:grid) { Grid.create!(name: 'test-grid') }
-
-    let(:certificate) {
-      Certificate.create!(grid: grid,
-        subject: 'kontena.io',
-        valid_until: Time.now + 90.days,
-        private_key: 'private_key',
-        certificate: 'certificate',
-        alt_names: ['www.kontena.io'],
-        chain: 'chain')
-    }
-
-    it 'returns false if some domain not tls-sni authorized' do
-      GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01')
-      GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'dns-01')
-      expect(certificate.auto_renewable?).to be_falsey
+      it 'is not auto-renewable' do
+        expect(certificate).to_not be_auto_renewable
+      end
     end
 
-    it 'returns true when all domains tls-sni authorized' do
-      GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01')
-      GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'tls-sni-01')
-      expect(certificate.auto_renewable?).to be_truthy
+    context 'with missing alt domain authorizations' do
+      let!(:authz1) { GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01') }
+
+      it 'is not auto-renewable' do
+        expect(certificate).to_not be_auto_renewable
+      end
+    end
+
+    context 'with non-tls-sni domain authorizations' do
+      let!(:authz1) { GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01') }
+      let!(:authz2) { GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'dns-01') }
+
+      it 'is not auto-renewable' do
+        expect(certificate).to_not be_auto_renewable
+      end
+    end
+
+    context 'with tls-sni domain authorizations' do
+      let!(:authz1) { GridDomainAuthorization.create!(grid: grid, domain: 'kontena.io', authorization_type: 'tls-sni-01') }
+      let!(:authz2) { GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'tls-sni-01') }
+
+      it 'is auto-renewable' do
+        expect(certificate).to be_auto_renewable
+      end
     end
   end
-
 end


### PR DESCRIPTION
Fixes #2881

Change `Certificate#auto_renewable?` to also check for `domain_auth.grid_service`.

99% specs, the fix is a one-liner

## Specs
```
Failures:

  1) CertificateRenewJob with an auto-renewable domain authz with the linked service having been removed #renew_certificate does not renew the cert
     Failure/Error: subject.renew_certificate(certificate)
       (#<CertificateRenewJob:0x00000005d15ad8>).error("Failed to renew certificate for kontena.io")
           expected: 0 times with any arguments
           received: 1 time with arguments: ("Failed to renew certificate for kontena.io")
     # ./app/jobs/certificate_renew_job.rb:43:in `rescue in renew_certificate'
     # ./app/jobs/certificate_renew_job.rb:37:in `renew_certificate'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:16:in `dispatch'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
     # (celluloid):0:in `remote procedure call'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:45:in `value'
     # ./vendor/bundle/ruby/2.3.0/gems/celluloid-0.17.3/lib/celluloid/proxy/sync.rb:22:in `method_missing'
     # ./spec/jobs/certificate_renew_job_spec.rb:107:in `block (5 levels) in <top (required)>'
     # ./spec/spec_helper.rb:88:in `block (2 levels) in <top (required)>'
```

## Testing
### Before
```
I, [2017-10-12T11:41:39.266202 #9]  INFO -- CertificateRenewJob: starting to watch certificate renewals
I, [2017-10-12T11:41:39.288648 #9]  INFO -- CertificateRenewJob: certificate renewal needed for test.188.226.131.23.nip.io
I, [2017-10-12T11:41:39.288773 #9]  INFO -- CertificateRenewJob: re-authorizing domain test.188.226.131.23.nip.io
E, [2017-10-12T11:41:39.295328 #9] ERROR -- CertificateRenewJob: Failed to renew certificate for test.188.226.131.23.nip.io
E, [2017-10-12T11:41:39.295431 #9] ERROR -- CertificateRenewJob: undefined method `stack' for nil:NilClass (NoMethodError)
/app/app/jobs/certificate_renew_job.rb:58:in `block in authorize_domains'
```

### After (with extra debug)
```
I, [2017-10-12T11:42:35.651524 #9]  INFO -- CertificateRenewJob: starting to watch certificate renewals
D, [2017-10-12T11:42:35.660704 #9] DEBUG -- CertificateRenewJob: unable to renew certificate for test.188.226.131.23.nip.io
```