### PR TITLE
Backport: Build: override libxslt download url (#3367)

### DIFF
--- a/cli/omnibus/Gemfile
+++ b/cli/omnibus/Gemfile
@@ -5,5 +5,5 @@ gem 'omnibus', '~> 5.6'
 
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.
-gem 'omnibus-software', github: 'opscode/omnibus-software'
+gem 'omnibus-software', github: 'chef/omnibus-software'
 

--- a/cli/omnibus/config/projects/kontena.rb
+++ b/cli/omnibus/config/projects/kontena.rb
@@ -13,6 +13,7 @@ homepage "https://kontena.io"
 
 override :ruby, version: "2.5.0"
 override :libxml2, version: '2.9.7', source: { url: 'http://xmlsoft.org/sources/libxml2-2.9.7.tar.gz' }
+override :libxslt, version: '1.1.30', source: { url: 'http://xmlsoft.org/sources/libxslt-1.1.30.tar.gz' }
 
 # Defaults to C:/kontena on Windows
 # and /opt/kontena on all other platforms


### PR DESCRIPTION
* Fix link to libxslt for building CLI

* Switch to chef/omnibus-software, opscode seems quiet