### PR TITLE
Fix server RpcServer to be supervised and restart on crashes

### DIFF
--- a/server/app/boot_jobs.rb
+++ b/server/app/boot_jobs.rb
@@ -4,7 +4,6 @@ require_relative 'services/mongodb/migrator'
 
 unless ENV['RACK_ENV'] == 'test' || ENV['NO_MONGO_PUBSUB']
   MongoPubsub.start!(PubsubChannel)
-  RpcServer.supervise(as: :rpc_server)
 
   JobSupervisor.run!
   WorkerSupervisor.run!

--- a/server/app/boot_jobs.rb
+++ b/server/app/boot_jobs.rb
@@ -4,6 +4,8 @@ require_relative 'services/mongodb/migrator'
 
 unless ENV['RACK_ENV'] == 'test' || ENV['NO_MONGO_PUBSUB']
   MongoPubsub.start!(PubsubChannel)
+  RpcServer.supervise(as: :rpc_server)
+
   JobSupervisor.run!
   WorkerSupervisor.run!
 end

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -38,8 +38,7 @@ class WebsocketBackend
     @msg_counter = 0
     @msg_dropped = 0
     @queue = SizedQueue.new(QUEUE_SIZE)
-    @rpc_server = RpcServer.new(@queue)
-    @rpc_server.async.process!
+    RpcServer.supervise(as: :rpc_server, args: [@queue])
     subscribe_to_rpc_channel
     watch_connections
     watch_queue
@@ -507,9 +506,5 @@ class WebsocketBackend
 
     # triggers on :close later, or after 30s timeout, but the client will already be gone
     client[:ws].close(code, reason)
-  end
-
-  def stop_rpc_server
-    Celluloid::Actor.kill(@rpc_server) if @rpc_server.alive?
   end
 end

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -15,9 +15,8 @@ class WebsocketBackend
   CLOCK_SKEW = Kernel::Float(ENV['KONTENA_CLOCK_SKEW'] || 1.seconds)
 
   RPC_MSG_TYPES = %w(request notify)
-  QUEUE_SIZE = 1000
   QUEUE_WATCH_PERIOD = 60 # once in a minute
-  QUEUE_DROP_NOTIFICATIONS_LIMIT = (QUEUE_SIZE * 0.8)
+  QUEUE_DROP_NOTIFICATIONS_LIMIT = (RpcServer::QUEUE_SIZE * 0.8)
 
   class CloseError < StandardError
     attr_reader :code
@@ -29,6 +28,11 @@ class WebsocketBackend
 
   attr_reader :logger
 
+  # @return [SizedQueue]
+  def rpc_queue
+    RpcServer.queue
+  end
+
   def initialize(app)
     @app     = app
     @clients = []
@@ -37,8 +41,6 @@ class WebsocketBackend
     @logger.progname = 'WebsocketBackend'
     @msg_counter = 0
     @msg_dropped = 0
-    @queue = SizedQueue.new(QUEUE_SIZE)
-    RpcServer.supervise(as: :rpc_server, args: [@queue])
     subscribe_to_rpc_channel
     watch_connections
     watch_queue
@@ -293,21 +295,23 @@ class WebsocketBackend
   def handle_rpc_request(ws, data)
     client = client_for_ws(ws)
     if client
-      @queue << [ws, client[:grid_id].to_s, data]
+      self.rpc_queue << [ws, client[:grid_id].to_s, data]
     end
   end
 
   # @param [Faye::WebSocket::Event] ws
   # @param [Array] data
   def handle_rpc_notification(ws, data)
-    if @queue.size > QUEUE_DROP_NOTIFICATIONS_LIMIT # too busy to handle notifications
+    rpc_queue = self.rpc_queue
+
+    if rpc_queue.size > QUEUE_DROP_NOTIFICATIONS_LIMIT # too busy to handle notifications
       @msg_dropped += 1
       return
     end
 
     client = client_for_ws(ws)
     if client
-      @queue << [client[:grid_id].to_s, data]
+      rpc_queue << [client[:grid_id].to_s, data]
     end
   end
 
@@ -425,7 +429,9 @@ class WebsocketBackend
 
   def watch_queue
     EM::PeriodicTimer.new(QUEUE_WATCH_PERIOD) do
-      logger.warn "#{@queue.size} messages in queue" if @queue.size > QUEUE_DROP_NOTIFICATIONS_LIMIT
+      if (queue_size = self.rpc_queue.size) > QUEUE_DROP_NOTIFICATIONS_LIMIT
+        logger.warn "#{queue_size} messages in queue"
+      end
       logger.warn "#{@msg_dropped} dropped notifications" if @msg_dropped > 0
       logger.info "#{@msg_counter / QUEUE_WATCH_PERIOD} messages per second"
       @msg_counter = 0

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -7,6 +7,12 @@ class RpcServer
   include Celluloid
   include Logging
 
+  QUEUE_SIZE = 1000
+
+  def self.queue
+    @queue ||= SizedQueue.new(QUEUE_SIZE)
+  end
+
   HANDLERS = {
     'containers' => Rpc::ContainerHandler,
     'container_exec' => Rpc::ContainerExecHandler,
@@ -29,8 +35,8 @@ class RpcServer
   attr_reader :handlers
 
   # @param [SizedQueue] queue
-  def initialize(queue, autostart: true)
-    @queue = queue
+  def initialize(autostart: true)
+    @queue = self.class.queue
     @handlers = {}
     @counter = 0
     @processing = false

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -29,11 +29,13 @@ class RpcServer
   attr_reader :handlers
 
   # @param [SizedQueue] queue
-  def initialize(queue)
+  def initialize(queue, autostart: true)
     @queue = queue
     @handlers = {}
     @counter = 0
     @processing = false
+
+    async.process! if autostart
   end
 
   def process!

--- a/server/app/services/worker_supervisor.rb
+++ b/server/app/services/worker_supervisor.rb
@@ -1,4 +1,6 @@
 class WorkerSupervisor < Celluloid::Supervision::Container
+  supervise type: RpcServer, as: :rpc_server
+  
   pool GridServiceSchedulerWorker, as: :grid_service_scheduler_worker, size: 4
   pool StackDeployWorker, as: :stack_deploy_worker
   pool StackRemoveWorker, as: :stack_remove_worker

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -3,12 +3,11 @@ require_relative '../../app/middlewares/websocket_backend'
 describe WebsocketBackend, celluloid: true, eventmachine: true do
   let(:app) { spy(:app) }
   let(:subject) { described_class.new(app) }
+  let(:rpc_queue) { instance_double(SizedQueue) }
 
   let(:logger) { instance_double(Logger) }
   before do
-    # avoid spawning any RpcServer actor, because the actor thread will block on @queue.pop and Celluloid.shutdown will get stuck
-    # totally not needed because we don't have any specs for handle_rpc_* anyways
-    allow(RpcServer).to receive(:supervise)
+    allow(subject).to receive(:rpc_queue).and_return(rpc_queue)
     allow(subject).to receive(:logger).and_return(logger)
     allow(logger).to receive(:debug)
   end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -6,16 +6,15 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
 
   let(:logger) { instance_double(Logger) }
   before do
+    # avoid spawning any RpcServer actor, because the actor thread will block on @queue.pop and Celluloid.shutdown will get stuck
+    # totally not needed because we don't have any specs for handle_rpc_* anyways
+    allow(RpcServer).to receive(:supervise)
     allow(subject).to receive(:logger).and_return(logger)
     allow(logger).to receive(:debug)
   end
 
   before(:each) do
     stub_const('Server::VERSION', '0.9.1')
-  end
-
-  after(:each) do
-    subject.stop_rpc_server
   end
 
   describe '#our_version' do

--- a/server/spec/services/rpc_server_spec.rb
+++ b/server/spec/services/rpc_server_spec.rb
@@ -13,7 +13,7 @@ describe RpcServer, celluloid: true do
   end
 
   let(:queue) { SizedQueue.new(800) }
-  let(:subject) { described_class.new(queue) }
+  let(:subject) { described_class.new(queue, autostart: false) }
 
   let(:grid) { Grid.create!(name: 'test') }
 

--- a/server/spec/services/rpc_server_spec.rb
+++ b/server/spec/services/rpc_server_spec.rb
@@ -12,8 +12,8 @@ describe RpcServer, celluloid: true do
     end
   end
 
-  let(:queue) { SizedQueue.new(800) }
-  let(:subject) { described_class.new(queue, autostart: false) }
+  let(:queue) { RpcServer.queue }
+  let(:subject) { described_class.new(autostart: false) }
 
   let(:grid) { Grid.create!(name: 'test') }
 

--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -83,6 +83,12 @@ RSpec.configure do |config|
     end
   end
 
+  config.around :each do |ex|
+    Timeout.timeout(5.0) do
+      ex.run
+    end
+  end
+
   config.around :each, celluloid: true do |ex|
     Celluloid.boot
     ex.run


### PR DESCRIPTION
Fixes #3035 by allowing the `RpcServer` to restart on crashes and continue processing RPC requests from the queue
Also kinda fixes #2348 because there is no more `WebsocketBackend@rpc_server`... however now the Celluloid `@supervisor.inspect` will hang for the same reason... replacing that issue with #3040

Supervise the `RpcServer` globally via `boot_jobs.rb` like `MongoPubsub`, instead of spawning it as an un-supervised actor in `WebsocketBackend#initialize`. The RPC server queue is now a global `RpcServer.queue` class-instance variable, which persists across any `RpcServer` actor crash-and-restart.
