### PR TITLE
Fix server node connected events

### DIFF
--- a/server/app/services/agent/node_plugger.rb
+++ b/server/app/services/agent/node_plugger.rb
@@ -55,6 +55,8 @@ module Agent
         .find_one_and_update({:$set => {connected_at: connected_at, **attrs}})
 
       fail "Node #{@node} has already re-connected at #{@node.connected_at}" unless connected_node
+
+      node.reload # find_one_and_update does not update mongoid document attrs
     end
 
     def publish_update_event

--- a/server/app/services/agent/node_unplugger.rb
+++ b/server/app/services/agent/node_unplugger.rb
@@ -36,6 +36,8 @@ module Agent
 
       fail "Node #{@node} has already re-connected at #{@node.connected_at}" unless connected_node
 
+      node.reload # find_one_and_update does not update mongoid document attrs
+
       info "Disconnected node #{@node.to_path} connected at #{connected_at}"
     end
 

--- a/server/spec/services/agent/node_plugger_spec.rb
+++ b/server/spec/services/agent/node_plugger_spec.rb
@@ -89,10 +89,10 @@ describe Agent::NodePlugger do
         expect(node.websocket_connection.close_code).to be_nil
         expect(node.websocket_connection.close_reason).to be_nil
       end
-    end
 
-    describe '#send_node_info' do
       it "sends node info" do
+        expect(subject).to receive(:publish_update_event)
+
         expect(rpc_client).to receive(:notify).with('/agent/node_info', hash_including(
           name: 'test-node',
           grid: hash_including(
@@ -100,7 +100,7 @@ describe Agent::NodePlugger do
           ),
         ))
 
-        subject.send_node_info
+        subject.plugin! connected_at
       end
     end
   end

--- a/server/spec/services/agent/node_plugger_spec.rb
+++ b/server/spec/services/agent/node_plugger_spec.rb
@@ -20,6 +20,7 @@ describe Agent::NodePlugger do
     describe '#plugin!' do
       it 'marks node as connected' do
         expect(subject).to receive(:send_node_info)
+        expect(subject).to receive(:publish_update_event)
 
         expect {
           subject.plugin! connected_at
@@ -30,6 +31,21 @@ describe Agent::NodePlugger do
         expect(node.websocket_connection.opened).to be true
         expect(node.websocket_connection.close_code).to be_nil
         expect(node.websocket_connection.close_reason).to be_nil
+      end
+
+      it 'publishes an update event with connected status' do
+        expect(subject).to receive(:send_node_info)
+
+        expect(node).to receive(:publish_async).with({
+          event: 'update',
+          type: 'HostNode',
+          object: hash_including(
+            name: 'test-node',
+            connected: true,
+          )
+        })
+
+        subject.plugin! connected_at
       end
     end
 

--- a/server/spec/services/agent/node_unplugger_spec.rb
+++ b/server/spec/services/agent/node_unplugger_spec.rb
@@ -14,6 +14,7 @@ describe Agent::NodeUnplugger do
     describe '#unplug!' do
       it 'marks node as disconnected' do
         expect(subject).to receive(:update_node_containers)
+        expect(subject).to receive(:publish_update_event)
 
         expect {
           subject.unplug! connected_at, 1006, "Agent closed connection"
@@ -24,6 +25,21 @@ describe Agent::NodeUnplugger do
         expect(node.websocket_connection.opened).to be true
         expect(node.websocket_connection.close_code).to eq 1006
         expect(node.websocket_connection.close_reason).to eq "Agent closed connection"
+      end
+
+      it 'publishes an update event with connected status' do
+        expect(subject).to receive(:update_node_containers)
+
+        expect(node).to receive(:publish_async).with({
+          event: 'update',
+          type: 'HostNode',
+          object: hash_including(
+            name: 'test-node',
+            connected: false,
+          )
+        })
+
+        subject.unplug! connected_at, 1006, "Agent closed connection"
       end
     end
   end


### PR DESCRIPTION
Fixes #2991 by reloading the `HostNode` document after the `HostNode.where(...).find_one_and_update`, for both node plug and unplug.

### spec failure without fix
```
  1) Agent::NodeUnplugger For a connected node #unplug! publishes an update event with connected status
     Failure/Error: subject.unplug! connected_at, 1006, "Agent closed connection"
       test-node received :publish_async with unexpected arguments
         expected: ({:event=>"update", :type=>"HostNode", :object=>hash_including(:name=>"test-node", :connected=>false)})
              got: ({:event=>"update", :type=>"HostNode", :object=>{:id=>"/test-node", :connected=>true, :created_at=>"2017-11-02T15:15:32Z", :updated_at=>"2017-11-02T15:15:32Z", :last_seen_at=>nil, :name=>"test-node", :os=>nil, :engine_root_dir=>nil, :driver=>nil, :kernel_version=>nil, :labels=>[], :mem_total=>nil, :mem_limit=>nil, :cpus=>nil, :public_ip=>nil, :private_ip=>nil, :agent_version=>nil, :docker_version=>nil, :peer_ips=>[], :node_id=>"ABC", :node_number=>1, :initial_member=>true, :grid=>{:id=>nil, :name=>nil, :initial_size=>1, :stats=>{:statsd=>nil}, :trusted_subnets=>[]}, :resource_usage=>nil}})
       Diff:
       @@ -1,4 +1,33 @@
        [{:event=>"update",
          :type=>"HostNode",
       -  :object=>hash_including(:name=>"test-node", :connected=>false)}]
       +  :object=>
       +   {:id=>"/test-node",
       +    :connected=>true,
       +    :created_at=>"2017-11-02T15:15:32Z",
       +    :updated_at=>"2017-11-02T15:15:32Z",
       +    :last_seen_at=>nil,
       +    :name=>"test-node",
       +    :os=>nil,
       +    :engine_root_dir=>nil,
       +    :driver=>nil,
       +    :kernel_version=>nil,
       +    :labels=>[],
       +    :mem_total=>nil,
       +    :mem_limit=>nil,
       +    :cpus=>nil,
       +    :public_ip=>nil,
       +    :private_ip=>nil,
       +    :agent_version=>nil,
       +    :docker_version=>nil,
       +    :peer_ips=>[],
       +    :node_id=>"ABC",
       +    :node_number=>1,
       +    :initial_member=>true,
       +    :grid=>
       +     {:id=>nil,
       +      :name=>nil,
       +      :initial_size=>1,
       +      :stats=>{:statsd=>nil},
       +      :trusted_subnets=>[]},
       +    :resource_usage=>nil}}]
       
     # ./app/models/event_stream.rb:30:in `publish_update_event'
     # ./app/services/agent/node_unplugger.rb:47:in `publish_update_event'
     # ./app/services/agent/node_unplugger.rb:27:in `unplug!'
     # ./spec/services/agent/node_unplugger_spec.rb:42:in `block (4 levels) in <top (required)>'

  2) Agent::NodePlugger for an initializing node #plugin! publishes an update event with connected status
     Failure/Error: subject.plugin! connected_at
       test-node received :publish_async with unexpected arguments
         expected: ({:event=>"update", :type=>"HostNode", :object=>hash_including(:name=>"test-node", :connected=>true)})
              got: ({:event=>"update", :type=>"HostNode", :object=>{:id=>"test-grid/test-node", :connected=>false, :created_at=>"2017-11-02T15:15:33Z", :updated_at=>"2017-11-02T15:15:33Z", :last_seen_at=>nil, :name=>"test-node", :os=>nil, :engine_root_dir=>nil, :driver=>nil, :kernel_version=>nil, :labels=>[], :mem_total=>nil, :mem_limit=>nil, :cpus=>nil, :public_ip=>nil, :private_ip=>nil, :agent_version=>nil, :docker_version=>nil, :peer_ips=>[], :node_id=>"xyz", :node_number=>1, :initial_member=>true, :grid=>{:id=>"test-grid", :name=>"test-grid", :initial_size=>1, :stats=>{:statsd=>nil}, :trusted_subnets=>[]}, :resource_usage=>nil}})
       Diff:
       @@ -1,4 +1,33 @@
        [{:event=>"update",
          :type=>"HostNode",
       -  :object=>hash_including(:name=>"test-node", :connected=>true)}]
       +  :object=>
       +   {:id=>"test-grid/test-node",
       +    :connected=>false,
       +    :created_at=>"2017-11-02T15:15:33Z",
       +    :updated_at=>"2017-11-02T15:15:33Z",
       +    :last_seen_at=>nil,
       +    :name=>"test-node",
       +    :os=>nil,
       +    :engine_root_dir=>nil,
       +    :driver=>nil,
       +    :kernel_version=>nil,
       +    :labels=>[],
       +    :mem_total=>nil,
       +    :mem_limit=>nil,
       +    :cpus=>nil,
       +    :public_ip=>nil,
       +    :private_ip=>nil,
       +    :agent_version=>nil,
       +    :docker_version=>nil,
       +    :peer_ips=>[],
       +    :node_id=>"xyz",
       +    :node_number=>1,
       +    :initial_member=>true,
       +    :grid=>
       +     {:id=>"test-grid",
       +      :name=>"test-grid",
       +      :initial_size=>1,
       +      :stats=>{:statsd=>nil},
       +      :trusted_subnets=>[]},
       +    :resource_usage=>nil}}]
       
     # ./app/models/event_stream.rb:30:in `publish_update_event'
     # ./app/services/agent/node_plugger.rb:61:in `publish_update_event'
     # ./app/services/agent/node_plugger.rb:25:in `plugin!'
     # ./spec/services/agent/node_plugger_spec.rb:48:in `block (4 levels) in <top (required)>'
```