### PR TITLE
Fix server websocket backend to not overwrite node labels on initial connection

### DIFF
--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -154,7 +154,6 @@ class WebsocketBackend
   def find_node(req)
     node_id = req.env['HTTP_KONTENA_NODE_ID']
     node_name = req.env['HTTP_KONTENA_NODE_NAME']
-    node_labels = req.env['HTTP_KONTENA_NODE_LABELS'].to_s.split(',')
     init_attrs = {
       labels: req.env['HTTP_KONTENA_NODE_LABELS'].to_s.split(','),
       agent_version: req.env['HTTP_KONTENA_VERSION'].to_s,

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -386,7 +386,9 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       end
 
       context 'with a valid node token' do
-        let!(:host_node) { grid.create_node!('test-1', token: 'asdfasdfasdfasdf') }
+        let!(:host_node) { grid.create_node!('test-1', token: 'asdfasdfasdfasdf',
+          labels: ['test-2=no'],
+        ) }
 
         let(:grid_token) { nil }
         let(:node_token) { 'asdfasdfasdfasdf' }
@@ -423,7 +425,7 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
           expect(host_node.node_id).to eq node_id
           expect(host_node.name).to eq 'test-1' # the agent-provided Kontena-Node-Name: node-1 header is ignored
-          expect(host_node.labels).to eq ['test=yes']
+          expect(host_node.labels).to contain_exactly('test=yes', 'test-2=no')
           expect(host_node.agent_version).to eq '0.9.1'
           expect(host_node.connected).to eq true
           expect(host_node.connected_at.to_s).to eq connected_at.to_s


### PR DESCRIPTION
Fixes #2986 using mongo `{:$addToSet => {labels: { :$each => labels } } }`

## Testing

### Before (broken)
```
$ bin/kontena node create --label region=test core-02
 [done] Creating core-02 node      
$ bin/kontena node list
NAME        VERSION     STATUS       INITIAL   LABELS
⊛ core-01   1.4.0.dev   online 54s   1 / 1     region=test
⊝ core-02   -           created 5s   -         region=test
$ bin/kontena node list
NAME        VERSION     STATUS      INITIAL   LABELS
⊛ core-01   1.4.0.dev   online 1m   1 / 1     region=test
⊛ core-02   1.4.0.dev   online 3s   -         test=label
```

### After (fixed)

```
$ bin/kontena node create --label region=test core-02
 [done] Creating core-02 node      
$ bin/kontena node list
NAME        VERSION     STATUS        INITIAL   LABELS
⊛ core-01   1.4.0.dev   online 36s    1 / 1     region=test
⊝ core-02   -           created 31s   -         region=test
$ bin/kontena node list
NAME        VERSION     STATUS       INITIAL   LABELS
⊛ core-01   1.4.0.dev   online 53s   1 / 1     region=test
⊛ core-02   1.4.0.dev   online 6s    -         region=test,test=label
```