### PR TITLE
Remove debug output from e2e healthcheck test

### DIFF
--- a/test/spec/features/stack/healthcheck_spec.rb
+++ b/test/spec/features/stack/healthcheck_spec.rb
@@ -29,8 +29,6 @@ describe 'kontena service health_check' do
         response = Net::HTTP.get_response(uri)
         status = response.code.to_i
 
-        puts "GET #{uri} => #{status}"
-
         if status == 503 && ((count += 1) < retry_503)
           # LB can return 503 temporarily during configuration, retry to make sure it's stable before returning it
           sleep 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/224971/36427038-aeea25ba-1654-11e8-8b79-f358a0b42d05.png)

I assume this was left here accidentally / temporarily
