### PR TITLE
Fix server omit container io.kontena.health_check.uri label for non-http health-check protocols

### DIFF
--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -118,7 +118,7 @@ module Rpc
         labels['io.kontena.load_balancer.mode'] = mode
       end
       if service.health_check && service.health_check.protocol
-        labels['io.kontena.health_check.uri'] = service.health_check.uri
+        labels['io.kontena.health_check.uri'] = service.health_check.uri if service.health_check.protocol == 'http'
         labels['io.kontena.health_check.protocol'] = service.health_check.protocol
         labels['io.kontena.health_check.interval'] = service.health_check.interval.to_s
         labels['io.kontena.health_check.timeout'] = service.health_check.timeout.to_s

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -242,6 +242,16 @@ describe Rpc::ServicePodSerializer do
         expect(labels).to include('io.kontena.health_check.initial_delay' => '10')
       end
 
+      it 'does not include health uri if tco check' do
+        service.health_check = GridServiceHealthCheck.new(port: 80, protocol: 'tcp')
+        expect(labels).to include('io.kontena.health_check.protocol' => 'tcp')
+        expect(labels).not_to include('io.kontena.health_check.uri' => '/')
+        expect(labels).to include('io.kontena.health_check.port' => '80')
+        expect(labels).to include('io.kontena.health_check.interval' => '60')
+        expect(labels).to include('io.kontena.health_check.timeout' => '10')
+        expect(labels).to include('io.kontena.health_check.initial_delay' => '10')
+      end
+
       it 'includes no health check labels if protocol nil' do
         service.health_check = GridServiceHealthCheck.new(uri: '/', port: 80)
         expect(labels).not_to include('io.kontena.health_check.protocol' => 'http')


### PR DESCRIPTION
fixes #3020 

Server will no longer send the URI for TCP checks. So the combination of `tcp` check and `http` mode LB link works. Even changing from `http` to `tcp` makes the agent to remove the URI from etcd as it gets the `io.kontena.health_check.uri` label as `nil`. 

I think it makes sense to have this kind of logic only on the server side.

# Testing

```
$ kontena service create --health-check-protocol http --health-check-port 80 nginx-health nginx:alpine
 [done] Creating nginx-health service      

$ kontena service deploy nginx-health
 [done] Deploying service nginx-health      
⊛ Deployed instance e2e/null/nginx-health-1 to node foo

$ docker inspect nginx-health-1 | jq .[0].Config.Labels | grep uri
  "io.kontena.health_check.uri": "/",
```
Now to change health check to `tcp` mode:
```
$ kontena service update --health-check-protocol tcp  --health-check-port 80 nginx-health
 [done] Updating nginx-health service      

$ kontena service deploy nginx-health
 [done] Deploying service nginx-health      
⊛ Deployed instance e2e/null/nginx-health-1 to node foo

$ docker inspect nginx-health-1 | jq .[0].Config.Labels | grep uri
<empty>
```
