### PR TITLE
Fix e2e remove specs to not use unsupported shell syntax

### DIFF
--- a/test/spec/features/service/remove_spec.rb
+++ b/test/spec/features/service/remove_spec.rb
@@ -1,19 +1,19 @@
 describe 'service remove' do
 
     after(:each) do
-      run 'kontena service rm --force $(kontena service ls -q)'
+      run 'kontena service rm --force rm-test'
+      run 'kontena service rm --force rm-test-1'
+      run 'kontena service rm --force rm-test-2'
     end
 
     it 'removes a service' do
-      run 'kontena service create rm-test redis:3-alpine'
-      k = run 'kontena service rm --force rm-test'
-      expect(k.code).to eq(0)
+      run! 'kontena service create rm-test redis:3-alpine'
+      run! 'kontena service rm --force rm-test'
     end
 
     it 'removes multiple services' do
-      run 'kontena service create rm-test-1 redis:3-alpine'
-      run 'kontena service create rm-test-2 redis:3-alpine'
-      k = run 'kontena service rm --force rm-test-1 rm-test-2'
-      expect(k.code).to eq(0)
+      run! 'kontena service create rm-test-1 redis:3-alpine'
+      run! 'kontena service create rm-test-2 redis:3-alpine'
+      run! 'kontena service rm --force rm-test-1 rm-test-2'
     end
   end

--- a/test/spec/features/vault/remove_spec.rb
+++ b/test/spec/features/vault/remove_spec.rb
@@ -1,19 +1,19 @@
 describe 'vault remove' do
   after(:each) do
-    run 'kontena vault rm --force $(kontena vault ls -q)'
+    run 'kontena vault rm --force foo'
+    run 'kontena vault rm --force foo0'
+    run 'kontena vault rm --force foo1'
   end
 
   it 'removes a vault key' do
-    run 'kontena vault write foo bar'
-    k = run 'kontena vault rm --force foo'
-    expect(k.code).to eq(0)
+    run! 'kontena vault write foo bar'
+    run! 'kontena vault rm --force foo'
   end
 
   it 'removes multiple vault keys' do
     2.times do |i|
-      run "kontena vault write foo#{i} bar"
+      run! "kontena vault write foo#{i} bar"
     end
-    k = run 'kontena vault rm --force foo0 foo1'
-    expect(k.code).to eq(0)
+    run! 'kontena vault rm --force foo0 foo1'
   end
 end

--- a/test/spec/features/volume/remove_spec.rb
+++ b/test/spec/features/volume/remove_spec.rb
@@ -1,19 +1,19 @@
 describe 'volume remove' do
   after(:each) do
-    run 'kontena volume rm --force $(kontena volume ls -q)'
+    run 'kontena volume rm --force test-volume'
+    run 'kontena volume rm --force test-volume0'
+    run 'kontena volume rm --force test-volume1'
   end
 
   it 'removes a volume' do
-    run 'kontena volume create --driver local --scope grid test-volume'
-    k = run 'kontena volume rm --force test-volume'
-    expect(k.code).to eq(0)
+    run! 'kontena volume create --driver local --scope grid test-volume'
+    run! 'kontena volume rm --force test-volume'
   end
 
   it 'removes multiple volumes' do
     2.times do |i|
-      run "kontena volume create --driver local --scope grid test-volume#{i}"
+      run! "kontena volume create --driver local --scope grid test-volume#{i}"
     end
-    k = run 'kontena volume rm --force test-volume0 test-volume1'
-    expect(k.code).to eq(0)
+    run! 'kontena volume rm --force test-volume0 test-volume1'
   end
 end


### PR DESCRIPTION
Fixes  #3226

```
service remove
  removes a service
  removes multiple services

vault remove
  removes a vault key
  removes multiple vault keys

volume remove
  removes a volume
  removes multiple volumes

Finished in 17.3 seconds (files took 0.10416 seconds to load)
6 examples, 0 failures
```