### PR TITLE
Backport: Ignore CVE-2018-1000539 (#3364)

### DIFF
--- a/build/travis/test.sh
+++ b/build/travis/test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ue
 
+ # CVE-2018-1000539 is a vulnerability in JSON-JWT, used by ancient Acme::Client for sending requests, not for validating.
 cd $TEST_DIR && \
   bundle install --path vendor/bundle && \
-  bundle audit check --update && \
+  bundle audit check --update --ignore CVE-2018-1000539 && \
   bundle exec rspec spec/


### PR DESCRIPTION
* Ignore CVE-2018-1000539 

(Vulnerable JSON-JWT is used for sending requests, not validating tokens)
