### PR TITLE
Suggest plugin install when using known cloud plugin subcommands

### DIFF
--- a/cli/lib/kontena/cli/cloud_command.rb
+++ b/cli/lib/kontena/cli/cloud_command.rb
@@ -1,9 +1,13 @@
 
 class Kontena::Cli::CloudCommand < Kontena::Command
+  include Kontena::Cli::Common
+
   subcommand "login", "Authenticate to Kontena Cloud", load_subcommand('cloud/login_command')
   subcommand "logout", "Logout from Kontena Cloud", load_subcommand('cloud/logout_command')
   subcommand "master", "Master specific commands", load_subcommand('cloud/master_command')
 
-  def execute
+  def subcommand_missing(name)
+    super unless %w(platform node org organization image-repository ir region token).include?(name)
+    exit_with_error "The #{pastel.cyan('cloud')} plugin has not been installed. Use: #{pastel.cyan('kontena plugin install cloud')}"
   end
 end

--- a/cli/lib/kontena/cli/cloud_command.rb
+++ b/cli/lib/kontena/cli/cloud_command.rb
@@ -7,7 +7,7 @@ class Kontena::Cli::CloudCommand < Kontena::Command
   subcommand "master", "Master specific commands", load_subcommand('cloud/master_command')
 
   def subcommand_missing(name)
-    super unless %w(platform node org organization image-repository ir region token).include?(name)
+    return super(name) unless %w(platform node org organization image-repository ir region token).include?(name)
     exit_with_error "The #{pastel.cyan('cloud')} plugin has not been installed. Use: #{pastel.cyan('kontena plugin install cloud')}"
   end
 end

--- a/cli/spec/kontena/cli/cloud_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud_command_spec.rb
@@ -1,0 +1,17 @@
+require 'kontena/cli/cloud_command'
+
+describe Kontena::Cli::CloudCommand do
+  let(:subject) { described_class.new('kontena') }
+
+
+  describe '#subcommand_missing' do
+    it 'suggests plugin install for known cloud plugin commands' do
+      expect{subject.run(['platform', 'xyz'])}.to exit_with_error.and output(/has not been installed/).to_stderr
+      expect{subject.run(['organization', 'xyz'])}.to exit_with_error.and output(/has not been installed/).to_stderr
+      expect{subject.run(['ir', 'xyz'])}.to exit_with_error.and output(/has not been installed/).to_stderr
+      expect{subject.run(['region', 'xyz'])}.to exit_with_error.and output(/has not been installed/).to_stderr
+      expect{subject.run(['node', 'xyz'])}.to exit_with_error.and output(/has not been installed/).to_stderr
+      expect{subject.run(['token', 'xyz'])}.to exit_with_error.and output(/has not been installed/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3097

Gives a hint about installing the cloud plugin when trying to use plugin subcommands without the plugin.
