### PR TITLE
Fix stack yaml service instance resolver

### DIFF
--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
@@ -6,8 +6,7 @@ module Kontena::Cli::Stacks
       def resolve
         return nil unless current_master && current_grid
         require 'kontena/cli/stacks/show_command'
-        read_command = Kontena::Cli::Stacks::ShowCommand.new([]).instance([self.stack])
-        stack = read_command.stack
+        stack = client.get("stacks/#{current_grid}/#{self.stack}")
         service = stack['services'].find { |s| s['name'] == hint }
         if service
           service['instances']

--- a/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
+++ b/cli/lib/kontena/cli/stacks/yaml/opto/service_instances_resolver.rb
@@ -6,8 +6,8 @@ module Kontena::Cli::Stacks
       def resolve
         return nil unless current_master && current_grid
         require 'kontena/cli/stacks/show_command'
-        read_command = Kontena::Cli::Stacks::ShowCommand.new([self.stack])
-        stack = read_command.fetch_stack(self.stack)
+        read_command = Kontena::Cli::Stacks::ShowCommand.new([]).instance([self.stack])
+        stack = read_command.stack
         service = stack['services'].find { |s| s['name'] == hint }
         if service
           service['instances']

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -147,14 +147,10 @@ describe 'stack install' do
   context 'For a stack using service_instances resolver' do
     it 'interpolates the correct instance count' do
       with_fixture_dir("stack/service_instances_resolver") do
-        k = run 'kontena stack install'
-        expect(k.code).to eq (0)
-        k = run 'kontena service scale simple/redis 2'
-        expect(k.code).to eq (0)
-        k = run 'kontena stack upgrade simple'
-        expect(k.code).to eq (0)
+        run! 'kontena stack install'
+        run! 'kontena service scale simple/redis 2'
+        run! 'kontena stack upgrade simple'
         k = run 'kontena service show simple/redis'
-        expect(k.code).to eq (0)
         expect(k.out).to match(/INSTANCE_COUNT=2[\r\n]/)
       end
     end

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -143,4 +143,20 @@ describe 'stack install' do
       expect(k.out.split(/[\r\n]/)).to match array_including('twemproxy', 'twemproxy-redis_from_registry', 'twemproxy-redis_from_yml')
     end
   end
+
+  context 'For a stack using service_instances resolver' do
+    it 'interpolates the correct instance count' do
+      with_fixture_dir("stack/service_instances_resolver") do
+        k = run 'kontena stack install'
+        expect(k.code).to eq (0)
+        k = run 'kontena service scale simple/redis 2'
+        expect(k.code).to eq (0)
+        k = run 'kontena stack upgrade simple'
+        expect(k.code).to eq (0)
+        k = run 'kontena service show simple/redis'
+        expect(k.code).to eq (0)
+        expect(k.out).to match(/INSTANCE_COUNT=2[\r\n]/)
+      end
+    end
+  end
 end

--- a/test/spec/fixtures/stack/service_instances_resolver/kontena.yml
+++ b/test/spec/fixtures/stack/service_instances_resolver/kontena.yml
@@ -1,0 +1,14 @@
+stack: test/simple
+version: 0.1.0
+variables:
+  svc_instances:
+    type: integer
+    default: 1
+    from:
+      service_instances: redis
+
+services:
+  redis:
+    image: redis:3-alpine
+    environment:
+      - "INSTANCE_COUNT=${svc_instances}"


### PR DESCRIPTION
Fixes #3145

Makes service instances resolver work again instead of getting a NoMethodError:

```
NoMethodError : Resolver 'service_instances' for 'seed_instances' : undefined method `fetch_stack' for #<Kontena::Cli::Stacks::ShowCommand:0x007fab1f342cf0>
```

