### PR TITLE
Drop Ruby 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,6 @@ jobs:
   include:
     - stage: test
       script: ./build/travis/test.sh
-      rvm: 2.2
-      env: TEST_DIR=cli
-      if: type = pull_request
-    - stage: test
-      script: ./build/travis/test.sh
       rvm: 2.3
       env: TEST_DIR=cli
       if: type = pull_request

--- a/cli/kontena-cli.gemspec
+++ b/cli/kontena-cli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.2.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Fixes #3341 

Ruby 2.2 has reached EOL.

The scheduled EOL for Ruby 2.3 is 2019-03-31.
