### PR TITLE
Fix CLI command exception handling with DEBUG

### DIFF
--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -241,7 +241,7 @@ class Kontena::Command < Clamp::Command
   rescue Clamp::HelpWanted, Clamp::UsageError
     raise
   rescue => ex
-    raise ex if debug?
+    raise ex if Kontena.debug?
     Kontena.logger.error(ex)
     abort(" [#{Kontena.pastel.red('error')}] #{ex.class.name} : #{ex.message}\n         See #{Kontena.log_target} or run the command again with environment DEBUG=true set to see the full exception")
   end

--- a/cli/spec/kontena/cli/main_command_spec.rb
+++ b/cli/spec/kontena/cli/main_command_spec.rb
@@ -15,5 +15,31 @@ describe Kontena::MainCommand do
       expect{subject.run(['testplugin', 'master', 'create'])}.to raise_error(Clamp::UsageError)
     end
   end
-end
 
+  context 'for a command that raises errors' do
+    let(:test_fail_command) { Class.new(Kontena::Command) do
+      def execute
+        fail 'test'
+      end
+    end}
+
+    before do
+      Kontena::MainCommand.subcommand 'test-fail', "Test failures", test_fail_command
+    end
+
+    it 'logs an error and aborts' do
+      expect{subject.run(['test-fail'])}.to raise_error(SystemExit).and output(/\[error\] RuntimeError : test\s+See .* or run the command again with environment DEBUG=true set to see the full exception/m).to_stderr
+    end
+
+    context 'with DEBUG' do
+      before do
+        allow(Kontena).to receive(:debug?).and_return(true)
+      end
+
+      it 'lets the error raise through' do
+        expect{subject.run(['test-fail'])}.to raise_error(RuntimeError, 'test')
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2985 

```
  1) Kontena::MainCommand for a command that raises errors logs an error and aborts
     Failure/Error: expect{subject.run(['test-fail'])}.to raise_error(SystemExit).and output(/\[error\] RuntimeError : test\s+See .* or run the command again with environment DEBUG=true set to see the full exception/m).to_stderr

          expected SystemExit, got #<NoMethodError: undefined method `debug?' for #<Kontena::MainCommand:0x000000014b0220>> with backtrace:
            # ./lib/kontena/command.rb:244:in `rescue in run'
            # ./lib/kontena/command.rb:200:in `run'
            # ./spec/kontena/cli/main_command_spec.rb:31:in `block (4 levels) in <top (required)>'
            # ./spec/kontena/cli/main_command_spec.rb:31:in `block (3 levels) in <top (required)>'
            # ./spec/spec_helper.rb:50:in `block (3 levels) in <top (required)>'
            # ./spec/spec_helper.rb:48:in `catch'
            # ./spec/spec_helper.rb:48:in `block (2 levels) in <top (required)>'

       ...and:

          expected block to output /\[error\] RuntimeError : test\s+See .* or run the command again with environment DEBUG=true set to see the full exception/m to stderr, but output nothing
     # ./spec/kontena/cli/main_command_spec.rb:31:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:50:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:48:in `catch'
     # ./spec/spec_helper.rb:48:in `block (2 levels) in <top (required)>'

  2) Kontena::MainCommand for a command that raises errors with DEBUG lets the error raise through
     Failure/Error: expect{subject.run(['test-fail'])}.to raise_error(RuntimeError, 'test')

       expected RuntimeError with "test", got #<NoMethodError: undefined method `debug?' for #<Kontena::MainCommand:0x00000002b05340>> with backtrace:
         # ./lib/kontena/command.rb:244:in `rescue in run'
         # ./lib/kontena/command.rb:200:in `run'
         # ./spec/kontena/cli/main_command_spec.rb:40:in `block (5 levels) in <top (required)>'
         # ./spec/kontena/cli/main_command_spec.rb:40:in `block (4 levels) in <top (required)>'
         # ./spec/spec_helper.rb:50:in `block (3 levels) in <top (required)>'
         # ./spec/spec_helper.rb:48:in `catch'
         # ./spec/spec_helper.rb:48:in `block (2 levels) in <top (required)>'
     # ./spec/kontena/cli/main_command_spec.rb:40:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:50:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:48:in `catch'
     # ./spec/spec_helper.rb:48:in `block (2 levels) in <top (required)>'
```