### PR TITLE
Fix agent to start container healthchecks for non-http protocols

### DIFF
--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -226,7 +226,7 @@ module Docker
 
     # @return [Boolean]
     def health_check?
-      !!self.labels['io.kontena.health_check.uri']
+      !!self.labels['io.kontena.health_check.protocol']
     end
 
     def reload

--- a/agent/lib/docker/container.rb
+++ b/agent/lib/docker/container.rb
@@ -224,6 +224,11 @@ module Docker
       (self.labels['io.kontena.container.stop_grace_period'] || 10).to_i
     end
 
+    # @return [Boolean]
+    def health_check?
+      !!self.labels['io.kontena.health_check.uri']
+    end
+
     def reload
       @cached_json = nil
       cached_json

--- a/agent/lib/kontena/workers/health_check_worker.rb
+++ b/agent/lib/kontena/workers/health_check_worker.rb
@@ -40,7 +40,7 @@ module Kontena::Workers
 
     # @param [Docker::Container] container
     def start_container_check(container)
-      return if container.nil? || container.labels['io.kontena.health_check.uri'].nil?
+      return unless container && container.health_check?
 
       exclusive {
         unless workers[container.id]

--- a/agent/spec/lib/docker/container_spec.rb
+++ b/agent/spec/lib/docker/container_spec.rb
@@ -4,13 +4,16 @@ describe Docker::Container do
   let(:subject) do
     Docker::Container.new()
   end
+  let(:labels) do
+    {
+      'io.kontena.container.name' => 'foo-1',
+    }
+  end
 
   before(:each) do
     allow(subject).to receive(:json).and_return({
       'Config' => {
-        'Labels' => {
-          'io.kontena.container.name' => 'foo-1'
-        }
+        'Labels' => labels,
       },
       'State' => {
         'Running' => true
@@ -158,6 +161,42 @@ describe Docker::Container do
 
       expect(subject.service_name_for_lb).to eq('stack-service')
     end
+  end
 
+  describe '#health_check?' do
+    context 'without labels' do
+      it 'is false' do
+        expect(subject.health_check?).to be_falsey
+      end
+    end
+
+    context 'with http labels' do
+      let(:labels) do
+        {
+          'io.kontena.container.name' => 'foo-1',
+          'io.kontena.health_check.protocol' => 'http',
+          'io.kontena.health_check.port' => '8000',
+          'io.kontena.health_check.uri' => '/',
+        }
+      end
+
+      it 'is true' do
+        expect(subject.health_check?).to be_truthy
+      end
+    end
+
+    context 'with tcp labels' do
+      let(:labels) do
+        {
+          'io.kontena.container.name' => 'foo-1',
+          'io.kontena.health_check.protocol' => 'tcp',
+          'io.kontena.health_check.port' => '8000',
+        }
+      end
+
+      it 'is true' do
+        expect(subject.health_check?).to be_truthy
+      end
+    end
   end
 end

--- a/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/health_check_worker_spec.rb
@@ -3,8 +3,8 @@ describe Kontena::Workers::HealthCheckWorker do
   include RpcClientMocks
 
   let(:subject) { described_class.new(false) }
-  let(:container) { spy(:container, id: 'foo', labels: {'io.kontena.health_check.uri' => '/'}) }
-  let(:container_not_to_check) { spy(:container, id: 'foo', labels: {}) }
+  let(:container) { spy(:container, id: 'foo', health_check?: true) }
+  let(:container_not_to_check) { spy(:container, id: 'foo', health_check?: false) }
 
 
   before(:each) do


### PR DESCRIPTION
Fixes #3079

Check the `io.kontena.health_check.protocol` label instead of `io.kontena.health_check.uri`: https://github.com/kontena/kontena/blob/4a88950cb5ef9ecfa6dcdb3ab12c8409c2a622ee/server/app/serializers/rpc/service_pod_serializer.rb#L121-L128