### PR TITLE
Agent: Fix ContainerExec to handle any type of Docker error during tty resize

### DIFF
--- a/agent/lib/kontena/actors/container_exec.rb
+++ b/agent/lib/kontena/actors/container_exec.rb
@@ -44,7 +44,7 @@ module Kontena::Actors
           'w' => size['width'], 'h' => size['height']
         })
         info "tty resized to #{size['width']}x#{size['height']}"
-      rescue Docker::Error::NotFoundError => exc
+      rescue Docker::Error::DockerError => exc
         # The Docker::Exec#resize races with the Docker::Exec#start, and the
         # resize (POST /exec/.../resize) will fail if the exec process is not
         # yet running:


### PR DESCRIPTION
Fixes #3140 

No specs for this code, unfortunately.

## Testing

### Fixed node

```
$ bin/kontena service exec -it --instance=1 redis date
Fri Dec 15 12:17:33 UTC 2017
$ bin/kontena service exec -it --instance=1 redis date
Fri Dec 15 12:17:34 UTC 2017
$ bin/kontena service exec -it --instance=1 redis date
Fri Dec 15 12:17:36 UTC 2017
$ bin/kontena service exec -it --instance=1 redis date
Fri Dec 15 12:17:37 UTC 2017
```

### Broken node (without fix)
Can fail in different ways depending on the timing and when the command executes, or it may even succeed:

```
$ bin/kontena service exec -it --instance=2 redis ls -la /
total 180
drwxr-xr-x.   1 root  root  4096 Dec 14 15:33 .
drwxr-xr-x.   1 root  root  4096 Dec 14 15:33 ..
-rwxr-xr-x.   1 root  root     0 Dec 14 15:33 .dockerenv
drwxr-xr-x.   2 root  root  4096 Dec 12 09:21 bin
drwxr-xr-x.   2 root  root  4096 Nov 19 15:32 boot
drwxr-xr-x.   2 redis redis 4096 Dec 14 15:33 data
drwxr-xr-x.   5 root  root   340 Dec 14 15:33 dev
drwxr-xr-x.   1 root  root  4096 Dec 14 15:33 etc
drwxr-xr-x.   2 root  root  4096 Nov 19 15:32 home
drwxr-xr-x.   9 root  root  4096 Dec 12 09:21 lib
drwxr-xr-x.   2 root  root  4096 Dec 12 09:21 lib64
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 media
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 mnt
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 opt
dr-xr-xr-x. 101 root  root     0 Dec 14 15:33 proc
drwx------.   2 root  root  4096 Dec 12 09:21 root
drwxr-xr-x.   3 root  root  4096 Dec 12 09:21 run
drwxr-xr-x.   2 root  root  4096 Dec 12 09:21 sbin
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 srv
dr-xr-xr-x.  13 root  root     0 Dec 11 09:52 sys
drwxrwxrwt.   2 root  root  4096 Dec 12 07:15 tmp
drwxr-xr-x.  10 root  root  4096 Dec 10 00:00 usr
drwxr-xr-x.  11 root  root  4096 Dec 12 09:21 var
drwxr-xr-x.   2 root  root  4096 Mar 21  2017 w
drwxr-xr-x.   2 root  root  4096 Mar 21  2017 w-nomcast
drwxr-xr-x.   2 root  root  4096 Mar 21  2017 w-noop
 [error] RuntimeError : Celluloid::TaskTerminated: task was terminated
         See /home/kontena/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
$ bin/kontena service exec -it --instance=2 redis ls -la /
total 180
drwxr-xr-x.   1 root  root  4096 Dec 14 15:33 .
drwxr-xr-x.   1 root  root  4096 Dec 14 15:33 ..
-rwxr-xr-x.   1 root  root     0 Dec 14 15:33 .dockerenv
drwxr-xr-x.   2 root  root  4096 Dec 12 09:21 bin
drwxr-xr-x.   2 root  root  4096 Nov 19 15:32 boot
drwxr-xr-x.   2 redis redis 4096 Dec 14 15:33 data
drwxr-xr-x.   5 root  root   340 Dec 14 15:33 dev
drwxr-xr-x.   1 root  root  4096 Dec 14 15:33 etc
drwxr-xr-x.   2 root  root  4096 Nov 19 15:32 home
drwxr-xr-x.   9 root  root  4096 Dec 12 09:21 lib
drwxr-xr-x.   2 root  root  4096 Dec 12 09:21 lib64
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 media
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 mnt
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 opt
dr-xr-xr-x. 101 root  root     0 Dec 14 15:33 proc
drwx------.   2 root  root  4096 Dec 12 09:21 root
drwxr-xr-x.   3 root  root  4096 Dec 12 09:21 run
drwxr-xr-x.   2 root  root  4096 Dec 12 09:21 sbin
drwxr-xr-x.   2 root  root  4096 Dec 10 00:00 srv
dr-xr-xr-x.  13 root  root     0 Dec 11 09:52 sys
drwxrwxrwt.   2 root  root  4096 Dec 12 07:15 tmp
drwxr-xr-x.  10 root  root  4096 Dec 10 00:00 usr
drwxr-xr-x.  11 root  root  4096 Dec 12 09:21 var
drwxr-xr-x.   2 root  root  4096 Mar 21  2017 w
drwxr-xr-x.   2 root  root  4096 Mar 21  2017 w-nomcast
drwxr-xr-x.   2 root  root  4096 Mar 21  2017 w-noop
$ bin/kontena service exec -it --instance=2 redis ls -la /
 [error] RuntimeError : Celluloid::TaskTerminated: task was terminated
         See /home/kontena/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
```