### PR TITLE
Allow container exec --tty with zero console width/height

### DIFF
--- a/server/app/services/docker/streaming_executor.rb
+++ b/server/app/services/docker/streaming_executor.rb
@@ -90,7 +90,7 @@ module Docker
     def exec_resize(width, height)
       raise ArgumentError, "width must be integer" unless Integer === width
       raise ArgumentError, "height must be integer" unless Integer === height
-      raise ArgumentError, "width and height must be integers > 0" unless width > 0 && height > 0
+      raise ArgumentError, "width and height must be integers > 0" unless width >= 0 && height >= 0
 
       tty_size = { 'width' => width, 'height' => height }
 

--- a/server/spec/services/docker/streaming_executor_spec.rb
+++ b/server/spec/services/docker/streaming_executor_spec.rb
@@ -86,6 +86,12 @@ describe Docker::StreamingExecutor do
         subject.exec_resize(80, 24)
       end
 
+      it 'accepts zero size' do
+        expect(rpc_client).to receive(:notify).with('/containers/tty_resize', exec_id, {'width' => 0, 'height' => 0})
+
+        subject.exec_resize(0, 0)
+      end
+
       it 'fails on invalid width' do
         expect{
           subject.exec_resize(nil, 24)


### PR DESCRIPTION
Fixes #3060

Relax the server exec validation introduced in 1.4.1 (#2912) to accept `tty_resize` with zero width/height.

It seems like this happened fairly often, including in the e2e specs and the Kontena Cloud terminal, so it should be considered a valid usecase. 