### PR TITLE
Fix e2e stack install spec stack conflicts

### DIFF
--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -7,6 +7,12 @@ describe 'stack install' do
   end
 
   context 'from registry' do
+    before do
+      # the two specs use the same stack name
+      wait_until_container_gone 'hello-ascii.lb-1'
+      wait_until_container_gone 'hello-ascii.web-1'
+    end
+
     after do
       run "kontena stack rm --force hello-ascii"
     end

--- a/test/spec/features/stack/install_spec.rb
+++ b/test/spec/features/stack/install_spec.rb
@@ -19,10 +19,8 @@ describe 'stack install' do
 
     context 'config from file' do
       it 'installs a stack' do
-        k = run "kontena stack install -v scaling=1 kontena/hello-ascii"
-        expect(k.code).to be_zero
-        k = run 'kontena stack show hello-ascii'
-        expect(k.code).to eq(0)
+        run! "kontena stack install -v scaling=1 kontena/hello-ascii"
+        run! 'kontena stack show hello-ascii'
       end
     end
 
@@ -33,11 +31,11 @@ describe 'stack install' do
           'KONTENA_TOKEN' => ENV['KONTENA_TOKEN'],
           'KONTENA_GRID' => ENV['KONTENA_GRID']
         }
-        k = run "kontena master current --url"
+        k = run! "kontena master current --url"
         ENV['KONTENA_URL'] = k.out.strip
-        k = run "kontena master token current --token"
+        k = run! "kontena master token current --token"
         ENV['KONTENA_TOKEN'] = k.out.strip
-        k = run "kontena grid current --name"
+        k = run! "kontena grid current --name"
         ENV['KONTENA_GRID'] = k.out.strip
       end
 
@@ -48,10 +46,8 @@ describe 'stack install' do
       end
 
       it 'installs a stack' do
-        k = run "kontena stack install -v scaling=1 kontena/hello-ascii"
-        expect(k.code).to be_zero
-        k = run 'kontena stack show hello-ascii'
-        expect(k.code).to eq(0)
+        run! "kontena stack install -v scaling=1 kontena/hello-ascii"
+        run! 'kontena stack show hello-ascii'
       end
     end
   end
@@ -60,20 +56,17 @@ describe 'stack install' do
 
     it 'installs a stack' do
       with_fixture_dir("stack/simple") do
-        run 'kontena stack install'
+        run! 'kontena stack install'
       end
-      k = run 'kontena stack show simple'
-      expect(k.code).to eq(0)
+      k = run! 'kontena stack show simple'
       expect(k.out.match(/state: running/)).to be_truthy
     end
 
     it 'skips deploy with --no-deploy' do
       with_fixture_dir("stack/simple") do
-        k = run 'kontena stack install --no-deploy'
-        expect(k.code).to eq(0)
+        k = run! 'kontena stack install --no-deploy'
       end
-      k = run 'kontena stack show simple'
-      expect(k.code).to eq(0)
+      k = run! 'kontena stack show simple'
       expect(k.out.match(/state: initialized/)).to be_truthy
     end
 
@@ -107,10 +100,9 @@ describe 'stack install' do
   context 'For a stack with stop_grace_period' do
     it 'creates stack service with stop_grace_period' do
       with_fixture_dir("stack/simple") do
-        run 'kontena stack install stop-period.yml'
+        run! 'kontena stack install stop-period.yml'
       end
-      k = run 'kontena service show simple/redis'
-      expect(k.code).to eq(0)
+      k = run! 'kontena service show simple/redis'
       expect(k.out.match(/stop_grace_period: 23s/)).to be_truthy
     end
   end
@@ -118,10 +110,9 @@ describe 'stack install' do
   context 'For a stack with read_only' do
     it 'creates stack service with read_only and updates it properly' do
       with_fixture_dir("stack/read_only") do
-        run 'kontena stack install redis.yml'
+        run! 'kontena stack install redis.yml'
       end
-      k = run 'kontena service show simple/redis'
-      expect(k.code).to eq(0)
+      k = run! 'kontena service show simple/redis'
       expect(k.out.match(/read_only: yes/)).to be_truthy
       with_fixture_dir("stack/read_only") do
         run 'kontena stack upgrade simple redis_read_only_false.yml'
@@ -142,19 +133,17 @@ describe 'stack install' do
 
     it 'installs all dependencies' do
       with_fixture_dir("stack/depends") do
-        k = run 'kontena stack install'
-        expect(k.code).to eq (0)
+        run! 'kontena stack install'
       end
-      k = run 'kontena stack ls -q'
+      k = run! 'kontena stack ls -q'
       expect(k.out.split(/[\r\n]/)).to match array_including('twemproxy', 'twemproxy-redis_from_registry', 'twemproxy-redis_from_yml')
     end
 
     it 'does not mutate the $STACK variable' do
       with_fixture_dir("stack/depends") do
-        k = run 'kontena stack install'
-        expect(k.code).to eq (0)
+        k = run! 'kontena stack install'
       end
-      k = run 'kontena service show twemproxy/twemproxy'
+      k = run! 'kontena service show twemproxy/twemproxy'
       expect(k.out).to match(/STACKNAME=twemproxy[\r\n]/)
     end
   end
@@ -165,7 +154,7 @@ describe 'stack install' do
         run! 'kontena stack install'
         run! 'kontena service scale simple/redis 2'
         run! 'kontena stack upgrade simple'
-        k = run 'kontena service show simple/redis'
+        k = run! 'kontena service show simple/redis'
         expect(k.out).to match(/INSTANCE_COUNT=2[\r\n]/)
       end
     end


### PR DESCRIPTION
Fixes #3174

Use `wait_until_container_gone` to delay the the spec until the stack installed by the previous spec has been cleaned up by the agent. This will loop forever in the `before` if there's some leaked `hello-ascii` stack installed from a previous spec run, but the same pattern is also used in the `vpn` specs?

Also refactor `k = run "..."; expect(k.code).to be_zero` to just `run! "..."`

## Testing

```
stack install
  from registry
    config from file
      installs a stack
    config from env
      installs a stack
  from file
    installs a stack
    skips deploy with --no-deploy
    returns error if file not found
    returns error if file is invalid
  For a stack with a broken link
    Returns an error
  For a stack with stop_grace_period
    creates stack service with stop_grace_period
  For a stack with read_only
    creates stack service with read_only and updates it properly
  For a stack with dependencies
    installs all dependencies
    does not mutate the $STACK variable
  For a stack using service_instances resolver
    interpolates the correct instance count

Finished in 1 minute 56.73 seconds (files took 0.10112 seconds to load)
12 examples, 0 failures
```