### PR TITLE
Allow configuring of Mongo ssl_verify and ssl_ca_cert through env

### DIFF
--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -25,6 +25,7 @@ production:
         max_pool_size: 40
         write:
           w: 1
+        ssl_verify: <%= ENV['MONGODB_SSL_VERIFY'] || true %>
       uri: <%= ENV['MONGODB_URI'] || ENV['MONGOHQ_URL'] %>
   options:
     use_utc: true

--- a/server/config/mongoid.yml
+++ b/server/config/mongoid.yml
@@ -26,6 +26,9 @@ production:
         write:
           w: 1
         ssl_verify: <%= ENV['MONGODB_SSL_VERIFY'] || true %>
+        <% if ENV['MONGODB_SSL_CA_CERT'] %>
+        ssl_ca_cert: <%= ENV['MONGODB_SSL_CA_CERT'] %>
+        <% end %>
       uri: <%= ENV['MONGODB_URI'] || ENV['MONGOHQ_URL'] %>
   options:
     use_utc: true


### PR DESCRIPTION
Compose, and probably other Mongo as a service providers, configure mongo behind SSL termination. In Compose, the SSL is not using trusted CA roots and thus when `ssl_verify == true` by default, the connection is not allowed.

<details>
  <summary>SSL Examination:</summary>
  
```
root@compose-test-master:~# openssl s_client -connect aws-eu-central-1-portal.1.dblayer.com:16749 -servername aws-eu-central-1-portal.1.dblayer.com
CONNECTED(00000003)
depth=0 CN = illustrious-mongodb-60
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 CN = illustrious-mongodb-60
verify error:num=21:unable to verify the first certificate
verify return:1
---
Certificate chain
 0 s:/CN=illustrious-mongodb-60
   i:/CN=Kontena Inc.-a1fc8abee11db4f0ab93118b359c3a3c
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIDhDCCAmygAwIBAgIEWhQZOjANBgkqhkiG9w0BAQ0FADA4MTYwNAYDVQQDDC1L
b250ZW5hIEluYy4tYTFmYzhhYmVlMTFkYjRmMGFiOTMxMThiMzU5YzNhM2MwHhcN
MTcxMTIxMTIxNjU4WhcNMzcxMTIxMTIwMDAwWjAhMR8wHQYDVQQDDBZpbGx1c3Ry
aW91cy1tb25nb2RiLTYwMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
x052wsgTcJY0zuFPA1WlGzwbACJzDx3BJVR8ZkOhKJXM3X2QQgFk1UZ5OpdX+fk2
XiaZrIxHjMOXyjiLI2qGP97IAXXFa7SdX+sqa8tmS7LUhyejPr7Hzf0ToQU9/8dG
jMqRB3yAtSIUSA/jIX8ONEvWZVuLVMGyB5nUt8Rx65JEBykJj5oiqCXtyO9dBumF
B9ZrYePKtrkC6Jj3OIoQEiovXAbCjkCGdjpNON67gmTNfXWr2MTYWxoaWXn+v0Q3
rmN2pnBhnJRxBvTbLH7eLPeoVbwuizHg3xx5NWwdkzevaqEn2oxpIqJT/aNCvvr2
kv2/A3gv5ihrI0Nxw/Tb5QIDAQABo4GsMIGpMB0GA1UdDgQWBBTlNq6HX9YCaFhu
/WMWwvAKywLgJDAwBgNVHREEKTAngiVhd3MtZXUtY2VudHJhbC0xLXBvcnRhbC4x
LmRibGF5ZXIuY29tMAsGA1UdDwQEAwIGwDAdBgNVHSUEFjAUBggrBgEFBQcDAQYI
KwYBBQUHAwIwCQYDVR0TBAIwADAfBgNVHSMEGDAWgBR4S/sk/YJEZKclLjnJI/9R
RKrNyTANBgkqhkiG9w0BAQ0FAAOCAQEAHR2uC5urHZZPgq7rSsiOaBd8Cd9pNoQr
OcCg/T46O03ivBupTEJjWtGsoUiVFXpzTqgm44A+iI/sSRfB4XewUpqaj+wkMGa1
fTavk0zCrCafy3zkymuznQQvPJoVjvlPTPwghP4KBljdwVIGZpryq/W1xitVXJ+u
pc2cnJzz6PVR0UjhYEUKfg713bN/+YWV0w0XZPHmgLXrp15WYJMreqRcyguyX4oo
Y6yRlPWLV7SmvD0Zs0W2FI5Jb7uVG3xWmwpK2kNMtaJI/XStiCBxTZOu5Sxn+Ssb
Mw8gaTvILk54evMDcERHKsZeqvyoVHikF6kykkITC0DwZM8/Ba4YlA==
-----END CERTIFICATE-----
subject=/CN=illustrious-mongodb-60
issuer=/CN=Kontena Inc.-a1fc8abee11db4f0ab93118b359c3a3c
---
No client certificate CA names sent
Peer signing digest: SHA512
Server Temp Key: ECDH, P-256, 256 bits
---
SSL handshake has read 1615 bytes and written 477 bytes
---
New, TLSv1/SSLv3, Cipher is ECDHE-RSA-AES256-GCM-SHA384
Server public key is 2048 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-AES256-GCM-SHA384
    Session-ID: 3538829A0385743FFE6D0780360A4642E616AD4C5395DFF37A9AE5413E2720FD
    Session-ID-ctx: 
    Master-Key: 677233C9D4194549A85315BB8AA0579316B1654F5E892DC1D37AAF1FFE91C982CA29941BC65818187F40ACC544889A16
    Key-Arg   : None
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 300 (seconds)
    TLS session ticket:
    0000 - db df 94 b9 8f e2 41 db-7f 7a 49 da ee 3c 24 b7   ......A..zI..<$.
    0010 - 72 ab 67 73 51 f4 91 25-7d 9b 8e 6b 81 09 b0 66   r.gsQ..%}..k...f
    0020 - 73 70 ff e8 70 ef 09 e1-7d dd 96 f9 1c b6 7b 6b   sp..p...}.....{k
    0030 - cf 91 d4 27 ef 90 39 df-dd ac 9f 0f f7 da 20 a3   ...'..9....... .
    0040 - 67 1e bc 3d 0b f8 b8 94-45 1f c1 71 19 5b 3f f6   g..=....E..q.[?.
    0050 - f8 4e a2 ec 8d 0a 80 31-ab 59 fe 72 67 97 33 02   .N.....1.Y.rg.3.
    0060 - 99 73 db e6 1d f4 68 27-40 be 35 0f 0e 29 24 27   .s....h'@.5..)$'
    0070 - ff 8c dd 65 15 a2 03 d9-18 f7 a1 d4 25 bd 1f a1   ...e........%...
    0080 - 96 d8 3b 93 82 4c 20 d9-d1 06 18 6d ae fe 50 59   ..;..L ....m..PY
    0090 - 0d 02 fd b5 99 2f a7 85-99 14 c7 0c dc 8b 18 2e   ...../..........
    00a0 - e2 8d bd ff cf 83 dd 7f-ba df 02 a6 51 0d 4c f2   ............Q.L.
    00b0 - f3 4b 5e 74 56 02 84 4c-ef 1f 58 33 11 ff b9 33   .K^tV..L..X3...3
    00c0 - 6c 81 2c 3b 6a 48 5b dc-50 3e 0f 7a 96 55 75 ca   l.,;jH[.P>.z.Uu.
    Start Time: 1511273614
    Timeout   : 300 (sec)
    Verify return code: 21 (unable to verify the first certificate)
---
```
</details>

There seems to be no way to pass this flag through [connection URL](https://github.com/mongodb/mongo-ruby-driver/blob/f8e5dbecd047452d67d7f050137de30a65727bf4/lib/mongo/uri.rb#L385-L386).

## Testing

I spinned up Mongo 3.2 on Compose and tested with these options:
```
- MONGODB_URI=mongodb://kontena:<passwd>@aws-eu-central-1-portal.2.dblayer.com:15748,aws-eu-central-1-portal.1.dblayer.com:15748/kontena?ssl=true
- MONGODB_SSL_VERIFY=false
```

