### PR TITLE
Remove repository root Rakefile gem dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ begin
   require 'dotenv'
   Dotenv.load
 rescue LoadError
-  fail "Gem 'dotenv' not installed, .env not loaded" if File.exist?('.env')
+  abort "Gem 'dotenv' not installed, .env not loaded" if File.exist?('.env')
 end
 
 VERSION = File.read('./VERSION').strip

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ begin
   require 'dotenv'
   Dotenv.load
 rescue LoadError
-  warn "Gem 'dotenv' not installed, .env not loaded" if File.exist?('.env')
+  fail "Gem 'dotenv' not installed, .env not loaded" if File.exist?('.env')
 end
 
 VERSION = File.read('./VERSION').strip

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ begin
   require 'dotenv'
   Dotenv.load
 rescue LoadError
+  warn "Gem 'dotenv' not installed, .env not loaded" if File.exist?('.env')
 end
 
 VERSION = File.read('./VERSION').strip

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,8 @@
-
-require 'colorize'
-require 'dotenv'
-Dotenv.load
+begin
+  require 'dotenv'
+  Dotenv.load
+rescue LoadError
+end
 
 VERSION = File.read('./VERSION').strip
 UBUNTU_IMAGE = 'kontena-ubuntu-build'
@@ -11,7 +12,7 @@ PKG_REV = ENV['PKG_REV'] || '1'
 namespace :release do
 
   def headline(text)
-    puts text.colorize(:yellow)
+    puts "\e[0;33m#{text}\e[0m"
   end
 
   task :setup => [:bump_version] do


### PR DESCRIPTION
Fixes #3073

Removes dependencies to Dotfile and Colorize gems which have to be manually installed as there's no Gemfile in the root.
