### PR TITLE
Fix server Celluloid::Proxy::Async<MongoPubsub> leak from RPC /container/health handler

### DIFF
--- a/server/app/models/event_stream.rb
+++ b/server/app/models/event_stream.rb
@@ -41,6 +41,7 @@ module EventStream
 
   def publish_async(event)
     MongoPubsub.publish_async(CHANNEL, event) if MongoPubsub.started?
+    return nil # do not leak Celluloid::Proxy::Async<MongoPubsub>!
   end
 
   def find_serializer_class

--- a/server/app/services/rpc/node_service_pod_handler.rb
+++ b/server/app/services/rpc/node_service_pod_handler.rb
@@ -31,7 +31,6 @@ module Rpc
     # @param [String] id
     # @return [Array<Hash>]
     def list(id)
-      start = Time.now.to_f
       node = @grid.host_nodes.find_by(node_id: id)
       raise 'Node not found' unless node
       raise 'Migration not done' unless migration_done?
@@ -39,8 +38,6 @@ module Rpc
       service_pods = node.grid_service_instances.includes(:grid_service).map { |i|
         cached_pod(i)
       }.compact
-      end_time = Time.now.to_f
-      debug "pod list rpc took: #{((end_time-start) * 1000).to_i}ms"
       { service_pods: service_pods }
     end
 

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -64,23 +64,27 @@ class RpcServer
   # @return [Array]
   def handle_request(ws_client, grid_id, message)
     msg_id = message[1]
-    handler = message[2].split('/')[1]
-    method = message[2].split('/')[2]
+    msg_path = message[2]
+    _, handler, method = msg_path.split('/')
     if instance = handling_instance(grid_id, handler)
+      start_time = Time.now
       begin
         result = instance.send(method, *message[3])
-        send_message(ws_client, [1, msg_id, nil, result])
       rescue RpcServer::Error => exc
         send_message(ws_client, [1, msg_id, {code: exc.code, message: exc.message}, nil])
         @handlers[grid_id].delete(handler)
       rescue => exc
-        error "#{exc.class.name}: #{exc.message}"
-        debug exc.backtrace.join("\n")
+        error "request #{msg_path} => #{exc.class}: #{exc}"
+        error exc
         send_message(ws_client, [1, msg_id, {code: 500, message: "#{exc.class.name}: #{exc.message}"}, nil])
         @handlers[grid_id].delete(handler)
+      else
+        dt = Time.now - start_time
+        debug "request #{msg_path} => #{result.class} in #{'%.3f' % dt}s"
+        send_message(ws_client, [1, msg_id, nil, result])
       end
     else
-      warn "handler #{handler} not implemented"
+      warn "handler #{msg_path} not implemented"
       send_message(ws_client, [1, msg_id, {code: 501, error: 'service not implemented'}, nil])
     end
   end
@@ -88,18 +92,22 @@ class RpcServer
   # @param [String] grid_id
   # @param [Array] message msgpack-rpc notification array
   def handle_notification(grid_id, message)
-    handler = message[1].split('/')[1]
-    method = message[1].split('/')[2]
+    msg_path = message[1]
+    _, handler, method = msg_path.split('/')
     if instance = handling_instance(grid_id, handler)
+      start_time = Time.now
       begin
         instance.send(method, *message[2])
       rescue => exc
-        error "#{exc.class.name}: #{exc.message}"
-        error exc.backtrace.join("\n")
+        error "notify #{msg_path} => #{exc.class}: #{exc}"
+        error exc
         @handlers[grid_id].delete(handler)
+      else
+        dt = Time.now - start_time
+        debug "notify #{msg_path} in #{'%.3f' % dt}s"
       end
     else
-      warn "handler #{handler} not implemented"
+      warn "handler #{msg_path} not implemented"
     end
   end
 

--- a/server/spec/services/rpc/container_handler_spec.rb
+++ b/server/spec/services/rpc/container_handler_spec.rb
@@ -1,5 +1,5 @@
 describe Rpc::ContainerHandler do
-  let(:grid) { Grid.create! }
+  let(:grid) { Grid.create!(name: 'test') }
   let(:subject) { described_class.new(grid) }
   let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
 
@@ -221,27 +221,37 @@ describe Rpc::ContainerHandler do
   end
 
   describe '#health' do
-    it 'saves container health status and sends pubsub notification' do
-      container = grid.containers.create!(grid_service: grid_service, container_id: SecureRandom.hex(16), name: 'foo-1', health_status: 'unknown')
-      expect {
-        subject.health({'id' => container.container_id, 'status' => 'healthy'})
-      }.to change{container.reload.health_status}.to 'healthy'
-    end
-
     it 'warns if container not found' do
       expect(subject).to receive(:warn).with('health status update failed, could not find container for id: foo')
-      subject.health({'id' => 'foo', 'status' => 'healthy'})
+      result = subject.health({'id' => 'foo', 'status' => 'healthy'})
+      expect(!result).to be_truthy # can't use nil? for celluloid async proxy
     end
 
-    it 'saves container health status, does not send notification when no service linked to container' do
-      container = grid.containers.create!(container_id: SecureRandom.hex(16), name: 'foo-1', health_status: 'unknown')
-      expect(MongoPubsub).not_to receive(:publish)
-      expect {
-        subject.health({'id' => container.container_id, 'status' => 'healthy'})
-      }.to change{container.reload.health_status}.to 'healthy'
+    context 'with an existing container' do
+      let(:container) { grid.containers.create!(grid_service: grid_service, container_id: SecureRandom.hex(16), name: 'foo-1', health_status: 'unknown') }
+
+      it 'saves container health status and sends pubsub notification' do
+        allow(MongoPubsub).to receive(:publish_async).and_call_original
+        expect(MongoPubsub).to receive(:publish_async).with('FirehoseApiEvent', {event: 'update', type: 'GridService', object: hash_including(id: 'test/null/redis')}).and_call_original
+
+        expect {
+          result = subject.health({'id' => container.container_id, 'status' => 'healthy'})
+          expect(!result).to be_truthy # can't use nil? for celluloid async proxy
+        }.to change{container.reload.health_status}.to 'healthy'
+      end
+
+      context 'not linked to any grid service' do
+        let(:grid_service) { nil }
+
+        it 'saves container health status, does not send notification when no service linked to container' do
+          expect(MongoPubsub).not_to receive(:publish_async).with('FirehoseApiEvent', {event: 'update', type: 'GridService', object: Hash})
+
+          expect {
+            result = subject.health({'id' => container.container_id, 'status' => 'healthy'})
+            expect(!result).to be_truthy # can't use nil? for celluloid async proxy
+          }.to change{container.reload.health_status}.to 'healthy'
+        end
+      end
     end
-
-
   end
-
 end


### PR DESCRIPTION
Fixes  #3207

* Fix the `Rpc::ContainerHandler#health` specs: they were only testing `expect(MongoPubsub).not_to receive(:publish)`, which is meaningless: it's actually `MongoPubsub.publish_async(...)`.
* Fix `EventStream#publish_async` to not return `Celluloid::Proxy::Async<MongoPubsub>`
* Improve the server RPC to log all request/notify timings and return values at `DEBUG` level

## Example `DEBUG` output
```
D, [2018-01-15T11:11:14.694776 #8] DEBUG -- WebsocketBackend: node core-01 connected using node token with node_id XI4K:NPOL:EQJ4:S4V7:EN3B:DHC5:KZJD:F3U2:PCAN:46EV:IO4A:63S5
I, [2018-01-15T11:11:14.696643 #8]  INFO -- WebsocketBackend: node core-01 agent version 1.5.0.dev connected at 2018-01-15 11:11:14 UTC, 0.06s ago
I, [2018-01-15T11:11:14.718142 #8]  INFO -- Agent::NodePlugger: Connected node development/core-01 at 2018-01-15 11:11:14 UTC
D, [2018-01-15T11:11:14.756983 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.814566 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.832138 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.844192 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.854505 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.866495 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.881725 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.886687 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.908923 #8] DEBUG -- Rpc::NodeServicePodHandler: pod_cache miss
D, [2018-01-15T11:11:14.920812 #8] DEBUG -- RpcServer: request /node_service_pods/list => Hash in 0.208s
D, [2018-01-15T11:11:14.943494 #8] DEBUG -- RpcServer: request /containers/save => Hash in 0.007s
D, [2018-01-15T11:11:14.961489 #8] DEBUG -- RpcServer: request /containers/save => Hash in 0.018s
D, [2018-01-15T11:11:17.460297 #8] DEBUG -- RpcServer: request /node_volumes/list => Hash in 0.027s
D, [2018-01-15T11:11:18.628937 #8] DEBUG -- RpcServer: notify /containers/log_batch in 0.020s
D, [2018-01-15T11:11:18.644608 #8] DEBUG -- RpcServer: notify /containers/log_batch in 0.004s
D, [2018-01-15T11:11:18.647713 #8] DEBUG -- RpcServer: notify /containers/log_batch in 0.003s
D, [2018-01-15T11:11:18.654810 #8] DEBUG -- RpcServer: notify /containers/log_batch in 0.002s
D, [2018-01-15T11:11:19.907534 #8] DEBUG -- RpcServer: request /nodes/update => TrueClass in 0.019s
D, [2018-01-15T11:11:20.666153 #8] DEBUG -- RpcServer: notify /containers/log_batch in 0.002s
D, [2018-01-15T11:11:23.088155 #8] DEBUG -- RpcServer: request /containers/health => NilClass in 0.006s
D, [2018-01-15T11:11:23.692110 #8] DEBUG -- RpcServer: notify /containers/log_batch in 0.004s
...
```