### PR TITLE
Fix flaky agent EventWorker#start spec

### DIFF
--- a/agent/spec/lib/kontena/workers/event_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/event_worker_spec.rb
@@ -46,7 +46,7 @@ describe Kontena::Workers::EventWorker do
         times.times {
           block.call(Docker::Event.new(event))
         }
-        sleep 0.1
+        sleep 0.5
         subject.stop_processing
       }
       subject.start

--- a/agent/spec/lib/kontena/workers/event_worker_spec.rb
+++ b/agent/spec/lib/kontena/workers/event_worker_spec.rb
@@ -33,7 +33,9 @@ describe Kontena::Workers::EventWorker do
     it 'starts processing events' do
       expect(subject.wrapped_object).to receive(:stream_events)
       expect(subject.wrapped_object).to receive(:process_events)
+
       subject.start
+      subject.nil? # ping it with something inconsequential to allow the async tasks to run
     end
 
     it 'streams and processes events' do


### PR DESCRIPTION
Fixes #2321

The specs assumed that the `async.foo` tasks would run by the time the sync call to `actor.start` completed and the spec example finished, which is racy.

The `streams and processes events` spec is also racy as in https://github.com/kontena/kontena/issues/2321#issuecomment-329765755, but fixing that would need changes to the `EventWorker`, which I'd rather avoid right now.