### PR TITLE
Add description field to master authentication access tokens

### DIFF
--- a/cli/lib/kontena/cli/master/token/common.rb
+++ b/cli/lib/kontena/cli/master/token/common.rb
@@ -9,7 +9,8 @@ module Kontena::Cli::Master::Token
         user_id: data["user"]["id"],
         user_email: data["user"]["email"],
         user_name: data["user"]["name"],
-        server_name: data["server"]["name"]
+        server_name: data["server"]["name"],
+        description: data['description']
       }
       if data["token_type"] == "bearer"
         output[:access_token_last_four] = data["access_token_last_four"]

--- a/cli/lib/kontena/cli/master/token/create_command.rb
+++ b/cli/lib/kontena/cli/master/token/create_command.rb
@@ -15,6 +15,7 @@ module Kontena::Cli::Master::Token
     option ['-u', '--user'], '[EMAIL]', 'Generate a token for another user'
     option ['--id'], :flag, "Only output the token ID"
     option ['--token'], :flag, "Only output the access_token (or authorization code)"
+    option ['-d', '--description'], '[DESCRIPTION]', 'Token description'
 
     option ['--return'], :flag, "Return the response hash", hidden: true
 
@@ -22,8 +23,9 @@ module Kontena::Cli::Master::Token
       params = {
         response_type: self.code? ? 'code' : 'token',
         scope: self.scopes,
-        expires_in: self.expires_in
+        expires_in: self.expires_in,
       }
+      params[:description] = self.description if self.description
       params[:user] = self.user if self.user
       data = token_data_to_hash(client.post("/oauth2/authorize", params))
 
@@ -39,8 +41,9 @@ module Kontena::Cli::Master::Token
         exit 0
       end
 
+      puts '%s:' % data.delete(:id)
       data.each do |key, value|
-        puts "%26.26s : %s" % [key, value]
+        puts "  %s: %s" % [key, value]
       end
     end
   end

--- a/cli/lib/kontena/cli/master/token/list_command.rb
+++ b/cli/lib/kontena/cli/master/token/list_command.rb
@@ -12,7 +12,7 @@ module Kontena::Cli::Master::Token
 
     def fields
       return ['id'] if quiet?
-      { id: 'id', token_type: 'token_type', token_last4: 'access_token_last_four', expires_in: 'expires_in', scopes: 'scopes' }
+      { id: 'id', token_type: 'token_type', token_last4: 'access_token_last_four', expires_in: 'expires_in', scopes: 'scopes', description: 'description' }
     end
 
     def execute

--- a/cli/spec/kontena/cli/master/token/create_command_spec.rb
+++ b/cli/spec/kontena/cli/master/token/create_command_spec.rb
@@ -1,0 +1,132 @@
+require 'kontena/cli/master/token_command'
+require 'kontena/cli/master/token/create_command'
+
+describe Kontena::Cli::Master::Token::CreateCommand do
+  include ClientHelpers
+  include RequirementsHelper
+  include OutputHelpers
+
+  expect_to_require_current_master
+  expect_to_require_current_master_token
+
+  let(:response) do
+    {
+      "id" => "123",
+      "token_type" => "bearer",
+      "access_token" => '1234abcd',
+      "refresh_token" => '2345defg',
+      "access_token_last_four" => "abcd",
+      "refresh_token_last_four" => "defg",
+      "expires_in" => 100,
+      "scopes" => "user",
+      "user" => {
+        "id" => "abc",
+        "email" => "user@email",
+        "name" => "username"
+      },
+      "server" => {
+        "name" => "foo"
+      },
+      "description" => "description test"
+    }
+  end
+
+  context '--description' do
+    it 'adds a description to token create request' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:description]).to eq 'description test'
+      end.and_return(response)
+      expect{subject.run(['--description', 'description test'])}.not_to exit_with_error
+    end
+  end
+
+  context '--scopes' do
+    it 'accepts a comma separated list of scopes' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:scope]).to eq 'xyz,zyx'
+      end.and_return(response)
+      expect{subject.run(['--scopes', 'xyz,zyx'])}.not_to exit_with_error
+    end
+  end
+
+  context '--code' do
+    it 'can request an authorization_code' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:response_type]).to eq 'code'
+      end.and_return(response)
+      expect{subject.run(['--code'])}.not_to exit_with_error
+    end
+  end
+
+  context '--expires-in' do
+    it 'can request a token without expiration' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:expires_in]).to eq '0'
+      end.and_return(response)
+      expect{subject.run(['--expires-in', '0'])}.not_to exit_with_error
+    end
+  end
+
+  context '--token' do
+    it 'requests a token and outputs the generated token' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:response_type]).to eq 'token'
+      end.and_return(response)
+      expect{subject.run(['--token'])}.to output(/\A1234abcd\Z/).to_stdout
+    end
+  end
+
+  context '--id' do
+    it 'requests a token and outputs the generated token id' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:response_type]).to eq 'token'
+      end.and_return(response)
+      expect{subject.run(['--id'])}.to output(/\A123\Z/).to_stdout
+    end
+  end
+
+  context '--user' do
+    it 'can request a token for another user' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:user]).to eq 'foo@example.com'
+      end.and_return(response)
+      expect{subject.run(['--user', 'foo@example.com'])}.not_to exit_with_error
+    end
+  end
+
+  context 'no parameters' do
+    it 'requests an expiring user scoped token with an empty description and outputs token and refresh token' do
+      expect(client).to receive(:post) do |path, data|
+        expect(path).to eq '/oauth2/authorize'
+        expect(data[:user]).to be_nil
+        expect(data[:description]).to be_nil
+        expect(data[:response_type]).to eq 'token'
+        expect(data[:expires_in]).to eq '7200'
+        expect(data[:scope]).to eq 'user'
+      end.and_return(response)
+      expect{subject.run([])}.to output_yaml(
+        123 => {
+          'access_token' => '1234abcd',
+          'refresh_token' => '2345defg',
+          'access_token_last_four' => 'abcd',
+          'refresh_token_last_four' => 'defg',
+          'expires_in' => 100,
+          'token_type' => 'bearer',
+          'scopes' => 'user',
+          'user_id' => 'abc',
+          'user_email' => 'user@email',
+          'user_name' => 'username',
+          'server_name' => 'foo',
+          'description' => 'description test'
+        }
+      )
+    end
+  end
+end

--- a/cli/spec/kontena/cli/master/token/show_command_spec.rb
+++ b/cli/spec/kontena/cli/master/token/show_command_spec.rb
@@ -28,7 +28,8 @@ describe Kontena::Cli::Master::Token::ShowCommand do
         },
         "server" => {
           "name" => "foo"
-        }
+        },
+        "description" => "description test"
       }
     end
 
@@ -44,7 +45,8 @@ describe Kontena::Cli::Master::Token::ShowCommand do
           'server_name' => 'foo',
           'access_token_last_four' => 'abcd',
           'refresh_token_last_four' => 'efgh',
-          'expires_in' => 100
+          'expires_in' => 100,
+          'description' => 'description test'
         }
       )
     end
@@ -64,7 +66,8 @@ describe Kontena::Cli::Master::Token::ShowCommand do
         },
         "server" => {
           "name" => "foo"
-        }
+        },
+        "description" => 'description test'
       }
     end
 
@@ -78,7 +81,8 @@ describe Kontena::Cli::Master::Token::ShowCommand do
           'user_id' => 'abc',
           'user_email' => 'user@email',
           'user_name' => 'username',
-          'server_name' => 'foo'
+          'server_name' => 'foo',
+          'description' => 'description test'
         }
       )
     end

--- a/server/app/models/access_token.rb
+++ b/server/app/models/access_token.rb
@@ -19,7 +19,8 @@ class AccessToken
   field :deleted_at, type: BSON::Timestamp, default: nil
   field :token_last_four, type: String
   field :refresh_token_last_four, type: String
-  
+  field :description, type: String
+
   # set to false when storing tokens to external services
   field :internal, type: Boolean, default: true
 
@@ -89,7 +90,8 @@ class AccessToken
         expires_at: Time.now.utc + 7200,
         scopes: old_token.scopes,
         internal: true,
-        user: old_token.user
+        user: old_token.user,
+        description: old_token.description
       )
 
       old_token.destroy
@@ -103,7 +105,7 @@ class AccessToken
         internal: true
       ).find_one_and_update({ '$set' => { updated_at: Time.now.utc } })
     end
-   
+
     # Since we don't know the original saved tokens, we just delete the old one and generate a duplicate with the same scope + user
     #
     # TODO consider hashing codes.
@@ -117,7 +119,8 @@ class AccessToken
         expires_at: coded_token.expires_at,
         scopes: coded_token.scopes,
         internal: true,
-        user: coded_token.user
+        user: coded_token.user,
+        description: coded_token.description
       )
 
       coded_token.destroy
@@ -146,7 +149,7 @@ class AccessToken
     !self[:code].nil?
   end
 
-  # Converts the access token to uri encoded format usable in 
+  # Converts the access token to uri encoded format usable in
   # redirects and as a x-www-form-encoded body response.
   #
   # If uri is not defined, just the parameters will be returned,

--- a/server/app/mutations/access_tokens/create.rb
+++ b/server/app/mutations/access_tokens/create.rb
@@ -18,6 +18,7 @@ module AccessTokens
       model :current_access_token
       string :token
       string :refresh_token
+      string :description, nils: true, empty_is_nil: true
     end
 
     def validate
@@ -56,7 +57,8 @@ module AccessTokens
         user: self.user,
         scopes: self.scopes,
         expires_at: expires_at,
-        with_code: self.with_code
+        with_code: self.with_code,
+        description: self.description
       }
 
       if self.token

--- a/server/app/routes/oauth2/authorization_api.rb
+++ b/server/app/routes/oauth2/authorization_api.rb
@@ -37,6 +37,7 @@ module OAuth2Api
     NOT_ADMIN          = 'User not admin, denying access'.freeze
     NOT_FOUND          = 'not_found'.freeze
     NOT_CONFIGURED     = 'Authentication provider not configured'.freeze
+    DESCRIPTION        = 'Description'.freeze
 
     route do |r|
       r.post do
@@ -73,7 +74,8 @@ module OAuth2Api
             scope: params[SCOPE],
             refreshable: params[EXPIRES_IN].to_i > 0,
             expires_in: params[EXPIRES_IN],
-            with_code: params[RESPONSE_TYPE] == CODE
+            with_code: params[RESPONSE_TYPE] == CODE,
+            description: params[DESCRIPTION]
           )
           if task.success?
             debug { "Created a #{params[RESPONSE_TYPE]} for user #{user.email}" }

--- a/server/app/routes/oauth2/authorization_api.rb
+++ b/server/app/routes/oauth2/authorization_api.rb
@@ -37,7 +37,7 @@ module OAuth2Api
     NOT_ADMIN          = 'User not admin, denying access'.freeze
     NOT_FOUND          = 'not_found'.freeze
     NOT_CONFIGURED     = 'Authentication provider not configured'.freeze
-    DESCRIPTION        = 'Description'.freeze
+    DESCRIPTION        = 'description'.freeze
 
     route do |r|
       r.post do

--- a/server/app/views/v1/access_tokens/_access_token.json.jbuilder
+++ b/server/app/views/v1/access_tokens/_access_token.json.jbuilder
@@ -18,6 +18,7 @@ else
 end
 
 json.set! :scopes, access_token.scopes.join(",")
+json.set! :description, access_token.description
 
 json.user do
   json.id access_token.user.id.to_s

--- a/server/spec/models/access_token_spec.rb
+++ b/server/spec/models/access_token_spec.rb
@@ -1,7 +1,7 @@
 
 describe AccessToken do
   it { should be_timestamped_document }
-  it { should have_fields(:token, :refresh_token, :expires_at, :scopes)}
+  it { should have_fields(:token, :refresh_token, :expires_at, :scopes, :description)}
 
   it { should belong_to(:user) }
 

--- a/server/spec/mutations/access_tokens/create_spec.rb
+++ b/server/spec/mutations/access_tokens/create_spec.rb
@@ -16,5 +16,10 @@ describe AccessTokens::Create do
         expect(outcome.success?).to be_falsey
       }.to change{ AccessToken.count }.by(0)
     end
+
+    it 'can add a description' do
+      described_class.new(user: user, scopes: ['user'], description: 'description test').run
+      expect(user.access_tokens.first.description).to eq 'description test'
+    end
   end
 end

--- a/test/spec/features/master/token/create_spec.rb
+++ b/test/spec/features/master/token/create_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'token create' do
+  it ' creates a token with description' do
+    k = run!('kontena master token create --description "token description test --id')
+    token_id = k.out.strip
+    k = run('kontena master token list')
+    expect(k.out).to match /token description test/
+    k = run('kontena master token show %s' % token_id)
+    expect(k.out).to match /description: token description test/
+  end
+end

--- a/test/spec/features/master/token/create_spec.rb
+++ b/test/spec/features/master/token/create_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'token create' do
   it ' creates a token with description' do
-    k = run!('kontena master token create --description "token description test --id')
+    k = run!('kontena master token create --description tokendescriptiontest --id')
     token_id = k.out.strip
     k = run('kontena master token list')
-    expect(k.out).to match /token description test/
+    expect(k.out).to match /tokendescriptiontest/
     k = run('kontena master token show %s' % token_id)
-    expect(k.out).to match /description: token description test/
+    expect(k.out).to match /description: tokendescriptiontest/
   end
 end


### PR DESCRIPTION
Fixes #3210

- [X] Adds an optional description field to master access tokens
- [X] Adds an optional argument to `kontena master token create` for setting a description to created tokens
- [X] Displays token description in `kontena master token <ls | show>`

Partial improvement for #3151 