### PR TITLE
Fix missing require for cli exec use of STDIN.raw

### DIFF
--- a/cli/lib/kontena/cli/helpers/exec_helper.rb
+++ b/cli/lib/kontena/cli/helpers/exec_helper.rb
@@ -1,3 +1,4 @@
+require 'io/console'
 require 'tty-screen'
 require 'kontena-websocket-client'
 


### PR DESCRIPTION
Fixes #3160

Regression from  #3139 removing the `require 'io/console'` in favor of `tty-screen` - the call to `STDIN.raw` still needed `io/console`, which was still being indirectly required as a side-effect of the plugin manager configuring `Gem::DefaultUserInteraction.ui`. That didn't happen when running with `DEBUG`, so `exec --tty` was broken. Unless using `bundle exec`, which seems to also auto-require things before executing the `bin/kontena` script?

No spec because this is next to impossible to test for... maybe possible in the e2e specs.