### PR TITLE
Fix CLI specs to not give false positives on SystemExit

### DIFF
--- a/cli/spec/kontena/cli/cloud/login_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/login_command_spec.rb
@@ -20,18 +20,15 @@ describe Kontena::Cli::Cloud::LoginCommand do
   end
 
   it 'should give error if trying to use --code and --force' do
-    expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-    subject.run(['--code', 'abcd', '--force'])
+    expect{subject.run(['--code', 'abcd', '--force'])}.to exit_with_error
   end
 
   it 'should give error if trying to use --token and --force' do
-    expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-    subject.run(['--token', 'abcd', '--force'])
+    expect{subject.run(['--token', 'abcd', '--force'])}.to exit_with_error
   end
 
   it 'should give error if trying to use --token and --code' do
-    expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-    subject.run(['--token', 'abcd', '--code', 'defg'])
+    expect{subject.run(['--token', 'abcd', '--code', 'defg'])}.to exit_with_error
   end
 
   context 'when config has token' do
@@ -180,8 +177,7 @@ describe Kontena::Cli::Cloud::LoginCommand do
           'error' => 'foo'
         })
         expect(Launchy).to receive(:open).and_return(true)
-        expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-        subject.run([])
+        expect{subject.run([])}.to exit_with_error.and output(/Authentication failed: foo/).to_stderr
       end
     end
   end
@@ -283,14 +279,12 @@ describe Kontena::Cli::Cloud::LoginCommand do
 
       it 'should exit with error if cloud responds with error' do
         expect(client).to receive(:get).and_return('error' => 'foo')
-        expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-        subject.update_userinfo
+        expect{subject.update_userinfo}.to exit_with_error
       end
 
       it 'should exit with error if cloud responds with something silly' do
         expect(client).to receive(:get).and_return('foo')
-        expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-        subject.update_userinfo
+        expect{subject.update_userinfo}.to exit_with_error
       end
     end
 
@@ -313,8 +307,7 @@ describe Kontena::Cli::Cloud::LoginCommand do
       end
 
       it 'should give error when response has error' do
-        expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-        subject.update_token('error' => 'fail!')
+        expect{subject.update_token('error' => 'fail!')}.to exit_with_error
       end
 
       it 'should raise if response is not a hash' do

--- a/cli/spec/kontena/cli/master/login_command_spec.rb
+++ b/cli/spec/kontena/cli/master/login_command_spec.rb
@@ -14,23 +14,19 @@ describe Kontena::Cli::Master::LoginCommand do
   let(:client) { double(:client) }
 
   it 'should exit with error if --code and --token both given' do
-    expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-    subject.run(%w(--code abcd --token defg))
+    expect{subject.run(%w(--code abcd --token defg))}.to exit_with_error
   end
 
   it 'should exit with error if --code and --join both given' do
-    expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-    subject.run(%w(--code abcd --join defg))
+    expect{subject.run(%w(--code abcd --join defg))}.to exit_with_error
   end
 
   it 'should exit with error if --code and --force both given' do
-    expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-    subject.run(%w(--code abcd --force))
+    expect{subject.run(%w(--code abcd --force))}.to exit_with_error
   end
 
   it 'should exit with error if --token and --force both given' do
-    expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-    subject.run(%w(--token abcd --force))
+    expect{subject.run(%w(--token abcd --force))}.to exit_with_error
   end
 
   describe '#select_a_server' do
@@ -49,8 +45,7 @@ describe Kontena::Cli::Master::LoginCommand do
 
       it 'exits with error if current_master not set' do
         expect(config).to receive(:current_master).and_return(nil)
-        expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-        subject.select_a_server(nil, nil)
+        expect{subject.select_a_server(nil, nil)}.to exit_with_error
       end
     end
 
@@ -88,8 +83,7 @@ describe Kontena::Cli::Master::LoginCommand do
         it 'should exit with error if a server with that name is found but it does not have an url' do
           server.url = nil
           expect(config).to receive(:find_server).with('foo').and_return(server)
-          expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-          subject.select_a_server('foo', nil)
+          expect{subject.select_a_server('foo', nil)}.to exit_with_error
         end
       end
     end
@@ -119,14 +113,12 @@ describe Kontena::Cli::Master::LoginCommand do
         it 'should exit with error if a server with that name is found but it does not have an url' do
           server.url = nil
           expect(config).to receive(:find_server).with('foo').and_return(server)
-          expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-          subject.select_a_server(nil, 'foo')
+          expect{subject.select_a_server(nil, 'foo')}.to exit_with_error
         end
 
         it 'should exit with error if a server with that name is not found' do
           expect(config).to receive(:find_server).with('foo').and_return(nil)
-          expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-          subject.select_a_server(nil, 'foo')
+          expect{subject.select_a_server(nil, 'foo')}.to exit_with_error
         end
       end
     end
@@ -350,24 +342,21 @@ describe Kontena::Cli::Master::LoginCommand do
       allow(Kontena::Client).to receive(:new).and_return(client)
       expect(client).to receive(:last_response).at_least(:once).and_return(OpenStruct.new(status: 400, headers: {}))
       expect(client).to receive(:request).and_return('error' => 'no good')
-      expect(subject).to receive(:exit_with_error).with(/no good/).and_throw(:exit_with_error)
-      subject.authentication_url_from_master('https://foo.example.com', remote: true)
+      expect{subject.authentication_url_from_master('https://foo.example.com', remote: true)}.to exit_with_error
     end
 
     it 'should exit with error if master returns text' do
       allow(Kontena::Client).to receive(:new).and_return(client)
       expect(client).to receive(:last_response).at_least(:once).and_return(OpenStruct.new(status: 400, headers: {}))
       expect(client).to receive(:request).and_return('Fail!')
-      expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-      subject.authentication_url_from_master('https://foo.example.com', remote: true)
+      expect{subject.authentication_url_from_master('https://foo.example.com', remote: true)}.to exit_with_error
     end
 
     it 'should exit with error if master returns nil' do
       allow(Kontena::Client).to receive(:new).and_return(client)
       expect(client).to receive(:last_response).at_least(:once).and_return(OpenStruct.new(status: 400, headers: {}))
       expect(client).to receive(:request).and_return(nil)
-      expect(subject).to receive(:exit_with_error).with(/Invalid.+?400/).and_throw(:exit_with_error)
-      subject.authentication_url_from_master('https://foo.example.com', remote: true)
+      expect{subject.authentication_url_from_master('https://foo.example.com', remote: true)}.to exit_with_error
     end
   end
 
@@ -399,8 +388,7 @@ describe Kontena::Cli::Master::LoginCommand do
     end
 
     it 'should exit with error if response has error' do
-      expect(subject).to receive(:exit_with_error).and_throw(:exit_with_error)
-      subject.update_server_token(server, "error" => "abcd")
+      expect{subject.update_server_token(server, "error" => "abcd")}.to exit_with_error
     end
 
     it 'should update the token if all is good' do

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -16,7 +16,7 @@ describe Kontena::Cli::Master::UseCommand do
     end
 
     it 'should abort with error message if master is not configured' do
-      expect { subject.run(['not_existing']) }.to output(/Could not resolve master with name: 'not_existing'/).to_stderr
+      expect { subject.run(['not_existing']) }.to exit_with_error.and output(/Could not resolve master with name: 'not_existing'/).to_stderr
     end
 
     it 'should abort with error message if master is not given' do

--- a/cli/spec/kontena/cli/master/use_command_spec.rb
+++ b/cli/spec/kontena/cli/master/use_command_spec.rb
@@ -16,7 +16,7 @@ describe Kontena::Cli::Master::UseCommand do
     end
 
     it 'should abort with error message if master is not configured' do
-      expect { subject.run(['not_existing']) }.to exit_with_error.and output(/Could not resolve master with name: 'not_existing'/).to_stderr
+      expect { subject.run(['not_existing']) }.to exit_with_error.and output(/Could not resolve master by name 'not_existing'/).to_stderr
     end
 
     it 'should abort with error message if master is not given' do

--- a/cli/spec/kontena/cli/nodes/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/remove_command_spec.rb
@@ -49,7 +49,7 @@ describe Kontena::Cli::Nodes::RemoveCommand do
     it 'does not remove the node' do
       expect(client).not_to receive(:delete)
 
-      expect{subject.run(['node-1'])}.to exit_with_error.and output(" [error] Node node-1 is still online. You must terminate the node before removing it.\n").to_stderr
+      expect{subject.run(['node-1'])}.to exit_with_error.and output(" [error] Node node-1 is still connected using a grid token. You must terminate the node before removing it.\n").to_stderr
     end
   end
 

--- a/cli/spec/kontena/cli/nodes/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/remove_command_spec.rb
@@ -49,7 +49,7 @@ describe Kontena::Cli::Nodes::RemoveCommand do
     it 'does not remove the node' do
       expect(client).not_to receive(:delete)
 
-      expect{subject.run(['node-1'])}.to output(" [error] Node node-1 is still online. You must terminate the node before removing it.\n").to_stderr
+      expect{subject.run(['node-1'])}.to exit_with_error.and output(" [error] Node node-1 is still online. You must terminate the node before removing it.\n").to_stderr
     end
   end
 

--- a/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
+++ b/cli/spec/kontena/cli/stacks/upgrade_command_spec.rb
@@ -76,7 +76,7 @@ describe Kontena::Cli::Stacks::UpgradeCommand do
           'stacks/test-grid/stack-a', anything
         ).and_return({})
         expect(Kontena).not_to receive(:run!).with(['stack', 'deploy', 'stack-a'])
-        subject.run(['--no-deploy', 'stack-a', fixture_path('kontena_v3.yml')])
+        subject.run(['--no-deploy', '--force', 'stack-a', fixture_path('kontena_v3.yml')])
       end
     end
 

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -48,8 +48,8 @@ RSpec.configure do |config|
     catch :exit_with_error do
       begin
         example.run
-      rescue SystemExit
-        puts "Got SystemExit: #{$!.message} - Exit code: #{$!.status}"
+      rescue SystemExit => exc
+        fail "SystemExit with code #{exc.status}: #{exc.message}"
       end
     end
   end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -45,6 +45,8 @@ RSpec.configure do |config|
   end
 
   config.around(:each) do |example|
+    stdout = $stdout
+    stderr = $stderr
     $stdout = $stderr = StringIO.new
 
     begin
@@ -52,8 +54,8 @@ RSpec.configure do |config|
     rescue SystemExit => exc
       fail "SystemExit with code #{exc.status}: \n#{$stderr.string}"
     ensure
-      $stdout = STDOUT
-      $stderr = STDERR
+      $stdout = stdout
+      $stderr = stderr
     end
   end
 end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -46,23 +46,16 @@ RSpec.configure do |config|
 
   config.around(:each) do |example|
     catch :exit_with_error do
+      $stdout = $stderr = StringIO.new
+
       begin
         example.run
       rescue SystemExit => exc
-        fail "SystemExit with code #{exc.status}: #{exc.message}"
+        fail "SystemExit with code #{exc.status}: \n#{$stderr.string}"
+      ensure
+        $stdout = STDOUT
+        $stderr = STDERR
       end
-    end
-  end
-
-  unless ENV["DEBUG"]
-    config.before(:each) do
-      $stdout = StringIO.new
-      $stderr = StringIO.new
-    end
-
-    config.after(:each) do
-      $stdout = STDOUT
-      $stderr = STDERR
     end
   end
 end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -45,17 +45,15 @@ RSpec.configure do |config|
   end
 
   config.around(:each) do |example|
-    catch :exit_with_error do
-      $stdout = $stderr = StringIO.new
+    $stdout = $stderr = StringIO.new
 
-      begin
-        example.run
-      rescue SystemExit => exc
-        fail "SystemExit with code #{exc.status}: \n#{$stderr.string}"
-      ensure
-        $stdout = STDOUT
-        $stderr = STDERR
-      end
+    begin
+      example.run
+    rescue SystemExit => exc
+      fail "SystemExit with code #{exc.status}: \n#{$stderr.string}"
+    ensure
+      $stdout = STDOUT
+      $stderr = STDERR
     end
   end
 end


### PR DESCRIPTION
The CLI specs were trapping `SystemExit`, and allowing any specs that hit `exit_with_error` to pass: https://github.com/kontena/kontena/blob/d2a8ef67cffbe62805f0b61419f9a74df84c3ae8/cli/spec/spec_helper.rb#L47-L55

Rescuing the `SystemExit` also bypassed any `except` assertions after/around the failing call, which includes `expect{...}.to output(...).to_stdout` assertions:

```ruby
    it 'should abort with error message if master is not configured' do
      expect { subject.run(['not_existing']) }.to output(/something that the command does not output/).to_stderr
      expect(true).to be false
    end
```

```
$ rspec --format doc --color spec/kontena/cli/master/use_command_spec.rb -e 'if master is not configured'

Kontena::Cli::Master::UseCommand
  #use
Got SystemExit: exit - Exit code: 1
    should abort with error message if master is not configured

Finished in 0.0288 seconds (files took 0.40903 seconds to load)
1 example, 0 failures
```

## Broken specs

Some specs were buggy but still passing because of this bug. Not aware of any bugs in the actual CLI code that were hidden by this bug, though:

```
  1) Kontena::Cli::Nodes::RemoveCommand for an online node without a node token does not remove the node
     Failure/Error: expect{subject.run(['node-1'])}.to exit_with_error.and output(" [error] Node node-1 is still online. You must terminate the node before removing it.\n").to_stderr
       expected block to output " [error] Node node-1 is still online. You must terminate the node before removing it.\n" to stderr, but output " [error] Node node-1 is still connected using a grid token. You must terminate the node before removing it.\n"
     # ./spec/kontena/cli/nodes/remove_command_spec.rb:52:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:52:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:48:in `catch'
     # ./spec/spec_helper.rb:48:in `block (2 levels) in <top (required)>'

  2) Kontena::Cli::Stacks::UpgradeCommand#execute --no-deploy option does not trigger deploy
     Failure/Error: fail "SystemExit with code #{exc.status}: \n#{$stderr.string}"
     
     RuntimeError:
       SystemExit with code 1: 
       * Reading stack stack-a from master.. 
       * Reading stack stack-a from master.. done
       * Parsing /home/kontena/kontena/kontena/cli/spec/fixtures/kontena_v3.yml.. 
       * Parsing /home/kontena/kontena/kontena/cli/spec/fixtures/kontena_v3.yml.. done
       * Analyzing upgrade.. 
       * Analyzing upgrade.. done
       SERVICES:
       ----------------------------------------
       These services will be removed from master:
        - stack-a/foo
     
       These new services will be created to master:
        - stack-a/wordpress
        - stack-a/mysql
     
       STACKS:
       ----------------------------------------
       These stacks will be upgraded:
       - stack-a
     
     
       Warning: This can not be undone, data will be lost.
        [error] Command requires --force
     # ./spec/spec_helper.rb:54:in `rescue in block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:58:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:48:in `catch'
     # ./spec/spec_helper.rb:48:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # SystemExit:
     #   exit
     #   ./lib/kontena/command.rb:222:in `exit'

  3) Kontena::Cli::Master::UseCommand#use should abort with error message if master is not configured
     Failure/Error: expect { subject.run(['not_existing']) }.to exit_with_error.and output(/Could not resolve master with name: 'not_existing'/).to_stderr
       expected block to output /Could not resolve master with name: 'not_existing'/ to stderr, but output " [error] Could not resolve master by name 'not_existing'. For a list of known masters please run: kontena master list\n"
     # ./spec/kontena/cli/master/use_command_spec.rb:19:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:52:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:48:in `catch'
     # ./spec/spec_helper.rb:48:in `block (2 levels) in <top (required)>'

Finished in 0.28216 seconds (files took 0.62986 seconds to load)
18 examples, 3 failures

Failed examples:

rspec ./spec/kontena/cli/nodes/remove_command_spec.rb:49 # Kontena::Cli::Nodes::RemoveCommand for an online node without a node token does not remove the node
rspec ./spec/kontena/cli/stacks/upgrade_command_spec.rb:73 # Kontena::Cli::Stacks::UpgradeCommand#execute --no-deploy option does not trigger deploy
rspec ./spec/kontena/cli/master/use_command_spec.rb:18 # Kontena::Cli::Master::UseCommand#use should abort with error message if master is not configured
```