### PR TITLE
Fix CLI config to correctly load both master server and cloud account settings from envs or config file

### DIFF
--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -40,51 +40,94 @@ module Kontena
       def initialize
         super
         @logger = Kontena.logger
-        load_settings_from_env || load_settings_from_config_file
 
-        debug { "Configuration loaded with #{servers.count} servers." }
+        load_settings_from_config_file
+
+        override_master_settings_from_env
+        override_cloud_settings_from_env
+
+        debug { "Configuration loaded with #{servers.count} servers and #{accounts.count} accounts." }
         debug { "Current master: #{current_server || '(not selected)'}" }
         debug { "Current grid: #{current_grid || '(not selected)'}" }
+        debug { "Current account: #{current_account.nil? ? '(not selected)' : current_account.name}" }
       end
 
       def debug(&block)
         Kontena.logger.add(Logger::DEBUG, nil, 'CONFIG', &block)
       end
 
-      # Craft a regular looking configuration based on ENV variables
-      def load_settings_from_env
-        load_cloud_settings_from_env
-        load_master_settings_from_env
+      def override_master_settings_from_env
+        if ENV['KONTENA_URL']
+          server = find_server_by(url: ENV['KONTENA_URL'])
+          if server.nil?
+            debug { 'Using new master url from env KONTENA_URL' }
+            server = Server.new(
+              url: ENV['KONTENA_URL'],
+              name: ENV['KONTENA_MASTER'] || 'default'
+            )
+            servers << server
+          else
+            debug { "Using master #{server.name} in config found via url in env KONTENA_URL" }
+          end
+        elsif ENV['KONTENA_MASTER']
+          server = find_server_by(name: ENV['KONTENA_MASTER'])
+          if server
+            debug { "Using master #{ENV['KONTENA_MASTER']} set via env KONTENA_MASTER" }
+          end
+        elsif current_master
+          server = current_master
+        end
+
+        if server.nil?
+          debug { 'Could not determine a master through config or env' }
+          self.current_master = nil
+          return
+        else
+          self.current_master = server.name
+        end
+
+        if ENV['KONTENA_GRID']
+          debug { "Using grid #{ENV['KONTENA_GRID']} from env KONTENA_GRID" }
+          server.grid = ENV['KONTENA_GRID']
+        end
+
+        if ENV['KONTENA_TOKEN']
+          debug { 'Using master token from env KONTENA_TOKEN' }
+          server.token ||= Token.new(parent_type: :master, parent_name: server.name)
+          server.token.access_token = ENV['KONTENA_TOKEN']
+          server.token.refresh_token = nil
+          server.token.expires_at = nil
+        end
       end
 
-      def load_master_settings_from_env
-        return nil unless ENV['KONTENA_URL']
+      def override_cloud_settings_from_env
+        if ENV['KONTENA_CLOUD']
+          account = find_account(ENV['KONTENA_CLOUD'])
+          if account
+            debug { "Using cloud account #{ENV['KONTENA_CLOUD']} from config selected by env KONTENA_CLOUD" }
+            self.current_account = account.name
+          else
+            debug { "Using new cloud account #{ENV['KONTENA_CLOUD']} from env" }
+            account = Accout.new(kontena_account_data.merge(name: ENV['KONTENA_CLOUD']))
+            accounts << account
+          end
+        elsif current_account
+          account = current_account
+        end
 
-        debug { 'Loading master configuration from ENV' }
-        servers << Server.new(
-          url: ENV['KONTENA_URL'],
-          name: 'default',
-          token: Token.new(
-            access_token: ENV['KONTENA_TOKEN'],
-            parent_type: :master, parent_name: 'default'
-          ),
-          grid: ENV['KONTENA_GRID'],
-          parent_type: :master,
-          parent_name: 'default'
-        )
+        if account.nil?
+          debug { 'No account data from config or env' }
+          self.current_account = nil
+          return
+        end
 
-        self.current_master  = 'default'
-      end
-
-      def load_cloud_settings_from_env
-        debug { 'Loading cloud configuration from ENV' }
-        accounts << Account.new(kontena_account_data.merge(
-          token: Token.new(
-            access_token: ENV['KONTENA_CLOUD_TOKEN'],
-            parent_type: :account, parent_name: 'default'
-          )
-        ))
-        self.current_account = 'kontena'
+        if ENV['KONTENA_CLOUD_TOKEN']
+          debug { 'Using cloud token from env KONTENA_CLOUD_TOKEN' }
+          account.token ||= Token.new(parent_type: :account, parent_name: account.name)
+          account.token.access_token = ENV['KONTENA_CLOUD_TOKEN']
+          account.token.refresh_token = nil
+          account.token.expires_at = nil
+        end
       end
 
       def extract_token!(hash={})
@@ -118,7 +161,7 @@ module Kontena
           servers << server
         end
 
-        self.current_server = ENV['KONTENA_MASTER'] || settings['current_server']
+        self.current_server = settings['current_server']
 
         Array(settings['accounts']).each do |account_data|
           if account_data['token']
@@ -144,7 +187,7 @@ module Kontena
         accounts.delete_at(master_index) if master_index
         accounts << Account.new(master_account_data)
 
-        self.current_account = ENV['KONTENA_CLOUD'] || settings['current_account'] || 'kontena'
+        self.current_account = settings['current_account'] || 'kontena'
       end
 
       def kontena_account_data
@@ -230,7 +273,13 @@ module Kontena
       #
       # @return [String] path
       def config_filename
-        @config_filename ||= ENV['KONTENA_CONFIG'] || default_config_filename
+        return @config_filename if @config_filename
+        if ENV['KONTENA_CONFIG']
+          debug { "Using #{ENV['KONTENA_CONFIG']} as config file set through env KONTENA_CONFIG"}
+          @config_filename = ENV['KONTENA_CONFIG']
+        else
+          @config_filename = default_config_filename
+        end
       end
 
       # Generate the default configuration filename
@@ -399,7 +448,9 @@ module Kontena
       #
       # @return [String, NilClass]
       def current_grid
-        ENV['KONTENA_GRID'] || (current_master && current_master.grid)
+        return ENV['KONTENA_GRID'] unless ENV['KONTENA_GRID'].to_s.empty?
+        return nil unless current_master
+        current_master.grid
       end
 
       # Set the current grid name.

--- a/cli/lib/kontena/cli/config.rb
+++ b/cli/lib/kontena/cli/config.rb
@@ -77,8 +77,6 @@ module Kontena
       end
 
       def load_cloud_settings_from_env
-        return unless ENV['KONTENA_CLOUD_TOKEN']
-
         debug { 'Loading cloud configuration from ENV' }
         accounts << Account.new(kontena_account_data.merge(
           token: Token.new(

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -6,6 +6,50 @@ describe 'stack install' do
     run 'kontena stack rm --force simple'
   end
 
+  context 'from registry' do
+    after do
+      run "kontena stack rm --force hello-ascii"
+    end
+
+    context 'config from file' do
+      it 'installs a stack' do
+        k = run "kontena stack install -v scaling=1 kontena/hello-ascii"
+        expect(k.code).to be_zero
+        k = run 'kontena stack show hello-ascii'
+        expect(k.code).to eq(0)
+      end
+    end
+
+    context 'config from env' do
+      before do
+        @old_env = {
+          'KONTENA_URL' => ENV['KONTENA_URL'],
+          'KONTENA_TOKEN' => ENV['KONTENA_TOKEN'],
+          'KONTENA_GRID' => ENV['KONTENA_GRID']
+        }
+        k = run "kontena master current --url"
+        ENV['KONTENA_URL'] = k.out.strip
+        k = run "kontena master token current --token"
+        ENV['KONTENA_TOKEN'] = k.out.strip
+        k = run "kontena grid current --name"
+        ENV['KONTENA_GRID'] = k.out.strip
+      end
+
+      after do
+        @old_env.each do |k,v|
+          ENV[k] = v
+        end
+      end
+
+      it 'installs a stack' do
+        k = run "kontena stack install -v scaling=1 kontena/hello-ascii"
+        expect(k.code).to be_zero
+        k = run 'kontena stack show hello-ascii'
+        expect(k.code).to eq(0)
+      end
+    end
+  end
+
   context 'from file' do
 
     it 'installs a stack' do


### PR DESCRIPTION
Fixes #3089 

When setting master through env with something like:
```
KONTENA_URL=xxx KONTENA_TOKEN=yyy KONTENA_GRID=zzz kontena stack install kontena/lb
```

The CLI gives a NoMethodError for `current_account.stacks_url` because the account settings are not initialized unless `KONTENA_CLOUD_TOKEN` is set.

This PR makes the cloud account settings initialize with defaults even when `KONTENA_CLOUD_TOKEN` is not set. 

This enables read access to stack registry.

