### PR TITLE
[WiP] Wait for service containers to terminate when removing

### DIFF
--- a/cli/lib/kontena/cli/services/list_command.rb
+++ b/cli/lib/kontena/cli/services/list_command.rb
@@ -43,6 +43,7 @@ module Kontena::Cli::Services
       when 'running' then :green
       when 'initialized' then :cyan
       when 'stopped' then :red
+      when 'terminated' then :dim
       else :blue
       end
     end

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -29,7 +29,12 @@ module Kontena::Cli::Services
 
       spinner "Terminating service #{pastel.cyan(name)}" do
         deployment = terminate_service(name)
-        wait_for_deploy_to_finish(deployment)
+        wait_for_deploy_to_finish(deployment, vocabulary: {
+            :verb => "Terminate",
+            :verb_ing => "Terminating",
+            :verb_ed  => "Terminated",
+            :preposition => "on",
+        })
       end
 
       spinner "Removing service #{pastel.cyan(name)}" do

--- a/cli/lib/kontena/cli/services/remove_command.rb
+++ b/cli/lib/kontena/cli/services/remove_command.rb
@@ -27,21 +27,13 @@ module Kontena::Cli::Services
     def remove(name)
       confirm_command(name) unless forced?
 
-      spinner "Removing service #{pastel.cyan(name)} " do
+      spinner "Terminating service #{pastel.cyan(name)}" do
+        deployment = terminate_service(name)
+        wait_for_deploy_to_finish(deployment)
+      end
+
+      spinner "Removing service #{pastel.cyan(name)}" do
         client.delete("services/#{parse_service_id(name)}")
-        removed = false
-        until removed == true
-          sleep 1
-          begin
-            client.get("services/#{parse_service_id(name)}")
-          rescue Kontena::Errors::StandardError => exc
-            if exc.status == 404
-              removed = true
-            else
-              raise exc
-            end
-          end
-        end
       end
     end
 

--- a/cli/lib/kontena/cli/services/services_helper.rb
+++ b/cli/lib/kontena/cli/services/services_helper.rb
@@ -355,6 +355,13 @@ module Kontena
 
         # @param [String] token
         # @param [String] service_id
+        def terminate_service(service_id)
+          param = parse_service_id(service_id)
+          client.post("services/#{param}/terminate", {})
+        end
+
+        # @param [String] token
+        # @param [String] service_id
         def delete_service(token, service_id)
           param = parse_service_id(service_id)
           client(token).delete("services/#{param}")

--- a/server/app/models/grid_service.rb
+++ b/server/app/models/grid_service.rb
@@ -150,6 +150,11 @@ class GridService
   end
 
   # @return [Boolean]
+  def terminated?
+    self.state == 'terminated'
+  end
+
+  # @return [Boolean]
   def stack_exposed?
     return false unless self.stack
     self.stack.exposed_service?(self)

--- a/server/app/mutations/grid_services/terminate.rb
+++ b/server/app/mutations/grid_services/terminate.rb
@@ -1,0 +1,15 @@
+require_relative 'helpers'
+
+module GridServices
+  class Terminate < Mutations::Command
+    include Helpers
+
+    required do
+      model :grid_service
+    end
+
+    def execute
+      deploy_grid_service(grid_service, 'terminated')
+    end
+  end
+end

--- a/server/app/routes/v1/services_api.rb
+++ b/server/app/routes/v1/services_api.rb
@@ -153,6 +153,20 @@ module V1
               halt_request(422, { error: outcome.errors.message })
             end
           end
+
+          # POST /v1/services/:grid_name/:stack_name/:service_name/terminate
+          r.on('terminate') do
+            outcome = GridServices::Terminate.run(
+                grid_service: @grid_service,
+            )
+            if outcome.success?
+              @grid_service_deploy = outcome.result
+              audit_event(r, @grid_service.grid, @grid_service, 'terminate', @grid_service)
+              render('grid_service_deploys/show')
+            else
+              halt_request(422, { error: outcome.errors.message })
+            end
+          end
         end
 
         # PUT /v1/services/:grid_name/:stack_name/:service_name


### PR DESCRIPTION
Follows #3277
Fixes #3030 Docker container name conflicts when deploying new services immediately after removing an earlier version

Adds a new `POST /v1/services/.../terminate` => `GridServices::Terminate` that deploys the service in the `terminated` state. The CLI `kontena service remove` waits for the service to terminate before removing it, ensuring that no lingering containers get left behind.

The agent is otherwise already capable of dealing with `service_pod.desired_state = 'terminated'`, but it just needs to be fixed to sync the terminated state back to the master instead of terminating the `ServicePodWorker` actor. Now the `ServicePodWorker` actor only gets terminated when the `ServicePodManager` destroys it.

## TODO
- [ ] specs
- [ ] Update stack remove to use the same semantics