### PR TITLE
Fix ping api to check that process is healthy

### DIFF
--- a/server/app/routes/v1/ping_api.rb
+++ b/server/app/routes/v1/ping_api.rb
@@ -1,5 +1,6 @@
 module V1
   class PingApi < Roda
+    include RequestHelpers
 
     plugin :json
     plugin :render, engine: 'json.jbuilder', views: 'app/views/v1/ping'
@@ -7,7 +8,13 @@ module V1
     route do |r|
       r.is do
         r.get do
-          render('show')
+          begin
+            Grid.count # test db connection
+            MongoPubsub.started? # test pubsub
+            render('show')
+          rescue
+            halt_request(500, {error: 'Internal server error'})
+          end
         end
       end
     end

--- a/server/app/routes/v1/ping_api.rb
+++ b/server/app/routes/v1/ping_api.rb
@@ -10,7 +10,7 @@ module V1
         r.get do
           begin
             Grid.count # test db connection
-            MongoPubsub.started? # test pubsub
+            MongoPubsub.actor.alive? # test pubsub
             render('show')
           rescue
             halt_request(500, {error: 'Internal server error'})

--- a/server/app/routes/v1/ping_api.rb
+++ b/server/app/routes/v1/ping_api.rb
@@ -12,7 +12,8 @@ module V1
             Grid.count # test db connection
             MongoPubsub.actor.alive? # test pubsub
             render('show')
-          rescue
+          rescue => ex
+            Logging.logger.error(ex)
             halt_request(500, {error: 'Internal server error'})
           end
         end

--- a/server/app/services/mongo_pubsub.rb
+++ b/server/app/services/mongo_pubsub.rb
@@ -137,6 +137,10 @@ class MongoPubsub
     !@supervisor.nil?
   end
 
+  def self.actor
+    @supervisor.actors.first
+  end
+
   # @param [Mongoid::Document] model
   def self.start!(model)
     @supervisor = Celluloid.supervise(as: :mongo_pubsub, type: MongoPubsub, args: [model])

--- a/server/spec/api/v1/ping_spec.rb
+++ b/server/spec/api/v1/ping_spec.rb
@@ -1,0 +1,19 @@
+describe '/v1/ping', celluloid: true do
+
+  it 'returns success' do
+    response = get '/v1/ping'
+    expect(response.status).to eq(200)
+  end
+
+  it 'returns error if mongo is down' do
+    expect(Grid).to receive(:count).and_raise(Mongo::Error::SocketError)
+    response = get '/v1/ping'
+    expect(response.status).to eq(500)
+  end
+
+  it 'returns error if pubsub is down' do
+    expect(MongoPubsub).to receive(:started?).and_raise(NoMethodError)
+    response = get '/v1/ping'
+    expect(response.status).to eq(500)
+  end
+end

--- a/server/spec/api/v1/ping_spec.rb
+++ b/server/spec/api/v1/ping_spec.rb
@@ -12,7 +12,9 @@ describe '/v1/ping', celluloid: true do
   end
 
   it 'returns error if pubsub is down' do
-    expect(MongoPubsub).to receive(:started?).and_raise(NoMethodError)
+    actor = double(:actor)
+    expect(actor).to receive(:alive?).and_raise(Celluloid::DeadActorError)
+    expect(MongoPubsub).to receive(:actor).and_return(actor)
     response = get '/v1/ping'
     expect(response.status).to eq(500)
   end


### PR DESCRIPTION
Currently `/v1/ping` is mostly used for health checks. Problem is that it will always respond `pong` even if server process mostly dead (because of db connections etc). This PR fixes this situation by adding few critical checks to ping api call.