### PR TITLE
Fix broken e2e stack remove spec after hook

### DIFF
--- a/test/spec/features/stack/remove_spec.rb
+++ b/test/spec/features/stack/remove_spec.rb
@@ -7,10 +7,9 @@ describe 'stack remove' do
 
   it "removes a stack" do
     with_fixture_dir("stack/simple") do
-      run 'kontena stack install --no-deploy'
+      run! 'kontena stack install --no-deploy'
     end
-    k = run "kontena stack rm --force simple"
-    expect(k.code).to eq(0)
+    k = run! "kontena stack rm --force simple"
     k = run "kontena stack show simple"
     expect(k.code).not_to eq(0)
   end
@@ -31,7 +30,7 @@ describe 'stack remove' do
   context "for a stack that has dependencies" do
     before do
       with_fixture_dir("stack/depends") do
-        run 'kontena stack install'
+        run! 'kontena stack install'
       end
     end
 
@@ -42,17 +41,16 @@ describe 'stack remove' do
     end
 
     it 'removes all the dependencies' do
-      k = run 'kontena stack ls -q'
+      k = run! 'kontena stack ls -q'
       expect(k.out.split(/[\r\n]/)).to match array_including(
         'twemproxy-redis_from_registry',
         'twemproxy-redis_from_yml',
         'twemproxy'
       )
 
-      k = run 'kontena stack rm --force twemproxy'
-      expect(k.code).to eq 0
+      k = run! 'kontena stack rm --force twemproxy'
 
-      k = run 'kontena stack ls -q'
+      k = run! 'kontena stack ls -q'
       expect(k.out).not_to match /twemproxy-redis_from_registry/
       expect(k.out).not_to match /twemproxy-redis_from_yml/
       expect(k.out).not_to match /twemproxy/

--- a/test/spec/features/stack/remove_spec.rb
+++ b/test/spec/features/stack/remove_spec.rb
@@ -36,7 +36,9 @@ describe 'stack remove' do
     end
 
     after do
-      run 'kontena stack ls -q|grep twemproxy|xargs -n1 kontena stack rm --force'
+      run 'kontena stack rm --force twemproxy'
+      run 'kontena stack rm --force twemproxy-redis_from_yml'
+      run 'kontena stack rm --force twemproxy-twemproxy-redis_from_registry'
     end
 
     it 'removes all the dependencies' do


### PR DESCRIPTION
Fixes #2936 

The spec was passing but not actually cleaning up after itself.

```
stack remove
  for a stack that has dependencies
> Installing dependency kontena/redis:0.1.0 as twemproxy-redis_from_registry ..
 [done] Creating stack twemproxy-redis_from_registry      
 [done] Triggering deployment of stack twemproxy-redis_from_registry     
 [done] Waiting for deployment to start     
 [done] Deploying service db     
> Installing dependency /kontena/test/spec/fixtures/stack/depends/redis.yml as twemproxy-redis_from_yml ..
 [done] Creating stack twemproxy-redis_from_yml      
 [done] Triggering deployment of stack twemproxy-redis_from_yml     
 [done] Waiting for deployment to start     
 [done] Deploying service redis     
 [done] Creating stack twemproxy      
 [done] Triggering deployment of stack twemproxy     
 [done] Waiting for deployment to start     
 [done] Deploying service twemproxy     
stty: standard input
twemproxy
twemproxy-redis_from_registry
twemproxy-redis_from_yml
> Removing dependency twemproxy-redis_from_registry ..
 [done] Removing stack twemproxy-redis_from_registry      
> Removing dependency twemproxy-redis_from_yml ..
 [done] Removing stack twemproxy-redis_from_yml      
 [done] Removing stack twemproxy      
 [error] 404 : Not Found (/v1/stacks/e2e/twemproxy)
 [error] 404 : Not Found (/v1/stacks/e2e/twemproxy-redis_from_yml)
 [error] 404 : Not Found (/v1/stacks/e2e/twemproxy-twemproxy-redis_from_registry)
 [error] 404 : Not Found (/v1/stacks/e2e/simple)
    removes all the dependencies

Finished in 41.59 seconds (files took 0.5392 seconds to load)
1 example, 0 failures
```