### PR TITLE
Fix server certificate domain verification request error handling

### DIFF
--- a/server/app/mutations/grid_certificates/request_certificate.rb
+++ b/server/app/mutations/grid_certificates/request_certificate.rb
@@ -64,9 +64,9 @@ module GridCertificates
       end
 
       domain_authorization.save
-    rescue Timeout::Error
-      warn 'timeout while waiting for DNS verfication status'
-      add_error(:challenge_verify, :timeout, 'Challenge verification timeout')
+    rescue Timeout::Error => exc
+      warn exc
+      add_error(:challenge_verify, :timeout, "Challenge verification timeout: #{exc}")
     rescue Acme::Client::Error => exc
       error exc
       add_error(:acme_client, :error, exc.message)

--- a/server/app/mutations/grid_certificates/request_certificate.rb
+++ b/server/app/mutations/grid_certificates/request_certificate.rb
@@ -45,6 +45,7 @@ module GridCertificates
           domain_authorization.save
         else
           add_error(:request_verification, :failed, "Requesting verification failed")
+          return
         end
       end
 

--- a/server/spec/mutations/grid_certificates/request_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/request_certificate_spec.rb
@@ -106,6 +106,18 @@ describe GridCertificates::RequestCertificate do
       expect(authz.status).to eq :requested
     end
 
+    it 'adds error if acme server returns an error' do
+      expect(challenge).to receive(:request_verification).and_return(false)
+      expect(subject).to receive(:add_error)
+
+      expect{
+        subject.verify_domain('example.com')
+      }.to_not change{authz.reload.state}.from(:created)
+
+      expect(authz.expires_at).to match Time
+      expect(authz.status).to eq :created
+    end
+
     it 'adds error if acme client errors' do
       expect(challenge).to receive(:request_verification).and_raise(Acme::Client::Error)
       expect(subject).to receive(:add_error)

--- a/server/spec/mutations/grid_certificates/request_certificate_spec.rb
+++ b/server/spec/mutations/grid_certificates/request_certificate_spec.rb
@@ -95,8 +95,8 @@ describe GridCertificates::RequestCertificate do
 
     it 'adds error if verification timeouts' do
       expect(challenge).to receive(:request_verification).and_return(true)
-      expect(challenge).to receive(:verify_status).and_raise(Timeout::Error)
-      expect(subject).to receive(:add_error)
+      expect(challenge).to receive(:verify_status).and_raise(Timeout::Error, "timeout after waiting ...")
+      expect(subject).to receive(:add_error).with(:challenge_verify, :timeout, "Challenge verification timeout: timeout after waiting ...")
 
       expect{
         subject.verify_domain('example.com')


### PR DESCRIPTION
In the case of non-2xx responses returned by the `challenge.request_verification` => ACME challenge API, the server was marking the mutation as failed, but still entering the `wait_until! { challenge.verify_status != 'pending' }` loop. I suspect that it would be possible for the challenge to remain stuck in the `pending` state, and thus cause the mutation to timeout. The CLI would not be able to report the `Requesting verification failed` because of #3119

I don't know what kind of situations that would happen in, vs the ACME API acceping the verification request and then later updating the `challenge.verify_status` from `pending` => `invalid`.