### PR TITLE
Require travis e2e specs to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ jobs:
       rvm: 2.4
       env:
         - TEST_DIR=cli
-        - ALLOW_FAILURES=true
     - stage: deploy gem
       script: "rvm $TRAVIS_RUBY_VERSION do $TRAVIS_BUILD_DIR/build/travis/deploy_gem.sh"
       tags: true


### PR DESCRIPTION
All known e2e spec failure cases should now be fixed, so we shouldn't ignore failures anymore.

The e2e specs actually catch useful bugs in PRs, but the e2e spec failures are not being noticed before merging.