### PR TITLE
Fix cli plugin uninstall to ignore --force

### DIFF
--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -7,6 +7,7 @@ module Kontena::Cli::Plugins
     include Kontena::PluginManager::Common
 
     parameter 'NAME', 'Plugin name'
+    option "--force", :flag, "Unused", hidden: true
 
     def uninstaller
       Kontena::PluginManager::Uninstaller.new(name)

--- a/cli/spec/kontena/cli/plugins/uninstall_command_spec.rb
+++ b/cli/spec/kontena/cli/plugins/uninstall_command_spec.rb
@@ -29,5 +29,11 @@ describe Kontena::Cli::Plugins::UninstallCommand do
 
       subject.run(['test'])
     end
+
+    it 'ignores --force' do
+      allow(uninstaller).to receive(:uninstall)
+
+      subject.run(['--force', 'test'])
+    end
   end
 end

--- a/cli/spec/kontena/cli/plugins/uninstall_command_spec.rb
+++ b/cli/spec/kontena/cli/plugins/uninstall_command_spec.rb
@@ -1,0 +1,33 @@
+require 'kontena/cli/plugins/uninstall_command'
+
+describe Kontena::Cli::Plugins::UninstallCommand do
+  let(:subject) { described_class.new([]) }
+  let(:uninstaller) { instance_double(Kontena::PluginManager::Uninstaller) }
+
+  context 'for a plugin that is not installed' do
+    let(:plugin_name) { 'test' }
+
+    before do
+      allow(subject).to receive(:installed?).with(plugin_name).and_return(false)
+    end
+
+    it 'exits with error if plugin not found' do
+      expect{subject.run(['test'])}.to exit_with_error.and output(/Plugin test has not been installed/).to_stderr
+    end
+  end
+
+  context 'for an installed plugin' do
+    let(:plugin_name) { 'test' }
+
+    before do
+      allow(subject).to receive(:installed?).with(plugin_name).and_return(true)
+      allow(Kontena::PluginManager::Uninstaller).to receive(:new).with(plugin_name).and_return(uninstaller)
+    end
+
+    it 'uninstalls the plugin' do
+      expect(uninstaller).to receive(:uninstall)
+
+      subject.run(['test'])
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2810

Adds a hidden `--force` option to the `kontena plugin uninstall` command that just gets ignored.

Add specs.