### PR TITLE
Fix Kontena::PluginManager::Loader#report_tracking use of spec

### DIFF
--- a/cli/lib/kontena/plugin_manager/loader.rb
+++ b/cli/lib/kontena/plugin_manager/loader.rb
@@ -40,7 +40,7 @@ module Kontena
         require(path)
         Kontena.logger.debug { "Loaded plugin #{spec.name}" } if plugin_debug?
 
-        report_tracking
+        report_tracking(spec)
         true
       rescue ScriptError, LoadError, StandardError => ex
         warn " [#{Kontena.pastel.red('error')}] Failed to load plugin: #{spec.name} from #{spec.gem_dir}\n\tRerun the command with environment DEBUG=true set to get the full exception."
@@ -79,7 +79,7 @@ module Kontena
         @load_path_before = $LOAD_PATH.dup
       end
 
-      def report_tracking
+      def report_tracking(spec)
         return unless plugin_debug?
         added_features = ($LOADED_FEATURES - @loaded_features_before).map {|feat| "- #{feat}"}
         added_paths = ($LOAD_PATH - @load_path_before).map {|feat| "- #{feat}"}


### PR DESCRIPTION
Fixes  #3149

## Testing

No specs...

```
/kontena/test # DEBUG=plugin kontena plugin list
DEBUG Kontena CLI 1.4.0.dev (ruby-2.3.6+x86_64-linux-musl)
DEBUG Activating plugin kontena-plugin-cloud
DEBUG Loading plugin kontena-plugin-cloud from /root/.kontena/gems/2.3.6/gems/kontena-plugin-cloud-1.2.0/lib/kontena_cli_plugin.rb
DEBUG Loaded plugin kontena-plugin-cloud
DEBUG Plugin manager loaded features for kontena-plugin-cloud:
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/version.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/messages.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/errors.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/help.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/attribute/declaration.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/attribute/instance.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/attribute/definition.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/truthy.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/option/definition.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/option/declaration.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/option/parsing.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/parameter/definition.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/parameter/declaration.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/parameter/parsing.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/definition.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/declaration.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/parsing.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp/command.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/clamp-1.1.2/lib/clamp.rb
DEBUG - /kontena/cli/lib/kontena/cli/subcommand_loader.rb
DEBUG - /kontena/cli/lib/kontena/util.rb
DEBUG - /kontena/cli/lib/kontena/cli/bytes_helper.rb
DEBUG - /kontena/cli/lib/kontena/cli/grid_options.rb
DEBUG - /usr/lib/ruby/2.3.0/cgi/core.rb
DEBUG - /usr/lib/ruby/2.3.0/x86_64-linux-musl/cgi/escape.so
DEBUG - /usr/lib/ruby/2.3.0/cgi/util.rb
DEBUG - /usr/lib/ruby/2.3.0/cgi/cookie.rb
DEBUG - /usr/lib/ruby/2.3.0/cgi.rb
DEBUG - /usr/lib/ruby/2.3.0/x86_64-linux-musl/digest.so
DEBUG - /usr/lib/ruby/2.3.0/digest.rb
DEBUG - /usr/lib/ruby/2.3.0/x86_64-linux-musl/openssl.so
DEBUG - /usr/lib/ruby/2.3.0/openssl/bn.rb
DEBUG - /usr/lib/ruby/2.3.0/openssl/pkey.rb
DEBUG - /usr/lib/ruby/2.3.0/openssl/cipher.rb
DEBUG - /usr/lib/ruby/2.3.0/openssl/config.rb
DEBUG - /usr/lib/ruby/2.3.0/openssl/digest.rb
DEBUG - /usr/lib/ruby/2.3.0/openssl/x509.rb
DEBUG - /usr/lib/ruby/2.3.0/openssl/buffering.rb
DEBUG - /usr/lib/ruby/2.3.0/x86_64-linux-musl/io/nonblock.so
DEBUG - /usr/lib/ruby/2.3.0/openssl/ssl.rb
DEBUG - /usr/lib/ruby/2.3.0/openssl.rb
DEBUG - /usr/lib/ruby/2.3.0/x86_64-linux-musl/socket.so
DEBUG - /usr/lib/ruby/2.3.0/x86_64-linux-musl/io/wait.so
DEBUG - /usr/lib/ruby/2.3.0/socket.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/rfc2396_parser.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/rfc3986_parser.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/common.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/generic.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/ftp.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/http.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/https.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/ldap.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/ldaps.rb
DEBUG - /usr/lib/ruby/2.3.0/uri/mailto.rb
DEBUG - /usr/lib/ruby/2.3.0/uri.rb
DEBUG - /usr/lib/ruby/2.3.0/x86_64-linux-musl/zlib.so
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/extensions/uri.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/base.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/expects.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/idempotent.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/instrumentor.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/mock.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/response_parser.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/constants.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/utils.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/connection.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/headers.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/response.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/decompress.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/escape_path.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/redirect_follower.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/middlewares/capture_cookies.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/pretty_printer.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/socket.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/ssl_socket.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/standard_instrumentor.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/unix_socket.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon.rb
DEBUG - /usr/lib/ruby/gems/2.3.0/gems/excon-0.59.0/lib/excon/error.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/01_clear_current_master_after_terminate.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/auth/01_list_and_select_grid_after_master_auth.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/01_show_logo_before_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/04_default_master_version.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/05_before_deploy_configuration_wizard.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/40_install_ssl_certificate_after_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/50_authenticate_after_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/55_create_initial_grid_after_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/56_set_server_provider_after_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/60_configure_auth_provider_after_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/70_invite_self_after_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callbacks/master/deploy/90_proptip_after_deploy.rb
DEBUG - /kontena/cli/lib/kontena/callback.rb
DEBUG - /kontena/cli/lib/kontena/command.rb
DEBUG - /root/.kontena/gems/2.3.6/gems/kontena-plugin-cloud-1.2.0/lib/kontena/plugin/cloud.rb
DEBUG - /root/.kontena/gems/2.3.6/gems/kontena-plugin-cloud-1.2.0/lib/kontena/plugin/cloud_command.rb
DEBUG - /usr/lib/ruby/2.3.0/ostruct.rb
DEBUG - /usr/lib/ruby/2.3.0/singleton.rb
DEBUG - /kontena/cli/lib/kontena/cli/config.rb
DEBUG - /kontena/cli/lib/kontena/client.rb
DEBUG - /root/.kontena/gems/2.3.6/gems/kontena-plugin-cloud-1.2.0/lib/kontena_cli_plugin.rb
DEBUG Plugin manager load paths added for kontena-plugin-cloud:
DEBUG - /root/.kontena/gems/2.3.6/gems/kontena-plugin-cloud-1.2.0/lib
DEBUG Running Kontena::MainCommand with ["plugin", "list"] -- callback matcher = 'nil'
DEBUG Running Kontena::Cli::PluginCommand with ["list"] -- callback matcher = 'nil'
DEBUG Running Kontena::Cli::Plugins::ListCommand with [] -- callback matcher = 'plugins list'
NAME    VERSION   DESCRIPTION
cloud   1.2.0     Kontena Cloud management for Kontena CLI
DEBUG Execution took 0.436 seconds
```