### PR TITLE
Log service:instance_exit event on container crashes

### DIFF
--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -109,7 +109,7 @@ module Kontena::Workers
       backoff = max_restart_backoff if backoff > max_restart_backoff
       info "#{@service_pod} exited with code #{exit_code}, restarting (delay: #{backoff}s)"
 
-      log_service_pod_event("service:instance_exit",
+      log_service_pod_event("service:instance_crash",
         "service #{@service_pod} instance exited with code #{exit_code}, restarting (delay: #{backoff}s)",
         Logger::WARN
       )

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -91,7 +91,7 @@ module Kontena::Workers
           debug "#{@service_pod} container event: #{event.status} at #{at.utc.xmlschema(9)}"
 
           if event.status == 'die'
-            handle_restart_on_die
+            on_container_die(exit_code: event.actor.attributes['exitCode'])
           end
         else
           debug "#{@service_pod} stale container event: #{event.status} at #{at.utc.xmlschema(9)} < #{@container.started_at.utc.xmlschema(9)}"
@@ -100,7 +100,7 @@ module Kontena::Workers
     end
 
     # Handles events when container has died
-    def handle_restart_on_die
+    def on_container_die(exit_code: )
       cancel_restart_timers
       return unless @service_pod.running?
 

--- a/agent/lib/kontena/workers/service_pod_worker.rb
+++ b/agent/lib/kontena/workers/service_pod_worker.rb
@@ -107,11 +107,13 @@ module Kontena::Workers
       # backoff restarts
       backoff = @restarts ** 2
       backoff = max_restart_backoff if backoff > max_restart_backoff
-      if backoff == 0
-        info "restarting #{@service_pod} because it has stopped"
-      else
-        info "restarting #{@service_pod} because it has stopped (delay: #{backoff}s)"
-      end
+      info "#{@service_pod} exited with code #{exit_code}, restarting (delay: #{backoff}s)"
+
+      log_service_pod_event("service:instance_exit",
+        "service #{@service_pod} instance exited with code #{exit_code}, restarting (delay: #{backoff}s)",
+        Logger::WARN
+      )
+
       ts = Time.now.utc
       @restarts += 1
       @restart_backoff_timer = after(backoff) {


### PR DESCRIPTION
Made possible by #3259 + #2780 to tell the difference between spontaneous container crashes and restarts/deploys.

Only gets logged if the container dies spontaneously:

```
$ kontena service exec shutdown-test/client kill 1
$ kontena service events shutdown-test/client
TIME                      TYPE                 MESSAGE
...
2018-02-16T12:38:38.583Z  instance_exit        service shutdown-test/client-1 instance exited with code 1, restarting (delay: 0s) (core-01)
2018-02-16T12:38:38.951Z  start_instance       starting service instance /shutdown-test/client-1 (core-01)
2018-02-16T12:38:39.513Z  start_instance       service instance /shutdown-test/client-1 started successfully (core-01)
```

Does not get logged on `kontena service restart`:

```
2018-02-16T12:37:57.422Z  restart_instance     service /shutdown-test/client-1 instance restarted successfully (core-01)
2018-02-16T12:37:58.861Z  restart_instance     service /shutdown-test/client-3 instance restarted successfully (core-01)
2018-02-16T12:37:58.876Z  restart_instance     service /shutdown-test/client-2 instance restarted successfully (core-01)
```

Does not get logged on deploys:

```
$ kontena service deploy --force shutdown-test/client
 [done] Deploying service shutdown-test/client      
⊛ Deployed instance development/shutdown-test/client-1 to node core-01
⊛ Deployed instance development/shutdown-test/client-2 to node core-01
⊛ Deployed instance development/shutdown-test/client-3 to node core-01
$ kontena service events shutdown-test/client
TIME                      TYPE                 MESSAGE
2018-02-16T12:39:36.477Z  deploy               service development/shutdown-test/client deploy started
2018-02-16T12:39:37.419Z  create_instance      pulling image 10.81.128.97/shutdown-test-client:latest for shutdown-test/client-1 (core-01)
2018-02-16T12:39:37.528Z  create_instance      pulled image 10.81.128.97/shutdown-test-client:latest for shutdown-test/client-1 (core-01)
2018-02-16T12:39:38.284Z  create_instance      removed previous version of service shutdown-test/client-1 instance (core-01)
2018-02-16T12:39:38.381Z  create_instance      service shutdown-test/client-1 instance created (core-01)
2018-02-16T12:39:39.011Z  create_instance      service shutdown-test/client-1 instance started (core-01)
2018-02-16T12:39:41.022Z  create_instance      pulling image 10.81.128.97/shutdown-test-client:latest for shutdown-test/client-2 (core-01)
2018-02-16T12:39:41.058Z  create_instance      pulled image 10.81.128.97/shutdown-test-client:latest for shutdown-test/client-2 (core-01)
2018-02-16T12:39:43.229Z  create_instance      removed previous version of service shutdown-test/client-2 instance (core-01)
2018-02-16T12:39:43.363Z  create_instance      service shutdown-test/client-2 instance created (core-01)
2018-02-16T12:39:44.358Z  create_instance      service shutdown-test/client-2 instance started (core-01)
2018-02-16T12:39:46.482Z  create_instance      pulling image 10.81.128.97/shutdown-test-client:latest for shutdown-test/client-3 (core-01)
2018-02-16T12:39:46.488Z  create_instance      pulled image 10.81.128.97/shutdown-test-client:latest for shutdown-test/client-3 (core-01)
2018-02-16T12:39:48.004Z  create_instance      removed previous version of service shutdown-test/client-3 instance (core-01)
2018-02-16T12:39:48.117Z  create_instance      service shutdown-test/client-3 instance created (core-01)
2018-02-16T12:39:48.860Z  create_instance      service shutdown-test/client-3 instance started (core-01)
2018-02-16T12:39:49.172Z  deploy               service development/shutdown-test/client deployed
```