### PR TITLE
Fix agent ServicePodWorker to ignore stale container events

### DIFF
--- a/agent/lib/kontena/models/service_pod.rb
+++ b/agent/lib/kontena/models/service_pod.rb
@@ -99,6 +99,11 @@ module Kontena
         @stop_grace_period = attrs['stop_grace_period']
       end
 
+      # @return [String]
+      def to_s
+        self.name_for_humans
+      end
+
       # @return [Boolean]
       def can_expose_ports?
         self.net == 'bridge'

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -84,9 +84,9 @@ module Kontena::Workers
       backoff = @restarts ** 2
       backoff = max_restart_backoff if backoff > max_restart_backoff
       if backoff == 0
-        info "restarting #{@service_pod.name_for_humans} because it has stopped"
+        info "restarting #{@service_pod} because it has stopped"
       else
-        info "restarting #{@service_pod.name_for_humans} because it has stopped (delay: #{backoff}s)"
+        info "restarting #{@service_pod} because it has stopped (delay: #{backoff}s)"
       end
       ts = Time.now.utc
       @restarts += 1
@@ -130,7 +130,7 @@ module Kontena::Workers
 
         # reset restart counter if instance stays up 10s
         @restart_counter_reset_timer = after(10) {
-          info "#{@service_pod.name_for_humans} stayed up 10s, resetting restart backoff counter" if restarting?
+          info "#{@service_pod} stayed up 10s, resetting restart backoff counter" if restarting?
           @restarts = 0
         }
         @container_state_changed = false
@@ -147,7 +147,7 @@ module Kontena::Workers
       end
 
     rescue => error
-      warn "failed to sync #{service_pod.name} at #{service_pod.deploy_rev}: #{error}"
+      warn "failed to apply #{service_pod.name} at #{service_pod.deploy_rev}: #{error}"
       warn error
       sync_state_to_master(service_pod, container, error) # XXX: unknown container?
     else
@@ -229,7 +229,7 @@ module Kontena::Workers
     rescue => exc
       log_service_pod_event(
         "service:create_instance",
-        "unexpected error while creating #{service_pod.name_for_humans}: #{exc.message}",
+        "unexpected error while creating #{service_pod}: #{exc.message}",
         Logger::ERROR
       )
       raise exc
@@ -240,7 +240,7 @@ module Kontena::Workers
     rescue => exc
       log_service_pod_event(
         "service:start_instance",
-        "Unexpected error while starting service instance #{service_pod.name_for_humans}: #{exc.message}",
+        "Unexpected error while starting service instance #{service_pod}: #{exc.message}",
         Logger::ERROR
       )
       raise exc
@@ -251,7 +251,7 @@ module Kontena::Workers
     rescue => exc
       log_service_pod_event(
         "service:stop_instance",
-        "Unexpected error while stopping service instance #{service_pod.name_for_humans}: #{exc.message}",
+        "Unexpected error while stopping service instance #{service_pod}: #{exc.message}",
         Logger::ERROR
       )
       raise exc
@@ -262,7 +262,7 @@ module Kontena::Workers
     rescue => exc
       log_service_pod_event(
         "service:remove_instance",
-        "Unexpected error while removing service instance #{service_pod.name_for_humans}: #{exc.message}",
+        "Unexpected error while removing service instance #{service_pod}: #{exc.message}",
         Logger::ERROR
       )
       raise exc
@@ -366,11 +366,11 @@ module Kontena::Workers
 
       exclusive {
         if @prev_state && @prev_state[:rev] && service_pod.deploy_rev < @prev_state[:rev]
-          warn "skip #{service_pod.name_for_humans} state sync at #{service_pod.deploy_rev}: stale, last sync at #{@prev_state[:rev]}"
+          warn "skip #{service_pod} state sync at #{service_pod.deploy_rev}: stale, last sync at #{@prev_state[:rev]}"
         elsif state == @prev_state
-          debug "skip #{service_pod.name_for_humans} state sync at #{service_pod.deploy_rev}: unchanged"
+          debug "skip #{service_pod} state sync at #{service_pod.deploy_rev}: unchanged"
         else
-          debug "sync #{service_pod.name_for_humans} state at #{service_pod.deploy_rev}: #{state}"
+          debug "sync #{service_pod} state at #{service_pod.deploy_rev}: #{state}"
           rpc_client.async.request('/node_service_pods/set_state', [node.id, state])
           @prev_state = state
         end

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -52,11 +52,6 @@ module Kontena::Workers
     end
 
     # @return [Boolean]
-    def apply_started?
-      @apply_started_at && (!@apply_finished_at || @apply_finished_at < @apply_started_at)
-    end
-
-    # @return [Boolean]
     def apply_finished?
       !!@apply_finished_at && @apply_finished_at > @apply_started_at
     end

--- a/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
@@ -287,10 +287,15 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
       expect(subject.needs_apply?(update)).to be_truthy
     end
 
-    context 'after a previous succesfull apply' do
+    context 'after a previous successful apply' do
       before do
-        subject.instance_variable_set('@apply_started_at', Time.now - 2.0)
-        subject.instance_variable_set('@apply_finished_at', Time.now - 1.0)
+        subject.apply_started!
+        sleep 0.001
+        subject.apply_finished!
+      end
+
+      it 'subject is not apply_finished?' do
+        expect(subject.apply_finished?).to be_truthy
       end
 
       it 'returns false if pod has not changed' do
@@ -310,10 +315,15 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
       end
     end
 
-    context 'after a previous unsuccesfull apply' do
+    context 'after a previous unsuccessful apply' do
       before do
-        subject.instance_variable_set('@apply_started_at', Time.now - 1.0)
-        subject.instance_variable_set('@apply_finished_at', Time.now - 20.0)
+        subject.apply_finished!
+        sleep 0.001
+        subject.apply_started!
+      end
+
+      it 'subject is not apply_finished?' do
+        expect(subject.apply_finished?).to be_falsey
       end
 
       it 'returns true if pod has not changed' do

--- a/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/service_pod_worker_spec.rb
@@ -71,7 +71,7 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
           # XXX: in this case both the failing initial wait_for_port, and the restart will report state...
           expect(subject.wrapped_object).to receive(:sync_state_to_master).with(service_pod, restarted_container)
 
-          subject.on_container_event('container:event', double(id: container_id, status: 'die'))
+          subject.on_container_event('container:event', double(id: container_id, status: 'die', time_nano: (Time.now.to_f * 1e9).to_s))
 
           false
         end
@@ -271,7 +271,7 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
   end
 
   describe '#needs_apply' do
-    it 'returns true if container_state_changed is true' do
+    it 'returns true when initialized' do
       expect(subject.needs_apply?(service_pod)).to be_truthy
     end
 
@@ -282,29 +282,43 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
 
     it 'returns true if restarting and deploy_rev has changed' do
       allow(subject.wrapped_object).to receive(:restarting?).and_return(true)
-      subject.container_state_changed = false
       update = service_pod.dup
       allow(update).to receive(:deploy_rev).and_return('new')
       expect(subject.needs_apply?(update)).to be_truthy
     end
 
-    it 'returns false if container_state_changed is false and pod has not changed' do
-      subject.container_state_changed = false
-      expect(subject.needs_apply?(service_pod)).to be_falsey
+    context 'after a previous succesfull apply' do
+      before do
+        subject.instance_variable_set('@apply_started_at', Time.now - 2.0)
+        subject.instance_variable_set('@apply_finished_at', Time.now - 1.0)
+      end
+
+      it 'returns false if pod has not changed' do
+        expect(subject.needs_apply?(service_pod)).to be_falsey
+      end
+
+      it 'returns true if deploy_rev has changed' do
+        update = service_pod.dup
+        allow(update).to receive(:deploy_rev).and_return('new')
+        expect(subject.needs_apply?(update)).to be_truthy
+      end
+
+      it 'returns true if desired_state has changed' do
+        update = service_pod.dup
+        allow(update).to receive(:desired_state).and_return('stopped')
+        expect(subject.needs_apply?(update)).to be_truthy
+      end
     end
 
-    it 'returns true if container_state_changed is false and deploy_rev has changed' do
-      subject.container_state_changed = false
-      update = service_pod.dup
-      allow(update).to receive(:deploy_rev).and_return('new')
-      expect(subject.needs_apply?(update)).to be_truthy
-    end
+    context 'after a previous unsuccesfull apply' do
+      before do
+        subject.instance_variable_set('@apply_started_at', Time.now - 1.0)
+        subject.instance_variable_set('@apply_finished_at', Time.now - 20.0)
+      end
 
-    it 'returns true if container_state_changed is false and desired_state has changed' do
-      subject.container_state_changed = false
-      update = service_pod.dup
-      allow(update).to receive(:desired_state).and_return('stopped')
-      expect(subject.needs_apply?(update)).to be_truthy
+      it 'returns true if pod has not changed' do
+        expect(subject.needs_apply?(service_pod)).to be_truthy
+      end
     end
   end
 
@@ -335,46 +349,67 @@ describe Kontena::Workers::ServicePodWorker, :celluloid => true do
   end
 
   describe '#on_container_event' do
-    before do
-      subject.container_state_changed = false
-    end
-
     context 'without any active container' do
       it 'ignores any events' do
-        event = double(:event, id: '2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025', status: 'start')
+        event = double(:event, id: '2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025', status: 'die')
 
-        expect {
-          subject.on_container_event('container:event', event)
-        }.not_to change { subject.container_state_changed }
+        expect(subject.wrapped_object).to_not receive(:handle_restart_on_die)
+
+        subject.on_container_event('container:event', event)
       end
     end
 
     context 'with an active container' do
-      let(:container) { double(:container, id: '2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025') }
+      let(:started_at) { Time.now - 60.0 }
+      let(:container) { double(:container,
+        id: '2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025',
+        started_at: started_at,
+      ) }
+
+      let(:event_id) { '2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025' }
+      let(:event_at) { Time.now - 59.0 }
+      let(:event_status) { 'die' }
+      let(:event) { double(:event,
+        id: event_id,
+        status: event_status,
+        time_nano: (event_at.to_f * 1e9).to_s,
+      ) }
 
       before do
         subject.instance_variable_set('@container', container)
       end
 
-      it 'ignores a mismatching event' do
-        event = double(:event, id: 'f02a583a0dd44a685a14c445b9826b5f8a8c46555fabf003de3009180ff7a24c', status: 'start')
+      context 'for an event with the wrong container ID' do
+        let(:event_id) { 'f02a583a0dd44a685a14c445b9826b5f8a8c46555fabf003de3009180ff7a24c' }
 
-        expect {
+        it 'ignores the event' do
+          expect(subject.wrapped_object).to_not receive(:handle_restart_on_die)
+
           subject.on_container_event('container:event', event)
-        }.not_to change { subject.container_state_changed }
+        end
       end
 
-      it 'marks container state as changed' do
-        event = double(:event, id: '2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025', status: 'start')
+      context 'for an event from before the container start' do
+        let(:event_at) { Time.now - 61.0 }
 
-        expect {
+        it 'ignores the event' do
+          expect(subject.wrapped_object).to_not receive(:handle_restart_on_die)
+
           subject.on_container_event('container:event', event)
-        }.to change { subject.container_state_changed }.from(false).to(true)
+        end
+      end
+
+      context 'for a start event' do
+        let(:event_status) { 'start' }
+
+        it 'ignores the event' do
+          expect(subject.wrapped_object).to_not receive(:handle_restart_on_die)
+
+          subject.on_container_event('container:event', event)
+        end
       end
 
       it 'triggers restart logic on container die events' do
-        event = double(:event, id: '2b52d7ac3c70f4533a47d93cb81a8864eb2608705e0a986bdcced468f20e5025', status: 'die')
-
         expect(subject.wrapped_object).to receive(:handle_restart_on_die)
 
         subject.on_container_event('container:event', event)


### PR DESCRIPTION
Split out of #2780
Really fixes #2766 to avoid double-applies by removing `@container_state_changed` and ignoring the `start` events

### Agent
* Simplify usage of `@service_pod.name_for_humans`
* The `ServicePodWorker` compares the event timestamp to the container `started_at` timestamp, and ignores container events from before the container was (re)started
* The `ServicePodWorker` only reacts to container `die` events
* Replace `@container_state_changed` with retry-apply-on-errors logic