### PR TITLE
Fix CLI exec to use TTY::Screen.size

### DIFF
--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -1,4 +1,4 @@
-require 'io/console'
+require 'tty-screen'
 require 'kontena-websocket-client'
 
 module Kontena::Cli::Helpers
@@ -107,7 +107,7 @@ module Kontena::Cli::Helpers
       Thread.new do
         begin
           if tty
-            console_height, console_width = IO.console.winsize
+            console_height, console_width = TTY::Screen.size
             websocket_exec_write(ws, 'tty_size' => {
               width: console_width, height: console_height
             })

--- a/cli/spec/kontena/cli/helpers/exec_helper_spec.rb
+++ b/cli/spec/kontena/cli/helpers/exec_helper_spec.rb
@@ -273,7 +273,7 @@ describe Kontena::Cli::Helpers::ExecHelper do
 
       it 'connects and sends messages from stdin' do
         stdin_eol = false
-        allow(IO.console).to receive(:winsize).and_return([100, 100])
+        allow(TTY::Screen).to receive(:size).and_return([100, 100])
         expect(websocket_client).to receive(:send).once.with('{"tty_size":{"width":100,"height":100}}')
         expect(websocket_client).to receive(:send).once.with('{"cmd":["test-tty"]}')
 

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'clamp'
 require 'ruby_dig'
 require 'kontena_cli'
 require 'webmock/rspec'
+require 'tmpdir'
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true

--- a/test/spec/features/container/exec_spec.rb
+++ b/test/spec/features/container/exec_spec.rb
@@ -46,5 +46,6 @@ describe 'container exec' do
       end
     end
     expect(k.run).to be_truthy
+    expect(k.code).to be_zero, k.out
   end
 end

--- a/test/spec/features/service/exec_spec.rb
+++ b/test/spec/features/service/exec_spec.rb
@@ -47,6 +47,7 @@ describe 'service exec' do
         end
       end
       expect(k.run).to be_truthy
+      expect(k.out).to match /lib64/
     end
 
     it 'runs a command with tty control input' do

--- a/test/spec/features/service/exec_spec.rb
+++ b/test/spec/features/service/exec_spec.rb
@@ -14,6 +14,7 @@ describe 'service exec' do
   it 'runs a command inside a service' do
     k = kommando("kontena service exec test-1 hostname -s")
     expect(k.run).to be_truthy
+    expect(k.code).to be_zero, k.out
     expect(k.out).to eq("test-1-1\r\n")
   end
 
@@ -47,7 +48,7 @@ describe 'service exec' do
         end
       end
       expect(k.run).to be_truthy
-      expect(k.out).to match /lib64/
+      expect(k.code).to be_zero, k.out
     end
 
     it 'runs a command with tty control input' do
@@ -62,6 +63,7 @@ describe 'service exec' do
       end
 
       expect(k.run).to be_truthy
+      expect(k.code).to_not be_zero, k.out
       expect(k.out).to match /\^C/
     end
 
@@ -76,6 +78,7 @@ describe 'service exec' do
       end
 
       expect(k.run).to be_truthy
+      expect(k.code).to be_zero, k.out
       expect(k.out).to match /\u00e5\u00e5f/
     end
 
@@ -98,6 +101,7 @@ describe 'service exec' do
       end
 
       expect(k.run).to be_truthy
+      expect(k.code).to be_zero, k.out
       expect(k.out).to match /^echo f\u00e5\u00e5$/ # XXX: fails on the invalid UTF-8 byte sequence
     end
   end
@@ -106,12 +110,14 @@ describe 'service exec' do
     it 'runs a command with piped stdin' do
       k = kommando("$ echo beer | kontena service exec -i test-1 rev")
       expect(k.run).to be_truthy
+      expect(k.code).to be_zero, k.out
       expect(k.out).to eq('reeb')
     end
 
     it 'runs a command with piped non-ascii stdin' do
       k = kommando("$ echo f\u00e5\u00e5 | kontena service exec -i test-1 sh -c 'LANG=C.UTF-8 rev'")
       expect(k.run).to be_truthy
+      expect(k.code).to be_zero, k.out
       expect(k.out).to eq("\u00e5\u00e5f")
     end
   end
@@ -128,6 +134,7 @@ describe 'service exec' do
     it 'runs a command inside a service on a given instances' do
       k = kommando("kontena service exec --instance 2 test-1 hostname -s")
       expect(k.run).to be_truthy
+      expect(k.code).to be_zero, k.out
       expect(k.out).to eq("test-1-2\r\n")
     end
 
@@ -135,20 +142,21 @@ describe 'service exec' do
     it 'runs a command on every instance with --all' do
       k = kommando("kontena service exec --all --silent test-1 hostname -s")
       expect(k.run).to be_truthy
+      expect(k.code).to be_zero, k.out
       expect(k.out).to eq("test-1-1\r\ntest-1-2\r\n")
     end
 
     it 'fails early if running a command on every instances with --all fails' do
       k = kommando("kontena service exec --all --silent --shell test-1 hostname -s && false")
       expect(k.run).to be_truthy
-      expect(k.code).to_not eq 0
+      expect(k.code).to_not be_zero, k.out
       expect(k.out).to eq("test-1-1\r\n")
     end
 
     it 'keeps going if running a command on every instances with --all --skip' do
       k = kommando("kontena service exec --all --skip --silent --shell test-1 hostname -s && false")
       expect(k.run).to be_truthy
-      expect(k.code).to_not eq 0
+      expect(k.code).to_not be_zero, k.out
       expect(k.out).to eq("test-1-1\r\ntest-1-2\r\n")
     end
   end


### PR DESCRIPTION
Fixes #3060

It seems like `TTY::Screen.size` behaves better than `IO.console.winsize` in some scenarios. Since we're already depending on `tty-screen` in the CLI, no reason to not use it.

This also seems to fix the e2e exec specs for me... but I'm not sure how dependent that is on how the e2e specs are being run exactly?