### PR TITLE
Fix server RpcServer to not hang the actor thread

### DIFF
--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -293,7 +293,7 @@ class WebsocketBackend
     if client = client_for_ws(ws)
       RpcServer.handle_rpc_request(client[:grid_id].to_s, data) do |message|
         EM.next_tick { # important to push sending back to EM reactor thread
-          send_message(message)
+          send_message(ws, message)
         }
       end
     end

--- a/server/app/middlewares/websocket_backend.rb
+++ b/server/app/middlewares/websocket_backend.rb
@@ -15,8 +15,6 @@ class WebsocketBackend
   CLOCK_SKEW = Kernel::Float(ENV['KONTENA_CLOCK_SKEW'] || 1.seconds)
 
   RPC_MSG_TYPES = %w(request notify)
-  QUEUE_WATCH_PERIOD = 60 # once in a minute
-  QUEUE_DROP_NOTIFICATIONS_LIMIT = (RpcServer::QUEUE_SIZE * 0.8)
 
   class CloseError < StandardError
     attr_reader :code
@@ -43,7 +41,6 @@ class WebsocketBackend
     @msg_dropped = 0
     subscribe_to_rpc_channel
     watch_connections
-    watch_queue
     watchdog
   end
 
@@ -293,25 +290,20 @@ class WebsocketBackend
   # @param [Faye::WebSocket::Event] ws
   # @param [Array] data
   def handle_rpc_request(ws, data)
-    client = client_for_ws(ws)
-    if client
-      self.rpc_queue << [ws, client[:grid_id].to_s, data]
+    if client = client_for_ws(ws)
+      RpcServer.handle_rpc_request(client[:grid_id].to_s, data) do |message|
+        EM.next_tick { # important to push sending back to EM reactor thread
+          send_message(message)
+        }
+      end
     end
   end
 
   # @param [Faye::WebSocket::Event] ws
   # @param [Array] data
   def handle_rpc_notification(ws, data)
-    rpc_queue = self.rpc_queue
-
-    if rpc_queue.size > QUEUE_DROP_NOTIFICATIONS_LIMIT # too busy to handle notifications
-      @msg_dropped += 1
-      return
-    end
-
-    client = client_for_ws(ws)
-    if client
-      rpc_queue << [client[:grid_id].to_s, data]
+    if client = client_for_ws(ws)
+      RpcServer.handle_rpc_notification(client[:grid_id].to_s, data)
     end
   end
 
@@ -424,18 +416,6 @@ class WebsocketBackend
       @clients.each do |client|
         self.verify_client_connection(client)
       end
-    end
-  end
-
-  def watch_queue
-    EM::PeriodicTimer.new(QUEUE_WATCH_PERIOD) do
-      if (queue_size = self.rpc_queue.size) > QUEUE_DROP_NOTIFICATIONS_LIMIT
-        logger.warn "#{queue_size} messages in queue"
-      end
-      logger.warn "#{@msg_dropped} dropped notifications" if @msg_dropped > 0
-      logger.info "#{@msg_counter / QUEUE_WATCH_PERIOD} messages per second"
-      @msg_counter = 0
-      @msg_dropped = 0
     end
   end
 

--- a/server/app/services/rpc_server.rb
+++ b/server/app/services/rpc_server.rb
@@ -15,6 +15,8 @@ class RpcServer
     @queue ||= SizedQueue.new(QUEUE_SIZE)
   end
 
+  # This can block if the queue is full.
+  #
   # @param grid_id [String]
   # @param rpc_request [Array{0, Integer, String, Array}] MsgPack-RPC request
   # @yield [rpc_response]
@@ -26,15 +28,21 @@ class RpcServer
   # @param rpc_notification [Array{2, String, Array}] MsgPack-RPC notification
   def self.handle_rpc_notification(grid_id, rpc_notification)
     if self.queue.size > QUEUE_DROP_NOTIFICATIONS_LIMIT # too busy to handle notifications
-      @msg_dropped += 1
+      msg_dropped!
       return
     end
 
     self.queue << [grid_id, rpc_notification, nil]
   end
 
-  def self.msg_dropped
-    @msg_dropped
+  def self.msg_dropped!
+    @msg_dropped += 1
+  end
+  def self.read_and_clear_msg_dropped
+    (@msg_dropped ||= 0).tap do
+      # this is not atomic, but who cares
+      @msg_dropped = 0
+    end
   end
 
   HANDLERS = {
@@ -60,42 +68,58 @@ class RpcServer
 
   # @param [SizedQueue] queue
   def initialize(autostart: true)
-    @queue = self.class.queue
     @handlers = {}
-    @counter = 0
+    @msg_counter = 0
 
     info "initialized"
 
-    async.process! if autostart
+    async.process if autostart
+    async.watch_queue if autostart
   end
 
-  # XXX: fixup
-  def watch_queue
-    EM::PeriodicTimer.new(QUEUE_WATCH_PERIOD) do
-      if (queue_size = self.rpc_queue.size) > QUEUE_DROP_NOTIFICATIONS_LIMIT
-        logger.warn "#{queue_size} messages in queue"
-      end
-      logger.warn "#{@msg_dropped} dropped notifications" if @msg_dropped > 0
-      logger.info "#{@msg_counter / QUEUE_WATCH_PERIOD} messages per second"
+  def queue
+    self.class.queue
+  end
+
+  def read_and_clear_msg_counter
+    @msg_counter.tap do
+      # this is not atomic, but who cares
       @msg_counter = 0
-      @msg_dropped = 0
     end
   end
 
-  def process!
-    while data = @queue.pop
-      @counter += 1
+  def watch_queue
+    every(QUEUE_WATCH_PERIOD) do
+      queue_size = self.queue.size
+      msg_dropped = self.class.read_and_clear_msg_dropped
+      msg_counter = self.read_and_clear_msg_counter
 
-      grid_id, rpc, block = data
-
-      if block
-        block.call(handle_request(grid_id, rpc).as_json)
-      else
-        handle_notification(grid_id, rpc)
-      end
-
-      Thread.pass
+      warn "#{queue_size} messages in queue" if queue_size  > QUEUE_DROP_NOTIFICATIONS_LIMIT
+      warn "#{msg_dropped} dropped notifications" if msg_dropped > 0
+      info "#{msg_counter / QUEUE_WATCH_PERIOD} messages per second"
     end
+  end
+
+  def process
+    @processing = true
+
+    # separate thread for blocking queue.pop
+    # XXX: all of the handle_* methods run in the defer thread, not the actor thread...
+    defer {
+      while @processing && data = self.queue.pop
+        @msg_counter += 1
+
+        grid_id, rpc, block = data
+
+        if block
+          block.call(handle_request(grid_id, rpc).as_json)
+        else
+          handle_notification(grid_id, rpc)
+        end
+
+        Thread.pass
+      end
+    }
   end
 
   # @param grid_id [String]
@@ -167,6 +191,8 @@ class RpcServer
   end
 
   def finalize
+    @processing = false # stop this actor's defer { ... } thread, so the restarted actor can process the queue
+
     info "terminated"
   end
 end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -542,6 +542,16 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       end
     end
 
+    describe '#handle_rpc_notification' do
+      it "calls RpcServer" do
+        rpc_notification = [2, '/test/test', ['test']]
+
+        expect(RpcServer).to receive(:handle_rpc_notification).with(grid.id, rpc_notification)
+
+        subject.handle_rpc_notification(client_ws, rpc_notification)
+      end
+    end
+
     describe '#on_close' do
       it "logs a warning if the client is not found" do
         subject.instance_variable_get('@clients').clear

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -3,11 +3,9 @@ require_relative '../../app/middlewares/websocket_backend'
 describe WebsocketBackend, celluloid: true, eventmachine: true do
   let(:app) { spy(:app) }
   let(:subject) { described_class.new(app) }
-  let(:rpc_queue) { instance_double(SizedQueue) }
 
   let(:logger) { instance_double(Logger) }
   before do
-    allow(subject).to receive(:rpc_queue).and_return(rpc_queue)
     allow(subject).to receive(:logger).and_return(logger)
     allow(logger).to receive(:debug)
   end

--- a/server/spec/middlewares/websocket_backend_spec.rb
+++ b/server/spec/middlewares/websocket_backend_spec.rb
@@ -525,6 +525,23 @@ describe WebsocketBackend, celluloid: true, eventmachine: true do
       end
     end
 
+    describe '#handle_rpc_request' do
+      it "calls RpcServer and sends response" do
+        rpc_request = [0, 100, '/test/test', ['test']]
+        rpc_response = [1, 100, nil, 'ack']
+
+        expect(RpcServer).to receive(:handle_rpc_request).with(grid.id, rpc_request).and_yield(rpc_response)
+        expect(client_ws).to receive(:send) do |bytes|
+          data = MessagePack.unpack(bytes.pack('c*'))
+
+          expect(data).to eq rpc_response
+        end
+
+        subject.handle_rpc_request(client_ws, rpc_request)
+        EM.run_deferred_callbacks
+      end
+    end
+
     describe '#on_close' do
       it "logs a warning if the client is not found" do
         subject.instance_variable_get('@clients').clear

--- a/server/spec/services/rpc_server_spec.rb
+++ b/server/spec/services/rpc_server_spec.rb
@@ -14,50 +14,41 @@ describe RpcServer, celluloid: true do
 
   let(:queue) { RpcServer.queue }
   let(:subject) { described_class.new(autostart: false) }
+  let(:msg_id) { 99 }
 
   let(:grid) { Grid.create!(name: 'test') }
-
-  let(:ws_client) do
-    double(:ws_client)
-  end
 
   before(:each) do
     stub_const("RpcServer::HANDLERS", {'hello' => HelloWorld})
   end
 
   describe '#handle_request' do
-    before(:each) { allow(subject.wrapped_object).to receive(:send_message) }
-
     it 'calls handler and sends response back to ws_client' do
-      expect(subject.wrapped_object).to receive(:send_message).with(ws_client, [1, 99, nil, {msg: 'hello world'}])
-      subject.handle_request(ws_client, grid.id, [1, 99, '/hello/hello', ['world']])
+      expect(subject.handle_request(grid.id, [0, msg_id, '/hello/hello', ['world']])).to eq [1, msg_id, nil, {msg: 'hello world'}]
     end
 
     it 'catches RpcServer::Error' do
-      subject.handle_request(ws_client, grid.id, [1, 99, '/hello/hello', ['world']])
+      subject.handle_request(grid.id, [0, msg_id, '/hello/hello', ['world']])
+
       allow(subject.wrapped_object.handlers[grid.id]['hello'].wrapped_object).to receive(:hello).once do
         raise RpcServer::Error.new(404, 'oh-no')
       end
-      expect(subject.wrapped_object).to receive(:send_message).with(ws_client, [1, 99, hash_including(code: 404) , nil])
-      subject.handle_request(ws_client, grid.id, [1, 99, '/hello/hello', ['space']])
+      expect(subject.handle_request(grid.id, [0, msg_id, '/hello/hello', ['space']])).to match [1, msg_id, hash_including(code: 404), nil]
       expect(subject.wrapped_object.handlers[grid.id].size).to eq(0)
     end
 
     it 'catches exceptions' do
-      subject.handle_request(ws_client, grid.id, [1, 99, '/hello/hello', ['world']])
+      subject.handle_request(grid.id, [0, msg_id, '/hello/hello', ['world']])
+
       allow(subject.wrapped_object.handlers[grid.id]['hello'].wrapped_object).to receive(:hello).once do
         raise StandardError.new('oh-no')
       end
-      expect(subject.wrapped_object).to receive(:send_message).with(ws_client, [1, 99, hash_including(code: 500) , nil])
-      subject.handle_request(ws_client, grid.id, [1, 99, '/hello/hello', ['space']])
+      expect(subject.handle_request(grid.id, [0, msg_id, '/hello/hello', ['space']])).to match [1, msg_id, hash_including(code: 500) , nil]
       expect(subject.wrapped_object.handlers[grid.id].size).to eq(0)
     end
 
     it 'responses with error if handler not found' do
-      expect(subject.wrapped_object).to receive(:send_message).with(
-        ws_client, [1, 99, {code: 501, error: "service not implemented"}, nil]
-      )
-      subject.handle_request(ws_client, grid.id, [1, 99, '/foo/bar', ['world']])
+      expect(subject.handle_request(grid.id, [1, msg_id, '/foo/bar', ['world']])).to eq [1, msg_id, {code: 501, error: "service not implemented"}, nil]
     end
   end
 end


### PR DESCRIPTION
Fixes #3040 to keep the `RpcServer` actor responsive to actor calls

The server now shuts down in <1s on Ctrl-C... that should lead to at least 10% development productivity improvements :)

* Refactor the `WebsocketBackend` <-> `RpcServer` interface to be less of a mess and add some specs
* Change the  `RpcServer#process` task to run in a `defer { ... }` thread, leaving the actor thread free to respond to actor calls


   However, this now means that all of the `handle_*` functions run in the `defer { ... }` thread, not in the actor thread... shouldn't be a problem, but it's ugly.

