### PR TITLE
Fix CLI travis to bundle install --without development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
   - docker
 before_install:
   - ./build/travis/before_install.sh
+bundler_args: --without development
 env:
   global:
     - secure: "UyygtUDLvV2+14mEG6Pddo/deLazXc2Hit63KlbZ26Pi8cxbr1FeDUBi4WFVWlFh01smKe5mO+kk/4k06aSdolcTC59QUsltRrsINmsxj/BS66L7JbWP8/yPQP1drE6CH5oh6t1JAchuK19bLUOK9Tycn0J2VufW69ckw3D+rqU=" # DOCKER_HUB_PASSWORD
@@ -90,4 +91,3 @@ jobs:
       repo: kontena/kontena
       rvm: 2.4
       env: TEST_DIR=server
-

--- a/cli/Gemfile
+++ b/cli/Gemfile
@@ -5,12 +5,12 @@ gemspec
 
 group :test do
   gem "rspec"
+  gem "kontena-plugin-hello", path: "./examples/kontena-plugin-hello"
   gem 'simplecov', :require => false, :group => :test
   gem 'webmock', '~> 3.0', require: false
 end
 
 group :development do
-  gem "kontena-plugin-hello", path: "./examples/kontena-plugin-hello"
   gem 'pry', require: false
   gem 'pry-byebug', require: false
 end

--- a/cli/Gemfile
+++ b/cli/Gemfile
@@ -2,11 +2,15 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kontena-cli.gemspec
 gemspec
+
 group :development, :test do
   gem "rspec"
   gem 'simplecov', :require => false, :group => :test
+  gem 'webmock', '~> 3.0', require: false
+end
+
+group :development do
   gem "kontena-plugin-hello", path: "./examples/kontena-plugin-hello"
   gem 'pry', require: false
   gem 'pry-byebug', require: false
-  gem 'webmock', '~> 3.0', require: false
 end

--- a/cli/Gemfile
+++ b/cli/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in kontena-cli.gemspec
 gemspec
 
-group :development, :test do
+group :test do
   gem "rspec"
   gem 'simplecov', :require => false, :group => :test
   gem 'webmock', '~> 3.0', require: false


### PR DESCRIPTION
Should also fix #2996 to skip the `byebug` dependency for the travis ruby 2.1 builds/tests.

Travis only needs to install the `test` gems, the `development` gems like `byebug` are not needed in order to run the specs.