### PR TITLE
Add buildtags to CLI UserAgent header

### DIFF
--- a/cli/lib/kontena/cli/version.rb
+++ b/cli/lib/kontena/cli/version.rb
@@ -6,5 +6,12 @@ module Kontena
       is_head = ENV["KONTENA_EXTRA_BUILDTAGS"].to_s.include?('head')
       VERSION = "#{version_file.read.strip}#{"-head" if is_head}"
     end
+
+    unless const_defined?(:BUILD_TAGS)
+      BUILD_TAGS = [ 'ruby' + RUBY_VERSION, RUBY_PLATFORM]
+        .concat(ENV["KONTENA_EXTRA_BUILDTAGS"].to_s.split(','))
+        .compact
+        .join('+').freeze
+    end
   end
 end

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -69,7 +69,7 @@ module Kontena
       @default_headers = {
         ACCEPT => CONTENT_JSON,
         CONTENT_TYPE => CONTENT_JSON,
-        'User-Agent' => "kontena-cli/#{Kontena::Cli::VERSION}"
+        'User-Agent' => "kontena-cli/#{Kontena::Cli::VERSION}+#{Kontena::Cli::BUILD_TAGS}"
       }.merge(options[:default_headers])
 
       if token

--- a/cli/lib/kontena/debug_instrumentor.rb
+++ b/cli/lib/kontena/debug_instrumentor.rb
@@ -23,6 +23,7 @@ module Kontena
         heads << "Content-Type: #{params[:headers]['Content-Type']}" if params[:headers]['Content-Type']
         heads << "Authorization: #{params[:headers]['Authorization'].split(' ', 2).first}" if params[:headers]['Authorization']
         heads << "X-Kontena-Version: #{params[:headers]['X-Kontena-Version']}" if params[:headers]['X-Kontena-Version']
+        heads << "User-Agent: #{params[:headers]['User-Agent']}" if params[:headers]['User-Agent']
         str << heads.join(', ')
         str << "} "
         result << str

--- a/cli/lib/kontena/main_command.rb
+++ b/cli/lib/kontena/main_command.rb
@@ -2,10 +2,7 @@ require 'kontena/command'
 
 class Kontena::MainCommand < Kontena::Command
   option ['-v', '--version'], :flag, "Output Kontena CLI version #{Kontena::Cli::VERSION}" do
-    build_tags = [ 'ruby' + RUBY_VERSION ]
-    build_tags << RUBY_PLATFORM
-    build_tags += ENV["KONTENA_EXTRA_BUILDTAGS"].to_s.split(',')
-    puts ['kontena-cli', Kontena::Cli::VERSION, "[#{build_tags.join('+')}]"].join(' ')
+    puts ['kontena-cli', Kontena::Cli::VERSION, "[#{Kontena::Cli::BUILD_TAGS}]"].join(' ')
     exit 0
   end
 


### PR DESCRIPTION
Before:

```
User-Agent: kontena/cli-1.4.0
```

After:
```
User-Agent: kontena/cli-1.4.0+ruby2.4.2+x86_64-darwin16+homebrew
```

Maybe needs a way to disable?
