### PR TITLE
Fix crash in kontena external registry ls -q

### DIFF
--- a/cli/lib/kontena/cli/external_registries/list_command.rb
+++ b/cli/lib/kontena/cli/external_registries/list_command.rb
@@ -9,7 +9,7 @@ module Kontena::Cli::ExternalRegistries
     requires_current_grid
 
     def fields
-      quiet? ? %(name) : %w(name username email)
+      quiet? ? %w(name) : %w(name username email)
     end
 
     def external_registries

--- a/test/spec/features/external_registry/list_spec.rb
+++ b/test/spec/features/external_registry/list_spec.rb
@@ -12,6 +12,7 @@ describe 'external-registry ls' do
     context '-q' do
       it "outputs nothing" do
         k = run 'kontena external-registry ls -q'
+        expect(k.code).to be_zero
         expect(k.out.strip).to be_empty
       end
     end

--- a/test/spec/features/external_registry/list_spec.rb
+++ b/test/spec/features/external_registry/list_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'external-registry ls' do
+  context 'when empty' do
+    it "outputs headers" do
+      k = run('kontena external registry ls')
+      expect(k.code).to be_zero
+      expect(k.out).to match(/NAME/)
+      expect(k.out.lines.size).to eq 1
+    end
+
+    context '-q' do
+      it "outputs nothing" do
+        k = run 'kontena external-registry ls -q'
+        expect(k.out.strip).to be_empty
+      end
+    end
+  end
+
+  context 'when not empty' do
+    before do
+      run 'kontena external-registry add -u foo -e foo@no.email -p secret registry.domain.com'
+    end
+
+    after do
+      run 'kontena external-registry rm --force registry.domain.com'
+    end
+
+    it "returns a list" do
+      k = run('kontena external registry ls')
+      expect(k.code).to be_zero
+      expect(k.out.lines.first).to match(/NAME/)
+      expect(k.out.lines.last).to start_with 'registry.domain.com'
+      expect(k.out.lines.last).to include 'foo'
+      expect(k.out.lines.last).not_to include 'secret'
+      expect(k.out.lines.size).to eq 2
+    end
+
+    context '-q' do
+      it "outputs the registry name" do
+        k = run 'kontena external-registry ls -q'
+        expect(k.code).to be_zero
+        expect(k.out.strip).to eq 'registry.domain.com'
+      end
+    end
+  end
+end

--- a/test/spec/features/external_registry/list_spec.rb
+++ b/test/spec/features/external_registry/list_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'external-registry ls' do
   context 'when empty' do
     it "outputs headers" do
-      k = run('kontena external registry ls')
+      k = run('kontena external-registry ls')
       expect(k.code).to be_zero
       expect(k.out).to match(/NAME/)
       expect(k.out.lines.size).to eq 1
@@ -28,7 +28,7 @@ describe 'external-registry ls' do
     end
 
     it "returns a list" do
-      k = run('kontena external registry ls')
+      k = run('kontena external-registry ls')
       expect(k.code).to be_zero
       expect(k.out.lines.first).to match(/NAME/)
       expect(k.out.lines.last).to start_with 'registry.domain.com'


### PR DESCRIPTION
Fixes #3050

A typo in the list-command caused `kontena external-registry ls -q` to crash with
```
NoMethodError : undefined method `map' for "name":String`
```

