### PR TITLE
Fix CLI certificate show output formatting

### DIFF
--- a/cli/lib/kontena/cli/certificate/show_command.rb
+++ b/cli/lib/kontena/cli/certificate/show_command.rb
@@ -25,7 +25,7 @@ module Kontena::Cli::Certificate
 
       show_yaml(cert['id'],
         'subject'         => cert['subject'],
-        'valid until'     => cert['valid_until'],
+        'valid until'     => Time.parse(cert['valid_until']),
         'alt names'       => (alt_names && !alt_names.empty?) ? alt_names : nil,
         'auto renewable'  => cert['auto_renewable'],
       )

--- a/cli/lib/kontena/cli/certificate/show_command.rb
+++ b/cli/lib/kontena/cli/certificate/show_command.rb
@@ -11,9 +11,14 @@ module Kontena::Cli::Certificate
     requires_current_master_token
     requires_current_grid
 
+    def print_yaml(object)
+      puts YAML.dump(object).sub("---\n", '')
+    end
+
     def execute
       certificate = client.get("certificates/#{current_grid}/#{self.subject}")
-      puts YAML.dump(certificate)
+      
+      print_yaml(certificate.delete('id') => certificate)
     end
   end
 end

--- a/cli/lib/kontena/cli/certificate/show_command.rb
+++ b/cli/lib/kontena/cli/certificate/show_command.rb
@@ -11,14 +11,24 @@ module Kontena::Cli::Certificate
     requires_current_master_token
     requires_current_grid
 
-    def print_yaml(object)
-      puts YAML.dump(object).sub("---\n", '')
+    # @param id [String]
+    # @param attrs [Hash{String => nil, Object}] elides nil values
+    def show_yaml(id, attrs)
+      puts YAML.dump(
+        id => Hash[attrs.select{|k, v| !!v}]
+      ).sub("---\n", '')
     end
 
     def execute
-      certificate = client.get("certificates/#{current_grid}/#{self.subject}")
-      
-      print_yaml(certificate.delete('id') => certificate)
+      cert = client.get("certificates/#{current_grid}/#{self.subject}")
+      alt_names = cert['alt_names']
+
+      show_yaml(cert['id'],
+        'subject'         => cert['subject'],
+        'valid until'     => cert['valid_until'],
+        'alt names'       => (alt_names && !alt_names.empty?) ? alt_names : nil,
+        'auto renewable'  => cert['auto_renewable'],
+      )
     end
   end
 end

--- a/cli/lib/kontena/cli/certificate/show_command.rb
+++ b/cli/lib/kontena/cli/certificate/show_command.rb
@@ -11,24 +11,23 @@ module Kontena::Cli::Certificate
     requires_current_master_token
     requires_current_grid
 
-    # @param id [String]
-    # @param attrs [Hash{String => nil, Object}] elides nil values
-    def show_yaml(id, attrs)
-      puts YAML.dump(
-        id => Hash[attrs.select{|k, v| !!v}]
-      ).sub("---\n", '')
+    def show_certificate(cert)
+      puts "#{cert['id']}:"
+      puts "  subject: #{cert['subject']}"
+      puts "  valid until: #{Time.parse(cert['valid_until']).utc.strftime("%FT%TZ")}"
+      if cert['alt_names'] && !cert['alt_names'].empty?
+        puts "  alt names:"
+        cert['alt_names'].each do |alt_name|
+          puts "    - #{alt_name}"
+        end
+      end
+      puts "  auto renewable: #{cert['auto_renewable']}"
     end
 
     def execute
       cert = client.get("certificates/#{current_grid}/#{self.subject}")
-      alt_names = cert['alt_names']
 
-      show_yaml(cert['id'],
-        'subject'         => cert['subject'],
-        'valid until'     => Time.parse(cert['valid_until']),
-        'alt names'       => (alt_names && !alt_names.empty?) ? alt_names : nil,
-        'auto renewable'  => cert['auto_renewable'],
-      )
+      show_certificate(cert)
     end
   end
 end

--- a/cli/spec/kontena/cli/certificates/show_command_spec.rb
+++ b/cli/spec/kontena/cli/certificates/show_command_spec.rb
@@ -25,7 +25,7 @@ describe Kontena::Cli::Certificate::ShowCommand do
     expect{subject.run(['test.example.com'])}.to output_lines([
       'test-grid/test.example.com:',
       '  subject: test.example.com',
-      "  valid until: '2017-12-14T13:34:00.000+00:00'",
+      "  valid until: 2017-12-14 13:34:00.000000000 +00:00",
       '  auto renewable: true',
     ])
   end
@@ -47,7 +47,7 @@ describe Kontena::Cli::Certificate::ShowCommand do
       expect{subject.run(['test.example.com'])}.to output_lines([
         'test-grid/test.example.com:',
         '  subject: test.example.com',
-        "  valid until: '2017-12-14T13:34:00.000+00:00'",
+        "  valid until: 2017-12-14 13:34:00.000000000 +00:00",
         '  alt names:',
         '  - test2.example.com',
         '  auto renewable: true',

--- a/cli/spec/kontena/cli/certificates/show_command_spec.rb
+++ b/cli/spec/kontena/cli/certificates/show_command_spec.rb
@@ -1,0 +1,36 @@
+require 'kontena/cli/certificate/show_command'
+
+describe Kontena::Cli::Certificate::ShowCommand do
+  include ClientHelpers
+  include OutputHelpers
+  include FixturesHelpers
+
+  let(:subject) { described_class.new("") }
+
+  let(:certificate) {
+    {
+      'id' => 'test-grid/test.example.com',
+      'subject' => 'test.example.com',
+      'valid_until' => '2017-12-14T13:34:00.000+00:00',
+      'alt_names' => [
+          'test2.example.com',
+      ],
+      'auto_renewable' => true,
+    }
+  }
+
+  before do
+    allow(client).to receive(:get).with('certificates/test-grid/test.example.com').and_return(certificate)
+  end
+
+  it "outputs the certificate info" do
+    expect{subject.run(['test.example.com'])}.to output_lines([
+      'test-grid/test.example.com:',
+      '  subject: test.example.com',
+      "  valid_until: '2017-12-14T13:34:00.000+00:00'",
+      '  alt_names:',
+      '  - test2.example.com',
+      '  auto_renewable: true',
+    ])
+  end
+end

--- a/cli/spec/kontena/cli/certificates/show_command_spec.rb
+++ b/cli/spec/kontena/cli/certificates/show_command_spec.rb
@@ -12,9 +12,7 @@ describe Kontena::Cli::Certificate::ShowCommand do
       'id' => 'test-grid/test.example.com',
       'subject' => 'test.example.com',
       'valid_until' => '2017-12-14T13:34:00.000+00:00',
-      'alt_names' => [
-          'test2.example.com',
-      ],
+      'alt_names' => [],
       'auto_renewable' => true,
     }
   }
@@ -28,9 +26,33 @@ describe Kontena::Cli::Certificate::ShowCommand do
       'test-grid/test.example.com:',
       '  subject: test.example.com',
       "  valid_until: '2017-12-14T13:34:00.000+00:00'",
-      '  alt_names:',
-      '  - test2.example.com',
+      '  alt_names: []',
       '  auto_renewable: true',
     ])
+  end
+
+  context 'with certificate alt_names' do
+    let(:certificate) {
+      {
+        'id' => 'test-grid/test.example.com',
+        'subject' => 'test.example.com',
+        'valid_until' => '2017-12-14T13:34:00.000+00:00',
+        'alt_names' => [
+            'test2.example.com',
+        ],
+        'auto_renewable' => true,
+      }
+    }
+
+    it "outputs the certificate info" do
+      expect{subject.run(['test.example.com'])}.to output_lines([
+        'test-grid/test.example.com:',
+        '  subject: test.example.com',
+        "  valid_until: '2017-12-14T13:34:00.000+00:00'",
+        '  alt_names:',
+        '  - test2.example.com',
+        '  auto_renewable: true',
+      ])
+    end
   end
 end

--- a/cli/spec/kontena/cli/certificates/show_command_spec.rb
+++ b/cli/spec/kontena/cli/certificates/show_command_spec.rb
@@ -25,9 +25,8 @@ describe Kontena::Cli::Certificate::ShowCommand do
     expect{subject.run(['test.example.com'])}.to output_lines([
       'test-grid/test.example.com:',
       '  subject: test.example.com',
-      "  valid_until: '2017-12-14T13:34:00.000+00:00'",
-      '  alt_names: []',
-      '  auto_renewable: true',
+      "  valid until: '2017-12-14T13:34:00.000+00:00'",
+      '  auto renewable: true',
     ])
   end
 
@@ -48,10 +47,10 @@ describe Kontena::Cli::Certificate::ShowCommand do
       expect{subject.run(['test.example.com'])}.to output_lines([
         'test-grid/test.example.com:',
         '  subject: test.example.com',
-        "  valid_until: '2017-12-14T13:34:00.000+00:00'",
-        '  alt_names:',
+        "  valid until: '2017-12-14T13:34:00.000+00:00'",
+        '  alt names:',
         '  - test2.example.com',
-        '  auto_renewable: true',
+        '  auto renewable: true',
       ])
     end
   end

--- a/cli/spec/kontena/cli/certificates/show_command_spec.rb
+++ b/cli/spec/kontena/cli/certificates/show_command_spec.rb
@@ -25,7 +25,7 @@ describe Kontena::Cli::Certificate::ShowCommand do
     expect{subject.run(['test.example.com'])}.to output_lines([
       'test-grid/test.example.com:',
       '  subject: test.example.com',
-      "  valid until: 2017-12-14 13:34:00.000000000 +00:00",
+      "  valid until: 2017-12-14T13:34:00Z",
       '  auto renewable: true',
     ])
   end
@@ -47,9 +47,9 @@ describe Kontena::Cli::Certificate::ShowCommand do
       expect{subject.run(['test.example.com'])}.to output_lines([
         'test-grid/test.example.com:',
         '  subject: test.example.com',
-        "  valid until: 2017-12-14 13:34:00.000000000 +00:00",
+        "  valid until: 2017-12-14T13:34:00Z",
         '  alt names:',
-        '  - test2.example.com',
+        '    - test2.example.com',
         '  auto renewable: true',
       ])
     end


### PR DESCRIPTION
Fixes #2957 

Disclaimer: any variations in color, syntax and indentation are a result of the hand-crafted nature of this output and are not considered flaws in the product.

## Testing
#### `kontena certificate show test.188.226.131.23.xip.io`
```yaml
development/test.188.226.131.23.xip.io:
  subject: test.188.226.131.23.xip.io
  valid until: 2017-12-14T13:34:00Z
  alt names:
    - test3.188.226.131.23.xip.io
  auto renewable: true
```

#### `bin/kontena certificate show test2.188.226.131.23.xip.io`
```yaml
development/test2.188.226.131.23.xip.io:
  subject: test2.188.226.131.23.xip.io
  valid until: 2018-02-06T13:47:20Z
  auto renewable: true
```