### PR TITLE
Drop CLI launchy dependency

### DIFF
--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "tty-prompt", "0.13.1"
   spec.add_runtime_dependency "clamp", "~> 1.1.0"
   spec.add_runtime_dependency "ruby_dig", "~> 0.0.2"
-  spec.add_runtime_dependency "launchy", "~> 2.4.3"
   spec.add_runtime_dependency "hash_validator", "~> 0.7.1"
   spec.add_runtime_dependency "retriable", "~> 2.1.0"
   spec.add_runtime_dependency "opto", "1.8.7"

--- a/cli/lib/kontena/cli/browser_launcher.rb
+++ b/cli/lib/kontena/cli/browser_launcher.rb
@@ -18,7 +18,7 @@ module Kontena
       end
 
       def command
-        if Kontena.on_windows?
+        cmd = if Kontena.on_windows?
           ['start', url]
         elsif RUBY_PLATFORM =~ /darwin/
           ["open", url]
@@ -27,14 +27,21 @@ module Kontena
         else
           [detect_unixlike_command, url]
         end
+
+        Kontena.logger.debug { "Using %p to launch browser" % cmd }
+
+        cmd
       end
 
       def detect_unixlike_command
+        Kontena.logger.debug { "Assuming unix-like environment, looking for browser" }
+
         cmd = %w(
           xdg-open
           sensible-browser
           x-www-browser
         ).find { |c| !which(c).nil? }
+
         if cmd.nil?
           if ENV['BROWSER']
             cmd = which(ENV['BROWSER'])
@@ -42,6 +49,7 @@ module Kontena
           end
           raise RuntimeError, "Unable to launch a local browser. Try installing xdg-utils or sensible-utils package, setting BROWSER environment variable or using the --remote option"
         end
+
         cmd
       end
 

--- a/cli/lib/kontena/cli/browser_launcher.rb
+++ b/cli/lib/kontena/cli/browser_launcher.rb
@@ -19,7 +19,7 @@ module Kontena
 
       def command
         cmd = if Kontena.on_windows?
-          ['start', url]
+          ['cmd', '/c', 'start', '/b', url.gsub(/&/, '^&')]
         elsif RUBY_PLATFORM =~ /darwin/
           ["open", url]
         elsif Kontena.browserless?

--- a/cli/lib/kontena/cli/browser_launcher.rb
+++ b/cli/lib/kontena/cli/browser_launcher.rb
@@ -19,7 +19,7 @@ module Kontena
 
       def command
         if Kontena.on_windows?
-          %w(cmd /c start) + url
+          ['start', url]
         elsif RUBY_PLATFORM =~ /darwin/
           ["open", url]
         elsif Kontena.browserless?

--- a/cli/lib/kontena/cli/browser_launcher.rb
+++ b/cli/lib/kontena/cli/browser_launcher.rb
@@ -1,0 +1,53 @@
+require 'kontena/util'
+
+module Kontena
+  module Cli
+    class BrowserLauncher
+      def self.open(url)
+        Kontena::Cli::BrowserLauncher.new(url).launch
+      end
+
+      attr_reader :url
+
+      def initialize(url)
+        @url = url
+      end
+
+      def launch
+        system(*command)
+      end
+
+      def command
+        if Kontena.on_windows?
+          %w(cmd /c start) + url
+        elsif RUBY_PLATFORM =~ /darwin/
+          ["open", url]
+        elsif Kontena.browserless?
+          raise RuntimeError, "Environment variable DISPLAY not set, assuming non-desktop session, unable to open browser. Try using '--remote' option."
+        else
+          [detect_unixlike_command, url]
+        end
+      end
+
+      def detect_unixlike_command
+        cmd = %w(
+          xdg-open
+          sensible-browser
+          x-www-browser
+        ).find { |c| !which(c).nil? }
+        if cmd.nil?
+          if ENV['BROWSER']
+            cmd = which(ENV['BROWSER'])
+            return cmd unless cmd.nil?
+          end
+          raise RuntimeError, "Unable to launch a local browser. Try installing xdg-utils or sensible-utils package, setting BROWSER environment variable or using the --remote option"
+        end
+        cmd
+      end
+
+      def which(cmd)
+        Kontena::Util.which(cmd)
+      end
+    end
+  end
+end

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -137,12 +137,11 @@ module Kontena::Cli::Cloud
       puts
 
       server_thread  = Thread.new { Thread.main['response'] = web_server.serve_one }
-      browser_thread = Thread.new { Kontena::Cli::BrowserLauncher.open(uri.to_s) }
+      Kontena::Cli::BrowserLauncher.open(uri.to_s)
 
       spinner "Waiting for browser authorization response" do
         server_thread.join
       end
-      browser_thread.join
 
       update_token(Thread.main['response'])
     end

--- a/cli/lib/kontena/cli/cloud/login_command.rb
+++ b/cli/lib/kontena/cli/cloud/login_command.rb
@@ -105,7 +105,7 @@ module Kontena::Cli::Cloud
       end
 
       require_relative '../localhost_web_server'
-      require 'launchy'
+      require 'kontena/cli/browser_launcher'
 
       uri = URI.parse(kontena_account.authorization_endpoint)
       uri.host ||= kontena_account.url
@@ -137,7 +137,7 @@ module Kontena::Cli::Cloud
       puts
 
       server_thread  = Thread.new { Thread.main['response'] = web_server.serve_one }
-      browser_thread = Thread.new { Launchy.open(uri.to_s) }
+      browser_thread = Thread.new { Kontena::Cli::BrowserLauncher.open(uri.to_s) }
 
       spinner "Waiting for browser authorization response" do
         server_thread.join

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -176,7 +176,7 @@ module Kontena::Cli::Master
 
     def web_flow(server, auth_params)
       require_relative '../localhost_web_server'
-      require 'launchy'
+      require 'kontena/cli/browser_launcher'
 
 
       web_server = Kontena::LocalhostWebServer.new
@@ -202,7 +202,7 @@ module Kontena::Cli::Master
       puts
 
       server_thread  = Thread.new { Thread.main['response'] = web_server.serve_one }
-      browser_thread = Thread.new { Launchy.open(uri.to_s) }
+      browser_thread = Thread.new { Kontena::Cli::BrowserLauncher.open(uri.to_s) }
 
       spinner "Waiting for browser authorization response" do
         server_thread.join

--- a/cli/lib/kontena/cli/master/login_command.rb
+++ b/cli/lib/kontena/cli/master/login_command.rb
@@ -202,12 +202,11 @@ module Kontena::Cli::Master
       puts
 
       server_thread  = Thread.new { Thread.main['response'] = web_server.serve_one }
-      browser_thread = Thread.new { Kontena::Cli::BrowserLauncher.open(uri.to_s) }
+      Kontena::Cli::BrowserLauncher.open(uri.to_s)
 
       spinner "Waiting for browser authorization response" do
         server_thread.join
       end
-      browser_thread.join
 
       update_server(server, Thread.main['response'])
       update_server_to_config(server)

--- a/cli/spec/kontena/cli/cloud/login_command_spec.rb
+++ b/cli/spec/kontena/cli/cloud/login_command_spec.rb
@@ -1,6 +1,6 @@
 require 'kontena/cli/cloud/login_command'
 require 'kontena/cli/localhost_web_server'
-require 'launchy'
+require 'kontena/cli/browser_launcher'
 
 describe Kontena::Cli::Cloud::LoginCommand do
 
@@ -145,7 +145,7 @@ describe Kontena::Cli::Cloud::LoginCommand do
         expect(webserver).to receive(:serve_one).and_return({
           'access_token' => 'abcd'
         })
-        expect(Launchy).to receive(:open).and_return(true)
+        expect(Kontena::Cli::BrowserLauncher).to receive(:open).and_return(true)
         expect(subject).to receive(:finish).and_return(true)
         subject.run([])
         expect(account.token.access_token).to eq 'abcd'
@@ -159,7 +159,7 @@ describe Kontena::Cli::Cloud::LoginCommand do
         expect(webserver).to receive(:serve_one).and_return({
           'code' => 'abcd'
         })
-        expect(Launchy).to receive(:open).and_return(true)
+        expect(Kontena::Cli::BrowserLauncher).to receive(:open).and_return(true)
         expect(client).to receive(:exchange_code).with('abcd').and_return({
           'access_token' => 'abcdefg'
         })
@@ -176,7 +176,7 @@ describe Kontena::Cli::Cloud::LoginCommand do
         expect(webserver).to receive(:serve_one).and_return({
           'error' => 'foo'
         })
-        expect(Launchy).to receive(:open).and_return(true)
+        expect(Kontena::Cli::BrowserLauncher).to receive(:open).and_return(true)
         expect{subject.run([])}.to exit_with_error.and output(/Authentication failed: foo/).to_stderr
       end
     end

--- a/cli/spec/kontena/cli/master/join_command_spec.rb
+++ b/cli/spec/kontena/cli/master/join_command_spec.rb
@@ -1,7 +1,4 @@
 require 'kontena/cli/master/join_command'
-require 'kontena/cli/localhost_web_server'
-require 'launchy'
-require 'ostruct'
 
 describe Kontena::Cli::Master::JoinCommand do
 

--- a/cli/spec/kontena/cli/master/login_command_spec.rb
+++ b/cli/spec/kontena/cli/master/login_command_spec.rb
@@ -1,6 +1,6 @@
 require 'kontena/cli/master/login_command'
 require 'kontena/cli/localhost_web_server'
-require 'launchy'
+require 'kontena/cli/browser_launcher'
 require 'ostruct'
 
 describe Kontena::Cli::Master::LoginCommand do
@@ -147,7 +147,7 @@ describe Kontena::Cli::Master::LoginCommand do
       allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:readable?).and_return(true)
       allow(Kontena::Client).to receive(:new).and_return(client)
-      allow(Launchy).to receive(:open).and_return(true)
+      allow(Kontena::Cli::BrowserLauncher).to receive(:open).and_return(true)
       allow(Kontena::LocalhostWebServer).to receive(:port).and_return(12345)
       allow(Kontena::LocalhostWebServer).to receive(:serve_one).and_return(
         { 'code' => 'abcd1234' }
@@ -254,7 +254,7 @@ describe Kontena::Cli::Master::LoginCommand do
         expect(opts[:path]).to eq "/authenticate?redirect_uri=http%3A%2F%2Flocalhost%3A12345%2Fcb&expires_in=7200"
         expect(opts[:http_method]).to eq :get
       end.and_return({})
-      expect(Launchy).to receive(:open).with('http://authprovider.example.com/authplz').and_return(true)
+      expect(Kontena::Cli::BrowserLauncher).to receive(:open).with('http://authprovider.example.com/authplz').and_return(true)
       expect(client).to receive(:exchange_code).with('abcd1234').and_return('access_token' => 'defg456', 'server' => { 'name' => 'foobar' }, 'user' => { 'name' => 'testuser' })
       subject.run(%w(--no-remote --skip-grid-auto-select http://foobar.example.com))
       expect(subject.config.servers.size).to eq 1
@@ -328,7 +328,7 @@ describe Kontena::Cli::Master::LoginCommand do
     it 'changes current master to created master' do
       allow(client).to receive(:last_response).at_least(:once).and_return(OpenStruct.new(status: 302, headers: { 'Location' => 'http://authprovider.example.com/authplz' }))
       allow(client).to receive(:request).and_return({})
-      allow(Launchy).to receive(:open).with('http://authprovider.example.com/authplz').and_return(true)
+      allow(Kontena::Cli::BrowserLauncher).to receive(:open).with('http://authprovider.example.com/authplz').and_return(true)
       allow(client).to receive(:exchange_code).with('abcd1234').and_return('access_token' => 'defg456', 'server' => { 'name' => 'foobar' }, 'user' => { 'name' => 'testuser' })
       subject.config.current_master = 'fooserver'
       subject.config.current_master


### PR DESCRIPTION
Fixes #2288

Drops launchy (used for opening a browser for interactive login) from dependencies (which brings in addressable and public_suffix which both seem to cause some problems when resolving gems).

This PR replaces launchy with a simpler `Kontena::Cli::BrowserLauncher` which should work in most common environments.

Tested on:
- [X] Mac
- [X] Desktop linux
- [X] Windows 10

  
  