### PR TITLE
Fix travis e2e allow_failures clause

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,6 @@ jobs:
     - env:
       - TEST_DIR=cli
       - ALLOW_FAILURES=true
-  fast_finish:
-    - env:
-      - TEST_DIR=cli
-      - ALLOW_FAILURES=true
   include:
     - stage: test
       script: ./build/travis/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,13 @@ stages:
 jobs:
   fast_finish: true
   allow_failures:
-    - env: ALLOW_FAILURES=true
+    - env:
+      - TEST_DIR=cli
+      - ALLOW_FAILURES=true
+  fast_finish:
+    - env:
+      - TEST_DIR=cli
+      - ALLOW_FAILURES=true
   include:
     - stage: test
       script: ./build/travis/test.sh


### PR DESCRIPTION
The `allow_failures` env needs to be exactly the env of the job that is allowed to fail.
