### PR TITLE
Fix CLI API client to ignore empty response JSON body

### DIFF
--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -514,11 +514,9 @@ module Kontena
     # @param response [Excon::Response]
     # @return [Hash,Object,NilClass]
     def parse_json(response)
-      if response.body.empty?
-        return nil
-      else
-        return JSON.parse(response.body)
-      end
+      return nil if response.body.empty?
+      
+      JSON.parse(response.body)
     rescue => ex
       raise Kontena::Errors::StandardError.new(520, "Invalid response JSON from server for #{response.path}: #{ex.class.name}: #{ex.message}")
     end

--- a/cli/lib/kontena/client.rb
+++ b/cli/lib/kontena/client.rb
@@ -514,7 +514,11 @@ module Kontena
     # @param response [Excon::Response]
     # @return [Hash,Object,NilClass]
     def parse_json(response)
-      JSON.parse(response.body)
+      if response.body.empty?
+        return nil
+      else
+        return JSON.parse(response.body)
+      end
     rescue => ex
       raise Kontena::Errors::StandardError.new(520, "Invalid response JSON from server for #{response.path}: #{ex.class.name}: #{ex.message}")
     end

--- a/cli/spec/kontena/client_spec.rb
+++ b/cli/spec/kontena/client_spec.rb
@@ -233,6 +233,24 @@ describe Kontena::Client do
       end
     end
 
+    context "with empty response JSON" do
+      before :each do
+        allow(subject).to receive(:http_client).and_call_original
+
+        WebMock.stub_request(:delete, 'http://localhost/v1/test').to_return(
+          status: 200,
+          headers: {
+            'Content-Type' => 'application/json',
+          },
+          body: '',
+        )
+      end
+
+      it "returns nil" do
+        expect(subject.delete('test')).to be_nil
+      end
+    end
+
     context "with invalid response JSON" do
       before :each do
         allow(subject).to receive(:http_client).and_call_original


### PR DESCRIPTION
Fixes #3251 as triggered by #3250

## Testing
### Fixed `kontena master token remove`

```
$ DEBUG=api bundle exec bin/kontena master token remove --force 5a7992e684943f000c9044bb
DEBUG Kontena CLI 1.5.0.dev (ruby-2.3.1+x86_64-linux-gnu)
DEBUG Loading plugin kontena-plugin-hello from /home/kontena/kontena/kontena/cli/examples/kontena-plugin-hello/lib/kontena_cli_plugin.rb
DEBUG Running Kontena::MainCommand with ["master", "token", "remove", "--force", "5a7992e684943f000c9044bb"] -- callback matcher = 'nil'
DEBUG Running Kontena::Cli::MasterCommand with ["token", "remove", "--force", "5a7992e684943f000c9044bb"] -- callback matcher = 'nil'
DEBUG Running Kontena::Cli::Master::TokenCommand with ["remove", "--force", "5a7992e684943f000c9044bb"] -- callback matcher = 'nil'
DEBUG Loading configuration from /home/kontena/.kontena_client.json
DEBUG Using master token from env KONTENA_TOKEN
DEBUG Configuration loaded with 25 servers and 2 accounts.
DEBUG Current master: development
DEBUG Current grid: development
DEBUG Current account: kontena
DEBUG Running Kontena::Cli::Master::Token::RemoveCommand with ["--force", "5a7992e684943f000c9044bb"] -- callback matcher = 'token remove'
DEBUG Excon opts: {:omit_default_port=>true, :connect_timeout=>10, :read_timeout=>30, :write_timeout=>10, :ssl_verify_peer=>true, :middlewares=>[Excon::Middleware::ResponseParser, Excon::Middleware::Expects, Excon::Middleware::Idempotent, Excon::Middleware::Instrumentor, Excon::Middleware::Mock, Excon::Middleware::Decompress], :instrumentor=>Kontena::DebugInstrumentor, :ssl_ca_file=>nil, :ssl_verify_peer_host=>nil}
DEBUG [Request]: DELETE http://localhost:9292/oauth2/tokens/5a7992e684943f000c9044bb | Headers: {Accept: application/json, Accept-Encoding: gzip, Authorization: Bearer} 
DEBUG [Response]: Headers: {Content-Type: application/json, X-Kontena-Version: 1.5.0.dev}  | Status: 201
DEBUG Execution took 0.257 seconds
```

### Failing spec
```
Failures:

  1) Kontena::Client#request with empty response JSON returns nil
     Failure/Error: raise Kontena::Errors::StandardError.new(520, "Invalid response JSON from server for #{response.path}: #{ex.class.name}: #{ex.message}")

     Kontena::Errors::StandardError:
       Invalid response JSON from server for : JSON::ParserError: 743: unexpected token at ''
     # ./lib/kontena/client.rb:519:in `rescue in parse_json'
     # ./lib/kontena/client.rb:517:in `parse_json'
     # ./lib/kontena/client.rb:490:in `parse_response'
     # ./lib/kontena/client.rb:330:in `request'
     # ./lib/kontena/client.rb:244:in `delete'
     # ./spec/kontena/client_spec.rb:250:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:55:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # JSON::ParserError:
     #   743: unexpected token at ''
     #   ./vendor/bundle/ruby/2.3.0/gems/json-2.0.2/lib/json/common.rb:156:in `parse'
```