### PR TITLE
Remove orphaned certificates and fix crashing migration

### DIFF
--- a/server/app/models/certificate.rb
+++ b/server/app/models/certificate.rb
@@ -19,7 +19,7 @@ class Certificate
   index({ grid_id: 1, subject: 1 }, {unique: true})
 
   def to_path
-    "#{self.grid.name}/#{self.subject}"
+    "#{self.grid.try(:name)}/#{self.subject}"
   end
 
   # @return [String] Actual certificate and the trust chain bundled together

--- a/server/app/models/grid.rb
+++ b/server/app/models/grid.rb
@@ -35,7 +35,7 @@ class Grid
   has_many :grid_domain_authorizations, dependent: :delete
   has_many :networks, dependent: :delete
   has_many :volumes, dependent: :destroy
-  has_many :certificates
+  has_many :certificates, dependent: :destroy
   has_and_belongs_to_many :users
   embeds_one :grid_logs_opts, class_name: 'GridLogsOpts'
 

--- a/server/db/migrations/31_reencrypt_vault_secrets.rb
+++ b/server/db/migrations/31_reencrypt_vault_secrets.rb
@@ -8,7 +8,7 @@ class ReencryptVaultSecrets < Mongodb::Migration
       secret.save
     end
 
-    Certificate.each do |cert|
+    Certificate.all.reject { |c| c.grid.nil? }.each do |cert|
       info "Re-encrypting Certificate #{cert.to_path}..."
       cert.private_key = cert.private_key
       cert.save
@@ -47,7 +47,7 @@ class ReencryptVaultSecrets < Mongodb::Migration
       end
     end
 
-    Certificate.each do |cert|
+    Certificate.all.reject { |c| c.grid.nil? }.each do |cert|
       info "Rollback Certificate #{cert.to_path}..."
       cert.set(encrypted_private_key: legacy_cipher.encrypt(cert.private_key))
     end

--- a/server/db/migrations/32_clean_up_orphan_certificates.rb
+++ b/server/db/migrations/32_clean_up_orphan_certificates.rb
@@ -1,0 +1,8 @@
+class CleanUpOrphanCertificates < Mongodb::Migration
+  def self.up
+    Certificate.all.select { |c| c.grid.nil? }.map(&:destroy)
+  end
+
+  def self.down
+  end
+end

--- a/server/spec/db/migrations/31_rencrypt_vault_secrets_spec.rb
+++ b/server/spec/db/migrations/31_rencrypt_vault_secrets_spec.rb
@@ -110,6 +110,16 @@ describe ReencryptVaultSecrets do
         expect(grid_secret.value).to eq 'foobar'
       end
     end
+
+    context 'for a deleted grid' do
+      before do
+        grid.delete
+      end
+
+      it 'does not crash' do
+        expect{described_class.up}.to_not raise_error
+      end
+    end
   end
 
   context 'with certificates' do
@@ -138,9 +148,9 @@ describe ReencryptVaultSecrets do
       end
     end
 
-    context 'for a deleted grid' do
+    context 'for a missing grid' do
       before do
-        grid.destroy!
+        grid.collection.delete_one({_id: grid.id})
       end
 
       it 'does not crash' do

--- a/server/spec/db/migrations/31_rencrypt_vault_secrets_spec.rb
+++ b/server/spec/db/migrations/31_rencrypt_vault_secrets_spec.rb
@@ -70,7 +70,6 @@ describe ReencryptVaultSecrets do
     let(:decoded_value) { SymmetricEncryption.cipher.decode(encrypted_value) }
 
     context 'before migration' do
-
       it 'does not have a header' do
         expect(SymmetricEncryption::Cipher.has_header?(decoded_value)).to be false
       end
@@ -109,6 +108,43 @@ describe ReencryptVaultSecrets do
 
       it 'is decryptable via the model' do
         expect(grid_secret.value).to eq 'foobar'
+      end
+    end
+  end
+
+  context 'with certificates' do
+    let!(:certificate) { Certificate.create!(grid: grid, subject: 'test.example.com',
+      valid_until: Time.now + 3600,
+      certificate: "placeholder that is not a PEM certificate\n",
+      encrypted_private_key: legacy_cipher.encrypt("placeholder that is not a PEM private key\n", false),
+    ) }
+    let(:encrypted_value) { certificate.reload.encrypted_private_key }
+
+    it 'is decryptable via the model' do
+      expect(certificate.reload.private_key).to eq "placeholder that is not a PEM private key\n"
+    end
+
+    context 'after migration' do
+      before do
+        described_class.up
+      end
+
+      it 'decrypts with the primary cipher' do
+        expect(primary_cipher.decrypt(encrypted_value)).to eq "placeholder that is not a PEM private key\n"
+      end
+
+      it 'is decryptable via the model' do
+        expect(certificate.reload.private_key).to eq "placeholder that is not a PEM private key\n"
+      end
+    end
+
+    context 'for a deleted grid' do
+      before do
+        grid.destroy!
+      end
+
+      it 'does not crash' do
+        expect{described_class.up}.to_not raise_error
       end
     end
   end

--- a/server/spec/db/migrations/32_clean_up_orphan_certificates_spec.rb
+++ b/server/spec/db/migrations/32_clean_up_orphan_certificates_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../../db/migrations/32_clean_up_orphan_certificates'
+
+describe CleanUpOrphanCertificates do
+  let!(:grid) { Grid.create!(name: 'test-grid') }
+  let!(:certificate) { Certificate.create!(grid: grid, subject: 'test.example.com',
+    valid_until: Time.now + 3600,
+  ) }
+
+  context 'for an existing grid' do
+    it 'does nothing' do
+      expect{
+        described_class.up
+      }.to_not change{Certificate.find_by(subject: 'test.example.com')}.from(certificate)
+    end
+  end
+
+  context 'for an missing grid' do
+    before do
+      grid.collection.delete_one({_id: grid.id})
+    end
+
+    it 'removes the orphaned certificate' do
+      expect{
+        described_class.up
+      }.to change{Certificate.find_by(subject: 'test.example.com')}.from(certificate).to(nil)
+    end
+  end
+end

--- a/server/spec/models/certificate_spec.rb
+++ b/server/spec/models/certificate_spec.rb
@@ -15,6 +15,28 @@ describe Certificate do
     )
   }
 
+  it 'gets cleaned up if the grid is deleted' do
+    expect{
+      grid.destroy!
+    }.to change {Certificate.find_by(subject: 'kontena.io')}.from(certificate).to(nil)
+  end
+
+  describe '#to_path' do
+    context 'for a deleted grid' do
+      before do
+        grid.destroy!
+        certificate.reload
+      end
+
+      it 'retuns a broken path instead of crashing' do
+        path = nil
+
+        expect{path = certificate.to_path}.to_not raise_error
+        expect(path).to eq '/kontena.io'
+      end
+    end
+  end
+
   describe '#auto_renewable?' do
     context 'with missing subject domain authorizations' do
       let!(:authz1) { GridDomainAuthorization.create!(grid: grid, domain: 'www.kontena.io', authorization_type: 'tls-sni-01') }


### PR DESCRIPTION
Fixes #3311 
Fixes #3312 

Upgrading to 1.5.0 goes into a crash loop if you ever had a grid with certificates and deleted the grid.

The grid `has_many :certificates` did not have the `dependent: :destroy` option enabled, so any certificates were left behind after a grid was removed.

This PR fixes that by adding the option, skipping gridless certificates in the migration and adding a new migration to clean up any orphaned certificates from the database.
