### PR TITLE
Fix cli plugin uninstall

### DIFF
--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -6,10 +6,10 @@ module Kontena::Cli::Plugins
     include Kontena::Cli::Common
     include Kontena::PluginManager::Common
 
-    parameter 'NAME ...', 'Plugin name', attribute_name: :plugins
+    parameter 'NAME ...', 'Plugin name', attribute_name: :plugins_to_uninstall
 
     def execute
-      plugins.each do |name|
+      plugins_to_uninstall.each do |name|
         exit_with_error "Plugin #{name} has not been installed" unless installed?(name)
         spinner "Uninstalling plugin #{pastel.cyan(name)}" do
           uninstaller(name).uninstall

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -4,22 +4,27 @@ module Kontena::Cli::Plugins
   class UninstallCommand < Kontena::Command
     include Kontena::Util
     include Kontena::Cli::Common
-    include Kontena::PluginManager::Common
 
-    parameter 'NAME ...', 'Plugin name', attribute_name: :plugins_to_uninstall
+    parameter 'NAME ...', 'Plugin name', attribute_name: :plugins
 
     def execute
-      plugins_to_uninstall.each do |name|
-        exit_with_error "Plugin #{name} has not been installed" unless installed?(name)
+      plugins.each do |name|
+        exit_with_error "Plugin #{name} has not been installed" unless plugin_installed?(name)
         spinner "Uninstalling plugin #{pastel.cyan(name)}" do
-          uninstaller(name).uninstall
+          plugin_uninstaller(name).uninstall
         end
       end
     end
 
     # @param name [String]
+    # @return [Boolean]
+    def plugin_installed?(name)
+      Kontena::PluginManager::Common.installed?(name)
+    end
+
+    # @param name [String]
     # @return [Kontena::PluginManager::Uninstaller]
-    def uninstaller(name)
+    def plugin_uninstaller(name)
       Kontena::PluginManager::Uninstaller.new(name)
     end
   end

--- a/cli/lib/kontena/cli/plugins/uninstall_command.rb
+++ b/cli/lib/kontena/cli/plugins/uninstall_command.rb
@@ -5,10 +5,10 @@ module Kontena::Cli::Plugins
     include Kontena::Util
     include Kontena::Cli::Common
 
-    parameter 'NAME ...', 'Plugin name', attribute_name: :plugins
+    parameter 'NAME ...', 'Plugin name'
 
     def execute
-      plugins.each do |name|
+      name_list.each do |name|
         exit_with_error "Plugin #{name} has not been installed" unless plugin_installed?(name)
         spinner "Uninstalling plugin #{pastel.cyan(name)}" do
           plugin_uninstaller(name).uninstall


### PR DESCRIPTION
Fixes #3228 to remove the `Kontena::PluginManager::Common` mixin.

No specs because mocking out `installed?` wouldn't really help catch this issue, so rely on the e2e specs instead.