### PR TITLE
Ignore CVE-2018-1000539

### DIFF
--- a/build/travis/test.sh
+++ b/build/travis/test.sh
@@ -3,5 +3,5 @@ set -ue
 
 cd $TEST_DIR && \
   bundle install --path vendor/bundle && \
-  bundle audit check --update && \
+  bundle audit check --update --ignore CVE-2018-1000539 && \ # ignore vulnerability in JSON-JWT, used by ancient Acme::Client for sending requests, not for validating.
   bundle exec rspec spec/

--- a/build/travis/test.sh
+++ b/build/travis/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ue
 
+ # CVE-2018-1000539 is a vulnerability in JSON-JWT, used by ancient Acme::Client for sending requests, not for validating.
 cd $TEST_DIR && \
   bundle install --path vendor/bundle && \
-  bundle audit check --update --ignore CVE-2018-1000539 && \ # ignore vulnerability in JSON-JWT, used by ancient Acme::Client for sending requests, not for validating.
+  bundle audit check --update --ignore CVE-2018-1000539 && \
   bundle exec rspec spec/


### PR DESCRIPTION
Whitelists [CVE-2018-1000539](https://nvd.nist.gov/vuln/detail/CVE-2018-1000539)

`Json::JWT` has a vulnerability when validating JWT tokens. The `Acme::Client` is using it only for generating requests, not validation.

Fixing will require changes to mongo schema and some code rewrite.