### PR TITLE
Add cleaner job for old deployments

### DIFF
--- a/server/app/jobs/deployment_cleanup_job.rb
+++ b/server/app/jobs/deployment_cleanup_job.rb
@@ -26,9 +26,7 @@ class DeploymentCleanupJob
       # Find the last 100th deployments id
       id = s.grid_service_deploys.finished.desc('_id').limit(100).to_a.last._id
       # Now delete all deployments older than the 100th one
-      s.grid_service_deploys.finished.where(:_id.lt => id).each do |d|
-        d.delete
-      end
+      s.grid_service_deploys.finished.where(:_id.lt => id).delete
     end
   end
 end

--- a/server/app/jobs/deployment_cleanup_job.rb
+++ b/server/app/jobs/deployment_cleanup_job.rb
@@ -21,7 +21,7 @@ class DeploymentCleanupJob
 
   def destroy_old_deployments
     GridService.each do |s|
-      return if s.grid_service_deploys.finished.count <= 100
+      next if s.grid_service_deploys.finished.count <= 100
       info "cleaning old deployments for service #{s.to_path}"
       # Find the last 100th deployments id
       id = s.grid_service_deploys.finished.desc('_id').limit(100).to_a.last._id

--- a/server/app/jobs/deployment_cleanup_job.rb
+++ b/server/app/jobs/deployment_cleanup_job.rb
@@ -21,12 +21,15 @@ class DeploymentCleanupJob
 
   def destroy_old_deployments
     GridService.each do |s|
-      next if s.grid_service_deploys.finished.count <= 100
-      info "cleaning old deployments for service #{s.to_path}"
-      # Find the last 100th deployments id
-      id = s.grid_service_deploys.finished.desc('_id').limit(100).to_a.last._id
-      # Now delete all deployments older than the 100th one
-      s.grid_service_deploys.finished.where(:_id.lt => id).delete
+      cleanup_old_deployments(s) if s.grid_service_deploys.finished.count > 100
     end
+  end
+
+  def cleanup_old_deployments(s)
+    info "cleaning old deployments for service #{s.to_path}"
+    # Find the last 100th deployments id
+    id = s.grid_service_deploys.finished.desc('_id').limit(100).to_a.last._id
+    # Now delete all deployments older than the 100th one
+    s.grid_service_deploys.finished.where(:_id.lt => id).delete
   end
 end

--- a/server/app/jobs/deployment_cleanup_job.rb
+++ b/server/app/jobs/deployment_cleanup_job.rb
@@ -1,0 +1,34 @@
+require_relative '../services/logging'
+
+class DeploymentCleanupJob
+  include Celluloid
+  include CurrentLeader
+  include Logging
+
+  def initialize(perform = true)
+    async.perform if perform
+  end
+
+  def perform
+    info 'starting to cleanup old deployments'
+    loop do
+      sleep 5.minute.to_i
+      if leader?
+        destroy_old_deployments
+      end
+    end
+  end
+
+  def destroy_old_deployments
+    GridService.each do |s|
+      return if s.grid_service_deploys.finished.count <= 100
+      info "cleaning old deployments for service #{s.to_path}"
+      # Find the last 100th deployments id
+      id = s.grid_service_deploys.finished.desc('_id').limit(100).to_a.last._id
+      # Now delete all deployments older than the 100th one
+      s.grid_service_deploys.finished.where(:_id.lt => id).each do |d|
+        d.delete
+      end
+    end
+  end
+end

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -51,7 +51,7 @@ class GridService
   has_many :container_logs
   has_many :container_stats
   has_many :audit_logs
-  has_many :grid_service_deploys, dependent: :destroy
+  has_many :grid_service_deploys, dependent: :delete
   has_many :event_logs
   has_many :grid_domain_authorizations
   has_and_belongs_to_many :networks

--- a/server/app/models/grid_service_deploy.rb
+++ b/server/app/models/grid_service_deploy.rb
@@ -43,6 +43,7 @@ class GridServiceDeploy
   scope :deploying, -> { any_of({:started_at => nil, :finished_at => nil}, {:started_at.gt => TIMEOUT.ago , finished_at: nil}) }
   scope :pending, -> { where(:started_at => nil, :finished_at => nil) }
   scope :running, -> { where(:started_at.ne => nil).where(:started_at.gt => TIMEOUT.ago, :finished_at => nil) }
+  scope :finished, -> { where(:finished_at.ne => nil) }
 
   # @return [Boolean]
   def queued?

--- a/server/app/services/job_supervisor.rb
+++ b/server/app/services/job_supervisor.rb
@@ -8,4 +8,5 @@ class JobSupervisor < Celluloid::Supervision::Container
   supervise type: GridServiceHealthMonitorJob, as: :service_health_monitor_job
   supervise type: CloudWebsocketClientManager, as: :cloud_websocket_client_manager
   supervise type: CertificateRenewJob, as: :certificate_renew_job
+  supervise type: DeploymentCleanupJob, as: :deployment_cleanup_job
 end

--- a/server/spec/jobs/deployment_cleanup_job_spec.rb
+++ b/server/spec/jobs/deployment_cleanup_job_spec.rb
@@ -1,0 +1,55 @@
+
+describe DeploymentCleanupJob, celluloid: true do
+
+  let(:grid) { Grid.create!(name: 'test-grid') }
+
+  let(:service) do
+    GridService.create!(name: 'test', image_name: 'test:latest', grid: grid)
+  end
+
+  let(:subject) { described_class.new(false) }
+
+  describe '#destroy_old_deployments' do
+    it 'destroys deployments older than 100th one' do
+      200.times do |i|
+        # Use the reason field to track the sequence
+        service.grid_service_deploys.create!(finished_at: Time.now.utc, reason: (i + 1).to_s)
+      end
+      expect {
+        subject.destroy_old_deployments
+      }.to change{ GridServiceDeploy.count }.by(-100)
+
+      expect(service.reload.grid_service_deploys.finished.desc('_id').to_a.first.reason).to eq(200.to_s)
+    end
+
+    it 'destroys nothing if less than 100 deployments' do
+      99.times do |i|
+        # Use the reason field to track the sequence
+        service.grid_service_deploys.create!(finished_at: Time.now.utc, reason: (i + 1).to_s)
+      end
+      expect {
+        subject.destroy_old_deployments
+      }.not_to change{ GridServiceDeploy.count }
+    end
+
+    it 'destroys nothing if no deployments' do
+      service
+      expect {
+        subject.destroy_old_deployments
+      }.not_to change{ GridServiceDeploy.count }
+    end
+
+
+    it 'destroys nothing if no finished deployments' do
+      200.times do |i|
+        # Use the reason field to track the sequence
+        service.grid_service_deploys.create!(reason: (i + 1).to_s)
+      end
+      expect {
+        subject.destroy_old_deployments
+      }.not_to change{ GridServiceDeploy.count }
+    end
+
+
+  end
+end


### PR DESCRIPTION
This PR add cleaner job to clean out old deployments.

It cleans up deployments older than 100th. The reason for this logic is that if people have services that they deploy not so often, cleaning deploys based on time only could remove even the latest deployment.

Also changed the dependency removal (service -> deploy) to use `delete` instead of `destroy` as it should not be that mem hungry. There's no hooks that needs to run on `GridServiceDeploy` side so `delete`should be fine to use.

fixes #3190 
fixes #2563
  