### PR TITLE
Change service start/stop to execute as deploys

### DIFF
--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -18,7 +18,7 @@ module Kontena::Cli::Services
       data[:force] = true if force?
       spinner "Deploying service #{pastel.cyan(name)} " do
         deployment = deploy_service(token, name, data)
-        wait_for_deploy_to_finish(token, deployment) if wait?
+        wait_for_deploy_to_finish(deployment) if wait?
       end
     end
   end

--- a/cli/lib/kontena/cli/services/scale_command.rb
+++ b/cli/lib/kontena/cli/services/scale_command.rb
@@ -13,7 +13,7 @@ module Kontena::Cli::Services
       token = require_token
       spinner "Scaling #{pastel.cyan(name)} to #{instances} instances " do
         deployment = scale_service(token, name, instances)
-        wait_for_deploy_to_finish(token, deployment)
+        wait_for_deploy_to_finish(deployment)
       end
     end
   end

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -306,16 +306,15 @@ module Kontena
           }
         end
 
-        # @param [String] token
         # @param [Hash] deployment
         # @param [Fixnum] timeout
         # @param [Boo lean] verbose
         # @raise [Kontena::Errors::StandardError]
-        def wait_for_deploy_to_finish(token, deployment, timeout: 600)
+        def wait_for_deploy_to_finish(deployment, timeout: 600)
           Timeout::timeout(timeout) do
             until deployment['finished_at']
               sleep 1
-              deployment = client(token).get("services/#{deployment['service_id']}/deploys/#{deployment['id']}")
+              deployment = client.get("services/#{deployment['service_id']}/deploys/#{deployment['id']}")
             end
 
             if deployment['state'] == 'error'

--- a/cli/lib/kontena/cli/services/start_command.rb
+++ b/cli/lib/kontena/cli/services/start_command.rb
@@ -7,13 +7,15 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME ...", "Service name", attribute_name: :names
+    option '--[no-]wait', :flag, 'Do not wait for service to start', default: true
 
     def execute
       require_api_url
       token = require_token
       names.each do |name|
-        spinner "Sending start signal to #{pastel.cyan(name)} service " do
-          start_service(token, name)
+        spinner "Starting service #{pastel.cyan(name)}" do
+          deployment = start_service(token, name)
+          wait_for_deploy_to_finish(deployment) if wait?
         end
       end
     end

--- a/cli/lib/kontena/cli/services/stop_command.rb
+++ b/cli/lib/kontena/cli/services/stop_command.rb
@@ -7,13 +7,15 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME ...", "Service name", attribute_name: :names
+    option '--[no-]wait', :flag, 'Do not wait for service to stop', default: true
 
     def execute
       require_api_url
       token = require_token
       names.each do |name|
-        spinner "Sending stop signal to #{pastel.cyan(name)} service " do
-          stop_service(token, name)
+        spinner "Stopping service #{pastel.cyan(name)}" do
+          deployment = stop_service(token, name)
+          wait_for_deploy_to_finish(deployment) if wait?
         end
       end
     end

--- a/server/app/jobs/grid_service_scheduler_worker.rb
+++ b/server/app/jobs/grid_service_scheduler_worker.rb
@@ -29,16 +29,10 @@ class GridServiceSchedulerWorker
       if service_deploy.grid_service.deploy_running?
         info "delaying #{service_deploy.grid_service.to_path} deploy because there is another deploy in progress"
         return nil
-
-      elsif service_deploy.grid_service.running? || service_deploy.grid_service.initialized?
+      else
         info "starting #{service_deploy.grid_service.to_path} deploy"
         service_deploy.set(started_at: Time.now.utc)
         return service_deploy
-
-      else
-        info "aborting #{service_deploy.grid_service.to_path} deploy of non-running service"
-        service_deploy.abort! "service is not running"
-        return nil
       end
     end
   rescue => exc

--- a/server/app/models/grid_service_deploy.rb
+++ b/server/app/models/grid_service_deploy.rb
@@ -70,6 +70,12 @@ class GridServiceDeploy
     started? && !finished? && !timeout?
   end
 
+  # GridService has newer deploy
+  # @return [Boolean]
+  def redeployed?
+    self.grid_service.deploy_requested_at > self.created_at
+  end
+
   # @return [Boolean]
   def finished?
     !!finished_at

--- a/server/app/mutations/grid_services/deploy.rb
+++ b/server/app/mutations/grid_services/deploy.rb
@@ -2,12 +2,7 @@ require_relative 'helpers'
 
 module GridServices
   class Deploy < Mutations::Command
-    include Workers
     include Helpers
-
-    ExecutionError = Class.new(StandardError)
-
-    VALID_STATES = %w(initialized running deploying stopped)
 
     required do
       model :grid_service
@@ -17,19 +12,8 @@ module GridServices
       boolean :force, default: false
     end
 
-    def validate
-      unless VALID_STATES.include?(grid_service.state)
-        add_error(:state, :invalid, "Cannot deploy because service state is #{grid_service.state}")
-      end
-    end
-
     def execute
-      grid_service.deploy_requested_at = Time.now.utc
-      grid_service.state = :running
-
-      if self.force ? update_grid_service(grid_service, force: true) : save_grid_service(grid_service)
-        GridServiceDeploy.create(grid_service: grid_service)
-      end
+      deploy_grid_service(grid_service, 'running', force: self.force)
     end
   end
 end

--- a/server/app/mutations/grid_services/helpers.rb
+++ b/server/app/mutations/grid_services/helpers.rb
@@ -42,5 +42,17 @@ module GridServices
 
       save_grid_service(grid_service)
     end
+
+    # @param grid_service [GridService]
+    # @param state [String] desired state
+    # @param force [Boolean] force-update revision
+    def deploy_grid_service(grid_service, state = 'running', force: false)
+      grid_service.deploy_requested_at = Time.now.utc
+      grid_service.state = state
+
+      if force ? update_grid_service(grid_service, force: true) : save_grid_service(grid_service)
+        GridServiceDeploy.create(grid_service: grid_service)
+      end
+    end
   end
 end

--- a/server/app/mutations/grid_services/scale.rb
+++ b/server/app/mutations/grid_services/scale.rb
@@ -1,6 +1,8 @@
+require_relative 'helpers'
+
 module GridServices
   class Scale < Mutations::Command
-    include Workers
+    include Helpers
 
     required do
       model :grid_service
@@ -8,8 +10,10 @@ module GridServices
     end
 
     def execute
-      self.grid_service.set(:container_count => self.instances)
-      GridServiceDeploy.create(grid_service: self.grid_service)
+      grid_service.container_count = self.instances
+
+      # without bumping the revision
+      deploy_grid_service(grid_service, 'running')
     end
   end
 end

--- a/server/app/mutations/grid_services/start.rb
+++ b/server/app/mutations/grid_services/start.rb
@@ -1,29 +1,15 @@
+require_relative 'helpers'
+
 module GridServices
   class Start < Mutations::Command
+    include Helpers
+
     required do
       model :grid_service
     end
 
     def execute
-      self.grid_service.set_state('running')
-      self.start_service_instances
-    rescue => exc
-      add_error(:start, :error, exc.message)
-    end
-
-    def start_service_instances
-      self.grid_service.grid_service_instances.each do |i|
-        i.set(desired_state: 'running')
-        notify_service_instance(i, 'start')
-      end
-    end
-
-    # @param node [HostNode]
-    # @param action [String]
-    def notify_service_instance(service_instance, action)
-      if service_instance.host_node
-        service_instance.host_node.rpc_client.notify('/service_pods/notify_update', action)
-      end
+      deploy_grid_service(grid_service, 'running')
     end
   end
 end

--- a/server/app/mutations/grid_services/stop.rb
+++ b/server/app/mutations/grid_services/stop.rb
@@ -1,29 +1,15 @@
+require_relative 'helpers'
+
 module GridServices
   class Stop < Mutations::Command
+    include Helpers
+
     required do
       model :grid_service
     end
 
     def execute
-      self.grid_service.set_state('stopped')
-      self.stop_service_instances
-    rescue => exc
-      add_error(:stop, :error, exc.message)
-    end
-
-    def stop_service_instances
-      self.grid_service.grid_service_instances.each do |i|
-        i.set(desired_state: 'stopped')
-        notify_service_instance(i, 'stop')
-      end
-    end
-
-    # @param node [HostNode]
-    # @param action [String]
-    def notify_service_instance(service_instance, action)
-      if service_instance.host_node
-        service_instance.host_node.rpc_client.notify('/service_pods/notify_update', action)
-      end
+      deploy_grid_service(grid_service, 'stopped')
     end
   end
 end

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -89,8 +89,8 @@ module V1
             data[:grid_service] = @grid_service
             outcome = GridServices::Deploy.run(data)
             if outcome.success?
-              audit_event(r, @grid_service.grid, @grid_service, 'deploy', @grid_service)
               @grid_service_deploy = outcome.result
+              audit_event(r, @grid_service.grid, @grid_service, 'deploy', @grid_service)
               render('grid_service_deploys/show')
             else
               halt_request(422, { error: outcome.errors.message })
@@ -105,8 +105,8 @@ module V1
                 instances: data['instances']
             )
             if outcome.success?
-              audit_event(r, @grid_service.grid, @grid_service, 'scale', @grid_service)
               @grid_service_deploy = outcome.result
+              audit_event(r, @grid_service.grid, @grid_service, 'scale', @grid_service)
               render('grid_service_deploys/show')
             else
               halt_request(422, { error: outcome.errors.message })
@@ -132,8 +132,9 @@ module V1
                 grid_service: @grid_service
             )
             if outcome.success?
+              @grid_service_deploy = outcome.result
               audit_event(r, @grid_service.grid, @grid_service, 'stop', @grid_service)
-              {}
+              render('grid_service_deploys/show')
             else
               halt_request(422, { error: outcome.errors.message })
             end
@@ -145,8 +146,9 @@ module V1
                 grid_service: @grid_service
             )
             if outcome.success?
+              @grid_service_deploy = outcome.result
               audit_event(r, @grid_service.grid, @grid_service, 'start', @grid_service)
-              {}
+              render('grid_service_deploys/show')
             else
               halt_request(422, { error: outcome.errors.message })
             end

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -61,7 +61,7 @@ class GridServiceDeployer
       if self.grid_service_deploy.redeployed?
         raise "halting deploy of #{self.grid_service.to_path}, service was redeployed"
       end
-      self.deploy_service_instance(total_instances, deploy_futures, instance_number, deploy_rev)
+      self.deploy_service_instance(total_instances, deploy_futures, instance_number, deploy_rev, grid_service.state)
       sleep 0.1
     end
     if deploy_futures.any?{|f| f.value.error?}
@@ -92,12 +92,13 @@ class GridServiceDeployer
     false
   end
 
-  # @param [Integer] total_instances
-  # @param [Array<Celluloid::Future>] deploy_futures
-  # @param [Integer] instance_number
-  # @param [Time] deploy_rev
+  # @param total_instances [Integer]
+  # @param deploy_futures [Array<Celluloid::Future>]
+  # @param instance_number [Integer]
+  # @param deploy_rev [Time]
+  # @param state [String]
   # @raise [DeployError]
-  def deploy_service_instance(total_instances, deploy_futures, instance_number, deploy_rev)
+  def deploy_service_instance(total_instances, deploy_futures, instance_number, deploy_rev, state)
     begin
       node = self.scheduler.select_node(
           self.grid_service, instance_number, self.nodes
@@ -113,7 +114,7 @@ class GridServiceDeployer
 
     deploy_futures << Celluloid::Future.new {
       instance_deployer = GridServiceInstanceDeployer.new(grid_service_instance_deploy)
-      instance_deployer.deploy(deploy_rev.to_s) # XXX: loss of precision
+      instance_deployer.deploy(deploy_rev.to_s, state) # XXX: loss of precision
     }
     pending_deploys = deploy_futures.select{|f| !f.ready?}
     if pending_deploys.size >= (total_instances * self.min_health).floor || pending_deploys.size >= 20

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -53,13 +53,13 @@ class GridServiceDeployer
     self.grid_service.grid_service_instances.where(:instance_number.gt => total_instances).destroy
     total_instances.times do |i|
       instance_number = i + 1
+      self.grid_service.reload
       self.grid_service_deploy.reload
       unless self.grid_service_deploy.running?
         raise "halting deploy of #{self.grid_service.to_path}, deploy was aborted: #{self.grid_service_deploy.reason}"
       end
-      self.grid_service.reload
-      unless self.grid_service.running? || self.grid_service.initialized?
-        raise "halting deploy of #{self.grid_service.to_path}, desired state has changed"
+      if self.grid_service_deploy.redeployed?
+        raise "halting deploy of #{self.grid_service.to_path}, service was redeployed"
       end
       self.deploy_service_instance(total_instances, deploy_futures, instance_number, deploy_rev)
       sleep 0.1

--- a/server/spec/api/v1/services_spec.rb
+++ b/server/spec/api/v1/services_spec.rb
@@ -356,22 +356,22 @@ describe '/v1/services' do
   end
 
   describe 'POST /:id/stop' do
-    it 'stops service' do
-      expect(GridServices::Stop).to receive(:run)
-        .with(grid_service: redis_service)
-        .and_return(double.as_null_object)
-      post "/v1/services/#{redis_service.to_path}/stop", nil, request_headers
-      expect(response.status).to eq(200)
+    it 'stops service and returns deploy' do
+      expect {
+        post "/v1/services/#{redis_service.to_path}/stop", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response).to match hash_including('id' => String, 'service_id' => redis_service.to_path)
+      }.to change{redis_service.reload.state}.to('stopped')
     end
   end
 
   describe 'POST /:id/start' do
-    it 'starts service' do
-      expect(GridServices::Start).to receive(:run)
-        .with(grid_service: redis_service)
-        .and_return(double.as_null_object)
-      post "/v1/services/#{redis_service.to_path}/start", nil, request_headers
-      expect(response.status).to eq(200)
+    it 'starts service and returns deploy' do
+      expect {
+        post "/v1/services/#{redis_service.to_path}/start", nil, request_headers
+        expect(response.status).to eq(200)
+        expect(json_response).to match hash_including('id' => String, 'service_id' => redis_service.to_path)
+      }.to change{redis_service.reload.state}.to('running')
     end
   end
 

--- a/server/spec/jobs/grid_service_scheduler_worker_spec.rb
+++ b/server/spec/jobs/grid_service_scheduler_worker_spec.rb
@@ -284,12 +284,13 @@ describe GridServiceSchedulerWorker, celluloid: true do
     end
 
     describe '#check_deploy_queue' do
-      it 'aborts deploy if service is stopped' do
-        expect(subject.check_deploy_queue).to be_nil
+      it "starts and returns the deploy" do
+        expect{
+          expect(subject.check_deploy_queue).to eq service_deploy
+        }.to change{service_deploy.reload.started_at}.from(nil).to(a_value >= 1.second.ago)
 
-        expect(service_deploy.reload).to be_aborted
-        expect(service_deploy.reload).to be_finished
-        expect(service_deploy.reload).to be_error
+        expect(service).to_not be_deploy_pending
+        expect(service).to be_deploy_running
       end
     end
   end

--- a/server/spec/mutations/grid_services/scale_spec.rb
+++ b/server/spec/mutations/grid_services/scale_spec.rb
@@ -20,6 +20,12 @@ describe GridServices::Scale, celluloid: true do
       }.to change{ redis_service.grid_service_deploys.count }.by(1)
     end
 
+    it 'does not change service revision' do
+      expect{
+        subject.run!
+      }.to_not change{redis_service.reload.revision}
+    end
+
     it 'updates container_count' do
       redis_service # create
       expect {

--- a/server/spec/mutations/grid_services/scale_spec.rb
+++ b/server/spec/mutations/grid_services/scale_spec.rb
@@ -1,11 +1,7 @@
 
 describe GridServices::Scale, celluloid: true do
-  let(:host_node) { HostNode.create(node_id: 'aa')}
-  let(:grid) {
-    grid = Grid.create!(name: 'test-grid', initial_size: 1)
-    grid.host_nodes << host_node
-    grid
-  }
+  let(:grid) { Grid.create!(name: 'test-grid', initial_size: 1) }
+  let(:host_node) { grid.create_node!('test-node', node_id: 'aa') }
   let(:redis_service) {
     GridService.create(
       grid: grid, name: 'redis', image_name: 'redis:2.8'
@@ -18,7 +14,7 @@ describe GridServices::Scale, celluloid: true do
   }
 
   describe '#run' do
-    it 'sends deploy call to worker' do
+    it 'creates a grid service deploy' do
       expect {
         subject.run
       }.to change{ redis_service.grid_service_deploys.count }.by(1)

--- a/server/spec/mutations/grid_services/start_spec.rb
+++ b/server/spec/mutations/grid_services/start_spec.rb
@@ -1,47 +1,21 @@
 describe GridServices::Start do
   let(:grid) { Grid.create!(name: 'test-grid') }
-  let(:service) { GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8') }
+  let(:service) { GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8', state: 'stopped') }
   let(:subject) { described_class.new(grid_service: service) }
 
-  describe '#run' do
-    it 'sets service state to running' do
-      expect{
-        subject.run!
-      }.to change{service.reload.state}.to('running')
-    end
+  it 'sets service state to running' do
+    expect{subject.run!}.to change{service.reload.state}.from('stopped').to('running')
+  end
 
-    context 'with a service instance' do
-      let(:node) { nil }
-      let!(:service_instance) { GridServiceInstance.create!(grid_service: service, instance_number: 1, host_node: node ) }
+  it 'does not change service revision' do
+    expect{subject.run!}.to_not change{service.reload.revision}
+  end
 
-      it 'starts the service instance' do
-        expect{
-          subject.run!
-        }.to change{service_instance.reload.desired_state}.to('running')
-      end
+  it 'creates deploy' do
+    expect{subject.run!}.to change{service.reload.deploying?}.from(false).to(true)
+  end
 
-      context 'with a host node' do
-        let!(:node) { grid.create_node!('test-node') }
-        let(:rpc_client) { instance_double(RpcClient) }
-
-        before do
-          allow(node).to receive(:rpc_client).and_return(rpc_client)
-        end
-
-        it 'notifies the host node' do
-          expect(rpc_client).to receive(:notify).with('/service_pods/notify_update', 'start')
-
-          outcome = subject.run!
-        end
-      end
-    end
-
-    it 'fails on errors' do
-      expect(subject).to receive(:start_service_instances).and_raise(StandardError.new('test'))
-
-      expect(outcome = subject.run).to_not be_success
-      expect(outcome.errors.message).to eq 'start' => 'test'
-      expect(outcome.errors.symbolic).to eq 'start' => :error
-    end
+  it 'returns deploy' do
+    expect(subject.run!).to be_a GridServiceDeploy
   end
 end

--- a/server/spec/mutations/grid_services/stop_spec.rb
+++ b/server/spec/mutations/grid_services/stop_spec.rb
@@ -1,47 +1,21 @@
 describe GridServices::Stop do
   let(:grid) { Grid.create!(name: 'test-grid') }
-  let(:service) { GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8') }
+  let(:service) { GridService.create!(grid: grid, name: 'redis', image_name: 'redis:2.8', state: 'running') }
   let(:subject) { described_class.new(grid_service: service) }
 
-  describe '#run' do
-    it 'sets service state to stopped' do
-      expect{
-        subject.run!
-      }.to change{service.reload.state}.to('stopped')
-    end
+  it 'sets service state to stopped' do
+    expect{subject.run!}.to change{service.reload.state}.from('running').to('stopped')
+  end
 
-    context 'with a service instance' do
-      let(:node) { nil }
-      let!(:service_instance) { GridServiceInstance.create!(grid_service: service, instance_number: 1, host_node: node ) }
+  it 'does not change service revision' do
+    expect{subject.run!}.to_not change{service.reload.revision}
+  end
 
-      it 'stops the service instance' do
-        expect{
-          subject.run!
-        }.to change{service_instance.reload.desired_state}.to('stopped')
-      end
+  it 'creates deploy' do
+    expect{subject.run!}.to change{service.reload.deploying?}.from(false).to(true)
+  end
 
-      context 'with a host node' do
-        let!(:node) { grid.create_node!('test-node') }
-        let(:rpc_client) { instance_double(RpcClient) }
-
-        before do
-          allow(node).to receive(:rpc_client).and_return(rpc_client)
-        end
-
-        it 'notifies the host node' do
-          expect(rpc_client).to receive(:notify).with('/service_pods/notify_update', 'stop')
-
-          outcome = subject.run!
-        end
-      end
-    end
-
-    it 'fails on errors' do
-      expect(subject).to receive(:stop_service_instances).and_raise(StandardError.new('test'))
-
-      expect(outcome = subject.run).to_not be_success
-      expect(outcome.errors.message).to eq 'stop' => 'test'
-      expect(outcome.errors.symbolic).to eq 'stop' => :error
-    end
+  it 'returns deploy' do
+    expect(subject.run!).to be_a GridServiceDeploy
   end
 end


### PR DESCRIPTION
Fixes #2290 to have `GridServices::Scale` set the service `state` to `running`
Maybe fixes #2710 to cancel running service deploys if service is redeployed

Change the `kontena service start/stop` => `POST /v1/services/.../{start,stop}`=> `GridServices::Start/Stop` to just update the `GridService.state = 'running' / 'stopped'` and create a `GridServiceDeploy`. The API now returns a deploy object, and the CLI will spin waiting for the services to actually start/stop. The new API should be backwards-compatible.

## TODO
- [ ] Change the `GridServiceDeployer` to run all of the instance `start/stop` deploys in parallel?
- [ ] Fix the CLI to show the `start/stop` deploy result correctly (not `Deployed ...` but `Stopped ...`)
- [ ] Test the redeploy => cancel mechanism, also for stack deploys