### PR TITLE
Change GridService.stop_grace_period to Integer

### DIFF
--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -41,7 +41,7 @@ class GridService
   field :stack_revision, type: Integer
   field :strategy, type: String, default: 'ha'
   field :stop_signal, type: String
-  field :stop_grace_period, type: Fixnum, default: 10
+  field :stop_grace_period, type: Integer, default: 10
 
   belongs_to :grid
   belongs_to :image


### PR DESCRIPTION
Fixes #3271 

Removes a warning about Fixnum being deprecated
