### PR TITLE
Add --profile to e2e suite .rspec

### DIFF
--- a/test/.rspec
+++ b/test/.rspec
@@ -1,3 +1,4 @@
 --color
 --format documentation
 --require spec_helper
+--profile


### PR DESCRIPTION
The e2e suite runs very long. Adding `--profile` to maybe spot some surprisingly long running specs.

Cleaning up the suite by removing some unnecessary redundant specs would perhaps make the suite more practical.
