### PR TITLE
Upgrade master json-jwt dependency to fix CVE-2018-1000539

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -20,7 +20,7 @@ gem 'mongoid-enum'
 gem 'rollbar', require: false
 gem 'rbtrace', require: false
 gem 'acme-client'
-gem 'json-jwt', '= 1.5.2'
+gem 'json-jwt', '= 1.9.4'
 gem 'jsonpath'
 gem 'json-serializer'
 gem 'bcrypt'


### PR DESCRIPTION
Fixes (CVE-2018-1000539)[https://nvd.nist.gov/vuln/detail/CVE-2018-1000539]
