### PR TITLE
Add support for entrypoint in stack files

### DIFF
--- a/cli/lib/kontena/cli/stacks/service_generator.rb
+++ b/cli/lib/kontena/cli/stacks/service_generator.rb
@@ -69,6 +69,7 @@ module Kontena::Cli::Stacks
       data['stop_signal'] = options['stop_signal'] if options['stop_signal']
       data['stop_grace_period'] = options['stop_grace_period'] if options['stop_grace_period']
       data['read_only'] = options['read_only'] || false
+      data['entrypoint'] = options['entrypoint'] if options['entrypoint']
       data
     end
 

--- a/cli/lib/kontena/cli/stacks/yaml/validations.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/validations.rb
@@ -82,7 +82,8 @@ module Kontena::Cli::Stacks::YAML
         }),
         'stop_signal' => optional('string'),
         'stop_grace_period' => optional(/(\d+(?:\.\d+)?)([hms])/),
-        'read_only' => optional('boolean')
+        'read_only' => optional('boolean'),
+        'entrypoint' => optional('string')
       }
     end
 

--- a/cli/spec/fixtures/docker-compose_v2.yml
+++ b/cli/spec/fixtures/docker-compose_v2.yml
@@ -8,3 +8,4 @@ services:
       - mysql
   mysql:
     image: mysql:5.6
+    entrypoint: test

--- a/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/reader_spec.rb
@@ -112,7 +112,8 @@ describe Kontena::Cli::Stacks::YAML::Reader do
               "links"=>[],
               "ports"=>[],
               "stateful"=>true,
-              "name"=>"mysql"
+              "name"=>"mysql",
+              "entrypoint" => "test"
             )
           )
         end

--- a/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
+++ b/cli/spec/kontena/cli/stacks/yaml/validator_v3_spec.rb
@@ -52,6 +52,23 @@ describe Kontena::Cli::Stacks::YAML::ValidatorV3 do
       expect(result.errors.key?('network_mode')).to be_falsey
     end
 
+    context 'entrypoint' do
+      it 'is optional' do
+        result = subject.validate_options({})
+        expect(result.errors.key?('entrypoint')).to be_falsey
+      end
+
+      it 'passes validation when string' do
+        result = subject.validate_options({'entrypoint' => 'abcd'})
+        expect(result.errors.key?('entrypoint')).to be_falsey
+      end
+
+      it 'fails validation when not a string' do
+        result = subject.validate_options({'entrypoint' => 1})
+        expect(result.errors.key?('entrypoint')).to be_truthy
+      end
+    end
+
     context 'affinity' do
       it 'is optional' do
         result = subject.validate_options({})

--- a/test/spec/features/stack/services/entrypoint_spec.rb
+++ b/test/spec/features/stack/services/entrypoint_spec.rb
@@ -1,0 +1,41 @@
+describe 'stack service entrypoint' do
+  include ContainerHelper
+
+  context 'for a stack service with an entrypoint' do
+    before(:all) do
+      with_fixture_dir("stack/entrypoint") do
+        run! 'kontena stack install sleep.yml'
+      end
+    end
+
+    after(:all) do
+      run! 'kontena stack rm --force sleep'
+    end
+
+    it 'configures the container with the nested /w/w entrypoint' do
+      inspect = inspect_container(container_id('sleep.sleep-1'))
+
+      expect(inspect['Config']['Entrypoint']).to eq ['/w/w']
+      expect(inspect['Config']['Cmd']).to eq ['/bin/sleep', '300']
+    end
+  end
+
+  context 'for a stack service with an entrypoint in network_mode=host' do
+    before(:all) do
+      with_fixture_dir("stack/entrypoint") do
+        run! 'kontena stack install etcdctl-watch.yml'
+      end
+    end
+
+    after(:all) do
+      run! 'kontena stack rm --force etcdctl-watch'
+    end
+
+    it 'configures the container with the correct entrypoint' do
+      inspect = inspect_container(container_id('etcdctl-watch.etcdctl-1'))
+
+      expect(inspect['Config']['Entrypoint']).to eq ['/usr/bin/etcdctl']
+      expect(inspect['Config']['Cmd']).to eq ['watch', '--forever', '--recursive', '/']
+    end
+  end
+end

--- a/test/spec/features/stack/validate_spec.rb
+++ b/test/spec/features/stack/validate_spec.rb
@@ -1,4 +1,15 @@
 describe 'stack validate' do
+  context 'keywords' do
+    context 'entrypoint' do
+      it 'sets stack entrypoint' do
+        with_fixture_dir("stack/keywords") do
+          k = run 'kontena stack validate entrypoint.yml'
+          expect(k.code).to be_zero
+          expect(k.out).to match(/entrypoint.+?foo.+?entrypoint.+?foo2/m)
+        end
+      end
+    end
+  end
   context 'service_link' do
     after(:each) do
       run 'kontena stack rm --force simple'

--- a/test/spec/fixtures/stack/entrypoint/etcdctl-watch.yml
+++ b/test/spec/fixtures/stack/entrypoint/etcdctl-watch.yml
@@ -1,0 +1,7 @@
+stack: test/etcdctl-watch
+services:
+  etcdctl:
+    network_mode: host
+    image: kontena/etcd:2.3.7
+    entrypoint: /usr/bin/etcdctl
+    command: watch --forever --recursive /

--- a/test/spec/fixtures/stack/entrypoint/sleep.yml
+++ b/test/spec/fixtures/stack/entrypoint/sleep.yml
@@ -1,0 +1,7 @@
+stack: test/sleep
+services:
+  sleep:
+    image: alpine:3.2
+    entrypoint: /bin/sleep
+    command: "300"
+    stop_signal: SIGKILL

--- a/test/spec/fixtures/stack/keywords/docker-compose-entrypoint.yml
+++ b/test/spec/fixtures/stack/keywords/docker-compose-entrypoint.yml
@@ -1,0 +1,6 @@
+version: '2'
+
+services:
+  redis:
+    image: redis
+    entrypoint: foo2

--- a/test/spec/fixtures/stack/keywords/entrypoint.yml
+++ b/test/spec/fixtures/stack/keywords/entrypoint.yml
@@ -1,0 +1,10 @@
+stack: test/simple
+version: 0.1.0
+services:
+  redis:
+    image: redis:3-alpine
+    entrypoint: foo
+  redis2:
+    extends:
+      file: docker-compose-entrypoint.yml
+      service: redis

--- a/test/spec/support/container_helper.rb
+++ b/test/spec/support/container_helper.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module ContainerHelper
 
   # Checks if a deployed container exists with given name
@@ -24,4 +26,10 @@ module ContainerHelper
     k.out.match("^(.+\/#{name})")[1]
   end
 
+  # @raise [RuntimeError]
+  # @return [Hash]
+  def inspect_container(container_id)
+    k = run("kontena container inspect #{container_id}")
+    ::JSON.parse(k.out)
+  end
 end


### PR DESCRIPTION
Fixes #2949

Adds / fixes support for the `entrypoint` keyword in stack/compose YAMLs.

