### PR TITLE
Agent Watchdog 

### DIFF
--- a/agent/lib/kontena-agent.rb
+++ b/agent/lib/kontena-agent.rb
@@ -54,4 +54,5 @@ require_relative 'kontena/actors/container_coroner'
 require_relative 'kontena/load_balancers/configurer'
 require_relative 'kontena/load_balancers/registrator'
 
+require_relative 'kontena/watchdog'
 require_relative 'kontena/agent'

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -93,6 +93,7 @@ module Kontena
       end
 
       self.supervise
+      @watchdog = self.watchdog
 
       while line = @read_pipe.gets
         handle_signal line.strip
@@ -115,6 +116,7 @@ module Kontena
     def handle_shutdown
       info "Shutting down..."
       @supervisor.shutdown # shutdown all actors
+      @watchdog.stop
       @write_pipe.close # let run! break and return
     end
 
@@ -134,6 +136,12 @@ module Kontena
       end
 
       info "Dump cellulooid actor and thread stacks: done"
+    end
+
+    def watchdog
+       Kontena::Watchdog.watch do
+        fail "Celluloid::Supervision::Container died" unless @supervisor.alive?
+      end
     end
 
     def supervise

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -139,7 +139,7 @@ module Kontena
     end
 
     def watchdog
-       Kontena::Watchdog.watch do
+      Kontena::Watchdog.watch do
         fail "Celluloid::Supervision::Container died" unless @supervisor.alive?
       end
     end

--- a/agent/lib/kontena/agent.rb
+++ b/agent/lib/kontena/agent.rb
@@ -138,6 +138,10 @@ module Kontena
       info "Dump cellulooid actor and thread stacks: done"
     end
 
+    # Setup a Kontena::Watchdog to kill the process, allowing it to be restarted if:
+    # * the main celluloid supervisor crashes
+    #
+    # @return [Kontena::Watchdog]
     def watchdog
       Kontena::Watchdog.watch do
         fail "Celluloid::Supervision::Container died" unless @supervisor.alive?

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -42,6 +42,7 @@ class Kontena::Watchdog
   def ping
     start = Time.now
 
+    # use exclusive mode to prevent the task from suspending and causing the Timeout::Error to crash the actor thread instead
     exclusive {
       Timeout.timeout(@timeout) do
         @block.call

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -1,4 +1,7 @@
-# Run the given block in a separate Thread every interval, and abort if it times out or fails
+# The watchdog is intended to recover the agent from unrepairable errors by killing it, and allowing it to be restarted.
+#
+# The watchdog takes a block, which gets run in a separate thread every interval.
+# The watchdog will abort if the block times out or fails with an exception.
 class Kontena::Watchdog
   include Celluloid
   include Kontena::Logging

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -2,6 +2,8 @@
 #
 # The watchdog takes a block, which gets run in a separate thread every interval.
 # The watchdog will abort if the block times out or fails with an exception.
+#
+# The watchdog abort will immediately exit! the process, without running any at_exit hooks for shutdown.
 class Kontena::Watchdog
   include Celluloid
   include Kontena::Logging

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -54,6 +54,7 @@ class Kontena::Watchdog
     }
 
   rescue => exc
+    error exc
     abort(exc)
   else
     pong(ping, Time.now)
@@ -91,13 +92,12 @@ class Kontena::Watchdog
   # @param delay [Float] > @timeout
   def bite(delay)
     exc = Timeout::Error.new "watchdog timeout after %.3fs @ %s" % [delay, trace.join("\n\t")]
+    error exc
     abort(exc)
   end
 
-  # kill the watched Thread
+  # kill the process
   def abort(exc)
-    error exc
-
     # only abort once
     stop
 

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -1,0 +1,94 @@
+# Run the given block in a separate Thread every interval, and abort if it times out or fails
+class Kontena::Watchdog
+  include Celluloid
+
+  INTERVAL = 10.0
+  THRESHOLD = 10.0
+  TIMEOUT = 30.0
+
+  # this is not a StandardError, it is supposed to abort the thread
+  class Abort < Exception
+
+  end
+
+  def self.watch(**options, &block)
+    new(Thread.current, block, **options)
+  end
+
+  def initialize(thread, block, interval: INTERVAL, threshold: THRESHOLD, timeout: TIMEOUT, abort: true)
+    @thread = thread
+    @block = block
+
+    @interval = interval
+    @threshold = threshold
+    @timeout = timeout
+    @abort = abort
+
+    async.start
+  end
+
+  def logger
+    Kontena::Logging.logger
+  end
+
+  def start
+    logger.info "watchdog start"
+    @timer = every(@interval) do
+      if !@ping || @ping < @pong
+        async.ping
+      elsif !@pong || @pong < @ping
+        check
+      else
+
+      end
+    end
+  end
+
+  # Stop the every loop from start
+  def stop
+    @timer.cancel
+  end
+
+  def ping
+    ping = @ping = Time.now
+
+    defer {
+      @block.call
+    }
+  rescue => exc
+    logger.fatal "watchdog error: #{exc}"
+    abort(exc) if @abort
+  else
+    @pong = Time.now if @ping == ping
+  end
+
+  def check
+    delay = @pong && @pong > @ping ? @pong - @ping : Time.now - @ping
+
+    if delay > @timeout
+      bite(delay)
+    elsif delay > @threshold
+      bark(delay)
+    else
+      logger.debug { "watchdog delay is %.3fs" % [delay] }
+    end
+  end
+
+  def bark(delay)
+    logger.warn "watchdog delayed by %.3fs" % [delay]
+  end
+
+  def bite(delay)
+    exc = Timeout::Error.new "watchdog timeout after %.3fs" % [delay]
+    logger.fatal exc.message
+    abort(exc) if @abort
+  end
+
+  def abort(exc)
+    # only abort once
+    stop
+
+    # assume that the thread has abort_on_exception and it does not rescue non-StandardError
+    @thread.raise Abort, "#{exc.class}: #{exc.message}"
+  end
+end

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -42,10 +42,15 @@ class Kontena::Watchdog
   def ping
     start = Time.now
 
-    Timeout.timeout(@timeout) do
-      @block.call
-    end
+    exclusive {
+      Timeout.timeout(@timeout) do
+        @block.call
+      end
+    }
 
+  rescue Timeout::Error => exc
+    error exc
+    abort(exc)
   rescue => exc
     error exc
     abort(exc)

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -46,6 +46,7 @@ class Kontena::Watchdog
     @timer.cancel
   end
 
+  # Start new watchdog ping
   def ping
     ping = @ping = Time.now
 
@@ -58,6 +59,7 @@ class Kontena::Watchdog
     @pong = Time.now if @ping == ping
   end
 
+  # Watchdog has not yet seen any @pong for the latest @ping, warn on threshold and abort on timeout
   def check
     delay = Time.now - @ping
 
@@ -70,15 +72,20 @@ class Kontena::Watchdog
     end
   end
 
+  # warn when @ping delay exceeds @threshold
+  # @param delay [Float] > @threshold
   def bark(delay)
     warn "watchdog delayed by %.3fs" % [delay]
   end
 
+  # abort when @ping delay exceeds @timeout
+  # @param delay [Float] > @timeout
   def bite(delay)
     exc = Timeout::Error.new "watchdog timeout after %.3fs" % [delay]
     abort(exc)
   end
 
+  # kill the watched Thread
   def abort(exc)
     error exc
 

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -31,7 +31,7 @@ class Kontena::Watchdog
   def start
     info "watchdog start"
     @timer = every(@interval) do
-      if !@ping || @ping < @pong
+      if !@ping || (@pong && @ping < @pong)
         async.ping
       elsif !@pong || @pong < @ping
         check
@@ -59,7 +59,7 @@ class Kontena::Watchdog
   end
 
   def check
-    delay = @pong && @pong > @ping ? @pong - @ping : Time.now - @ping
+    delay = Time.now - @ping
 
     if delay > @timeout
       bite(delay)

--- a/agent/lib/kontena/watchdog.rb
+++ b/agent/lib/kontena/watchdog.rb
@@ -7,11 +7,6 @@ class Kontena::Watchdog
   THRESHOLD = 10.0
   TIMEOUT = 30.0
 
-  # this is not a StandardError, it is supposed to abort the thread
-  class Abort < Exception
-
-  end
-
   def self.watch(**options, &block)
     # pass block as a proc, instead of as a celluloid block proxy
     new(block, **options)

--- a/agent/spec/lib/kontena/watchdog_spec.rb
+++ b/agent/spec/lib/kontena/watchdog_spec.rb
@@ -1,6 +1,6 @@
 describe Kontena::Watchdog, :celluloid => true do
   subject do
-    @watchdog = described_class.new(block, interval: 0.01, threshold: 0.05, timeout: 0.1, abort_exit: false)
+    @watchdog = described_class.new(block, interval: 0.01, timeout: 0.1, abort_exit: false)
   end
 
   after do
@@ -39,8 +39,6 @@ describe Kontena::Watchdog, :celluloid => true do
     end}
 
     it "aborts" do
-      expect(subject.wrapped_object).to receive(:bark).at_least(:once).and_call_original
-      expect(subject.wrapped_object).to receive(:bite).once.and_call_original
       expect(subject.wrapped_object).to receive(:abort).with(Timeout::Error).and_call_original
 
       subject

--- a/agent/spec/lib/kontena/watchdog_spec.rb
+++ b/agent/spec/lib/kontena/watchdog_spec.rb
@@ -1,48 +1,50 @@
 describe Kontena::Watchdog, :celluloid => true do
-  let(:context) { double() }
-
   subject do
-    @watchdog = described_class.watch(interval: 0.01, threshold: 0.05, timeout: 0.1, abort_exit: false) do
-      context.ping
-    end
+    @watchdog = described_class.new(block, interval: 0.01, threshold: 0.05, timeout: 0.1, abort_exit: false)
   end
 
   after do
     @watchdog.terminate if @watchdog.alive?
   end
 
-  it "does nothing if the watchdog block is okay" do
-    allow(context).to receive(:ping) do
-      nil
+  context "with a block that is okay" do
+    let(:block) { Proc.new do
+      true
+    end}
+
+    it "does nothing" do
+      expect(subject.wrapped_object).to_not receive(:abort)
+
+      subject
+      sleep 0.2
     end
-
-    expect(subject.wrapped_object).to_not receive(:abort)
-
-    subject
-    sleep 0.2
   end
 
-  it "aborts the thread if the watchdog block raises" do
-    allow(context).to receive(:ping) do
+  context "with a block that raises" do
+    let(:block) { Proc.new do
       raise RuntimeError, 'testing'
+    end}
+
+    it "abort" do
+      expect(subject.wrapped_object).to receive(:abort).with(RuntimeError).and_call_original
+
+      subject
+      sleep 0.2
     end
-
-    expect(subject.wrapped_object).to receive(:abort).with(RuntimeError).and_call_original
-
-    subject
-    sleep 0.2
   end
 
-  it "aborts the thread if the watchdog block timeouts" do
-    allow(context).to receive(:ping) do
+  context "with a block that times out" do
+    let(:block) { Proc.new do
       sleep 1
+    end}
+
+    it "aborts" do
+      expect(subject.wrapped_object).to receive(:bark).at_least(:once).and_call_original
+      expect(subject.wrapped_object).to receive(:bite).once.and_call_original
+      expect(subject.wrapped_object).to receive(:abort).with(Timeout::Error).and_call_original
+
+      subject
+      sleep 0.2
     end
-
-    expect(subject.wrapped_object).to receive(:bark).at_least(:once).and_call_original
-    expect(subject.wrapped_object).to receive(:bite).once.and_call_original
-    expect(subject.wrapped_object).to receive(:abort).with(Timeout::Error).and_call_original
-
-    subject
-    sleep 0.2
   end
 end

--- a/agent/spec/lib/kontena/watchdog_spec.rb
+++ b/agent/spec/lib/kontena/watchdog_spec.rb
@@ -33,6 +33,9 @@ describe Kontena::Watchdog, :celluloid => true do
       sleep 1
     end
 
+    expect(subject.wrapped_object).to receive(:bark).at_least(:once).and_call_original
+    expect(subject.wrapped_object).to receive(:bite).once.and_call_original
+
     expect{
       subject
       sleep 0.5

--- a/agent/spec/lib/kontena/watchdog_spec.rb
+++ b/agent/spec/lib/kontena/watchdog_spec.rb
@@ -33,9 +33,22 @@ describe Kontena::Watchdog, :celluloid => true do
     end
   end
 
-  context "with a block that times out" do
+  context "with a block that times out in a hard thread suspend" do
     let(:block) { Proc.new do
-      sleep 1
+      Kernel.sleep 1
+    end}
+
+    it "aborts" do
+      expect(subject.wrapped_object).to receive(:abort).with(Timeout::Error).and_call_original
+
+      subject
+      sleep 0.2
+    end
+  end
+
+  context "with a block that times out in a celluloid task suspend" do
+    let(:block) { Proc.new do
+      Celluloid.sleep 1.0
     end}
 
     it "aborts" do

--- a/agent/spec/lib/kontena/watchdog_spec.rb
+++ b/agent/spec/lib/kontena/watchdog_spec.rb
@@ -1,0 +1,41 @@
+describe Kontena::Watchdog, :celluloid => true do
+  let(:context) { double() }
+
+  subject do
+    @watchdog = described_class.watch(interval: 0.01, threshold: 0.05, timeout: 0.1) do
+      context.ping
+    end
+  end
+
+  after do
+    @watchdog.terminate if @watchdog.alive?
+  end
+
+  it "does nothing if the watchdog block is okay" do
+    allow(context).to receive(:ping).and_return(nil)
+
+    expect{
+      subject
+      sleep 0.5
+    }.to_not raise_error
+  end
+
+  it "aborts the thread if the watchdog blocks raises" do
+    allow(context).to receive(:ping).and_raise(RuntimeError.new 'testing')
+    expect{
+      subject
+      sleep 0.5
+    }.to raise_error(Kontena::Watchdog::Abort, 'RuntimeError: testing')
+  end
+
+  it "aborts the thread if the watchdog blocks blocks" do
+    allow(context).to receive(:ping) do
+      sleep 1
+    end
+
+    expect{
+      subject
+      sleep 0.5
+    }.to raise_error(Kontena::Watchdog::Abort, /Timeout::Error: watchdog timeout after 0.\d+s/)
+  end
+end


### PR DESCRIPTION
Fixes #2733 by having the agent process exit within 10s if the `Celluloid::Supervision::Container` crashes

Implement a new `Kontena::Watchdog` used by the `Kontena::Agent`. This is a Celluloid actor that runs a polling function in a `defer` thread, and then aborts the main process thread on errors/timeouts.

The `Kontena::Agent` watchdog currently checks for the `@supervisor.alive?` case in #2733, but this could also be extended to cover other cases.

TODO: the watchdog timeout functionality isn't really used yet, but it would become relevant if the `Kontena::Agent` watchdog block starts to poll other actors for their health, and those polled actors might become stuck.

## Testing

### Watchdog error
With a supervised actor that likes to crash a lot:

```
E, [2017-12-13T14:27:03.336939 #1] ERROR -- : Actor crashed!
RuntimeError: asdf
	/app/lib/kontena/workers/container_info_worker.rb:25:in `start'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `public_send'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/calls.rb:28:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/async.rb:7:in `dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:50:in `block in dispatch'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```

The `Celluloid::Supervision::Container` actor will eventually hit a race condition and also crash:

```
E, [2017-12-13T14:27:03.342813 #1] ERROR -- : Error ( RuntimeError ) at start of supervised instance of Kontena::Workers::ContainerInfoWorker
E, [2017-12-13T14:27:03.343666 #1] ERROR -- : Actor crashed!
RuntimeError: a container instance went missing. This shouldn't be!
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-supervision-0.20.5/lib/celluloid/supervision/container.rb:118:in `restart_actor'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:15:in `block in call'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/cell.rb:76:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
	/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```

The watchdog will hit an error on the next interval check:

```
E, [2017-12-13T16:35:52.617327 #1] ERROR -- Kontena::Watchdog: Celluloid::Supervision::Container died (RuntimeError)
/app/lib/kontena/agent.rb:147:in `block in watchdog'
/app/lib/kontena/watchdog.rb:48:in `block (2 levels) in ping'
/usr/lib/ruby/2.4.0/timeout.rb:93:in `block in timeout'
/usr/lib/ruby/2.4.0/timeout.rb:33:in `block in catch'
/usr/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/usr/lib/ruby/2.4.0/timeout.rb:33:in `catch'
/usr/lib/ruby/2.4.0/timeout.rb:108:in `timeout'
/app/lib/kontena/watchdog.rb:47:in `block in ping'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:97:in `exclusive'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid.rb:421:in `exclusive'
/app/lib/kontena/watchdog.rb:46:in `ping'
/app/lib/kontena/watchdog.rb:32:in `block in start'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```

The agent process will exit, without running any of Celluloid `at_exit` shutdown handlers. The host systemd can then restart the `kontena-agent.service` unit.

### Watchdog timeout

```
E, [2017-12-13T16:23:03.057953 #1] ERROR -- Kontena::Watchdog: execution expired (Timeout::Error)
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `sleep'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `wait'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:63:in `block in check'
/usr/lib/ruby/gems/2.4.0/gems/timers-4.1.1/lib/timers/wait.rb:14:in `for'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:58:in `check'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:77:in `block in receive'
/usr/lib/ruby/gems/2.4.0/gems/timers-4.1.1/lib/timers/wait.rb:14:in `for'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/mailbox.rb:76:in `receive'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:50:in `wait'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid.rb:141:in `suspend'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:41:in `response'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/call/sync.rb:45:in `value'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/proxy/sync.rb:22:in `method_missing'
/app/lib/kontena/agent.rb:149:in `block in watchdog'
/app/lib/kontena/watchdog.rb:47:in `block (2 levels) in ping'
/usr/lib/ruby/2.4.0/timeout.rb:108:in `timeout'
/app/lib/kontena/watchdog.rb:46:in `block in ping'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:97:in `exclusive'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid.rb:421:in `exclusive'
/app/lib/kontena/watchdog.rb:45:in `ping'
/app/lib/kontena/watchdog.rb:32:in `block in start'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/actor.rb:339:in `block in task'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task.rb:44:in `block in initialize'
/usr/lib/ruby/gems/2.4.0/gems/celluloid-0.17.3/lib/celluloid/task/fibered.rb:14:in `block in create'
```

The process exits.