### PR TITLE
Fix agent LogWorker to not exclusively sleep in start until websocket connected

### DIFF
--- a/agent/lib/kontena/workers/log_worker.rb
+++ b/agent/lib/kontena/workers/log_worker.rb
@@ -74,9 +74,9 @@ module Kontena::Workers
 
     # Start streaming and processing after etcd is running
     def start
-      exclusive {
-        wait_until!("etcd running") { Actor[:etcd_launcher].running? }
+      wait_until!("etcd running") { Actor[:etcd_launcher].running? }
 
+      exclusive {
         start_streaming unless streaming?
         resume_processing
       }


### PR DESCRIPTION
Fixes #3067

The agent `LogWorker#start` was blocking the actor in an exclusive sleep until the websocket was connected, the node info updated, and the etcd launcher started. This caused a deadlock for the websocket connection close -> `Kontena::Agent.shutdown`, because the shutdown blocked on the `LogWorker` terminate, and the agent was unable to shut down for e.g. version upgrades until the wait timed out and the `LogWorker` crashed.