### PR TITLE
Agent: Close websocket early during agent shutdown, and on actor termination

### DIFF
--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -112,8 +112,21 @@ module Kontena
       end
     end
 
+    # yield websocket client actor if exists and alive
+    #
+    def close_websocket_client(**options)
+      if websocket_client = Celluloid::Actor[:websocket_client]
+        websocket_client.close!(**options)
+      end
+    rescue => exc
+      error exc
+    end
+
     def handle_shutdown
       info "Shutting down..."
+
+      close_websocket_client reason: "Agent shutting down..."
+
       @supervisor.shutdown # shutdown all actors
       @write_pipe.close # let run! break and return
     end

--- a/agent/lib/kontena/websocket_client.rb
+++ b/agent/lib/kontena/websocket_client.rb
@@ -400,10 +400,10 @@ module Kontena
 
     # Close the websocket connection
     # The connect_client => defer thread will exit once the server acknowledges the close
-    def close!
+    def close!(code: 1000, reason: nil)
       if ws = @ws
         info "close..."
-        ws.close(1000, "Terminated")
+        ws.close(code, reason)
       else
         debug "close: not connected"
       end
@@ -414,7 +414,7 @@ module Kontena
     # Actor terminated, disconnect
     # NOTE: the connect_client task will get Celluloid::TaskTerminated, and will not see the disconnect
     def finalize
-      close!
+      close! reason: "Terminated"
 
       info "terminated"
     end

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -621,7 +621,7 @@ describe Kontena::WebsocketClient, :celluloid => true do
 
     describe '#disconnected!' do
       it "reconnects" do
-        expect(subject.wrapped_object).to receive(:reconnect!)
+        expect(subject).to receive(:reconnect!)
 
         subject.disconnected!
 
@@ -649,6 +649,35 @@ describe Kontena::WebsocketClient, :celluloid => true do
         expect(ws_client).to receive(:close).with(1000, "Testing")
 
         actor.close! reason: "Testing"
+
+        expect(subject).to be_closed
+      end
+    end
+
+    context 'which is closed?' do
+      before do
+        expect(ws_client).to receive(:close)
+
+        actor.close!
+      end
+
+      describe '#disconnected!' do
+        it 'does not reconnect' do
+          expect(subject).to_not receive(:reconnect!)
+
+          actor.disconnected!
+
+          expect(subject).to_not be_connected
+        end
+      end
+
+      describe '#reconnect!' do
+        it 'does not connect' do
+          expect(subject).to receive(:reconnect_backoff).and_return(0)
+          expect(subject).to_not receive(:connect!)
+
+          actor.reconnect!
+        end
       end
     end
   end

--- a/agent/spec/lib/kontena/websocket_client_spec.rb
+++ b/agent/spec/lib/kontena/websocket_client_spec.rb
@@ -646,9 +646,9 @@ describe Kontena::WebsocketClient, :celluloid => true do
 
     describe '#close!' do
       it 'closes the websocket client' do
-        expect(ws_client).to receive(:close).with(1000, "Terminated")
+        expect(ws_client).to receive(:close).with(1000, "Testing")
 
-        actor.close!
+        actor.close! reason: "Testing"
       end
     end
   end


### PR DESCRIPTION
Mitigation for #2733 to have the agent disconnect from the master faster when shutting down or terminating itself

If the `Kontena::WebsocketClient` was terminated by Celluloid, the websocket may remain connected for a brief period of time, because the `connect_client` => `Celluloid.defer` thread (running `Kontena::Websocket::Client#read`) will still remain alive and responding to websocket pings: only the `connect_client` task/fiber gets terminated (`Celluloid.defer` raises `Celluloid::TaskTerminated`). This means means that the server may still see the node as online, even though `Celluloid.shutdown` was triggered or the supervisor actor crashed/terminated and terminated all supervised actors. 

As an implementation detail of the new `Kontena::WebsocketClient` actor design in 1.4, the `read` thread will crash on the first received websocket message, because the [`actor.on_message`](https://github.com/kontena/kontena/blob/v1.4.0/agent/lib/kontena/websocket_client.rb#L146) call will raise `Celluloid::DeadActorError` and crash the `defer` thread, dropping the last reference to the `Kontena::Websocket::Client` and closing the socket.

Fixes the `Kontena::WebsocketClient` to explicitly close the websocket connection early in the `Kontena::Agent` shutdown handler, as well as in the actor finalizer.