### PR TITLE
Fix CLI stack / service deploy --no-wait description

### DIFF
--- a/cli/lib/kontena/cli/services/deploy_command.rb
+++ b/cli/lib/kontena/cli/services/deploy_command.rb
@@ -7,7 +7,7 @@ module Kontena::Cli::Services
     include ServicesHelper
 
     parameter "NAME", "Service name"
-    option '--[no-]wait', :flag, 'Do not wait for service deployment', default: true
+    option '--[no-]wait', :flag, 'Wait for service deployment to finish', default: true
     option '--force', :flag, 'Force deploy even if service does not have any changes'
 
     def execute

--- a/cli/lib/kontena/cli/stacks/deploy_command.rb
+++ b/cli/lib/kontena/cli/stacks/deploy_command.rb
@@ -10,7 +10,7 @@ module Kontena::Cli::Stacks
 
     parameter "NAME ...", "Stack name", attribute_name: :names
 
-    option '--[no-]wait', :flag, 'Do not wait for service deployment', default: true
+    option '--[no-]wait', :flag, 'Wait for deployment to finish', default: true
 
     requires_current_master
     requires_current_master_token


### PR DESCRIPTION
Fixes #3289

The `--wait` flag description in `kontena stack deploy` and `kontena service deploy`  was misleading.

Before:
```
--[no-]wait                   Do not wait for service deployment (default: true)
```

After:
```
--[no-]wait                  Wait for service deployment to finish (default: true)
```

Alternative would be to change to even more obvious:

```
--no-wait                   Do not wait for service deployment to finish
```
