### PR TITLE
Fix cli certificate authorize --help for http-01

### DIFF
--- a/cli/lib/kontena/cli/certificate/authorize_command.rb
+++ b/cli/lib/kontena/cli/certificate/authorize_command.rb
@@ -10,8 +10,8 @@ module Kontena::Cli::Certificate
 
     parameter "DOMAIN", "Domain to authorize"
 
-    option '--type', 'AUTHORIZATION_TYPE', 'Authorization type, either tls-sni-01 or dns-01', default: 'dns-01'
-    option '--linked-service', "LINKED_SERVICE", 'A service (usually LB) where the tls-sni-01 challenge certificate is bundled to'
+    option '--type', 'AUTHORIZATION_TYPE', 'Authorization type, either http-01, dns-01 or tls-sni-01 (renewals only)', default: 'dns-01'
+    option '--linked-service', "LINKED_SERVICE", 'A service (usually LB) where the http-01/tls-sni-01 challenge is deployed to'
 
     requires_current_master
     requires_current_master_token


### PR DESCRIPTION
Fixes #3317

Also updates the `--linked-service` wording to cover http-01, and discourage use of `tls-sni-01` for `--type`.

```
Usage:
    kontena certificate authorize [OPTIONS] DOMAIN

Parameters:
    DOMAIN                        Domain to authorize

Options:
    --grid GRID                   Specify grid to use
    --type AUTHORIZATION_TYPE     Authorization type, either http-01, dns-01 or tls-sni-01 (renewals only) (default: "dns-01")
    --linked-service LINKED_SERVICE A service (usually LB) where the http-01/tls-sni-01 challenge is deployed to
    -h, --help                    print help
    -D, --[no-]debug              Enable debug (default: $DEBUG)
```