### PR TITLE
CLI: Use a unique temp dir during tests instead of /tmp

### DIFF
--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -27,7 +27,8 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = 'random'
   config.before(:each) do
-    allow(Dir).to receive(:home).and_return('/tmp/')
+    @_temp_home_dir = Dir.mktmpdir
+    allow(Dir).to receive(:home).and_return(@_temp_home_dir)
     allow(ENV).to receive(:[]).with(anything).and_call_original
     allow(ENV).to receive(:[]).with('DEBUG').and_call_original
     Kontena::Cli::Config.reset_instance
@@ -41,7 +42,7 @@ RSpec.configure do |config|
   config.after(:each) do
     RSpec::Mocks.space.proxy_for(File).reset
     RSpec::Mocks.space.proxy_for(Kontena::Cli::Config).reset
-    File.unlink(Kontena::Cli::Config.default_config_filename) if File.exist?(Kontena::Cli::Config.default_config_filename)
+    FileUtils.remove_entry @_temp_home_dir if @_temp_home_dir
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
Before this PR the tests always used `/tmp` as Dir.home.

This had some problems, such as destroying `/tmp/.kontena_client.json` in case it was moved there for temporary safekeeping.

It may also have had some problems on non-unix environments.

This PR makes the specs create a temporary dir for each test case and removes the tempdir when the test case is finished.
