### PR TITLE
Fix CLI kontena service scale missing --no-wait flag

### DIFF
--- a/cli/lib/kontena/cli/services/scale_command.rb
+++ b/cli/lib/kontena/cli/services/scale_command.rb
@@ -8,12 +8,13 @@ module Kontena::Cli::Services
 
     parameter "NAME", "Service name"
     parameter "INSTANCES", "Scales service to given number of instances"
+    option '--[no-]wait', :flag, 'Wait for service deployment', default: true
 
     def execute
       token = require_token
       spinner "Scaling #{pastel.cyan(name)} to #{instances} instances " do
         deployment = scale_service(token, name, instances)
-        wait_for_deploy_to_finish(token, deployment)
+        wait_for_deploy_to_finish(token, deployment) if wait?
       end
     end
   end


### PR DESCRIPTION
Adds missing `kontena service scale --no-wait` flag https://github.com/kontena/kontena/pull/3277#discussion_r168144573