### PR TITLE
[WiP] Pre-validate TLS-SNI-01 challenge before certificate request

### DIFF
--- a/server/app/models/grid_domain_authorization.rb
+++ b/server/app/models/grid_domain_authorization.rb
@@ -59,4 +59,10 @@ class GridDomainAuthorization
       self.state
     end
   end
+
+  # @param acme_client [Acme::Client]
+  # @return [Acme::Client::Resources::Challenges::Base]
+  def acme_challenge(acme_client)
+    acme_client.challenge_from_hash(self.challenge)
+  end
 end

--- a/server/app/mutations/grid_certificates/request_certificate.rb
+++ b/server/app/mutations/grid_certificates/request_certificate.rb
@@ -36,7 +36,7 @@ module GridCertificates
 
     def verify_domain(domain)
       domain_authorization = get_authz_for_domain(self.grid, domain)
-      challenge = le_client.challenge_from_hash(domain_authorization.challenge)
+      challenge = domain_authorization.acme_challenge(le_client)
       if domain_authorization.state == :created
         info "requesting verification for domain #{domain}"
         success = challenge.request_verification


### PR DESCRIPTION
TODO: specs

Implement a similar style of server-side pre-validation for Let's Encrypt TLS-SNI-01 domain authorization challenges as exists for the DNS-01 challenges.

## Testing

```
$ bin/kontena certificate request test2.95.85.10.113.xip.io
 [done] Requesting certificate for test2.95.85.10.113.xip.io   
```

```
I, [2017-12-18T13:05:55.207968 #9]  INFO -- GridCertificates::RequestCertificate: validating tls-sni-01 challenge at test2.95.85.10.113.xip.io:443...
I, [2017-12-18T13:05:55.719237 #9]  INFO -- GridCertificates::RequestCertificate: got tls-sni-01 challenge cert with subjectAltName: DNS:554a8283efe96217fd428065887830cb.f108d4186fa671e72521863cfbbc37a6.acme.invalid
```

### Loadbalancer is not exposed to public internet
```
$ bin/kontena certificate request test2.95.85.10.113.xip.io
 [fail] Requesting certificate for test2.95.85.10.113.xip.io      
 [error] 422 : Unprocessable Entity:
	domains: 'Failed to pre-validate tls-sni-01 challenge cert at test2.95.85.10.113.xip.io:443:
	  Errno::ECONNREFUSED: Connection refused - connect(2) for 95.85.10.113:443'
```

```
I, [2017-12-18T13:02:49.813116 #9]  INFO -- GridCertificates::RequestCertificate: validating tls-sni-01 challenge at test2.95.85.10.113.xip.io:443...
E, [2017-12-18T13:02:50.035540 #9] ERROR -- GridCertificates::RequestCertificate: Connection refused - connect(2) for 95.85.10.113:443 (Errno::ECONNREFUSED)
...
```