### PR TITLE
Fix remaining plugin uninstall --force usages in tests

### DIFF
--- a/test/spec/features/plugin/install_spec.rb
+++ b/test/spec/features/plugin/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'plugin install' do
   after(:each) do
-    run('kontena plugin uninstall --force aws')
+    run('kontena plugin uninstall aws')
   end
 
   it 'installs a plugin' do

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
   end
 
   config.after :context, :subcommand => :app do
-    k = Kommando.run "kontena plugin uninstall --force app-command"
+    k = Kommando.run "kontena plugin uninstall app-command"
   end
 
   config.before :each do


### PR DESCRIPTION
See #2810

There were still a couple places in the e2e specs using `kontena plugin uninstall --force`. They were in un-checked `around/before/after do run ...` calls, so they were only showing up in the `DEBUG_KOMMANDO=1` output. The plugin specs probably still ended up testing both installs and upgrades, but just not necessarily in the expected ways.

Someone really needs to fix the e2e specs to actually fail by default on any command failures..