### PR TITLE
Less shuffling when nodes missing with daemon strategy

### DIFF
--- a/server/app/services/scheduler/strategy/daemon.rb
+++ b/server/app/services/scheduler/strategy/daemon.rb
@@ -15,11 +15,33 @@ module Scheduler
         10.minutes
       end
 
+      # @param [GridService] grid_service
+      # @param [Integer] instance_number
+      # @param [Array<Scheduler::Node>] nodes
+      # @return [Scheduler::Node,NilClass]
+      def find_stateless_node(grid_service, instance_number, nodes)
+        prev_instance = grid_service.grid_service_instances.has_node.find_by(
+          instance_number: instance_number
+        )
+        if prev_instance
+          node = nodes.find { |n| n.node == prev_instance.host_node }
+          unless node
+            selector = (instance_number.to_f / nodes.size.to_f).floor
+            candidates = self.sort_candidates(nodes, grid_service, instance_number)
+            node = candidates.select { |c| c.schedule_counter <= selector }.last
+          end
+          node
+        else
+          candidates = self.sort_candidates(nodes, grid_service, instance_number)
+          candidates.first
+        end
+      end
+
       # @param [Array<Scheduler::Node>] nodes
       # @param [GridService] grid_service
       # @param [Integer] instance_number
       def sort_candidates(nodes, grid_service, instance_number)
-        nodes.sort_by{|node|
+        nodes.sort_by { |node|
           [node.schedule_counter, node.node_number]
         }
       end

--- a/server/spec/services/scheduler/strategy/daemon_spec.rb
+++ b/server/spec/services/scheduler/strategy/daemon_spec.rb
@@ -4,24 +4,114 @@ describe Scheduler::Strategy::Daemon do
   let(:grid) { Grid.create(name: 'test') }
 
   let(:host_nodes) do
-    [
+    10.times.map do |i|
+      n = i + 1
       HostNode.create!(
-      node_id: 'node1', name: 'node-1', connected: true, grid: grid, node_number: 1
-      ),
-      HostNode.create!(
-        node_id: 'node2', name: 'node-2', connected: true, grid: grid, node_number: 2
-      ),
-      HostNode.create!(
-        node_id: 'node3', name: 'node-3', connected: true, grid: grid, node_number: 3
-      ),
-    ]
+        node_id: "node#{n}", name: "node-#{n}", connected: true, grid: grid, node_number: n
+      )
+    end
   end
+
   let(:scheduler_nodes) do
     host_nodes.map{|n| Scheduler::Node.new(n)}
   end
 
   let(:stateless_service) do
     GridService.create!(name: 'test', grid: grid, image_name: 'foo/bar:latest', stateful: false)
+  end
+
+  describe '#find_node' do
+    it 'finds matching nodes' do
+      nodes = scheduler_nodes
+      nodes.each do |n|
+        node = subject.find_node(stateless_service, n.node_number, nodes)
+        node.schedule_counter += 1
+        expect(node).to eq(nodes[n.node_number - 1])
+      end
+    end
+
+    context 'with existing nodes' do
+      before(:each) do
+        host_nodes.each do |n|
+          stateless_service.grid_service_instances.create!(
+            host_node: n,
+            instance_number: n.node_number
+          )
+        end
+      end
+
+      it 'minimizes shuffle when nodes 2 & 3 are missing' do
+        nodes = scheduler_nodes.tap do |n|
+          n.delete_at(1)
+          n.delete_at(1)
+        end
+
+        scheduled = []
+        nodes.each_with_index do |n, i|
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map {|s| s.node_number}).to eq([
+          1, 10, 9, 4, 5, 6, 7, 8
+        ])
+      end
+
+      it 'minimizes shuffle when nodes 2 & 3 are missing (2 instances per node)' do
+        nodes = scheduler_nodes.tap do |n|
+          n.delete_at(1)
+          n.delete_at(1)
+        end
+
+        scheduled = []
+        16.times do |i| # 2 instances per node
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map {|s| s.node_number}).to eq([
+          1, 10, 9, 4, 5, 6, 7, 8,
+          9, 10, 1, 4, 5, 6, 7, 8
+        ])
+      end
+
+      it 'minimizes shuffle when last two nodes are missing' do
+        nodes = scheduler_nodes[0..-3]
+        scheduled = []
+        nodes.each_with_index do |n, i|
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map {|s| s.node_number}).to eq([
+          1, 2, 3, 4, 5, 6, 7, 8
+        ])
+      end
+    end
+
+    context 'with newly added nodes' do
+      before(:each) do
+        host_nodes[0..-3].each do |n|
+          stateless_service.grid_service_instances.create!(
+            host_node: n,
+            instance_number: n.node_number
+          )
+        end
+      end
+
+      it 'finds correct nodes' do
+        nodes = scheduler_nodes
+        scheduled = []
+        nodes.each_with_index do |n, i|
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map { |s| s.node_number}).to eq([
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        ])
+      end
+    end
   end
 
   describe '#instance_count' do


### PR DESCRIPTION
Example:

All nodes are online and service has been deployed with daemon strategy:

```
node-1: instance-1
node-2: instance-2
node-3: instance-3
node-4: instance-4
node-5: instance-5
```

node-2 goes to offline (or is terminated/removed):

old behaviour:

```
node-1: instance-1
node-2: 
node-3: instance-2
node-4: instance-3
node-5: instance-4
```

new behaviour:

```
node-1: instance-1
node-2: 
node-3: instance-3
node-4: instance-4
node-5: instance-2
```
