### PR TITLE
Fix stack list tree icon

### DIFF
--- a/cli/lib/kontena/cli/stacks/list_command.rb
+++ b/cli/lib/kontena/cli/stacks/list_command.rb
@@ -53,7 +53,7 @@ module Kontena::Cli::Stacks
 
     print_table(stacks) do |row|
         next if quiet?
-        row['name'] = health_icon(stack_health(row)) + " " + tree_icon(row) + row['name']
+        row['name'] = health_icon(stack_health(row)) + " " + tree_icon(row) + " " + row['name']
         row['stack'] = "#{row['stack']}:#{row['version']}"
         row['services_count'] = row['services'].size
         row['ports'] = stack_ports(row).join(',')
@@ -88,8 +88,7 @@ module Kontena::Cli::Stacks
         char = '┗━'
       end
       left_pad = ' ' * (2 * (row['depth'] - 1))
-      right_pad = row['depth'] > 1 ? '━' : ''
-      left_pad + char + right_pad
+      left_pad + char
     end
 
     # @param [Hash] stack


### PR DESCRIPTION
Before:
```
$ kontena stack ls
NAME                STACK                          SERVICES   STATE               EXPOSED PORTS
⊝ fn                kontena/fn:0.2.0               2          partially_running
⊛   ┗━━fn-mariadb   kontena/mariadb:0.2.1          1          running
⊛   ┗━━fn-redis     kontena/redis-sentinel:0.1.0   3          running
```

After:
```
$ kontena stack ls
NAME                STACK                          SERVICES   STATE               EXPOSED PORTS
⊝  fn               kontena/fn:0.2.0               2          partially_running
⊛   ┗━ fn-mariadb   kontena/mariadb:0.2.1          1          running
⊛   ┗━ fn-redis     kontena/redis-sentinel:0.1.0   3          running
```