### PR TITLE
Require --force if some items in node label rm list are missing

### DIFF
--- a/cli/lib/kontena/cli/nodes/labels/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/labels/remove_command.rb
@@ -5,14 +5,28 @@ module Kontena::Cli::Nodes::Labels
     parameter "NODE", "Node name"
     parameter "LABEL ...", "Labels"
 
+    option '--force', :flag, "Do not abort if items in label list are not found"
+
     requires_current_master
     requires_current_master_token
     requires_current_grid
 
     def execute
-      node = client.get("nodes/#{current_grid}/#{self.node}")
-      data = { labels: Array(node['labels']).reject {|label| label_list.include?(label) } }
-      client.put("nodes/#{node['id']}", data)
+      node_data = client.get("nodes/#{current_grid}/#{self.node}")
+
+      node_data['labels'] ||= []
+
+      found_labels = label_list.uniq & node_data['labels']
+
+      if !force? && found_labels.size != label_list.uniq.size
+        missing = label_list - found_labels
+        exit_with_error "Label#{'s' if missing.size > 1} #{pastel.cyan(missing.join(', '))} not found on node #{pastel.cyan(node)}"
+      end
+
+      return nil if found_labels.empty?
+
+      data = { labels: node_data['labels'] - found_labels }
+      client.put("nodes/#{node_data['id']}", data)
     end
   end
 end

--- a/cli/spec/kontena/cli/nodes/labels/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/nodes/labels/remove_command_spec.rb
@@ -18,11 +18,20 @@ describe Kontena::Cli::Nodes::Labels::RemoveCommand do
       }
     end
 
-    it "doesn't remove anything" do
-      expect(client).to receive(:put).with('nodes/test-grid/node', {
-          labels: [],
-      })
-      subject.run(['node', 'test=yes'])
+    context "when removing an unknown label" do
+      context "with --force" do
+        it 'does nothing' do
+          expect(client).not_to receive(:put)
+          expect{subject.run(['--force', 'node', 'test=yes'])}.not_to exit_with_error
+        end
+      end
+
+      context "without --force" do
+        it "exits with error" do
+          expect(client).not_to receive(:put)
+          expect{subject.run(['node', 'test=yes'])}.to exit_with_error.and output(/not found/).to_stderr
+        end
+      end
     end
   end
 
@@ -52,6 +61,27 @@ describe Kontena::Cli::Nodes::Labels::RemoveCommand do
       })
 
       subject.run(['node', 'test=yes', 'test=no'])
+    end
+
+    context "when removing an unknown label" do
+      context "without --force" do
+        it "exits with error" do
+          expect{subject.run(['node', 'test=yes', 'test=no', 'test=maybe'])}.to exit_with_error.and output(/Label test=maybe not found/).to_stderr
+        end
+
+        it "exits with plural error" do
+          expect{subject.run(['node', 'test=yes', 'test=no', 'test=maybe', 'test=almost'])}.to exit_with_error.and output(/Labels test=maybe, test=almost not found/).to_stderr
+        end
+      end
+      context "with --force" do
+        it 'ignores any labels that were not found with --force' do
+          expect(client).to receive(:put).with('nodes/test-grid/node', {
+              labels: ['test=yes'],
+          })
+
+          expect{subject.run(['--force', 'node', 'test=no', 'test=maybe', 'test=almost'])}.not_to exit_with_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #3064

Makes the `kontena node label remove` command exit with error when trying to remove a nonexisting label / labels.

You can force the removal of the ones that do exist by using `--force`.

Not sure if 1.4.3 or 1.5.0. In a way it's a breaking change. On the other hand, the wrong exit code could be considered a bug.
