### PR TITLE
Fix agent container log dropping entries when queue size exactly matches the throttle limit

### DIFF
--- a/agent/lib/kontena/workers/container_log_worker.rb
+++ b/agent/lib/kontena/workers/container_log_worker.rb
@@ -80,7 +80,7 @@ module Kontena::Workers
       elsif @queue.size > LogWorker::QUEUE_THROTTLE
         @queue << msg
         sleep 0.0001
-      elsif @queue.size < LogWorker::QUEUE_THROTTLE
+      else
         @queue << msg
       end
     end


### PR DESCRIPTION
Container logs would get unintentionally dropped if the `@queue.size` happened to be exactly `LogWorker::QUEUE_THROTTLE`.