### PR TITLE
Fix service scale to set service running state

### DIFF
--- a/server/app/jobs/grid_service_scheduler_worker.rb
+++ b/server/app/jobs/grid_service_scheduler_worker.rb
@@ -30,7 +30,7 @@ class GridServiceSchedulerWorker
         info "delaying #{service_deploy.grid_service.to_path} deploy because there is another deploy in progress"
         return nil
 
-      elsif service_deploy.grid_service.running? || service_deploy.grid_service.initialized?
+      elsif service_deploy.grid_service.running?
         info "starting #{service_deploy.grid_service.to_path} deploy"
         service_deploy.set(started_at: Time.now.utc)
         return service_deploy

--- a/server/app/mutations/grid_services/deploy.rb
+++ b/server/app/mutations/grid_services/deploy.rb
@@ -2,12 +2,7 @@ require_relative 'helpers'
 
 module GridServices
   class Deploy < Mutations::Command
-    include Workers
     include Helpers
-
-    ExecutionError = Class.new(StandardError)
-
-    VALID_STATES = %w(initialized running deploying stopped)
 
     required do
       model :grid_service
@@ -17,19 +12,8 @@ module GridServices
       boolean :force, default: false
     end
 
-    def validate
-      unless VALID_STATES.include?(grid_service.state)
-        add_error(:state, :invalid, "Cannot deploy because service state is #{grid_service.state}")
-      end
-    end
-
     def execute
-      grid_service.deploy_requested_at = Time.now.utc
-      grid_service.state = :running
-
-      if self.force ? update_grid_service(grid_service, force: true) : save_grid_service(grid_service)
-        GridServiceDeploy.create(grid_service: grid_service)
-      end
+      deploy_grid_service(grid_service, 'running', force: self.force)
     end
   end
 end

--- a/server/app/mutations/grid_services/helpers.rb
+++ b/server/app/mutations/grid_services/helpers.rb
@@ -42,5 +42,17 @@ module GridServices
 
       save_grid_service(grid_service)
     end
+
+    # @param grid_service [GridService]
+    # @param state [String] desired state
+    # @param force [Boolean] force-update revision
+    def deploy_grid_service(grid_service, state = 'running', force: false)
+      grid_service.deploy_requested_at = Time.now.utc
+      grid_service.state = state
+
+      if force ? update_grid_service(grid_service, force: true) : save_grid_service(grid_service)
+        GridServiceDeploy.create(grid_service: grid_service)
+      end
+    end
   end
 end

--- a/server/app/mutations/grid_services/scale.rb
+++ b/server/app/mutations/grid_services/scale.rb
@@ -1,6 +1,8 @@
+require_relative 'helpers'
+
 module GridServices
   class Scale < Mutations::Command
-    include Workers
+    include Helpers
 
     required do
       model :grid_service
@@ -8,8 +10,10 @@ module GridServices
     end
 
     def execute
-      self.grid_service.set(:container_count => self.instances)
-      GridServiceDeploy.create(grid_service: self.grid_service)
+      grid_service.container_count = self.instances
+
+      # without bumping the revision
+      deploy_grid_service(grid_service, 'running')
     end
   end
 end

--- a/server/app/services/grid_service_deployer.rb
+++ b/server/app/services/grid_service_deployer.rb
@@ -58,7 +58,7 @@ class GridServiceDeployer
         raise "halting deploy of #{self.grid_service.to_path}, deploy was aborted: #{self.grid_service_deploy.reason}"
       end
       self.grid_service.reload
-      unless self.grid_service.running? || self.grid_service.initialized?
+      unless self.grid_service.running?
         raise "halting deploy of #{self.grid_service.to_path}, desired state has changed"
       end
       self.deploy_service_instance(total_instances, deploy_futures, instance_number, deploy_rev)

--- a/server/spec/jobs/grid_service_scheduler_worker_spec.rb
+++ b/server/spec/jobs/grid_service_scheduler_worker_spec.rb
@@ -2,7 +2,9 @@
 describe GridServiceSchedulerWorker, celluloid: true do
 
   let(:grid) { Grid.create(name: 'test')}
-  let(:service) { GridService.create(name: 'test', image_name: 'foo/bar:latest', grid: grid)}
+  let(:service) { GridService.create(name: 'test', image_name: 'foo/bar:latest', grid: grid,
+    state: :running,
+  )}
   let(:subject) { described_class.new(false) }
 
   describe '#watch' do

--- a/server/spec/mutations/grid_services/scale_spec.rb
+++ b/server/spec/mutations/grid_services/scale_spec.rb
@@ -1,11 +1,7 @@
 
 describe GridServices::Scale, celluloid: true do
-  let(:host_node) { HostNode.create(node_id: 'aa')}
-  let(:grid) {
-    grid = Grid.create!(name: 'test-grid', initial_size: 1)
-    grid.host_nodes << host_node
-    grid
-  }
+  let(:grid) { Grid.create!(name: 'test-grid', initial_size: 1) }
+  let(:host_node) { grid.create_node!('test-node', node_id: 'aa') }
   let(:redis_service) {
     GridService.create(
       grid: grid, name: 'redis', image_name: 'redis:2.8'
@@ -18,10 +14,16 @@ describe GridServices::Scale, celluloid: true do
   }
 
   describe '#run' do
-    it 'sends deploy call to worker' do
+    it 'creates a grid service deploy' do
       expect {
         subject.run
       }.to change{ redis_service.grid_service_deploys.count }.by(1)
+    end
+
+    it 'does not change service revision' do
+      expect{
+        subject.run!
+      }.to_not change{redis_service.reload.revision}
     end
 
     it 'updates container_count' do

--- a/server/spec/services/grid_service_deployer_spec.rb
+++ b/server/spec/services/grid_service_deployer_spec.rb
@@ -1,7 +1,9 @@
 
 describe GridServiceDeployer do
   let(:grid) { Grid.create!(name: 'test-grid') }
-  let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid) }
+  let(:grid_service) { GridService.create!(image_name: 'kontena/redis:2.8', name: 'redis', grid: grid,
+    state: :running,
+  ) }
   let(:grid_service_deploy) { GridServiceDeploy.create(grid_service: grid_service, started_at: Time.now.utc) }
   let(:node1) { grid.create_node!('node-1', node_id: SecureRandom.uuid, node_number: 1, mem_total: 1.gigabytes) }
   let(:strategy) { Scheduler::Strategy::HighAvailability.new }
@@ -121,6 +123,7 @@ describe GridServiceDeployer do
           grid.grid_services.create!(
             name: 'redis',
             image_name: 'kontena/redis:2.8',
+            state: :running,
             deploy_opts: {
               min_health: 0.0,
             },


### PR DESCRIPTION
Split out of #3277
Fixes #2290 `GridServices::Scale` can leave the service in the `initialized` state

Set the `GridService.state` to `running` for `GridServices::Scale` when deploying the service.

Includes `GridServices::Deploy` refactoring for #3277.

Services will no longer get deployed in the `initialized` state, removing some special cases.