### PR TITLE
Fix kontena wrapper when PATH contains spaces.

### DIFF
--- a/cli/omnibus/wrappers/sh/kontena
+++ b/cli/omnibus/wrappers/sh/kontena
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export PATH=/opt/kontena/embedded/bin:$PATH
+export PATH="/opt/kontena/embedded/bin:$PATH"
 export GEM_HOME=/opt/kontena/embedded/lib/ruby/gems/2.5.0
 export GEM_PATH=$GEM_HOME
 


### PR DESCRIPTION
For example when I'm on Windows Subsystem for Linux and have installed the deb package the PATH contains some Windows directories so I get:

```
~ $ kontena whoami
/usr/local/bin/kontena: 3: export: (x86)/NVIDIA: bad variable name
```

This fixes it.