### PR TITLE
Allow to command multiple items via cli

### DIFF
--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -5,24 +5,26 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
     include Common
 
-    parameter "NAME", "Grid name"
+    parameter "NAME ...", "Grid name", attribute_name: :grids
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      confirm_command(name) unless forced?
-      grid = find_grid_by_name(name)
+      grids.each do |name|
+        confirm_command(name) unless forced?
+        grid = find_grid_by_name(name)
 
-      if !grid.nil?
-        spinner "removing #{pastel.cyan(name)} grid " do
-          response = client(token).delete("grids/#{grid['id']}")
-          if response
-            clear_current_grid if grid['id'] == current_grid
+        if !grid.nil?
+          spinner "removing #{pastel.cyan(name)} grid " do
+            response = client(token).delete("grids/#{grid['id']}")
+            if response
+              clear_current_grid if grid['id'] == current_grid
+            end
           end
+        else
+          exit_with_error "Could not resolve grid by name [#{name}]. For a list of existing grids please run: kontena grid list"
         end
-      else
-        exit_with_error "Could not resolve grid by name [#{name}]. For a list of existing grids please run: kontena grid list"
       end
     end
   end

--- a/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/trusted_subnets/remove_command.rb
@@ -3,21 +3,23 @@ module Kontena::Cli::Grids::TrustedSubnets
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "SUBNET", "Trusted subnet"
+    parameter "SUBNET ...", "Trusted subnet", attribute_name: :subnets
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     requires_current_master
 
     def execute
-      grid = client.get("grids/#{current_grid}")
-      confirm_command(subnet) unless forced?
-      trusted_subnets = grid['trusted_subnets'] || []
-      unless trusted_subnets.delete(self.subnet)
-        exit_with_error("Grid #{pastel.cyan(current_grid)} does not have trusted subnet #{pastel.cyan(subnet)}")
-      end
-      data = {trusted_subnets: trusted_subnets}
-      spinner "Removing trusted subnet #{pastel.cyan(subnet)} from #{pastel.cyan(current_grid)} grid " do
-        client.put("grids/#{current_grid}", data)
+      subnets.each do |subnet|
+        grid = client.get("grids/#{current_grid}")
+        confirm_command(subnet) unless forced?
+        trusted_subnets = grid['trusted_subnets'] || []
+        unless trusted_subnets.delete(subnet)
+          exit_with_error("Grid #{pastel.cyan(current_grid)} does not have trusted subnet #{pastel.cyan(subnet)}")
+        end
+        data = {trusted_subnets: trusted_subnets}
+        spinner "Removing trusted subnet #{pastel.cyan(subnet)} from #{pastel.cyan(current_grid)} grid " do
+          client.put("grids/#{current_grid}", data)
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/nodes/remove_command.rb
+++ b/cli/lib/kontena/cli/nodes/remove_command.rb
@@ -3,7 +3,7 @@ module Kontena::Cli::Nodes
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "NODE", "Node name"
+    parameter "NODE ...", "Node name", attribute_name: :nodes
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
@@ -11,18 +11,20 @@ module Kontena::Cli::Nodes
       require_current_grid
       token = require_token
 
-      node = client(token).get("nodes/#{current_grid}/#{self.node}")
+      nodes.each do |node_name|
+        node = client(token).get("nodes/#{current_grid}/#{node_name}")
 
-      if node['has_token'] && node['connected']
-        warning "Node #{node['name']} is still connected using a node token, but will be force-disconnected"
-      elsif node['connected']
-        exit_with_error "Node #{node['name']} is still connected using a grid token. You must terminate the node before removing it."
-      end
+        if node['has_token'] && node['connected']
+          warning "Node #{node['name']} is still connected using a node token, but will be force-disconnected"
+        elsif node['connected']
+          exit_with_error "Node #{node['name']} is still connected using a grid token. You must terminate the node before removing it."
+        end
 
-      confirm_command(self.node) unless forced?
+        confirm_command(node_name) unless forced?
 
-      spinner "Removing #{pastel.cyan(self.node)} node from #{pastel.cyan(current_grid)} grid " do
-        client(token).delete("nodes/#{node['id']}")
+        spinner "Removing #{pastel.cyan(node_name)} node from #{pastel.cyan(current_grid)} grid " do
+          client(token).delete("nodes/#{node['id']}")
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -6,17 +6,21 @@ module Kontena::Cli::Plugins
     include Kontena::Cli::Common
     include Kontena::PluginManager::Common
 
-    parameter 'NAME', 'Plugin name'
-
-    def uninstaller
-      Kontena::PluginManager::Uninstaller.new(name)
-    end
+    parameter 'NAME ...', 'Plugin name', attribute_name: :plugins
 
     def execute
-      exit_with_error "Plugin #{name} has not been installed" unless installed?(name)
-      spinner "Uninstalling plugin #{pastel.cyan(name)}" do
-        uninstaller.uninstall
+      plugins.each do |name|
+        exit_with_error "Plugin #{name} has not been installed" unless installed?(name)
+        spinner "Uninstalling plugin #{pastel.cyan(name)}" do
+          uninstaller(name).uninstall
+        end
       end
+    end
+
+    # @param name [String]
+    # @return [Kontena::PluginManager::Uninstaller]
+    def uninstaller(name)
+      Kontena::PluginManager::Uninstaller.new(name)
     end
   end
 end

--- a/cli/lib/kontena/cli/services/envs/remove_command.rb
+++ b/cli/lib/kontena/cli/services/envs/remove_command.rb
@@ -7,13 +7,15 @@ module Kontena::Cli::Services::Envs
     include Kontena::Cli::Services::ServicesHelper
 
     parameter "NAME", "Service name"
-    parameter "ENV", "Environment variable name"
+    parameter "ENV ...", "Environment variable name", attribute_name: :envs
 
     def execute
       require_api_url
       token = require_token
-      spinner "Removing env variable #{pastel.cyan(env)} from #{pastel.cyan(name)} service " do
-        client(token).delete("services/#{parse_service_id(name)}/envs/#{env}")
+      envs.each do |env|
+        spinner "Removing env variable #{pastel.cyan(env)} from #{pastel.cyan(name)} service " do
+          client(token).delete("services/#{parse_service_id(name)}/envs/#{env}")
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -5,7 +5,7 @@ module Kontena::Cli::Services
     include Kontena::Cli::Common
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "NAME ...", "Service name", attribute_name: :names
     option "--instance", "INSTANCE", "Remove only given instance"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
@@ -15,14 +15,16 @@ module Kontena::Cli::Services
     requires_current_master_token
 
     def execute
-      if instance
-        remove_instance
-      else
-        remove
+      names.each do |name|
+        if instance
+          remove_instance(name)
+        else
+          remove(name)
+        end
       end
     end
 
-    def remove
+    def remove(name)
       confirm_command(name) unless forced?
 
       spinner "Removing service #{pastel.cyan(name)} " do
@@ -43,7 +45,7 @@ module Kontena::Cli::Services
       end
     end
 
-    def remove_instance
+    def remove_instance(name)
       instance_name = "#{name}/#{instance}"
       confirm_command("#{name}/#{instance}") unless forced?
       service_instance = client.get("services/#{parse_service_id(name)}/instances")['instances'].find{ |i|

--- a/cli/lib/kontena/cli/services/start_command.rb
+++ b/cli/lib/kontena/cli/services/start_command.rb
@@ -6,13 +6,15 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "NAME ...", "Service name", attribute_name: :names
 
     def execute
       require_api_url
       token = require_token
-      spinner "Sending start signal to #{pastel.cyan(name)} service " do
-        start_service(token, name)
+      names.each do |name|
+        spinner "Sending start signal to #{pastel.cyan(name)} service " do
+          start_service(token, name)
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/services/stop_command.rb
+++ b/cli/lib/kontena/cli/services/stop_command.rb
@@ -6,13 +6,15 @@ module Kontena::Cli::Services
     include Kontena::Cli::GridOptions
     include ServicesHelper
 
-    parameter "NAME", "Service name"
+    parameter "NAME ...", "Service name", attribute_name: :names
 
     def execute
       require_api_url
       token = require_token
-      spinner "Sending stop signal to #{pastel.cyan(name)} service " do
-        stop_service(token, name)
+      names.each do |name|
+        spinner "Sending stop signal to #{pastel.cyan(name)} service " do
+          stop_service(token, name)
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -6,9 +6,9 @@ module Kontena::Cli::Stacks
     include Kontena::Cli::GridOptions
     include StacksHelper
 
-    banner "Deploys all services of a stack that has been installed in a grid on Kontena Master"
+    banner "Deploys all services of a stack"
 
-    parameter "NAME", "Stack name"
+    parameter "NAME ...", "Stack name", attribute_name: :names
 
     option '--[no-]wait', :flag, 'Do not wait for service deployment', default: true
 
@@ -16,15 +16,17 @@ module Kontena::Cli::Stacks
     requires_current_master_token
 
     def execute
-      deployment = nil
-      spinner "Triggering deployment of stack #{pastel.cyan(name)}" do
-        deployment = deploy_stack(name)
-      end
-      if wait?
-        spinner "Waiting for deployment to start" do
-          wait_for_deployment_to_start(deployment)
+      names.each do |name|
+        deployment = nil
+        spinner "Triggering deployment of stack #{pastel.cyan(name)}" do
+          deployment = deploy_stack(name)
         end
-        wait_for_deploy_to_finish(deployment)
+        if wait?
+          spinner "Waiting for deployment to start" do
+            wait_for_deployment_to_start(deployment)
+          end
+          wait_for_deploy_to_finish(deployment)
+        end
       end
     end
 

--- a/cli/lib/kontena/cli/stacks/restart_command.rb
+++ b/cli/lib/kontena/cli/stacks/restart_command.rb
@@ -8,16 +8,17 @@ module Kontena::Cli::Stacks
 
     banner "Restarts all services of a stack that has been installed in a grid on Kontena Master"
 
-    parameter "NAME", "Stack name"
+    parameter "NAME ...", "Stack name", attribute_name: :names
 
     requires_current_master
     requires_current_master_token
 
     def execute
-      spinner "Sending restart signal for stack services" do
-        client.post("stacks/#{current_grid}/#{name}/restart", {})
+      names.each do |name|
+        spinner "Sending restart signal for stack #{name} services" do
+          client.post("stacks/#{current_grid}/#{name}/restart", {})
+        end
       end
     end
-
   end
 end

--- a/cli/lib/kontena/cli/stacks/stop_command.rb
+++ b/cli/lib/kontena/cli/stacks/stop_command.rb
@@ -6,18 +6,19 @@ module Kontena::Cli::Stacks
     include Kontena::Cli::GridOptions
     include Common
 
-    banner "Stops all services of a stack that has been installed in a grid on Kontena Master"
+    banner "Stops all services of a stack"
 
-    parameter "NAME", "Stack name"
+    parameter "NAME ...", "Stack name", attribute_name: :names
 
     requires_current_master
     requires_current_master_token
 
     def execute
-      spinner "Sending stop signal for stack services" do
-        client.post("stacks/#{current_grid}/#{name}/stop", {})
+      names.each do |name|
+        spinner "Sending stop signal for stack #{name} services" do
+          client.post("stacks/#{current_grid}/#{name}/stop", {})
+        end
       end
     end
-
   end
 end

--- a/cli/lib/kontena/cli/vault/remove_command.rb
+++ b/cli/lib/kontena/cli/vault/remove_command.rb
@@ -3,18 +3,20 @@ module Kontena::Cli::Vault
     include Kontena::Cli::Common
     include Kontena::Cli::GridOptions
 
-    parameter "NAME", "Secret name"
+    parameter "NAME ...", "Secret name", attribute_name: :names
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
     option "--silent", :flag, "Reduce output verbosity"
 
     def execute
       require_api_url
       require_current_grid
-      confirm_command(name) unless forced?
+      names.each do |name|
+        confirm_command(name) unless forced?
 
-      token = require_token
-      vspinner "Removing #{pastel.cyan(name)} from the vault " do
-        client(token).delete("secrets/#{current_grid}/#{name}")
+        token = require_token
+        vspinner "Removing #{pastel.cyan(name)} from the vault " do
+          client(token).delete("secrets/#{current_grid}/#{name}")
+        end
       end
     end
   end

--- a/cli/lib/kontena/cli/volumes/remove_command.rb
+++ b/cli/lib/kontena/cli/volumes/remove_command.rb
@@ -6,17 +6,19 @@ module Kontena::Cli::Volumes
 
 
     banner "Removes a volume"
-    parameter 'VOLUME', 'Volume'
+    parameter 'VOLUME ...', 'Volume name', attribute_name: :volumes
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     requires_current_master
     requires_current_master_token
 
     def execute
-      confirm_command(volume) unless forced?
+      volumes.each do |volume|
+        confirm_command(volume) unless forced?
 
-      spinner "Removing volume #{pastel.cyan(volume)} " do
-        remove_volume(volume)
+        spinner "Removing volume #{pastel.cyan(volume)} " do
+          remove_volume(volume)
+        end
       end
     end
 

--- a/test/spec/features/grid/trusted_subnet_spec.rb
+++ b/test/spec/features/grid/trusted_subnet_spec.rb
@@ -1,0 +1,27 @@
+describe 'grid trusted-subnet' do
+  describe 'list' do
+    it 'lists subnets' do
+      k = run "kontena grid trusted-subnet ls"
+      expect(k.code).to eq(0)
+    end
+  end
+
+  describe 'add' do
+    after(:each) do
+      run "kontena grid trusted-subnet rm --force 192.168.22.0/24"
+    end
+
+    it 'adds a subnet' do
+      k = run "kontena grid trusted-subnet add 192.168.22.0/24"
+      expect(k.code).to eq(0)
+    end
+  end
+
+  describe 'remove' do
+    it 'removes subnet' do
+      run "kontena grid trusted-subnet add 192.168.23.0/24"
+      k = run "kontena grid trusted-subnet rm --force 192.168.23.0/24"
+      expect(k.code).to eq(0)
+    end
+  end
+end

--- a/test/spec/features/nodes/remove_spec.rb
+++ b/test/spec/features/nodes/remove_spec.rb
@@ -1,0 +1,19 @@
+describe 'node remove' do
+
+  after(:each) do
+    run 'kontena node rm --force rm-test-1 rm-test-2'
+  end
+
+  it 'removes a node' do
+    run 'kontena node create rm-test-1'
+    k = run 'kontena node rm --force rm-test-1'
+    expect(k.code).to eq(0)
+  end
+
+  it 'removes multiple nodes' do
+    run 'kontena node create rm-test-1'
+    run 'kontena node create rm-test-2'
+    k = run 'kontena node rm --force rm-test-1 rm-test-2'
+    expect(k.code).to eq(0)
+  end
+end

--- a/test/spec/features/service/create_spec.rb
+++ b/test/spec/features/service/create_spec.rb
@@ -1,0 +1,11 @@
+describe 'service create' do
+
+  after(:each) do
+    run 'kontena service rm --force create-test'
+  end
+
+  it 'creates a service' do
+    k = run 'kontena service create create-test redis:3-alpine'
+    expect(k.code).to eq(0)
+  end
+end

--- a/test/spec/features/service/remove_spec.rb
+++ b/test/spec/features/service/remove_spec.rb
@@ -1,0 +1,19 @@
+describe 'service remove' do
+
+    after(:each) do
+      run 'kontena service rm --force $(kontena service ls -q)'
+    end
+
+    it 'removes a service' do
+      run 'kontena service create rm-test redis:3-alpine'
+      k = run 'kontena service rm --force rm-test'
+      expect(k.code).to eq(0)
+    end
+
+    it 'removes multiple services' do
+      run 'kontena service create rm-test-1 redis:3-alpine'
+      run 'kontena service create rm-test-2 redis:3-alpine'
+      k = run 'kontena service rm --force rm-test-1 rm-test-2'
+      expect(k.code).to eq(0)
+    end
+  end

--- a/test/spec/features/service/start_spec.rb
+++ b/test/spec/features/service/start_spec.rb
@@ -29,4 +29,14 @@ describe 'service start' do
     k = run("kontena service show test-2")
     expect(k.out.scan('desired_state: running').size).to eq(1)
   end
+
+  it 'starts multiple services' do
+    k = kommando("kontena service start test-1 test-2")
+    expect(k.run).to be_truthy
+    sleep 1
+    k = run("kontena service show test-1")
+    expect(k.out.scan('desired_state: running').size).to eq(1)
+    k = run("kontena service show test-2")
+    expect(k.out.scan('desired_state: running').size).to eq(1)
+  end
 end

--- a/test/spec/features/service/stop_spec.rb
+++ b/test/spec/features/service/stop_spec.rb
@@ -30,11 +30,21 @@ describe 'service stop' do
     expect(k.out.scan('desired_state: stopped').size).to eq(1)
   end
 
+  it 'stops multiple services' do
+    k = run "kontena service stop test-1 test-2"
+    expect(k.code).to eq(0)
+    sleep 1
+    k = run("kontena service show test-1")
+    expect(k.out.scan('desired_state: stopped').size).to eq(1)
+    k = run("kontena service show test-2")
+    expect(k.out.scan('desired_state: stopped').size).to eq(1)
+  end
+
   context 'stop_signal set' do
     after(:each) do
       run "kontena stack rm --force simple"
     end
-  
+
     it 'sets StopSignal for container' do
       with_fixture_dir("stack/stop_signal") do
         k = run 'kontena stack install --deploy'

--- a/test/spec/features/stack/remove_spec.rb
+++ b/test/spec/features/stack/remove_spec.rb
@@ -14,6 +14,16 @@ describe 'stack remove' do
     expect(k.code).not_to eq(0)
   end
 
+  it "removes multiple stacks" do
+    with_fixture_dir("stack/simple") do
+      run! 'kontena stack install --no-deploy'
+      run! 'kontena stack install --no-deploy --name simple2'
+    end
+    k = run! "kontena stack rm --force simple simple2"
+    k = run "kontena stack show simple2"
+    expect(k.code).not_to eq(0)
+  end
+
   it "prompts without --force" do
     with_fixture_dir("stack/simple") do
       run 'kontena stack install --no-deploy'

--- a/test/spec/features/vault/remove_spec.rb
+++ b/test/spec/features/vault/remove_spec.rb
@@ -1,0 +1,19 @@
+describe 'vault remove' do
+  after(:each) do
+    run 'kontena vault rm --force $(kontena vault ls -q)'
+  end
+
+  it 'removes a vault key' do
+    run 'kontena vault write foo bar'
+    k = run 'kontena vault rm --force foo'
+    expect(k.code).to eq(0)
+  end
+
+  it 'removes multiple vault keys' do
+    2.times do |i|
+      run "kontena vault write foo#{i} bar"
+    end
+    k = run 'kontena vault rm --force foo0 foo1'
+    expect(k.code).to eq(0)
+  end
+end

--- a/test/spec/features/volume/remove_spec.rb
+++ b/test/spec/features/volume/remove_spec.rb
@@ -1,0 +1,19 @@
+describe 'volume remove' do
+  after(:each) do
+    run 'kontena volume rm --force $(kontena volume ls -q)'
+  end
+
+  it 'removes a volume' do
+    run 'kontena volume create --driver local --scope grid test-volume'
+    k = run 'kontena volume rm --force test-volume'
+    expect(k.code).to eq(0)
+  end
+
+  it 'removes multiple volumes' do
+    2.times do |i|
+      run "kontena volume create --driver local --scope grid test-volume#{i}"
+    end
+    k = run 'kontena volume rm --force test-volume0 test-volume1'
+    expect(k.code).to eq(0)
+  end
+end


### PR DESCRIPTION
Allows user to do things like:

```
$ kontena volume rm --force $(kontena volume ls -q)
```

or

```
$ kontena service stop $(kontena service ls -q | grep test)
```
