### PR TITLE
Fix POST /v1/grids/:grid/external_registries API error response

### DIFF
--- a/server/app/routes/v1/grids/external_registries.rb
+++ b/server/app/routes/v1/grids/external_registries.rb
@@ -26,8 +26,7 @@ V1::GridsApi.route('external_registries') do |r|
         response.status = 201
         render('external_registries/show')
       else
-        response.status = 422
-        outcome.errors.message
+        halt_request(422, { error: outcome.errors.message })
       end
     end
   end

--- a/server/spec/api/v1/grid_external_registries_spec.rb
+++ b/server/spec/api/v1/grid_external_registries_spec.rb
@@ -54,6 +54,18 @@ describe '/v1/grids/:name/external_registries' do
       post "/v1/grids/#{grid.to_path}/external_registries", data.to_json
       expect(response.status).to eq(403)
     end
+
+    it 'handles validation errors' do
+      data = {username: 'david', password: 'secret', email: david.email, url: 'index.docker.io'}
+      expect {
+        post "/v1/grids/#{grid.to_path}/external_registries", data.to_json, request_headers
+      }.to_not change{ grid.registries.count }
+
+      expect(response.status).to eq(422)
+      expect(json_response).to eq(
+        'error' => { 'url' => "Url isn't in the right format" },
+      )
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #2400
Complements #3034 

The server was returning the wrong kind of error response JSON for `POST /v1/grids/:grid/external_registries`:

```json
DEBUG Request POST /v1/grids/development/external_registries: 422 Unprocessable Entity: {"url":"Url isn't in the right format"}
```

Fixed to use the same `halt_request(422, { error: outcome.errors.message })` copypasta as everything else:

```json
DEBUG Request POST /v1/grids/development/external_registries: 422 Unprocessable Entity: {"error":{"url":"Url isn't in the right format"}}
```

Now the CLI can understand the server-side validation/mutations errors:

```
$ bin/kontena external-registry add -u test -e test@test -p 'test' images.example.com
 [fail] Adding images.example.com to external registries      
 [error] 422 : Unprocessable Entity:
	url: Url isn't in the right format
```