### PR TITLE
Remove dependant service logic

### DIFF
--- a/server/app/jobs/grid_service_scheduler_worker.rb
+++ b/server/app/jobs/grid_service_scheduler_worker.rb
@@ -45,7 +45,7 @@ class GridServiceSchedulerWorker
     error "aborting deploy on un-handled error: #{exc.message}"
     error exc.backtrace.join("\n") if exc.backtrace
     service_deploy.abort! "service deploy aborted: #{exc.message}" if service_deploy
-    
+
     nil
   end
 
@@ -66,19 +66,8 @@ class GridServiceSchedulerWorker
   # @param service_deploy [GridServiceDeploy]
   def deploy(service_deploy)
     self.deployer(service_deploy).deploy
-    self.deploy_dependant_services(service_deploy.grid_service)
   ensure
     service_deploy.set(:finished_at => Time.now.utc)
-  end
-
-  # Create deploys for dependent services.
-  #
-  # @param grid_service [GridService]
-  def deploy_dependant_services(grid_service)
-    grid_service.dependant_services.each do |service|
-      info "deploying dependent service #{service.to_path} of deployed service #{grid_service.to_path}"
-      GridServiceDeploy.create!(grid_service: service)
-    end
   end
 
   # @param [GridServiceDeploy] grid_service_deploy

--- a/server/app/jobs/stack_deploy_worker.rb
+++ b/server/app/jobs/stack_deploy_worker.rb
@@ -23,11 +23,7 @@ class StackDeployWorker
     stack.reload
     services = sort_services(stack.grid_services.to_a)
     services.each do |service|
-      unless service.depending_on_other_services?
-        deploy_service(service, stack_deploy)
-      else
-        info "skipping deployment of #{service.to_path} because it will be deployed by dependencies"
-      end
+      deploy_service(service, stack_deploy)
     end
 
     stack_deploy.success!

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -237,55 +237,6 @@ class GridService
     self.grid.grid_services.where(:'grid_service_links.linked_grid_service_id' => self.id)
   end
 
-  # Resolve services that depend on us
-  #
-  # @return [Array<GridService>]
-  def dependant_services
-    grid = self.grid
-    dependant = []
-    dependant += grid.grid_services.where(:$or => [
-        {:volumes_from => {:$regex => /^#{self.name}-%s/}},
-        {:volumes_from => {:$regex => /^#{self.name}-\d+/}},
-        {:affinity => "service==#{self.name}"},
-        {:affinity => "service!=#{self.name}"},
-        {:net => {:$regex => /^container:#{self.name}-%s/}},
-        {:net => {:$regex => /^container:#{self.name}-\d+/}}
-      ]
-    )
-    dependant.delete(self)
-
-    dependant
-  end
-
-  # Are there any dependant services?
-  #
-  # @return [Boolean]
-  def dependant_services?
-    self.dependant_services.size > 0
-  end
-
-  # Is service depending on other services?
-  #
-  # @return [Boolean]
-  def depending_on_other_services?
-    if self.affinity
-      if self.affinity.any?{|a| a.match(/\Aservice(!=|==).+/)}
-        return true
-      end
-      if self.affinity.any?{|a| a.match(/\Acontainer(!=|==).+/)}
-        return true
-      end
-    end
-
-    if self.volumes_from
-      return true if self.volumes_from.size > 0
-    end
-
-    return true if self.net.to_s.match(/\Acontainer:.+/)
-
-    false
-  end
-
   def health_status
     healthy = 0
     unhealthy = 0

--- a/server/spec/models/grid_service_spec.rb
+++ b/server/spec/models/grid_service_spec.rb
@@ -154,42 +154,6 @@ describe GridService do
     end
   end
 
-  describe '#dependant_services' do
-    let(:subject) { grid_service }
-
-    it 'returns dependant by volumes_from' do
-      backupper = GridService.create!(
-        grid: grid, name: 'backupper',
-        image_name: 'backupper:latest', volumes_from: ["#{subject.name}-%s"]
-      )
-      follower = GridService.create!(
-        grid: grid, name: 'follower',
-        image_name: 'follower:latest', volumes_from: ["#{subject.name}-1"]
-      )
-      dependant_services = subject.dependant_services
-      expect(dependant_services.size).to eq(2)
-      expect(dependant_services).to include(backupper)
-      expect(dependant_services).to include(follower)
-    end
-
-    it 'returns dependant services by service affinity' do
-      avoider = GridService.create!(
-        grid: grid, name: 'avoider',
-        image_name: 'avoider:latest',
-        affinity: ["service!=#{subject.name}"]
-      )
-      follower = GridService.create!(
-        grid: grid, name: 'follower',
-        image_name: 'follower:latest',
-        affinity: ["service==#{subject.name}"]
-      )
-      dependant_services = subject.dependant_services
-      expect(dependant_services.size).to eq(2)
-      expect(dependant_services).to include(avoider)
-      expect(dependant_services).to include(follower)
-    end
-  end
-
   describe '#linked_from_services' do
     it 'returns Mongoid::Criteria' do
       expect(grid_service.linked_from_services).to be_instance_of(Mongoid::Criteria)
@@ -276,24 +240,6 @@ describe GridService do
 
     it 'returns false if service is not exposed via stack' do
       expect(grid_service.stack_exposed?).to be_falsey
-    end
-  end
-
-  describe '#depending_on_other_services?' do
-    it 'returns false by default' do
-      expect(subject.depending_on_other_services?).to be_falsey
-    end
-
-    it 'returns true if service affinity' do
-      subject.affinity = ['service==foobar']
-      expect(subject.depending_on_other_services?).to be_truthy
-      subject.affinity = ['service!=foobar']
-      expect(subject.depending_on_other_services?).to be_truthy
-    end
-
-    it 'returns true if volumes_from' do
-      subject.volumes_from = ['foobar-%i']
-      expect(subject.depending_on_other_services?).to be_truthy
     end
   end
 


### PR DESCRIPTION
Logic is too fuzzy and many times does not do "the right thing". Scheduler loop should fix most of the conditions automatically. If stack services don't have proper order/linking then user needs to fix the stack file.