### PR TITLE
un-break e2e stack validate entrypoint spec

### DIFF
--- a/test/spec/features/stack/validate_spec.rb
+++ b/test/spec/features/stack/validate_spec.rb
@@ -14,7 +14,7 @@ describe 'stack validate' do
               ),
               hash_including(
                 'name' => 'redis2',
-                'entrypoint' => 'foo',
+                'entrypoint' => 'foo2',
               )
             ),
           )


### PR DESCRIPTION
The e2e spec in #3163 was accidentally committed with intentional changes meant to test that the spec actually failed.

```
stack validate
  keywords
    entrypoint
      sets stack entrypoint

Finished in 0.69554 seconds (files took 0.09634 seconds to load)
1 example, 0 failures
```