### PR TITLE
Enhance daemon strategy to implement node stickiness

### DIFF
--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -26,7 +26,7 @@ class GridServiceDeployer
   # @return [Array<HostNode>]
   def selected_nodes
     count = self.instance_count
-    available_nodes = self.nodes.map { |n| n.clone }
+    available_nodes = self.nodes.map { |n| Scheduler::Node.new(n.node) }
     nodes = []
     count.times do |i|
       begin
@@ -128,7 +128,7 @@ class GridServiceDeployer
 
   # @return [Integer]
   def instance_count
-    available_nodes = self.nodes.map { |n| n.clone } # we don't want to touch originals here
+    available_nodes = self.nodes.map { |n| Scheduler::Node.new(n.node) } # we don't want to touch originals here
     max_instances = self.scheduler.instance_count(self.nodes.size, self.grid_service.container_count)
     nodes = []
     max_instances.times do |i|

--- a/server/app/services/grid_service_scheduler.rb
+++ b/server/app/services/grid_service_scheduler.rb
@@ -57,7 +57,7 @@ class GridServiceScheduler
     end
 
     node = nodes.find{ |n| n == selected_node }
-    node.schedule_counter += 1
+    node.scheduled_instance! instance_number
 
     selected_node
   end

--- a/server/app/services/scheduler/node.rb
+++ b/server/app/services/scheduler/node.rb
@@ -21,7 +21,7 @@ module Scheduler
     end
 
     def to_s
-      "#{@node.name}: #{@schedule_counter}"
+      "#{@node.name}: #{schedule_counter}"
     end
 
     private

--- a/server/app/services/scheduler/node.rb
+++ b/server/app/services/scheduler/node.rb
@@ -1,11 +1,19 @@
 module Scheduler
   class Node
 
-    attr_accessor :schedule_counter
+    attr_reader :scheduled_instances
 
     def initialize(node)
       @node = node
-      @schedule_counter = 0
+      @scheduled_instances = Set.new
+    end
+
+    def scheduled_instance!(instance_number)
+      @scheduled_instances << instance_number
+    end
+
+    def schedule_counter
+      @scheduled_instances.size
     end
 
     def node

--- a/server/app/services/scheduler/strategy/daemon.rb
+++ b/server/app/services/scheduler/strategy/daemon.rb
@@ -24,13 +24,15 @@ module Scheduler
         service_instance = service_instances.find { |i| i.instance_number == instance_number }
 
         nodes.sort_by { |node|
+          scheduled_instances = Set.new
+          scheduled_instances.merge service_instances.select { |i| i.host_node_id == node.id && i.instance_number <= total_instances }.map{|i| i.instance_number}
+          scheduled_instances.merge node.scheduled_instances
+
           if service_instance && service_instance.host_node_id == node.id
             instance_rank = -1
           else
-            instance_rank = service_instances.select { |i| i.host_node_id == node.id && i.instance_number <= total_instances }.size
+            instance_rank = scheduled_instances.size
           end
-
-          instance_rank += node.schedule_counter - service_instances.select { |i| i.host_node_id == node.id && i.instance_number < instance_number }.size
 
           [instance_rank, node.node_number]
         }

--- a/server/app/services/scheduler/strategy/daemon.rb
+++ b/server/app/services/scheduler/strategy/daemon.rb
@@ -30,7 +30,9 @@ module Scheduler
             instance_rank = service_instances.select { |i| i.host_node_id == node.id && i.instance_number <= total_instances }.size
           end
 
-          [instance_rank + node.schedule_counter, node.node_number]
+          instance_rank += node.schedule_counter - service_instances.select { |i| i.host_node_id == node.id && i.instance_number < instance_number }.size
+
+          [instance_rank, node.node_number]
         }
       end
     end

--- a/server/app/services/scheduler/strategy/daemon.rb
+++ b/server/app/services/scheduler/strategy/daemon.rb
@@ -30,11 +30,7 @@ module Scheduler
             instance_rank = service_instances.select { |i| i.host_node_id == node.id && i.instance_number <= total_instances }.size
           end
 
-          rank = [instance_rank + node.schedule_counter, node.node_number]
-
-          puts "rank ##{instance_number}@#{node.node_number} = #{rank}"
-
-          rank
+          [instance_rank + node.schedule_counter, node.node_number]
         }
       end
     end

--- a/server/app/services/scheduler/strategy/daemon.rb
+++ b/server/app/services/scheduler/strategy/daemon.rb
@@ -15,11 +15,33 @@ module Scheduler
         10.minutes
       end
 
+      # @param [GridService] grid_service
+      # @param [Integer] instance_number
+      # @param [Array<Scheduler::Node>] nodes
+      # @return [Scheduler::Node,NilClass]
+      def find_stateless_node(grid_service, instance_number, nodes)
+        prev_instance = grid_service.grid_service_instances.has_node.find_by(
+          instance_number: instance_number
+        )
+        if prev_instance
+          node = nodes.find { |n| n.node == prev_instance.host_node }
+          unless node
+            selector = (instance_number.to_f / nodes.size.to_f).floor
+            candidates = self.sort_candidates(nodes, grid_service, instance_number)
+            node = candidates.select { |c| c.schedule_counter <= selector }.last
+          end
+          node
+        else
+          candidates = self.sort_candidates(nodes, grid_service, instance_number)
+          candidates.first
+        end
+      end
+
       # @param [Array<Scheduler::Node>] nodes
       # @param [GridService] grid_service
       # @param [Integer] instance_number
       def sort_candidates(nodes, grid_service, instance_number)
-        nodes.sort_by{|node|
+        nodes.sort_by { |node|
           [node.schedule_counter, node.node_number]
         }
       end

--- a/server/spec/services/scheduler/strategy/daemon_spec.rb
+++ b/server/spec/services/scheduler/strategy/daemon_spec.rb
@@ -28,7 +28,7 @@ describe Scheduler::Strategy::Daemon do
       nodes = scheduler_nodes
       nodes.each do |n|
         node = subject.find_node(stateless_service, n.node_number, nodes)
-        node.schedule_counter += 1
+        node.scheduled_instance! n.node_number
         expect(node).to eq(nodes[n.node_number - 1])
       end
     end
@@ -51,7 +51,7 @@ describe Scheduler::Strategy::Daemon do
         scheduled = []
         nodes.each_with_index do |n, i|
           node = subject.find_node(stateless_service, i + 1, nodes)
-          node.schedule_counter += 1
+          node.scheduled_instance! i + 1
           scheduled << node
         end
         expect(scheduled.map {|s| s.node_number}).to eq([
@@ -71,7 +71,7 @@ describe Scheduler::Strategy::Daemon do
           scheduled = []
           (nodes.size * container_count).times do |i|
             node = subject.find_node(stateless_service, i + 1, nodes)
-            node.schedule_counter += 1
+            node.scheduled_instance! i + 1
             scheduled << node
           end
           expect(scheduled.map {|s| s.node_number}).to eq([
@@ -93,7 +93,7 @@ describe Scheduler::Strategy::Daemon do
           scheduled = []
           (nodes.size * container_count).times do |i|
             node = subject.find_node(stateless_service, i + 1, nodes)
-            node.schedule_counter += 1
+            node.scheduled_instance! i + 1
             scheduled << node
           end
           expect(scheduled.map {|s| s.node_number}).to eq([
@@ -110,7 +110,7 @@ describe Scheduler::Strategy::Daemon do
         scheduled = []
         nodes.each_with_index do |n, i|
           node = subject.find_node(stateless_service, i + 1, nodes)
-          node.schedule_counter += 1
+          node.scheduled_instance! i + 1
           scheduled << node
         end
         expect(scheduled.map {|s| s.node_number}).to eq([
@@ -140,7 +140,7 @@ describe Scheduler::Strategy::Daemon do
         scheduled = []
         (nodes.size * container_count).times do |i|
           node = subject.find_node(stateless_service, i + 1, nodes)
-          node.schedule_counter += 1
+          node.scheduled_instance! i + 1
           scheduled << node
         end
         expect(scheduled.map {|s| s.node_number}).to eq([
@@ -164,7 +164,7 @@ describe Scheduler::Strategy::Daemon do
         scheduled = []
         (nodes.size * container_count).times do |i|
           node = subject.find_node(stateless_service, i + 1, nodes)
-          node.schedule_counter += 1
+          node.scheduled_instance! i + 1
           scheduled << node
         end
         expect(scheduled.map {|s| s.node_number}).to eq([
@@ -190,7 +190,7 @@ describe Scheduler::Strategy::Daemon do
         scheduled = []
         (nodes.size * container_count).times do |i|
           node = subject.find_node(stateless_service, i + 1, nodes)
-          node.schedule_counter += 1
+          node.scheduled_instance! i + 1
           scheduled << node
         end
         expect(scheduled.map {|s| s.node_number}).to eq([
@@ -214,7 +214,7 @@ describe Scheduler::Strategy::Daemon do
         scheduled = []
         nodes.each_with_index do |n, i|
           node = subject.find_node(stateless_service, i + 1, nodes)
-          node.schedule_counter += 1
+          node.scheduled_instance! i + 1
           scheduled << node
         end
         expect(scheduled.map { |s| s.node_number}).to eq([

--- a/server/spec/services/scheduler/strategy/daemon_spec.rb
+++ b/server/spec/services/scheduler/strategy/daemon_spec.rb
@@ -4,24 +4,114 @@ describe Scheduler::Strategy::Daemon do
   let(:grid) { Grid.create(name: 'test') }
 
   let(:host_nodes) do
-    [
+    10.times.map do |i|
+      n = i + 1
       HostNode.create!(
-      node_id: 'node1', name: 'node-1', connected: true, grid: grid, node_number: 1
-      ),
-      HostNode.create!(
-        node_id: 'node2', name: 'node-2', connected: true, grid: grid, node_number: 2
-      ),
-      HostNode.create!(
-        node_id: 'node3', name: 'node-3', connected: true, grid: grid, node_number: 3
-      ),
-    ]
+        node_id: "node#{n}", name: "node-#{n}", connected: true, grid: grid, node_number: n
+      )
+    end
   end
+
   let(:scheduler_nodes) do
     host_nodes.map{|n| Scheduler::Node.new(n)}
   end
 
   let(:stateless_service) do
     GridService.create!(name: 'test', grid: grid, image_name: 'foo/bar:latest', stateful: false)
+  end
+
+  describe '#find_node' do
+    it 'finds matching nodes' do
+      nodes = scheduler_nodes
+      nodes.each do |n|
+        node = subject.find_node(stateless_service, n.node_number, nodes)
+        node.schedule_counter += 1
+        expect(node).to eq(nodes[n.node_number - 1])
+      end
+    end
+
+    context 'with existing nodes' do
+      before(:each) do
+        host_nodes.each do |n|
+          stateless_service.grid_service_instances.create!(
+            host_node: n,
+            instance_number: n.node_number
+          )
+        end
+      end
+
+      it 'minimizes shuffle when nodes 2 & 3 are missing' do
+        nodes = scheduler_nodes.tap do |n|
+          n.delete_at(1)
+          n.delete_at(1)
+        end
+
+        scheduled = []
+        nodes.each_with_index do |n, i|
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map {|s| s.node_number}).to eq([
+          1, 10, 9, 4, 5, 6, 7, 8
+        ])
+      end
+
+      it 'minimizes shuffle when nodes 2 & 3 are missing (2 instances per node)' do
+        nodes = scheduler_nodes.tap do |n|
+          n.delete_at(1)
+          n.delete_at(1)
+        end
+
+        scheduled = []
+        16.times do |i| # 2 instances per node
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map {|s| s.node_number}).to eq([
+          1, 10, 9, 4, 5, 6, 7, 8,
+          9, 10, 1, 4, 5, 6, 7, 8
+        ])
+      end
+
+      it 'minimizes shuffle when last two nodes are missing' do
+        nodes = scheduler_nodes[0..-3]
+        scheduled = []
+        nodes.each_with_index do |n, i|
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map {|s| s.node_number}).to eq([
+          1, 2, 3, 4, 5, 6, 7, 8
+        ])
+      end
+    end
+
+    context 'with newly added nodes' do
+      before(:each) do
+        host_nodes[0..-3].each do |n|
+          stateless_service.grid_service_instances.create!(
+            host_node: n,
+            instance_number: n.node_number
+          )
+        end
+      end
+
+      it 'finds correct nodes' do
+        nodes = scheduler_nodes
+        scheduled = []
+        nodes.each_with_index do |n, i|
+          node = subject.find_node(stateless_service, i + 1, nodes)
+          node.schedule_counter += 1
+          scheduled << node
+        end
+        expect(scheduled.map { |s| s.node_number}).to eq([
+          1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        ])
+      end
+    end
   end
 
   describe '#instance_count' do

--- a/server/spec/services/scheduler/strategy/high_availability_spec.rb
+++ b/server/spec/services/scheduler/strategy/high_availability_spec.rb
@@ -51,9 +51,9 @@ describe Scheduler::Strategy::HighAvailability do
       end
 
       it 'returns node from az that does not yet have service instance' do
-        nodes[2].schedule_counter = 1 # az=b
+        nodes[2].scheduled_instance! 1 # az=b
         expect(['a', 'c']).to include(subject.find_node(stateful_service, 2, nodes).availability_zone)
-        nodes[1].schedule_counter = 1 # az=a
+        nodes[1].scheduled_instance! 2 # az=a
         expect(['c']).to include(subject.find_node(stateful_service, 3, nodes).availability_zone)
       end
 
@@ -96,9 +96,9 @@ describe Scheduler::Strategy::HighAvailability do
       end
 
       it 'returns node from az that does not yet have service instance' do
-        nodes[2].schedule_counter = 1 # az=b
+        nodes[2].scheduled_instance! 1 # az=b
         expect(['a', 'c']).to include(subject.find_node(stateless_service, 2, nodes).availability_zone)
-        nodes[1].schedule_counter = 1 # az=a
+        nodes[1].scheduled_instance! 2 # az=a
         expect(['c']).to include(subject.find_node(stateless_service, 3, nodes).availability_zone)
       end
     end
@@ -143,8 +143,10 @@ describe Scheduler::Strategy::HighAvailability do
       node1 = nodes[0]
       node2 = nodes[1]
       node3 = nodes[2]
-      node1.schedule_counter = 2
-      node2.schedule_counter = 2
+      node1.scheduled_instance! 1
+      node1.scheduled_instance! 2
+      node1.scheduled_instance! 3
+      node1.scheduled_instance! 4
       node3.set(labels: ['region=eu-west-1', 'az=b'])
       expect(subject.availability_zone_count(node1, nodes)).to eq(4)
       expect(subject.availability_zone_count(node3, nodes)).to eq(0)


### PR DESCRIPTION
Alternative approach to #3124 that tries to be more easily understandable, and with additional specs

* Change `Scheduler::Node#schedule_counter` to track each scheduled `instance_number` separately in a `Set`
* Change `Scheduler::Strategy::Daemon#sort_candidates` to:
  * Make existing instances sticky to their nodes
  * Ensure even distribution of instances by also taking the number of existing instances into account when sorting