### PR TITLE
Fix confirmation dialog in stack related commands

### DIFF
--- a/cli/lib/kontena/cli/common.rb
+++ b/cli/lib/kontena/cli/common.rb
@@ -270,7 +270,7 @@ module Kontena
         exit_with_error 'Command requires --force' unless $stdout.tty? && $stdin.tty?
         puts "Destructive command. To proceed, type \"#{name}\" or re-run this command with --force option."
 
-        ask("Enter '#{name}' to confirm: ") == name || error("Confirmation did not match #{name}. Aborted command.")
+        ask("Enter '#{name}' to confirm: ") == name.to_s || error("Confirmation did not match #{name}. Aborted command.")
       end
 
       def confirm(message = 'Destructive command. You can skip this prompt by running this command with --force option. Are you sure?')

--- a/cli/spec/kontena/cli/common_spec.rb
+++ b/cli/spec/kontena/cli/common_spec.rb
@@ -137,8 +137,15 @@ describe Kontena::Cli::Common do
       it 'returns true if input matches' do
         allow(subject).to receive(:ask).and_return('name-to-confirm')
 
-        expect(subject.confirm_command('name-to-confirm')).to be_truthy
         expect{subject.confirm_command('name-to-confirm')}.to_not raise_error
+        expect(subject.confirm_command('name-to-confirm')).to be_truthy
+      end
+
+      it 'returns true if input matches and param is not a string' do
+        allow(subject).to receive(:ask).and_return('123')
+
+        expect{subject.confirm_command(123)}.to_not raise_error
+        expect(subject.confirm_command(123)).to be_truthy
       end
 
       it 'raises error unless input matches' do


### PR DESCRIPTION
Fixes #3168

Some commands, such as `kontena stack registry remove xyz/xyz` require you to confirm the action by entering the repository name. It's currently broken for some stack commands and never accept the correct string as answer. You can work around this by using `--force`.

Stack related commands return a `StackName` object instead of a string when calling `name` method.

The confirmation dialogs compared it with a string which returned false.

Solved by calling `#to_s` on the `name` like the string interpolation in the prompt title does.

