### PR TITLE
Use --no-log-forwarder instead of --log-forwarder none in grid update

### DIFF
--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -137,12 +137,8 @@ module Kontena::Cli::Grids
           raise Kontena::Errors::StandardError.new(1, "Need to specify --log-forwarder when using --log-opt")
         end
 
-        if no_log_forwarder?
-          if log_forwarder && log_forwarder != "none"
-            exit_with_error "Can't use --log-forwarder and --no-log-forwarder together"
-          else
-            self.log_forwarder = "none"
-          end
+        if no_log_forwarder? && !log_forwarder.nil? && log_forwarder != "none"
+          exit_with_error "Can't use --log-forwarder and --no-log-forwarder together"
         end
       end
 
@@ -170,9 +166,9 @@ module Kontena::Cli::Grids
           }
         end
 
-        if log_forwarder
+        if log_forwarder || no_log_forwarder?
           payload[:logs] = {
-            forwarder: log_forwarder,
+            forwarder: no_log_forwarder? ? 'none' : log_forwarder,
             opts: parse_log_opts
           }
         end

--- a/cli/lib/kontena/cli/grids/common.rb
+++ b/cli/lib/kontena/cli/grids/common.rb
@@ -122,13 +122,27 @@ module Kontena::Cli::Grids
       def self.included(base)
         base.option "--default-affinity", "[AFFINITY]", "Default affinity rule for the grid", multivalued: true
         base.option "--statsd-server", "STATSD_SERVER", "Statsd server address (host:port)"
-        base.option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder (set to 'none' to disable)"
+        base.option "--log-forwarder", "LOG_FORWARDER", "Set grid wide log forwarder" do |log_forwarder|
+          if log_forwarder == 'none'
+            warn "[DEPRECATED] --log-forwarder none will be replaced with --no-log-forwarder"
+          end
+          log_forwarder
+        end
+        base.option "--no-log-forwarder", :flag, "Disable log forwarding"
         base.option "--log-opt", "[LOG_OPT]", "Set log options (key=value)", multivalued: true
       end
 
       def validate_log_opts
-        if !log_opt_list.empty? && log_forwarder.nil?
+        if !log_opt_list.empty? && (log_forwarder.nil? || no_log_forwarder?)
           raise Kontena::Errors::StandardError.new(1, "Need to specify --log-forwarder when using --log-opt")
+        end
+
+        if no_log_forwarder?
+          if log_forwarder && log_forwarder != "none"
+            exit_with_error "Can't use --log-forwarder and --no-log-forwarder together"
+          else
+            self.log_forwarder = "none"
+          end
         end
       end
 

--- a/cli/spec/kontena/cli/grids/update_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/update_command_spec.rb
@@ -51,6 +51,19 @@ describe Kontena::Cli::Grids::UpdateCommand do
         subject.run(['--no-statsd-server', 'test'])
       end
 
+      it 'should send "none" as log forwarder when --no-log-forwarder given' do
+        expect(client).to receive(:put).with(
+          'grids/test', hash_including(
+            logs: hash_including(forwarder: 'none')
+          )
+        )
+        subject.run(['--no-log-forwarder', 'test'])
+      end
+
+      it 'should exit with error if --log-forwarder and --no-log-forwarder given' do
+        expect{subject.run(['--log-forwarder', 'fluentd', '--no-log-forwarder', 'test'])}.to exit_with_error.and output(/together/).to_stderr
+      end
+
       it 'should send empty default_affinity when --no-default-affinity given' do
         expect(client).to receive(:put).with(
           'grids/test', hash_including({


### PR DESCRIPTION
Fixes #3088

Adds `--no-log-forwarder` to `kontena grid update` and adds a deprecation warning when using `--log-forwarder none`. 
