### PR TITLE
Bump cadvisor to 0.27.2

### DIFF
--- a/agent/lib/kontena/launchers/cadvisor.rb
+++ b/agent/lib/kontena/launchers/cadvisor.rb
@@ -6,7 +6,7 @@ module Kontena::Launchers
     include Celluloid::Notifications
     include Kontena::Logging
 
-    CADVISOR_VERSION = ENV['CADVISOR_VERSION'] || 'v0.24.1'
+    CADVISOR_VERSION = ENV['CADVISOR_VERSION'] || 'v0.27.2'
     CADVISOR_IMAGE = ENV['CADVISOR_IMAGE'] || 'google/cadvisor'
 
     def initialize(autostart = true)


### PR DESCRIPTION
Fixes `overlay2` errors like:

```
W1208 10:24:15.347926       1 raw.go:87] Error while processing event ("/var/lib/docker/overlay2/38204fb140f962df2aa614a4d4898965bca2384db113dab62c8a66a5dedac156/merged/sys/fs/cgroup/blkio/system.slice/var-lib-docker-containers-6afd98044bda4c467d96a5b5397cbb52f5d9b3e59c7180b33add1fc3ab440a5e-shm.mount": 0x40000100 == IN_CREATE|IN_ISDIR): inotify_add_watch /var/lib/docker/overlay2/38204fb140f962df2aa614a4d4898965bca2384db113dab62c8a66a5dedac156/merged/sys/fs/cgroup/blkio/system.slice/var-lib-docker-containers-6afd98044bda4c467d96a5b5397cbb52f5d9b3e59c7180b33add1fc3ab440a5e-shm.mount: no such file or directory
```

and bunch of other bugs (see release notes).

- https://github.com/google/cadvisor/releases/tag/v0.27.2
- https://github.com/google/cadvisor/releases/tag/v0.27.0