### PR TITLE
Upgrade CLI hash_validator dependency to 0.8.0

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
   spec.add_runtime_dependency "launchy", "~> 2.4.3"
-  spec.add_runtime_dependency "hash_validator", "~> 0.7.1"
+  spec.add_runtime_dependency "hash_validator", "0.8.0"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
   spec.add_runtime_dependency "opto", "1.8.7"
   spec.add_runtime_dependency "semantic", "~> 1.5"


### PR DESCRIPTION
Upgrade hash_validator dependency from `~> 0.7.1` to 0.8.0.
