### PR TITLE
Fix e2e specs to run! (some of) the things

### DIFF
--- a/test/spec/features/plugin/uninstall_spec.rb
+++ b/test/spec/features/plugin/uninstall_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe 'plugin uninstall' do
-  before(:each) do
-    run('kontena plugin install aws')
-  end
+  context 'with the aws plugin installed' do
+    before(:each) do
+      run! 'kontena plugin install aws'
+    end
 
-  it 'removes installed plugin' do
-    k = run('kontena plugin uninstall aws')
-    expect(k.code).to eq(0)
+    it 'removes installed plugin' do
+      run! 'kontena plugin uninstall aws'
 
-    k = run('kontena plugin ls')
-    expect(k.code).to eq(0)
-    expect(k.out).to_not match(/aws/)
+      k = run! 'kontena plugin ls'
+      expect(k.out).to_not match(/aws/)
+    end
   end
 end

--- a/test/spec/features/plugin/upgrade_spec.rb
+++ b/test/spec/features/plugin/upgrade_spec.rb
@@ -10,8 +10,8 @@ describe 'plugin upgrade' do
     end
 
     after(:each) do
-      run! 'kontena plugin uninstall aws'
-      run! 'kontena plugin uninstall digitalocean'
+      run 'kontena plugin uninstall aws'
+      run 'kontena plugin uninstall digitalocean'
     end
 
     it 'upgrades all plugins' do

--- a/test/spec/features/plugin/upgrade_spec.rb
+++ b/test/spec/features/plugin/upgrade_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'plugin upgrade' do
   context "with older versions of the aws, digitalocean plugins installed" do
     before(:each) do
-      run! 'kontena plugin uninstall aws'
-      run! 'kontena plugin uninstall digitalocean'
+      run 'kontena plugin uninstall aws'
+      run 'kontena plugin uninstall digitalocean'
       run! 'kontena plugin install --version 0.2.7 aws'
       run! 'kontena plugin install --version 0.2.5 digitalocean'
     end

--- a/test/spec/features/plugin/upgrade_spec.rb
+++ b/test/spec/features/plugin/upgrade_spec.rb
@@ -1,30 +1,32 @@
 require 'spec_helper'
 
 describe 'plugin upgrade' do
-  after(:each) do
-    run('kontena plugin uninstall aws')
-    run('kontena plugin uninstall digitalocean')
-  end
+  context "with older versions of the aws, digitalocean plugins installed" do
+    before(:each) do
+      run! 'kontena plugin uninstall aws'
+      run! 'kontena plugin uninstall digitalocean'
+      run! 'kontena plugin install --version 0.2.7 aws'
+      run! 'kontena plugin install --version 0.2.5 digitalocean'
+    end
 
-  before(:each) do
-    run('kontena plugin uninstall aws')
-    run('kontena plugin uninstall digitalocean')
-    run('kontena plugin install --version 0.2.7 aws')
-    run('kontena plugin install --version 0.2.5 digitalocean')
-  end
+    after(:each) do
+      run! 'kontena plugin uninstall aws'
+      run! 'kontena plugin uninstall digitalocean'
+    end
 
-  it 'upgrades all plugins' do
-    k = run!('kontena plugin upgrade')
-    expect(k.out).to match(/aws/)
-    expect(k.out).to match(/digitalocean/)
-    k = run('kontena plugin list')
-    lines = k.out.split(/[\r\n]/)
-    lines.each do |line|
-      plugin, version, _ = line.split(/\s+/, 3)
-      if plugin == 'aws'
-        expect(Gem::Version.new(version) > Gem::Version.new("0.2.7")).to be_truthy
-      elsif plugin == 'digitalocean'
-        expect(Gem::Version.new(version) > Gem::Version.new("0.2.5")).to be_truthy
+    it 'upgrades all plugins' do
+      k = run!('kontena plugin upgrade')
+      expect(k.out).to match(/aws/)
+      expect(k.out).to match(/digitalocean/)
+      k = run('kontena plugin list')
+      lines = k.out.split(/[\r\n]/)
+      lines.each do |line|
+        plugin, version, _ = line.split(/\s+/, 3)
+        if plugin == 'aws'
+          expect(Gem::Version.new(version) > Gem::Version.new("0.2.7")).to be_truthy
+        elsif plugin == 'digitalocean'
+          expect(Gem::Version.new(version) > Gem::Version.new("0.2.5")).to be_truthy
+        end
       end
     end
   end

--- a/test/spec/features/stack/remove_spec.rb
+++ b/test/spec/features/stack/remove_spec.rb
@@ -26,7 +26,7 @@ describe 'stack remove' do
 
   it "prompts without --force" do
     with_fixture_dir("stack/simple") do
-      run 'kontena stack install --no-deploy'
+      run! 'kontena stack install --no-deploy'
     end
     k = kommando 'kontena stack rm simple', timeout: 5
     k.out.on "To proceed, type" do


### PR DESCRIPTION
Makes it possible to diagnose the e2e spec failures caused by #3228, having the `before` hooks just `run` without any error checking leads to impossible to understand `expect(...)` failures.

There's a lot more of these where this comes from... should I try and fix all of the unchecked `run` usages in the specs?

## Before
```
Failures:

  1) plugin uninstall removes installed plugin
     Failure/Error: expect(k.code).to eq(0)
     
       expected: 0
            got: 1
     
       (compared using ==)
     # ./spec/features/plugin/uninstall_spec.rb:10:in `block (2 levels) in <top (required)>'

  2) plugin upgrade upgrades all plugins
     Failure/Error: expect(k.out).to match(/aws/)
     
       expected "    *   Checking for upgrades .. \\\r                                  \r\r    *   Checking for upgr...                      \r\r    *   Running cleanup .. -\r [\e[32mdone\e[0m] Running cleanup     \r\n" to match /aws/
       Diff:
       @@ -1,2 +1,8 @@
       -/aws/
 [done] Checking for upgrades     des .. \
    *   Upgrading digitalocean from 0.2.5 to 0.3.3 .. -WARN: Unresolved specs during Gem::Specification.reset:
       +      minitest (~> 5.1)
       +WARN: Clearing out unresolved specs.
       +Please report a bug if this causes problems.
 [done] Upgrading digitalocean from 0.2.5 to 0.3.3     
 [done] Running cleanup     nup .. \
       
     # ./spec/features/plugin/upgrade_spec.rb:18:in `block (2 levels) in <top (required)>'
```

## After
```
Failures:

  1) plugin upgrade with older versions of the aws, digitalocean plugins installed upgrades all plugins
     Failure/Error: raise Error.new(cmd, k.code, k.out) unless k.code.zero?
     
     Shell::Error:
       command failed with code 1: kontena plugin uninstall aws
        [error] NoMethodError : undefined method `name' for "aws":String
                See /home/terom/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
     # ./spec/support/shell.rb:28:in `block in run!'
     # ./spec/support/shell.rb:27:in `tap'
     # ./spec/support/shell.rb:27:in `run!'
     # ./spec/features/plugin/upgrade_spec.rb:6:in `block (3 levels) in <top (required)>'

  2) plugin uninstall with the aws plugin installed removes installed plugin
     Failure/Error: raise Error.new(cmd, k.code, k.out) unless k.code.zero?
     
     Shell::Error:
       command failed with code 1: kontena plugin uninstall aws
        [error] NoMethodError : undefined method `name' for "aws":String
                See /home/terom/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
     # ./spec/support/shell.rb:28:in `block in run!'
     # ./spec/support/shell.rb:27:in `tap'
     # ./spec/support/shell.rb:27:in `run!'
     # ./spec/features/plugin/uninstall_spec.rb:10:in `block (3 levels) in <top (required)>'

``` 