### PR TITLE
Server: Mongo debug logging with DEBUG_MONGO=true

### DIFF
--- a/server/app/initializers/00_mongoid.rb
+++ b/server/app/initializers/00_mongoid.rb
@@ -1,6 +1,6 @@
 Mongoid.load!('./config/mongoid.yml', ENV['RACK_ENV'])
 Mongoid.raise_not_found_error
-Mongo::Logger.logger.level = Logger::WARN
+Mongo::Logger.logger.level = ENV['DEBUG_MONGO'] ? Logger::DEBUG : Logger::WARN
 
 # Returns an array such as [3, 0, 12, 0]
 mongo_db_version = Mongoid.default_client.command(buildinfo: 1).documents.first["versionArray"]
@@ -8,4 +8,3 @@ mongo_db_version = Mongoid.default_client.command(buildinfo: 1).documents.first[
 unless mongo_db_version[0] == 3 && mongo_db_version[1] >= 0
   abort "MongoDB version >= 3.0 is required for running Kontena Master. Your version #{mongo_db_version[0]}.#{mongo_db_version[1]}.#{mongo_db_version[2]} is incompatible."
 end
-


### PR DESCRIPTION
Add a `DEBUG_MONGO=true` env to the server for testing/debugging mongo queries, rather than hacking `server/app/initializers/00_mongoid.rb` every time.