### PR TITLE
Enable gzip response parsing in CLI API client where supported

### DIFF
--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -55,7 +55,8 @@ module Kontena
         connect_timeout: ENV["EXCON_CONNECT_TIMEOUT"] ? ENV["EXCON_CONNECT_TIMEOUT"].to_i : 10,
         read_timeout:    ENV["EXCON_READ_TIMEOUT"]    ? ENV["EXCON_READ_TIMEOUT"].to_i    : 30,
         write_timeout:   ENV["EXCON_WRITE_TIMEOUT"]   ? ENV["EXCON_WRITE_TIMEOUT"].to_i   : 10,
-        ssl_verify_peer: ignore_ssl_errors? ? false : true
+        ssl_verify_peer: ignore_ssl_errors? ? false : true,
+        middlewares:     Excon.defaults[:middlewares] + [Excon::Middleware::Decompress]
       }
       if Kontena.debug?
         require 'kontena/debug_instrumentor'

--- a/cli/lib/kontena/debug_instrumentor.rb
+++ b/cli/lib/kontena/debug_instrumentor.rb
@@ -20,7 +20,9 @@ module Kontena
         str = "Headers: {"
         heads = []
         heads << "Accept: #{params[:headers]['Accept']}" if params[:headers]['Accept']
+        heads << "Accept-Encoding: #{params[:headers]['Accept-Encoding']}" if params[:headers]['Accept-Encoding']
         heads << "Content-Type: #{params[:headers]['Content-Type']}" if params[:headers]['Content-Type']
+        heads << "Content-Encoding: #{params[:headers]['Content-Encoding']}" if params[:headers]['Content-Encoding']
         heads << "Authorization: #{params[:headers]['Authorization'].split(' ', 2).first}" if params[:headers]['Authorization']
         heads << "X-Kontena-Version: #{params[:headers]['X-Kontena-Version']}" if params[:headers]['X-Kontena-Version']
         str << heads.join(', ')
@@ -39,12 +41,19 @@ module Kontena
       end
 
       if params[:body] && !params[:body].empty?
+        if params[:headers]['Content-Encoding'].to_s =~ /gzip/
+          body_content = Zlib::GzipReader.new(StringIO.new(params[:body])).read
+          body = "(GZIPPED 1:%d) %s" % [body_content.bytesize / params[:body].bytesize, body_content]
+        else
+          body = params[:body]
+        end
+
         str = "Body: "
         if ENV["DEBUG"] == "api"
           str << "\n"
-          str << params[:body]
+          str << body
         else
-          body = params[:body].inspect.strip
+          body = body.inspect.strip
           str << body[0,80]
           if body.length > 80
             str << "...\""


### PR DESCRIPTION
Sets the `Accept-Encoding: gzip` header to API requests. The HTTP client library handles the decompression (except when raising errors, in which case the response is decompressed in rescue for displaying)

JSON-API responses compress to about 10% of their original size, almost always more efficient than for example MsgPack (which is fine for streaming requests).

If the server does not support `Accept-Encoding: gzip` nothing is changed.

Enabling server side support in Roda-based applications such as the kontena master or any of the micro service API's is simply an addition of:

```ruby
use Rack::Deflater, include: %w(application/json application/vnd.api+json application/yaml)
```

in the `server.rb` or equivalent.

Extracted from #3219

