### PR TITLE
Fix variable interpolation in extended stack files

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -46,10 +46,6 @@ module Kontena::Cli::Stacks
         @notifications    = []
       end
 
-      def is_compose?
-        internals_interpolated_yaml['version'] =~ /^[23](?:\.\d+)?$/
-      end
-
       # @param without_defaults [TrueClass,FalseClass] strip the GRID, STACK, etc from response
       # @param without_vault [TrueClass,FalseClass] strip out any values that are going to or coming from VAULT
       # @return [Hash] a hash of key value pairs representing the values of stack variables
@@ -204,10 +200,6 @@ module Kontena::Cli::Stacks
         raise RuntimeError, "Variable validation failed: #{variables.errors.inspect} in #{file}" unless variables.valid? || skip_validation
 
         validate unless skip_validation
-
-        if is_compose? && internals_interpolated_yaml['version'].split('.').first != '2'
-          notifications << { 'file' => "Docker compose yaml version #{internals_interpolated_yaml['version']} is not fully supported" }
-        end
 
         result = {}
         Dir.chdir(from_file? ? File.dirname(File.expand_path(file)) : Dir.pwd) do

--- a/cli/spec/fixtures/docker-compose_v2_with_variables.yml
+++ b/cli/spec/fixtures/docker-compose_v2_with_variables.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  wordpress:
+    image: wordpress:4.1
+    ports:
+      - 80:80
+    depends_on:
+      - mysql
+  mysql:
+    image: mysql:5.6
+    environment:
+      - ENV_VAR=$ENV_VAR

--- a/cli/spec/fixtures/kontena_v3_with_compose_variables.yml
+++ b/cli/spec/fixtures/kontena_v3_with_compose_variables.yml
@@ -5,7 +5,7 @@ variables:
     type: string
     value: abcd
 services:
-  wordpress:
+  mysql:
     extends:
       file: docker-compose_v2_with_variables.yml
       service: mysql

--- a/cli/spec/fixtures/kontena_v3_with_compose_variables.yml
+++ b/cli/spec/fixtures/kontena_v3_with_compose_variables.yml
@@ -1,0 +1,11 @@
+stack: user/stackname
+version: 0.1.1
+variables:
+  ENV_VAR:
+    type: string
+    value: abcd
+services:
+  wordpress:
+    extends:
+      file: docker-compose_v2_with_variables.yml
+      service: mysql

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -117,6 +117,19 @@ describe Kontena::Cli::Stacks::YAML::Reader do
           )
         end
 
+        it 'passes variables to extended file' do
+          allow(File).to receive(:exist?).with(fixture_path('docker-compose_v2_with_variables.yml')).and_call_original
+          allow(File).to receive(:read).with(fixture_path('docker-compose_v2_with_variables.yml')).and_call_original
+          allow(File).to receive(:exist?).with(fixture_path('kontena_v3.yml')).and_call_original
+          allow(File).to receive(:read).with(fixture_path('kontena_v3.yml')).and_return(fixture('kontena_v3_with_compose_variables.yml'))
+          expect(subject.execute['services']).to match array_including(
+            hash_including(
+              "name" => 'wordpress',
+              "env" => ["ENV_VAR=abcd"]
+            )
+          )
+        end
+
         it 'merges validation errors' do
           expect(File).to receive(:read).with(fixture_path('docker-compose_v2.yml')).and_return(fixture('docker-compose-invalid.yml'))
           outcome = subject.execute

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -124,7 +124,7 @@ describe Kontena::Cli::Stacks::YAML::Reader do
           allow(File).to receive(:read).with(fixture_path('kontena_v3.yml')).and_return(fixture('kontena_v3_with_compose_variables.yml'))
           expect(subject.execute['services']).to match array_including(
             hash_including(
-              "name" => 'wordpress',
+              "name" => 'mysql',
               "env" => ["ENV_VAR=abcd"]
             )
           )


### PR DESCRIPTION
Fixes #2943

Extending Docker compose files that include ENV-variables was broken in 1.4.0. This PR fixes that.

It's still required that you declare the env variables in the parent yaml:

```yaml
# kontena.yml
stack: user/stack
variables:
  ENV_VAR:
    type: string
    from:
      prompt: Enter env var value

services:
  mysql:
    extends:
      file: docker-compose.yml
      service: mysql

# docker-compose.yml
version: '2'
services:
  mysql:
    image: mysql:5.6
    environment:
      - ENV_VAR=$ENV_VAR
```
