### PR TITLE
Fix CLI byebug dependency to 9.0.x for Ruby 2.1 compatibility

### DIFF
--- a/cli/Gemfile
+++ b/cli/Gemfile
@@ -8,5 +8,6 @@ group :development, :test do
   gem "kontena-plugin-hello", path: "./examples/kontena-plugin-hello"
   gem 'pry', require: false
   gem 'pry-byebug', require: false
+  gem 'byebug', '~> 9.0', require: false
   gem 'webmock', '~> 3.0', require: false
 end


### PR DESCRIPTION
Fixes #2996 flaky CLI ruby 2.1 specs because rubygems/bundler doesn't always select the compatible version?

[`byebug` version 9.1.x](https://rubygems.org/gems/byebug/versions/9.1.0) is not compatible with ruby 2.1, so pin the CLI to [`byebug` version 9.0.x](https://rubygems.org/gems/byebug/versions/9.0.6).