### PR TITLE
[WiP] Fix server MongoPubsub supervision

### DIFF
--- a/server/app/boot_jobs.rb
+++ b/server/app/boot_jobs.rb
@@ -3,8 +3,6 @@ require_relative 'services/worker_supervisor'
 require_relative 'services/mongodb/migrator'
 
 unless ENV['RACK_ENV'] == 'test' || ENV['NO_MONGO_PUBSUB']
-  MongoPubsub.start!(PubsubChannel)
-
   WorkerSupervisor.run!
   JobSupervisor.run!
 end

--- a/server/app/boot_jobs.rb
+++ b/server/app/boot_jobs.rb
@@ -4,6 +4,7 @@ require_relative 'services/mongodb/migrator'
 
 unless ENV['RACK_ENV'] == 'test' || ENV['NO_MONGO_PUBSUB']
   MongoPubsub.start!(PubsubChannel)
-  JobSupervisor.run!
+
   WorkerSupervisor.run!
+  JobSupervisor.run!
 end

--- a/server/app/services/mongo_pubsub.rb
+++ b/server/app/services/mongo_pubsub.rb
@@ -110,40 +110,44 @@ class MongoPubsub
     @subscriptions = []
   end
 
+  # @return [Celluloid::Proxy::Cell<MongoPubsub>]
+  def self.actor
+    Celluloid::Actor[:mongo_pubsub]
+  end
+
+  # Celluloid has been booted and the supervised actor started.
+  # This will still return true if the actor has died.
+  #
+  # @return [Boolean]
+  def self.started?
+    !!self.actor
+  end
+
   # @param [String] channel
   # @param [Hash] data
   def self.publish(channel, data)
-    @supervisor.actors.first.publish(channel, data)
+    self.actor.publish(channel, data)
   end
 
   # @param [String] channel
   # @param [Hash] data
   def self.publish_async(channel, data)
-    @supervisor.actors.first.async.publish(channel, data)
+    self.actor.async.publish(channel, data)
   end
 
   # @param [String] channel
   # @return [Subscription]
   def self.subscribe(channel, &block)
-    @supervisor.actors.first.subscribe(channel, block)
+    self.actor.subscribe(channel, block)
   end
 
   # @param [Subscription] subscription
   def self.unsubscribe(subscription)
-    @supervisor.actors.first.unsubscribe(subscription)
-  end
-
-  def self.started?
-    !@supervisor.nil?
-  end
-
-  # @param [Mongoid::Document] model
-  def self.start!(model)
-    @supervisor = Celluloid.supervise(as: :mongo_pubsub, type: MongoPubsub, args: [model])
+    self.actor.unsubscribe(subscription)
   end
 
   def self.clear!
-    @supervisor.actors.first.clear!
+    self.actor.clear!
   end
 
   private

--- a/server/app/services/worker_supervisor.rb
+++ b/server/app/services/worker_supervisor.rb
@@ -1,4 +1,6 @@
 class WorkerSupervisor < Celluloid::Supervision::Container
+  supervise type: MongoPubsub, as: :mongo_pubsub, args: [PubsubChannel]
+
   pool GridServiceSchedulerWorker, as: :grid_service_scheduler_worker, size: 4
   pool StackDeployWorker, as: :stack_deploy_worker
   pool StackRemoveWorker, as: :stack_remove_worker

--- a/server/spec/models/event_stream_spec.rb
+++ b/server/spec/models/event_stream_spec.rb
@@ -81,6 +81,7 @@ describe EventStream do
 
   describe '#publish_async' do
     it 'publishes pub sub message to EventStream channel' do
+      expect(MongoPubsub).to receive(:started?).and_return(true)
       expect(MongoPubsub).to receive(:publish_async).with(EventStream.channel, {}).once
       subject.publish_async({})
     end

--- a/server/spec/mutations/grids/update_spec.rb
+++ b/server/spec/mutations/grids/update_spec.rb
@@ -9,7 +9,7 @@ describe Grids::Update do
   let(:grid_scheduler_job_async) { instance_double(GridSchedulerJob) }
 
   before do
-    allow(Celluloid::Actor).to receive(:[]).with(:grid_scheduler_job).and_return(grid_scheduler_job)
+    allow_any_instance_of(described_class).to receive(:grid_scheduler).and_return(grid_scheduler_job)
     allow(grid_scheduler_job).to receive(:async).and_return(grid_scheduler_job_async)
   end
 

--- a/server/spec/services/mongo_pubsub_spec.rb
+++ b/server/spec/services/mongo_pubsub_spec.rb
@@ -3,8 +3,8 @@ describe MongoPubsub, :celluloid => true do
 
   describe '.publish' do
     it 'sends message to channel subscribers' do
-      david = spy(:david)
-      lisa = spy(:lisa)
+      david = double(:david)
+      lisa = double(:lisa)
       messages = []
       subs = []
       subs << described_class.subscribe('channel1') {|msg|
@@ -96,15 +96,18 @@ describe MongoPubsub, :celluloid => true do
       sub1.terminate
       sub2.terminate
 
-      thread_count = Thread.list.count
-
-      sub1 = described_class.subscribe('channel1') {|msg| }
-      sub2 = described_class.subscribe('channel1') {|msg| }
-      sub1.terminate
-      sub2.terminate
-
+      MongoPubsub.actor.inspect # ping to allow subscriptions to terminate
       GC.start
-      expect(thread_count == Thread.list.count).to be_truthy
+
+      expect{
+        sub1 = described_class.subscribe('channel1') {|msg| }
+        sub2 = described_class.subscribe('channel1') {|msg| }
+        sub1.terminate
+        sub2.terminate
+
+        MongoPubsub.actor.inspect # ping to allow subscriptions to terminate
+        GC.start
+      }.to_not change{Thread.list}
     end
 
     it 'should perform', performance: true do


### PR DESCRIPTION
TODO: fix spec flakyness

The way the server `MongoPubsub` was using [`@supervision = Celluloid.supervise(...)`](https://github.com/kontena/kontena/blob/dd68aadceb3f8d0cc6e447b54095ae60ea2f1e37/server/app/services/mongo_pubsub.rb#L142) and [`@supervisor.actors.first`](https://github.com/kontena/kontena/blob/dd68aadceb3f8d0cc6e447b54095ae60ea2f1e37/server/app/services/mongo_pubsub.rb#L116) was wrong: calling `MongoPubsub.supervise` or `Celluloid.supervise(type: MongoPubsub` does not return a supervisor for that specific actor: it returns the default ` Celluloid::Supervision::Service::Public` supervisor actor used for **all** actors. The `MongoPubsub` class methods only worked because `MongoPubsub` was the first (and only?) actor being supervised outside of the non-default `JobSupervisor` and `WorkerSupervisor` supervision containers.

Changing the `boot_jobs.rb` to call `RpcServer.supervise` before `MongoPubsub.start!` to demonstrate this confusion:

```
MongoPubsub#start!: @supervisor=#<Celluloid::Supervision::Service::Public:0x005649a306ec10> actors=["#<RpcServer:0x005649a40b3ee0>", "#<MongoPubsub:0x005649a40a0fe8>"]
E, [2017-11-13T15:31:36.041286 #3246] ERROR -- : Actor crashed!
NoMethodError: undefined method `subscribe' for #<RpcServer:0x2b24d2059f70>
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:42:in `rescue in check'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:39:in `check'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:26:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:16:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
	(celluloid):0:in `remote procedure call'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:45:in `value'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/proxy/sync.rb:22:in `method_missing'
	/app/app/services/mongo_pubsub.rb:128:in `subscribe'
	/app/app/jobs/leader_elector_job.rb:50:in `listen_events'
	/app/app/jobs/leader_elector_job.rb:18:in `perform'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/async.rb:7:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```

This fix needs some spec fixes to not mock `Celluloid::Actor[...]`, and to not assume that `MongoPubsub.started?` without `:celluloid => true`. A new `MongoPubsub` actor is now started for each `:celluloid => true` spec, instead of calling `clear!` before each spec... I'm not sure how that was even working for non-`:celluloid => true` specs after `Celluloid.shutdown`?