### PR TITLE
CLI: Upgrade excon dependency to 0.59

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_runtime_dependency "excon", "~> 0.49.0"
+  spec.add_runtime_dependency "excon", "~> 0.59.0"
   spec.add_runtime_dependency "tty-prompt", "0.13.1"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -284,7 +284,7 @@ module Kontena
       retried ||= false
 
       if auth && token_expired?
-        raise Excon::Errors::Unauthorized, "Token expired or not valid, you need to login again, use: kontena #{token_is_for_master? ? "master" : "cloud"} login"
+        raise Excon::Error::Unauthorized, "Token expired or not valid, you need to login again, use: kontena #{token_is_for_master? ? "master" : "cloud"} login"
       end
 
       request_headers = request_headers(headers, auth)
@@ -325,7 +325,7 @@ module Kontena
       @last_response = http_client.request(request_options)
 
       parse_response(@last_response)
-    rescue Excon::Errors::Unauthorized
+    rescue Excon::Error::Unauthorized
       if token
         debug { 'Server reports access token expired' }
 
@@ -337,7 +337,7 @@ module Kontena
         retry if refresh_token
       end
       raise Kontena::Errors::StandardError.new(401, 'Unauthorized')
-    rescue Excon::Errors::HTTPStatusError => error
+    rescue Excon::Error::HTTPStatus => error
       debug { "Request #{error.request[:method].upcase} #{error.request[:path]}: #{error.response.status} #{error.response.reason_phrase}: #{error.response.body}" }
 
       handle_error_response(error.response)

--- a/cli/lib/kontena/command.rb
+++ b/cli/lib/kontena/command.rb
@@ -3,7 +3,7 @@ require 'kontena/cli/subcommand_loader'
 require 'kontena/util'
 require 'kontena/cli/bytes_helper'
 require 'kontena/cli/grid_options'
-require 'excon/errors'
+require 'excon/error'
 
 class Kontena::Command < Clamp::Command
 
@@ -221,7 +221,7 @@ class Kontena::Command < Clamp::Command
     run_callbacks :after unless help_requested?
     exit(@exit_code) if @exit_code.to_i > 0
     @result
-  rescue Excon::Errors::SocketError => ex
+  rescue Excon::Error::Socket => ex
     if ex.message.include?('Unable to verify certificate')
       $stderr.puts " [#{Kontena.pastel.red('error')}] The server uses a certificate signed by an unknown authority."
       $stderr.puts "         You can trust this server by copying server CA pem file to: #{Kontena.pastel.yellow("~/.kontena/certs/<hostname>.pem")}"

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -239,7 +239,7 @@ describe Kontena::Client do
         expect(http_client).to receive(:request).with(
           hash_including(path: '/v1/coffee', method: :brew)
         ) {
-          raise Excon::Errors::HTTPStatusError.new("I'm a teapot",
+          raise Excon::Error::HTTPStatus.new("I'm a teapot",
             {
               method: 'brew',
               path: '/v1/coffee',


### PR DESCRIPTION
Plugins do not seem to use any of the `Excon::Errors` classes, just `Excon.new` and  `Excon.defaults`.
