### PR TITLE
Deploy tls-sni challenge certs as separate SSL_CERT_acme_challenge_* envs

### DIFF
--- a/server/app/serializers/rpc/service_pod_serializer.rb
+++ b/server/app/serializers/rpc/service_pod_serializer.rb
@@ -83,7 +83,9 @@ module Rpc
       # Why secrets? Well, secrets are already handled in a way they can be concatenated with same env names
       # Must be injected after any secrets/certificates, because the first certificate in `SSL_CERTS` is special
       service.grid_domain_authorizations.select{|d| d.deployable?}.each do |domain_auth|
-        secrets << {name: "SSL_CERTS", type: 'env', value: domain_auth.tls_sni_certificate}
+        env = "SSL_CERT_acme_challenge_#{domain_auth.domain.gsub(/[^a-z0-9]/, '_')}"
+
+        secrets << {name: env, type: 'env', value: domain_auth.tls_sni_certificate}
       end
 
       secrets

--- a/server/spec/serializers/rpc/service_pod_serializer_spec.rb
+++ b/server/spec/serializers/rpc/service_pod_serializer_spec.rb
@@ -216,7 +216,7 @@ describe Rpc::ServicePodSerializer do
           it 'includes the challenge cert as a secret after the normal certificate' do
             expect(subject.to_hash[:secrets]).to eq [
               { name: 'SSL_CERTS', type: 'env', value: 'certificatechainprivate_key' },
-              { name: 'SSL_CERTS', type: 'env', value: 'TLS_AUTH' },
+              { name: 'SSL_CERT_acme_challenge_www_kontena_io', type: 'env', value: 'TLS_AUTH' },
             ]
           end
         end
@@ -247,7 +247,7 @@ describe Rpc::ServicePodSerializer do
 
         it 'includes the challenge cert as a secret' do
           expect(subject.to_hash[:secrets]).to eq [
-            { name: 'SSL_CERTS', type: 'env', value: 'TLS_AUTH' }
+            { name: 'SSL_CERT_acme_challenge_www_kontena_io', type: 'env', value: 'TLS_AUTH' }
           ]
         end
       end
@@ -266,7 +266,7 @@ describe Rpc::ServicePodSerializer do
 
         it 'includes the challenge cert as a secret' do
           expect(subject.to_hash[:secrets]).to eq [
-            { name: 'SSL_CERTS', type: 'env', value: 'TLS_AUTH' }
+            { name: 'SSL_CERT_acme_challenge_www_kontena_io', type: 'env', value: 'TLS_AUTH' }
           ]
         end
       end


### PR DESCRIPTION
See #2963 and #2924 

Avoid consuming `SSL_CERTS` env size for TLS-SNI-01 domain authorizations by deploying the challenge certs using `SSL_CERT_acme_challenge_*`envs. This requires the service to be running an newer version of `kontena/lb` that includes https://github.com/kontena/kontena-loadbalancer/pull/28 - so I don't think we can actually merge and release this yet?

The Let's Encrypt challenge certs seem to be about 2.7KB each, so that's slightly over 2% of the total `SSL_CERTS` capacity per domain authorization challenge... #2994 should reduce the number of  authz challenges that get deployed, but without something like #2964 it would still be possible to fill up the LB service `SSL_CERTS`, and then be unable to deploy the service until the challenges expire or you manually remove them using `bin/kontena-console`.
