### PR TITLE
Add commands&apis to list and delete domain authorizations

### DIFF
--- a/cli/lib/kontena/cli/certificate/domain_authorization/list_command.rb
+++ b/cli/lib/kontena/cli/certificate/domain_authorization/list_command.rb
@@ -1,0 +1,24 @@
+
+module Kontena::Cli::Certificate::DomainAuthorization
+  class ListCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+    include Kontena::Cli::TableGenerator::Helper
+    include Kontena::Util
+
+    requires_current_master
+    requires_current_master_token
+    requires_current_grid
+
+    def fields
+      quiet? ? ['domain'] : {domain: 'domain', authorization_type: 'authorization_type', status: 'status'}
+    end
+
+    def execute
+      authorizations = client.get("grids/#{current_grid}/domain_authorizations")['domain_authorizations']
+
+      print_table(authorizations)
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/certificate/domain_authorization/remove_authorization_command.rb
+++ b/cli/lib/kontena/cli/certificate/domain_authorization/remove_authorization_command.rb
@@ -1,0 +1,25 @@
+
+module Kontena::Cli::Certificate::DomainAuthorization
+  class RemoveAuthorizationCommand < Kontena::Command
+    include Kontena::Cli::Common
+    include Kontena::Cli::GridOptions
+
+    parameter "DOMAIN", "Domain authorization to remove"
+    option "--force", :flag, "Force remove", default: false, attribute_name: :forced
+
+
+    def execute
+      confirm_command(self.domain) unless forced?
+
+      require_api_url
+      token = require_token
+
+
+      spinner "Deleting domain authorization for #{self.domain.colorize(:cyan)}" do
+        client.delete("domain_authorizations/#{current_grid}/#{self.domain}")
+      end
+
+    end
+
+  end
+end

--- a/cli/lib/kontena/cli/certificate/domain_authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/domain_authorize_command.rb
@@ -1,0 +1,7 @@
+
+module Kontena::Cli::Certificate
+  class DomainAuthorizeCommand < Kontena::Command
+    subcommand ["rm", "remove"], "Remove domain authorization", load_subcommand('certificate/domain_authorization/remove_authorization_command')
+    subcommand ["ls", "list"], "List domain authorizations", load_subcommand('certificate/domain_authorization/list_command')
+  end
+end

--- a/cli/lib/kontena/cli/certificate_command.rb
+++ b/cli/lib/kontena/cli/certificate_command.rb
@@ -8,6 +8,7 @@ class Kontena::Cli::CertificateCommand < Kontena::Command
   subcommand "request", "Request certificate for domain", load_subcommand('certificate/request_command')
   subcommand "get", "Get certificate for domain", load_subcommand('certificate/get_command')
   subcommand ["remove", "rm"], "Remove certificate for domain", load_subcommand('certificate/remove_command')
+  subcommand "domain-authorization", "Domain authorization sub-commands", load_subcommand('certificate/domain_authorize_command')
 
 
   def execute

--- a/server/app/mutations/domain_authorizations/remove_authorization.rb
+++ b/server/app/mutations/domain_authorizations/remove_authorization.rb
@@ -1,0 +1,24 @@
+
+require_relative '../../services/logging'
+
+module GridDomainAuthorizations
+  class RemoveAuthorization < Mutations::Command
+    include Logging
+
+    required do
+      model :domain_authorization, class: GridDomainAuthorization
+
+    end
+
+    def validate
+
+    end
+
+    def execute
+      self.domain_authorization.destroy!
+
+      # TODO Should we trigger deploy for the service that was linked?
+    end
+
+  end
+end

--- a/server/app/routes/v1/domain_authorizations_api.rb
+++ b/server/app/routes/v1/domain_authorizations_api.rb
@@ -22,6 +22,21 @@ module V1
 
             render('domain_authorizations/show')
           end
+
+          r.delete do
+            @domain_authorization = load_domain_auth(grid_name, domain)
+            halt_request(404, {error: "Domain authorization not found)"}) unless @domain_authorization
+
+            outcome = GridDomainAuthorizations::RemoveAuthorization.run(domain_authorization: @domain_authorization)
+            if outcome.success?
+              response.status = 200
+              {}
+            else
+              response.status = 422
+              {error: outcome.errors.message}
+            end
+
+          end
         end
       end
     end

--- a/server/spec/api/v1/domain_authorizations_spec.rb
+++ b/server/spec/api/v1/domain_authorizations_spec.rb
@@ -1,0 +1,63 @@
+describe '/v1/certificates' do
+
+  let(:request_headers) do
+    {
+        'HTTP_AUTHORIZATION' => "Bearer #{valid_token.token_plain}"
+    }
+  end
+
+  let(:grid) do
+    Grid.create!(name: 'terminal-a')
+  end
+
+  let(:david) do
+    user = User.create!(email: 'david@domain.com', external_id: '123456')
+    grid.users << user
+
+    user
+  end
+
+  let(:valid_token) do
+    AccessToken.create!(user: david, scopes: ['user'])
+  end
+
+  let(:domain_auth) do
+    grid.grid_domain_authorizations.create!(domain: 'kontena.io')
+  end
+
+  describe 'GET  grids/<grid/domain_authorizations' do
+    it 'returns empty list by default' do
+      get "/v1/grids/#{grid.name}/domain_authorizations", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['domain_authorizations'].size).to eq(0)
+    end
+
+
+    it 'returns all domain authorizations' do
+      domain_auth
+      get "/v1/grids/#{grid.name}/domain_authorizations", nil, request_headers
+      expect(response.status).to eq(200)
+      expect(json_response['domain_authorizations'].size).to eq(1)
+      expect(json_response['domain_authorizations'][0]['domain']).to eq('kontena.io')
+    end
+
+  end
+
+  describe 'DELETE domain_authorizations/<grid>/<domain>' do
+    it 'return 404 for missing domain auth' do
+      delete "/v1/domain_authorizations/#{grid.name}/foo.bar.com", nil, request_headers
+      expect(response.status).to eq(404)
+    end
+
+    it 'deletes domain auth' do
+      auth = grid.grid_domain_authorizations.create!(domain: 'delete.kontena.io')
+      expect {
+        delete "/v1/domain_authorizations/#{grid.name}/#{auth.domain}", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(GridDomainAuthorization.find_by(domain: 'delete.kontena.io')).to be_nil
+      }.to change {GridDomainAuthorization.count}.by (-1)
+
+    end
+  end
+
+end


### PR DESCRIPTION
There's no way to delete a domain authorization at the moment. Now with the env size limits this leaves all tls-sni authorizations linked to a service to "linger" around for eternity. :( And with the Linux env size limit issue, things are even worse now when all the certs (including the tls-sni ones) are bundled to single `SSL_CERTS` env.

Deleting a tls-sni domain auth that's still "in use" will cause the cert renewal to fail as the renewal logic cannot see where the new tls-sni certs should be deployed to.

fixes #2963 