### PR TITLE
Fix stack commands not to modify STACK/GRID env of parent when installing child stacks

### DIFF
--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -43,8 +43,6 @@ module Kontena::Cli::Stacks
       dependencies = loader.dependencies
       return if dependencies.nil?
 
-      original_env = current_stack_env
-
       dependencies.each do |dependency|
         target_name = "#{stack_name}-#{dependency['name']}"
         caret "Installing dependency #{pastel.cyan(dependency['stack'])} as #{pastel.cyan(target_name)}"
@@ -58,19 +56,10 @@ module Kontena::Cli::Stacks
 
         cmd << dependency['stack']
         Kontena.run!(cmd)
-        original_env.each { |k,v| ENV[k] = v }
+        set_env_variables(stack_name, current_grid)
       end
 
     end
-
-    def current_stack_env
-      {
-        'STACK' => ENV['STACK'],
-        'GRID' => ENV['GRID'],
-        'PLATFORM' => ENV['PLATFORM']
-      }
-    end
-
 
     def create_stack
       spinner "Creating stack #{pastel.cyan(stack['name'])} " do

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -42,6 +42,9 @@ module Kontena::Cli::Stacks
     def install_dependencies
       dependencies = loader.dependencies
       return if dependencies.nil?
+
+      original_env = current_stack_env
+
       dependencies.each do |dependency|
         target_name = "#{stack_name}-#{dependency['name']}"
         caret "Installing dependency #{pastel.cyan(dependency['stack'])} as #{pastel.cyan(target_name)}"
@@ -55,8 +58,19 @@ module Kontena::Cli::Stacks
 
         cmd << dependency['stack']
         Kontena.run!(cmd)
+        original_env.each { |k,v| ENV[k] = v }
       end
+
     end
+
+    def current_stack_env
+      {
+        'STACK' => ENV['STACK'],
+        'GRID' => ENV['GRID'],
+        'PLATFORM' => ENV['PLATFORM']
+      }
+    end
+
 
     def create_stack
       spinner "Creating stack #{pastel.cyan(stack['name'])} " do

--- a/cli/lib/kontena/cli/stacks/install_command.rb
+++ b/cli/lib/kontena/cli/stacks/install_command.rb
@@ -24,9 +24,9 @@ module Kontena::Cli::Stacks
     requires_current_master_token
 
     def execute
-      set_env_variables(stack_name, current_grid)
-
       install_dependencies unless skip_dependencies?
+
+      set_env_variables(stack_name, current_grid)
 
       stack # runs validations
 
@@ -56,7 +56,6 @@ module Kontena::Cli::Stacks
 
         cmd << dependency['stack']
         Kontena.run!(cmd)
-        set_env_variables(stack_name, current_grid)
       end
 
     end

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -198,6 +198,7 @@ module Kontena::Cli::Stacks
         caret "Installing new dependency #{cmd.last} as #{added_stack}"
         deployable_stacks << added_stack
         Kontena.run!(cmd)
+        set_env_variables(stack_name, current_grid)
       end
       deployable_stacks
     end
@@ -219,6 +220,7 @@ module Kontena::Cli::Stacks
     def run_deploys(deployable_stacks)
       deployable_stacks.each do |deployable_stack|
         Kontena.run!(['stack', 'deploy', deployable_stack])
+        set_env_variables(stack_name, current_grid)
       end
     end
 

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -218,7 +218,6 @@ module Kontena::Cli::Stacks
       deployable_stacks.each do |deployable_stack|
         Kontena.run!(['stack', 'deploy', deployable_stack])
       end
-      set_env_variables(stack_name, current_grid)
     end
 
     def update_stack(name, data)

--- a/cli/lib/kontena/cli/stacks/upgrade_command.rb
+++ b/cli/lib/kontena/cli/stacks/upgrade_command.rb
@@ -29,8 +29,6 @@ module Kontena::Cli::Stacks
 
     # @return [Kontena::Cli::Stacks::ChangeResolver]
     def execute
-      set_env_variables(stack_name, current_grid)
-
       old_data = spinner "Reading stack #{pastel.cyan(stack_name)} from master" do
         gather_master_data(stack_name)
       end
@@ -198,7 +196,6 @@ module Kontena::Cli::Stacks
         caret "Installing new dependency #{cmd.last} as #{added_stack}"
         deployable_stacks << added_stack
         Kontena.run!(cmd)
-        set_env_variables(stack_name, current_grid)
       end
       deployable_stacks
     end
@@ -220,8 +217,8 @@ module Kontena::Cli::Stacks
     def run_deploys(deployable_stacks)
       deployable_stacks.each do |deployable_stack|
         Kontena.run!(['stack', 'deploy', deployable_stack])
-        set_env_variables(stack_name, current_grid)
       end
+      set_env_variables(stack_name, current_grid)
     end
 
     def update_stack(name, data)

--- a/cli/lib/kontena/cli/stacks/validate_command.rb
+++ b/cli/lib/kontena/cli/stacks/validate_command.rb
@@ -39,19 +39,19 @@ module Kontena::Cli::Stacks
     end
 
     def execute
-      if online?
-        set_env_variables(stack_name, require_current_grid)
-      else
-        config.current_master = nil
-        set_env_variables(stack_name, 'validate', 'validate-platform')
-      end
-
       if dependency_tree?
         puts ::YAML.dump('name' => stack_name, 'stack' => source, 'depends' => stack['dependencies'])
         exit 0
       end
 
       validate_dependencies if dependencies?
+
+      if online?
+        set_env_variables(stack_name, require_current_grid)
+      else
+        config.current_master = nil
+        set_env_variables(stack_name, 'validate', 'validate-platform')
+      end
 
       stack # runs validations
 

--- a/cli/lib/kontena/cli/stacks/yaml/reader.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/reader.rb
@@ -63,7 +63,7 @@ module Kontena::Cli::Stacks
       # Values that are set always when parsing stacks
       # @return [Hash] a hash of key value pairs
       def default_envs
-        @default_envs ||= {
+        {
           'GRID' => env['GRID'],
           'STACK' => env['STACK'],
           'PLATFORM' => env['PLATFORM'] || env['GRID']

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -142,5 +142,14 @@ describe 'stack install' do
       k = run 'kontena stack ls -q'
       expect(k.out.split(/[\r\n]/)).to match array_including('twemproxy', 'twemproxy-redis_from_registry', 'twemproxy-redis_from_yml')
     end
+
+    it 'does not mutate the $STACK variable' do
+      with_fixture_dir("stack/depends") do
+        k = run 'kontena stack install'
+        expect(k.code).to eq (0)
+      end
+      k = run 'kontena service show twemproxy/twemproxy'
+      expect(k.out).to match(/STACKNAME=twemproxy$/m)
+    end
   end
 end

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -149,7 +149,7 @@ describe 'stack install' do
         expect(k.code).to eq (0)
       end
       k = run 'kontena service show twemproxy/twemproxy'
-      expect(k.out).to match(/STACKNAME=twemproxy$/m)
+      expect(k.out).to match(/STACKNAME=twemproxy[\r\n]/)
     end
   end
 end

--- a/test/spec/fixtures/stack/depends/kontena.yml
+++ b/test/spec/fixtures/stack/depends/kontena.yml
@@ -24,5 +24,6 @@ services:
     environment:
       - "REDIS1_PORT_6379_TCP_ADDR=${redis_from_registry}"
       - "REDIS2_PORT_6379_TCP_ADDR=${redis_from_yml}"
+      - "STACKNAME=${STACK}"
     ports:
       - "${port}:6000"


### PR DESCRIPTION
Fixes #3144 

Child stack installations mutated the $STACK variable. This PR makes the dependency installation restore the original STACK environment variable when returning from the child installation.
