### PR TITLE
Fix e2e test specs debug output

### DIFF
--- a/test/spec/features/stack/healthcheck_spec.rb
+++ b/test/spec/features/stack/healthcheck_spec.rb
@@ -9,7 +9,7 @@ describe 'kontena service health_check' do
         run! 'kontena stack build --no-push'
       end
     end
-  
+
     def check_service_health(service)
       out = ''
 
@@ -18,10 +18,10 @@ describe 'kontena service health_check' do
         k = run! "kontena service show #{service}"
         out = k.out
       end
-      
+
       match[1]
     end
-    
+
     def check_lb_response_code(url = 'http://localhost/', retry_503: 5)
       uri = URI(url)
       count = 0
@@ -44,7 +44,7 @@ describe 'kontena service health_check' do
         end
 
         last_status = status
-      end 
+      end
     end
 
     context "returning HTTP 200 for healthchecks" do
@@ -83,7 +83,7 @@ describe 'kontena service health_check' do
       it "has a healthy status" do
         expect(check_service_health('healthcheck-test-302-200/server')).to eq 'healthy'
       end
-      
+
       it "returns HTTP 200 via the LB" do
         expect(check_lb_response_code).to eq 200
       end
@@ -104,7 +104,7 @@ describe 'kontena service health_check' do
       it "has a healthy status" do
         expect(check_service_health('healthcheck-test-302-500/server')).to eq 'healthy'
       end
-      
+
       it "returns HTTP 200 via the LB" do
         expect(check_lb_response_code).to eq 200
       end
@@ -120,7 +120,7 @@ describe 'kontena service health_check' do
       after(:all) do
         run! 'kontena stack rm --force healthcheck-test-500'
       end
- 
+
       it "has an unhealthy status" do
         expect(check_service_health('healthcheck-test-500/server')).to eq 'unhealthy'
       end

--- a/test/spec/features/stack/healthcheck_spec.rb
+++ b/test/spec/features/stack/healthcheck_spec.rb
@@ -2,6 +2,8 @@ require 'net/http'
 
 describe 'kontena service health_check' do
   context 'for a http test service' do
+    include DebugHelper
+
     before(:all) do
       with_fixture_dir('stack/healthcheck') do
         run! 'kontena stack build --no-push'
@@ -29,7 +31,7 @@ describe 'kontena service health_check' do
         response = Net::HTTP.get_response(uri)
         status = response.code.to_i
 
-        puts "GET #{uri} => #{status}"
+        debug "GET #{uri} => #{status}"
 
         if status == 503 && ((count += 1) < retry_503)
           # LB can return 503 temporarily during configuration, retry to make sure it's stable before returning it

--- a/test/spec/support/debug_helper.rb
+++ b/test/spec/support/debug_helper.rb
@@ -1,0 +1,11 @@
+module DebugHelper
+  def debug?
+    ENV.has_key?('DEBUG_SPECS')
+  end
+
+  def debug(msg = nil, &block)
+    msg = msg || yield
+
+    puts msg if debug?
+  end
+end

--- a/test/spec/support/shell.rb
+++ b/test/spec/support/shell.rb
@@ -15,7 +15,7 @@ module Shell
   # @param [Hash] opts
   # @return [Kommando]
   def run(cmd, opts = {})
-    opts[:output] = debug? unless opts.has_key?(:output)
+    opts[:output] = debug_kommando? unless opts.has_key?(:output)
     Kommando.run(cmd, opts)
   end
 
@@ -33,11 +33,11 @@ module Shell
   # @param [Hash] opts
   # @return [Kommando]
   def kommando(cmd, opts = {})
-    opts[:output] = debug? unless opts.has_key?(:output)
+    opts[:output] = debug_kommando? unless opts.has_key?(:output)
     Kommando.new(cmd, opts)
   end
 
-  def debug?
+  def debug_kommando?
     ENV.has_key?('DEBUG_KOMMANDO')
   end
 


### PR DESCRIPTION
Alternative to #3301

Add a new `DebugHelper` to the e2e test specs, allowing specs to output optional debugging information if running with `DEBUG_SPECS=true` (ref `DEBUG_KOMMANDO=true`).