### PR TITLE
Fix e2e test spec helpers to fail instead of aborting

### DIFF
--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -67,7 +67,7 @@ RSpec.configure do |config|
 
     unless k.code == 0
       STDERR.puts(k.out)
-      abort "Unable to install app-command plugin"
+      fail "Unable to install app-command plugin"
     end
   end
 
@@ -79,7 +79,7 @@ RSpec.configure do |config|
     k = Kommando.run "kontena grid use e2e"
     unless k.code == 0
       STDERR.puts(k.out)
-      abort "e2e grid does not exist"
+      fail "e2e grid does not exist"
     end
   end
 


### PR DESCRIPTION
Calling `abort` in the spec `before` / `after` hooks will raise `SystemExit` and cause `rspec` to stop running any further tests, without actually showing the failed spec as failed.

### Broken
```
app subcommand
  with the app-command plugin
    app deploy
 [error] Failed to load plugin: kontena-plugin-app-command from /root/.kontena/gems/2.3.6/gems/kontena-plugin-app-command-0.1.0
	Rerun the command with environment DEBUG=true set to get the full exception.
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require': cannot load such file -- excon/error (LoadError)
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /kontena/cli/lib/kontena/command.rb:6:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /kontena/cli/lib/kontena/main_command.rb:1:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/bin/kontena:19:in `<main>'
e2e grid does not exist

Finished in 11.49 seconds (files took 0.39143 seconds to load)
1 example, 0 failures
```

### Fixed
```
app subcommand
  with the app-command plugin
    app deploy
 [error] Failed to load plugin: kontena-plugin-app-command from /root/.kontena/gems/2.3.6/gems/kontena-plugin-app-command-0.1.0
	Rerun the command with environment DEBUG=true set to get the full exception.
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require': cannot load such file -- excon/error (LoadError)
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /kontena/cli/lib/kontena/command.rb:6:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /kontena/cli/lib/kontena/main_command.rb:1:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/bin/kontena:19:in `<main>'
      deploys a simple app (FAILED - 1)

app subcommand
  with the app-command plugin
 [error] Failed to load plugin: kontena-plugin-app-command from /root/.kontena/gems/2.3.6/gems/kontena-plugin-app-command-0.1.0
	Rerun the command with environment DEBUG=true set to get the full exception.
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require': cannot load such file -- excon/error (LoadError)
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /kontena/cli/lib/kontena/command.rb:6:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /kontena/cli/lib/kontena/main_command.rb:1:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/bin/kontena:19:in `<main>'
    app ps
      returns list (FAILED - 2)

app subcommand
  with the app-command plugin
 [error] Failed to load plugin: kontena-plugin-app-command from /root/.kontena/gems/2.3.6/gems/kontena-plugin-app-command-0.1.0
	Rerun the command with environment DEBUG=true set to get the full exception.
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require': cannot load such file -- excon/error (LoadError)
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /kontena/cli/lib/kontena/command.rb:6:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /kontena/cli/lib/kontena/main_command.rb:1:in `<top (required)>'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/bin/kontena:19:in `<main>'
    app remove
      removes a deployed app (FAILED - 3)

Failures:

  1) app subcommand with the app-command plugin app deploy deploys a simple app
     Failure/Error: fail "e2e grid does not exist"
     
     RuntimeError:
       e2e grid does not exist
     # ./spec/spec_helper.rb:82:in `block (2 levels) in <top (required)>'

  2) app subcommand with the app-command plugin app ps returns list
     Failure/Error: fail "Unable to install app-command plugin"
     
     RuntimeError:
       Unable to install app-command plugin
     # ./spec/spec_helper.rb:70:in `block (2 levels) in <top (required)>'

  3) app subcommand with the app-command plugin app remove removes a deployed app
     Failure/Error: fail "Unable to install app-command plugin"
     
     RuntimeError:
       Unable to install app-command plugin
     # ./spec/spec_helper.rb:70:in `block (2 levels) in <top (required)>'

Finished in 13.01 seconds (files took 0.2338 seconds to load)
3 examples, 3 failures

Failed examples:

rspec ./spec/features/plugin/app-command/deploy_spec.rb:6 # app subcommand with the app-command plugin app deploy deploys a simple app
rspec ./spec/features/plugin/app-command/ps_spec.rb:6 # app subcommand with the app-command plugin app ps returns list
rspec ./spec/features/plugin/app-command/remove_spec.rb:6 # app subcommand with the app-command plugin app remove removes a deployed app
```