### PR TITLE
Clean CLI stacks cache debug puts

### DIFF
--- a/cli/lib/kontena/stacks_cache.rb
+++ b/cli/lib/kontena/stacks_cache.rb
@@ -19,7 +19,6 @@ module Kontena
       end
 
       def write(content)
-        puts "WHATHAT??? #{stack_name.inspect} #{stack_name.version} #{stack_name.stack_name}"
         raise ArgumentError, "Stack name and version required" unless stack_name.stack_name && stack_name.version
         unless File.directory?(File.dirname(path))
           require 'fileutils'
@@ -75,7 +74,6 @@ module Kontena
           content = client.pull(stack_name)
           yaml    = ::YAML.safe_load(content, [], [], true, stack.stack_name.to_s)
           new_stack_name = Kontena::Cli::Stacks::StackName.new(yaml['stack'], yaml['version'])
-          puts new_stack_name.inspect
           new_stack = CachedStack.new(new_stack_name)
           if new_stack.cached?
             dputs "Already cached"


### PR DESCRIPTION
Fixes #3316 spurious `puts` output from `kontena stack` commands

Cleanup `Kontena::StacksCache` debugging `puts` that were left in #3219