### PR TITLE
Fix CLI client to not ignore invalid response JSON

### DIFF
--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -479,7 +479,7 @@ module Kontena
       check_version_and_warn(response.headers[X_KONTENA_VERSION])
 
       if response.headers[CONTENT_TYPE] =~ JSON_REGEX
-        parse_json(response.body)
+        parse_json(response)
       else
         response.body
       end
@@ -503,13 +503,12 @@ module Kontena
 
     # Parse json
     #
-    # @param [String] json
+    # @param response [Excon::Response]
     # @return [Hash,Object,NilClass]
-    def parse_json(json)
-      JSON.parse(json)
+    def parse_json(response)
+      JSON.parse(response.body)
     rescue => ex
-      debug { "JSON parse exception: #{ex.class.name} : #{ex.message}" }
-      nil
+      raise Kontena::Errors::StandardError.new(400, "Invalid response JSON from server for #{response.path}: #{ex.class.name}: #{ex.message}")
     end
 
     # Dump json


### PR DESCRIPTION
Fix the CLI API client JSON parser error handling to make the resulting errors more useful for tracking down any issues related to invalid responses returned by the server:

```
$ bundle exec bin/kontena stack list
 [error] 400 : Invalid response JSON from server for /v1/grids/development/stacks: JSON::ParserError: 743: unexpected token at ''
```

This stricter error handling could potentially cause issues if any code is doing e.g. `POST/DELETE` requests that end up returning invalid JSON, which currently gets ignored because the code is not using the result.

Testing in a scenario where the API returns invalid JSON, the current errors are useless, because the current client API response json parsing error handling is of the form `rescue nil`: https://github.com/kontena/kontena/blob/2d361edba192ea8fe32f76ef58c9855411617e68/cli/lib/kontena/client.rb#L508-L513

This just hides the the problem, leading to indirect errors further away in the code paths which are much harder to debug:

```
$ bundle exec bin/kontena stack list
 [error] NoMethodError : undefined method `[]' for nil:NilClass
         See /home/kontena/.kontena/kontena.log or run the command again with environment DEBUG=true set to see the full exception
$ DEBUG=true bundle exec bin/kontena stack list
DEBUG Kontena CLI 1.5.0.dev (ruby-2.3.1+x86_64-linux-gnu)
DEBUG Loading plugin kontena-plugin-hello from /home/kontena/kontena/kontena/cli/examples/kontena-plugin-hello/lib/kontena_cli_plugin.rb
DEBUG Running Kontena::MainCommand with ["stack", "list"] -- callback matcher = 'nil'
DEBUG Running Kontena::Cli::StackCommand with ["list"] -- callback matcher = 'nil'
DEBUG Loading configuration from /home/kontena/.kontena_client.json
DEBUG Configuration loaded with 25 servers and 2 accounts.
DEBUG Current master: development
DEBUG Current grid: development
DEBUG Current account: kontena
DEBUG Running Kontena::Cli::Stacks::ListCommand with [] -- callback matcher = 'stacks list'
DEBUG Excon opts: {:omit_default_port=>true, :connect_timeout=>10, :read_timeout=>30, :write_timeout=>10, :ssl_verify_peer=>true, :instrumentor=>Kontena::DebugInstrumentor, :ssl_ca_file=>nil, :ssl_verify_peer_host=>nil}
DEBUG [Request]: GET http://localhost:9292/v1/grids/development/stacks | Headers: {Accept: application/json, Accept-Encoding: gzip, Authorization: Bearer} 
DEBUG [Response]: Headers: {Content-Type: application/json, Content-Encoding: gzip, X-Kontena-Version: 1.5.0.dev}  | Status: 200 | Body: "(GZIPPED 1:5) {\"stacks\":[{\"id\":\"development/deptest\",\"name\":\"deptest\"..."
DEBUG JSON parse exception: JSON::ParserError : 743: unexpected token at ''
bundler: failed to load command: bin/kontena (bin/kontena)
NoMethodError: undefined method `[]' for nil:NilClass
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/stacks/list_command.rb:37:in `get_stacks'
  /home/kontena/kontena/kontena/cli/lib/kontena/cli/stacks/list_command.rb:52:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:215:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:215:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
  /home/kontena/kontena/kontena/cli/lib/kontena/command.rb:215:in `run'
  /home/kontena/kontena/kontena/cli/vendor/bundle/ruby/2.3.0/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
  bin/kontena:20:in `<top (required)>'
DEBUG Execution took 0.652 seconds
DEBUG SystemExit status 1
```