### PR TITLE
Fix e2e test container to use bundle exec

### DIFF
--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -22,5 +22,6 @@ ADD cli/VERSION /kontena/cli/VERSION
 WORKDIR /kontena/test
 RUN bundle install
 
-# XXX: bundler does not install executables from path: ... gems?
 RUN ln -s /kontena/cli/bin/kontena /usr/local/bin/kontena
+ADD test/entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec bundle exec "$@"


### PR DESCRIPTION
Fixes #3148 by activating the `kontena-cli`gem, but also breaks any specs that use `kontena plugin install` by preventing the plugins from getting loaded after installation

Use `bundle exec` to activate the `kontena-cli` gem in development mode, while still allowing changes to the bind-mounted CLI code to have immediate effect.

Something with how `bundle exec` works prevents the [CLI `PluginManager::Loader`](https://github.com/kontena/kontena/blob/master/cli/lib/kontena/plugin_manager/loader.rb) from finding the `kontena-plugin-*` gems from the custom [`ENV['GEM_HOME']`](https://github.com/kontena/kontena/blob/16ca2e92124fa58c83d84d0c7a496ea75214196b/cli/lib/kontena/plugin_manager.rb#L12), so the `app-command` and `plugin install` related e2e specs are now broken.