### PR TITLE
Override CLI omnibus libxml2 download source to avoid FTP

### DIFF
--- a/cli/omnibus/config/projects/kontena.rb
+++ b/cli/omnibus/config/projects/kontena.rb
@@ -12,6 +12,7 @@ maintainer "Kontena, Inc."
 homepage "https://kontena.io"
 
 override :ruby, version: "2.5.0"
+override :libxml2, version: '2.9.7', source: { url: 'http://xmlsoft.org/sources/libxml2-2.9.7.tar.gz' }
 
 # Defaults to C:/kontena on Windows
 # and /opt/kontena on all other platforms


### PR DESCRIPTION
Fixes #3327

```
      [Software: libxml2] I | 2018-03-13T11:15:26+02:00 | Resolving manifest entry for libxml2
    [NetFetcher: libxml2] I | 2018-03-13T11:15:26+02:00 | Downloading from `http://xmlsoft.org/sources/libxml2-2.9.7.tar.gz'
    [NetFetcher: libxml2] I | 2018-03-13T11:15:30+02:00 | Verifying checksum
...
   [Builder: preparation] I | 2018-03-13T11:15:31+02:00 | Starting build
```
