### PR TITLE
Make kontena master token show output consistent with other show commands

### DIFF
--- a/cli/lib/kontena/cli/master/token/show_command.rb
+++ b/cli/lib/kontena/cli/master/token/show_command.rb
@@ -14,8 +14,10 @@ module Kontena::Cli::Master::Token
     def execute
       data = client.get("/oauth2/tokens/#{token_or_id}")
       output = token_data_to_hash(data)
+      id = output.delete(:id)
+      puts '%s:' % id
       output.each do |key, value|
-        puts "%s: %s" % [key, value]
+        puts "  %s: %s" % [key, value.nil? ? '-' : value]
       end
     end
   end

--- a/cli/lib/kontena/cli/master/token/show_command.rb
+++ b/cli/lib/kontena/cli/master/token/show_command.rb
@@ -15,7 +15,7 @@ module Kontena::Cli::Master::Token
       data = client.get("/oauth2/tokens/#{token_or_id}")
       output = token_data_to_hash(data)
       output.each do |key, value|
-        puts "%26.26s : %s" % [key, value]
+        puts "%s: %s" % [key, value]
       end
     end
   end

--- a/cli/spec/kontena/cli/master/token/show_command_spec.rb
+++ b/cli/spec/kontena/cli/master/token/show_command_spec.rb
@@ -35,16 +35,17 @@ describe Kontena::Cli::Master::Token::ShowCommand do
     it 'requests token data from master and displays it' do
       expect(client).to receive(:get).with("/oauth2/tokens/123").and_return(response)
       expect{subject.run(['123'])}.to output_yaml(
-        'id' => 123,
-        'token_type' => 'bearer',
-        'scopes' => 'user',
-        'user_id' => 'abc',
-        'user_email' => 'user@email',
-        'user_name' => 'username',
-        'server_name' => 'foo',
-        'access_token_last_four' => 'abcd',
-        'refresh_token_last_four' => 'efgh',
-        'expires_in' => 100
+        123 => {
+          'token_type' => 'bearer',
+          'scopes' => 'user',
+          'user_id' => 'abc',
+          'user_email' => 'user@email',
+          'user_name' => 'username',
+          'server_name' => 'foo',
+          'access_token_last_four' => 'abcd',
+          'refresh_token_last_four' => 'efgh',
+          'expires_in' => 100
+        }
       )
     end
   end
@@ -52,7 +53,7 @@ describe Kontena::Cli::Master::Token::ShowCommand do
   context 'for an authorization code' do
     let(:response) do
       {
-        "id" => "123",
+        "id" => 123,
         "grant_type" => "authorization_code",
         "code" => "abcd",
         "scopes" => "user",
@@ -70,14 +71,15 @@ describe Kontena::Cli::Master::Token::ShowCommand do
     it 'requests auth code data from master and displays it' do
       expect(client).to receive(:get).with("/oauth2/tokens/123").and_return(response)
       expect{subject.run(['123'])}.to output_yaml(
-        'id' => 123,
-        'code' => 'abcd',
-        'token_type' => 'authorization_code',
-        'scopes' => 'user',
-        'user_id' => 'abc',
-        'user_email' => 'user@email',
-        'user_name' => 'username',
-        'server_name' => 'foo'
+        123 => {
+          'code' => 'abcd',
+          'token_type' => 'authorization_code',
+          'scopes' => 'user',
+          'user_id' => 'abc',
+          'user_email' => 'user@email',
+          'user_name' => 'username',
+          'server_name' => 'foo'
+        }
       )
     end
   end

--- a/cli/spec/kontena/cli/master/token/show_command_spec.rb
+++ b/cli/spec/kontena/cli/master/token/show_command_spec.rb
@@ -1,0 +1,84 @@
+require 'kontena/cli/master/token_command'
+require 'kontena/cli/master/token/show_command'
+
+describe Kontena::Cli::Master::Token::ShowCommand do
+
+  include ClientHelpers
+  include RequirementsHelper
+  include OutputHelpers
+
+  expect_to_require_current_master
+  expect_to_require_current_master_token
+
+  context 'for an access token' do
+    let(:response) do
+      {
+        "id" => "123",
+        "token_type" => "bearer",
+        "access_token" => nil,
+        "refresh_token" => nil,
+        "access_token_last_four" => "abcd",
+        "refresh_token_last_four" => "efgh",
+        "expires_in" => 100,
+        "scopes" => "user",
+        "user" => {
+          "id" => "abc",
+          "email" => "user@email",
+          "name" => "username"
+        },
+        "server" => {
+          "name" => "foo"
+        }
+      }
+    end
+
+    it 'requests token data from master and displays it' do
+      expect(client).to receive(:get).with("/oauth2/tokens/123").and_return(response)
+      expect{subject.run(['123'])}.to output_yaml(
+        'id' => 123,
+        'token_type' => 'bearer',
+        'scopes' => 'user',
+        'user_id' => 'abc',
+        'user_email' => 'user@email',
+        'user_name' => 'username',
+        'server_name' => 'foo',
+        'access_token_last_four' => 'abcd',
+        'refresh_token_last_four' => 'efgh',
+        'expires_in' => 100
+      )
+    end
+  end
+
+  context 'for an authorization code' do
+    let(:response) do
+      {
+        "id" => "123",
+        "grant_type" => "authorization_code",
+        "code" => "abcd",
+        "scopes" => "user",
+        "user" => {
+          "id" => "abc",
+          "email" => "user@email",
+          "name" => "username"
+        },
+        "server" => {
+          "name" => "foo"
+        }
+      }
+    end
+
+    it 'requests auth code data from master and displays it' do
+      expect(client).to receive(:get).with("/oauth2/tokens/123").and_return(response)
+      expect{subject.run(['123'])}.to output_yaml(
+        'id' => 123,
+        'code' => 'abcd',
+        'token_type' => 'authorization_code',
+        'scopes' => 'user',
+        'user_id' => 'abc',
+        'user_email' => 'user@email',
+        'user_name' => 'username',
+        'server_name' => 'foo'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3155

Also a partial improvement to #3151 

Before:
```yaml
                        id : xxx
                token_type : bearer
                    scopes : user
                   user_id : xxx
                user_email : xxx@xxx
                 user_name : xxx
               server_name : xxx
    access_token_last_four : xxxx
   refresh_token_last_four :
                expires_in :
```

After:
```yaml
5a0059xxxxxxxxxx8c53f:
  token_type: bearer
  scopes: user
  user_id: xxxxxxx0060002a2
  user_email: xxxx@yyyy
  user_name: xxx
  server_name: xxx
  access_token_last_four: xxxx
  refresh_token_last_four: -
  expires_in: -
```
