### PR TITLE
Server: Validate HostNode grid presence

### DIFF
--- a/server/app/models/host_node.rb
+++ b/server/app/models/host_node.rb
@@ -54,6 +54,7 @@ class HostNode
   has_many :volume_instances, dependent: :destroy
   has_and_belongs_to_many :images
 
+  validates :grid, presence: true
   validates :node_number, presence: true
   validates :name, presence: true
   validates_length_of :token, minimum: 16, maximum: 256, allow_nil: true

--- a/server/spec/services/grid_service_scheduler_spec.rb
+++ b/server/spec/services/grid_service_scheduler_spec.rb
@@ -5,7 +5,7 @@ describe GridServiceScheduler do
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
   let(:grid_nodes) do
     (1..3).map { |i|
-      HostNode.create!(node_id: SecureRandom.uuid, name: "node-#{i}", node_number: i, mem_total: 1.gigabytes)
+      grid.create_node!("node-#{i}", node_id: SecureRandom.uuid, mem_total: 1.gigabytes)
     }
   end
   let(:nodes) do

--- a/server/spec/services/scheduler/filter/port_spec.rb
+++ b/server/spec/services/scheduler/filter/port_spec.rb
@@ -1,17 +1,11 @@
 
 describe Scheduler::Filter::Port do
-
-  let(:nodes) do
-    nodes = []
-    nodes << HostNode.create!(node_id: 'node1', name: 'node-1', node_number: 1)
-    nodes << HostNode.create!(node_id: 'node2', name: 'node-2', node_number: 2)
-    nodes << HostNode.create!(node_id: 'node3', name: 'node-3', node_number: 3)
-    nodes
-  end
-
-  let(:grid) do
-    Grid.create!(name: 'test-grid')
-  end
+  let(:grid) { Grid.create(name: 'test') }
+  let(:nodes) { [
+    grid.create_node!('node-1'),
+    grid.create_node!('node-2'),
+    grid.create_node!('node-3'),
+  ] }
 
   let(:service) do
     GridService.create(

--- a/server/spec/services/volume_instance_deployer_spec.rb
+++ b/server/spec/services/volume_instance_deployer_spec.rb
@@ -11,7 +11,7 @@ describe VolumeInstanceDeployer do
     grid.grid_services.create!(name: 'redis', image_name: 'redis')
   end
 
-  let(:node) { HostNode.create!(node_id: SecureRandom.uuid, name: 'node', node_number: 1) }
+  let(:node) { grid.create_node!('node', node_id: SecureRandom.uuid) }
 
   it 'creates volume instance if needed' do
     expect_any_instance_of(RpcClient).to receive(:request).with('/volumes/notify_update', [])


### PR DESCRIPTION
Some specs were using `HostNode.create!(...)` without any `grid`. Add a `HostNode` model validation to fail the create, and then fix the specs to use `grid.create_node!`.

```
rspec ./spec/services/grid_service_scheduler_spec.rb:34 # GridServiceScheduler#filter_nodes filters every node
rspec ./spec/services/grid_service_scheduler_spec.rb:18 # GridServiceScheduler#select_node filters nodes
rspec ./spec/services/grid_service_scheduler_spec.rb:23 # GridServiceScheduler#select_node returns a node
rspec ./spec/services/volume_instance_deployer_spec.rb:16 # VolumeInstanceDeployer creates volume instance if needed
rspec ./spec/services/volume_instance_deployer_spec.rb:24 # VolumeInstanceDeployer creates volume instance if needed
rspec ./spec/services/scheduler/filter/port_spec.rb:39 # Scheduler::Filter::Port#for_service returns all nodes if nodes does not have any conflicting containers
rspec ./spec/services/scheduler/filter/port_spec.rb:44 # Scheduler::Filter::Port#for_service does not filter out same service instance
rspec ./spec/services/scheduler/filter/port_spec.rb:64 # Scheduler::Filter::Port#for_service returns empty array if nodes does not have port free
rspec ./spec/services/scheduler/filter/port_spec.rb:53 # Scheduler::Filter::Port#for_service returns filtered nodes
```

```
  1) Scheduler::Filter::Port#for_service does not filter out same service instance
     Failure/Error: nodes << HostNode.create!(node_id: 'node1', name: 'node-1', node_number: 1)
     Mongoid::Errors::Validations:
       
       message:
         Validation of HostNode failed.
       summary:
         The following errors were found: Grid can't be blank
       resolution:
         Try persisting the document with valid data or remove the validations.
     # ./vendor/bundle/ruby/2.3.0/gems/mongoid-5.2.1/lib/mongoid/persistable.rb:78:in `fail_due_to_validation!'
     # ./vendor/bundle/ruby/2.3.0/gems/mongoid-5.2.1/lib/mongoid/persistable/creatable.rb:180:in `block in create!'
     # ./vendor/bundle/ruby/2.3.0/gems/mongoid-5.2.1/lib/mongoid/threaded/lifecycle.rb:161:in `_creating'
     # ./vendor/bundle/ruby/2.3.0/gems/mongoid-5.2.1/lib/mongoid/persistable/creatable.rb:175:in `create!'
     # ./spec/services/scheduler/filter/port_spec.rb:6:in `block (2 levels) in <top (required)>'
     # ./spec/services/scheduler/filter/port_spec.rb:46:in `block (3 levels) in <top (required)>'
```