### PR TITLE
Fix e2e app remove spec race on terminating service

### DIFF
--- a/test/spec/features/plugin/app-command/deploy_spec.rb
+++ b/test/spec/features/plugin/app-command/deploy_spec.rb
@@ -8,6 +8,11 @@ describe 'app subcommand' do
           k = run('kontena app deploy')
           k.wait
           expect(k.code).to eq(0)
+          
+          # hack to ensure that the app services get cleaned up before the next spec runs
+          run! 'kontena service update --stop-timeout=1s simple-lb'
+          run! 'kontena service deploy --force simple-lb'
+
           k = run!('kontena service ls')
           %w(lb nginx redis).each do |service|
             expect(k.out).to match(/simple-#{service}/)


### PR DESCRIPTION
Fixes #3243 by hacking the `simple-lb` service to have a 1s stop timeout

The `simple-lb` service can occasionally take up to 10s to terminate: https://github.com/kontena/kontena/issues/3243#issuecomment-363058190

This causes the following `app remove` spec to fail, which leaves some services behind that also break the `service list` spec.