### PR TITLE
Fix cli grid remove parameter attribute conflict

### DIFF
--- a/cli/lib/kontena/cli/grids/remove_command.rb
+++ b/cli/lib/kontena/cli/grids/remove_command.rb
@@ -5,13 +5,13 @@ module Kontena::Cli::Grids
     include Kontena::Cli::Common
     include Common
 
-    parameter "NAME ...", "Grid name", attribute_name: :grids
+    parameter "NAME ...", "Grid name"
     option "--force", :flag, "Force remove", default: false, attribute_name: :forced
 
     def execute
       require_api_url
       token = require_token
-      grids.each do |name|
+      name_list.each do |name|
         confirm_command(name) unless forced?
         grid = find_grid_by_name(name)
 

--- a/cli/spec/kontena/cli/grids/remove_command_spec.rb
+++ b/cli/spec/kontena/cli/grids/remove_command_spec.rb
@@ -1,0 +1,28 @@
+require 'kontena/cli/grids/remove_command'
+
+describe Kontena::Cli::Grids::RemoveCommand do
+  include ClientHelpers
+
+  before do
+    # Kontena::Cli::Grids::Common#grids
+    allow(client).to receive(:get).with('grids').and_return('grids' => grids)
+  end
+
+  context 'without any grids' do
+    let(:grids) { [] }
+
+    it 'errors out' do
+      expect{subject.run ['--force', 'test-grid']}.to exit_with_error.and output(/Could not resolve grid by name/).to_stderr
+    end
+  end
+
+  context 'with a grid' do
+    let(:grids) { [{'id' => 'test-grid', 'name' => 'test-grid'}] }
+
+    it 'deletes the grid' do
+      expect(client).to receive(:delete).with('grids/test-grid')
+
+      subject.run ['--force', 'test-grid']
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3262

Adds specs to catch the  [`parameter attribute_name: :grids`](https://github.com/kontena/kontena/blob/339a3ac302ebd1f92ac0f45500fedec9653c43df/cli/lib/kontena/cli/grids/remove_command.rb#L8) conflict with [`Kontena::Cli::Grids::Common#grids`](https://github.com/kontena/kontena/blob/339a3ac302ebd1f92ac0f45500fedec9653c43df/cli/lib/kontena/cli/grids/common.rb#L53-L55).

Fix by renaming the parameter to `name_list`.